### PR TITLE
feat(dev-workflow): implement install_<tool> for setup scripts

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup tools (no lefthook install)
         run: bash scripts/setup.sh --tools-only
 
-      - name: just audit (pip-audit + osv-scanner)
+      - name: just audit (pip-audit + pnpm audit)
         run: just audit
 
       - name: just audit-secrets (gitleaks on history)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -191,7 +191,7 @@ pwsh scripts/setup.ps1
 | `just test` | backend (pytest) + frontend (vitest) を順次実行 |
 | `just test-backend` | backend のみ（pytest） |
 | `just test-frontend` | frontend のみ（vitest） |
-| `just audit` | 依存脆弱性監査（pip-audit + osv-scanner） |
+| `just audit` | 依存脆弱性監査（pip-audit + pnpm audit） |
 | `just audit-secrets` | staged 差分の secret 検査（gitleaks） |
 | `just audit-pin-sync` | setup.sh / setup.ps1 のピン定数同期検査 |
 | `just check-all` | 全品質ゲートを順次実行（最終確認用） |

--- a/justfile
+++ b/justfile
@@ -41,10 +41,10 @@ test-backend:
 test-frontend:
     pnpm --dir frontend vitest run
 
-# Audit dependencies (pip-audit + osv-scanner)
+# Audit dependencies (pip-audit for Python, pnpm audit for Node)
 audit:
     uv run pip-audit
-    pnpm dlx osv-scanner --recursive .
+    pnpm audit
 
 # Scan staged changes for secrets (gitleaks)
 audit-secrets:

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -143,44 +143,182 @@ function Test-Pins {
 }
 Test-Pins
 
-# ───────────────────────────────────────────────────────────────
-# 各ツールの GitHub Releases からの導入は Sub-issue C で実装する。
-# 本スケルトンでは、ピン定数の確定後に以下を実装する想定:
-#
-#   Install-Uv       - astral-sh/uv の OS/arch に対応した tar.gz/zip を取得
-#   Install-Just     - casey/just
-#   Install-Convco   - convco/convco
-#   Install-Lefthook - evilmartians/lefthook
-#   Install-Gitleaks - gitleaks/gitleaks
-#
-# 各関数は以下を共通実装:
-#   1. Get-Command で既存検査 → あれば MSG-DW-006 を表示してスキップ
-#   2. プラットフォームに対応した URL を合成
-#   3. Invoke-WebRequest でダウンロード
-#   4. (Get-FileHash -Algorithm SHA256).Hash で実測値を取得し、ピン値と -eq 比較
-#   5. Expand-Archive で展開し、$env:USERPROFILE\.local\bin\ に配置
-# ───────────────────────────────────────────────────────────────
-
 $BinDir = Join-Path $env:USERPROFILE '.local\bin'
 if (-not (Test-Path $BinDir)) {
     New-Item -ItemType Directory -Path $BinDir | Out-Null
 }
 
-# Step 11. Python ツール導入
+# PATH 拡張（GitHub Actions 互換 + 現セッション）
+$env:PATH = "$BinDir;$env:PATH"
+if ($env:GITHUB_PATH) {
+    Add-Content -Path $env:GITHUB_PATH -Value $BinDir
+}
+
+# ───────────────────────────────────────────────────────────────
+# プラットフォーム検出（Windows x86_64 のみ MVP 対象）
+# ───────────────────────────────────────────────────────────────
+$Platform = 'WINDOWS_X86_64'
+
+function Get-DownloadAndVerify {
+    param([string]$Url, [string]$ExpectedSha)
+    $tmpfile = New-TemporaryFile
+    Invoke-WebRequest -Uri $Url -OutFile $tmpfile -UseBasicParsing
+    $actual = ((Get-FileHash $tmpfile -Algorithm SHA256).Hash).ToLower()
+    if ($actual -ne $ExpectedSha.ToLower()) {
+        Remove-Item $tmpfile -ErrorAction SilentlyContinue
+        Write-Error -Message @"
+[FAIL] バイナリの SHA256 検証に失敗しました。サプライチェーン改ざんの可能性があります。
+次のコマンド: 一時ファイルを削除後にネットワーク状況を確認し再実行。繰り返し失敗する場合は Issue で報告してください。
+  expected: $ExpectedSha
+  actual:   $actual
+"@
+        exit 1
+    }
+    return $tmpfile.FullName
+}
+
+# ───────────────────────────────────────────────────────────────
+# Step 6-10. GitHub Releases から 5 ツール導入
+# ───────────────────────────────────────────────────────────────
+
+function Install-Uv {
+    if (Get-Command uv -ErrorAction SilentlyContinue) {
+        Write-Host "[SKIP] uv は既にインストール済みです。"
+        Write-Host "バージョン: $((uv --version) -join ' ')"
+        return
+    }
+    $asset = 'uv-x86_64-pc-windows-msvc.zip'
+    $sha = $UV_SHA256_WINDOWS_X86_64
+    $url = "https://github.com/astral-sh/uv/releases/download/$UV_VERSION/$asset"
+    $tmpfile = Get-DownloadAndVerify -Url $url -ExpectedSha $sha
+    $tmpdir = New-Item -ItemType Directory -Path (Join-Path $env:TEMP "uv-$([Guid]::NewGuid().Guid)")
+    Expand-Archive -Path $tmpfile -DestinationPath $tmpdir -Force
+    # uv-{platform}\uv.exe を取り出す
+    $uvBin = Get-ChildItem -Path $tmpdir -Filter 'uv.exe' -Recurse | Select-Object -First 1
+    Move-Item -Path $uvBin.FullName -Destination (Join-Path $BinDir 'uv.exe') -Force
+    Remove-Item -Path $tmpdir -Recurse -Force
+    Remove-Item -Path $tmpfile -Force
+    Write-Host "[OK] uv $UV_VERSION を $BinDir\uv.exe に配置しました。"
+}
+
+function Install-Just {
+    if (Get-Command just -ErrorAction SilentlyContinue) {
+        Write-Host "[SKIP] just は既にインストール済みです。"
+        Write-Host "バージョン: $((just --version) -join ' ')"
+        return
+    }
+    $asset = "just-$JUST_VERSION-x86_64-pc-windows-msvc.zip"
+    $sha = $JUST_SHA256_WINDOWS_X86_64
+    $url = "https://github.com/casey/just/releases/download/$JUST_VERSION/$asset"
+    $tmpfile = Get-DownloadAndVerify -Url $url -ExpectedSha $sha
+    $tmpdir = New-Item -ItemType Directory -Path (Join-Path $env:TEMP "just-$([Guid]::NewGuid().Guid)")
+    Expand-Archive -Path $tmpfile -DestinationPath $tmpdir -Force
+    Move-Item -Path (Join-Path $tmpdir 'just.exe') -Destination (Join-Path $BinDir 'just.exe') -Force
+    Remove-Item -Path $tmpdir -Recurse -Force
+    Remove-Item -Path $tmpfile -Force
+    Write-Host "[OK] just $JUST_VERSION を $BinDir\just.exe に配置しました。"
+}
+
+function Install-Convco {
+    if (Get-Command convco -ErrorAction SilentlyContinue) {
+        Write-Host "[SKIP] convco は既にインストール済みです。"
+        Write-Host "バージョン: $((convco --version) -join ' ')"
+        return
+    }
+    $asset = 'convco-windows.zip'
+    $sha = $CONVCO_SHA256_WINDOWS_X86_64
+    $url = "https://github.com/convco/convco/releases/download/v$CONVCO_VERSION/$asset"
+    $tmpfile = Get-DownloadAndVerify -Url $url -ExpectedSha $sha
+    $tmpdir = New-Item -ItemType Directory -Path (Join-Path $env:TEMP "convco-$([Guid]::NewGuid().Guid)")
+    Expand-Archive -Path $tmpfile -DestinationPath $tmpdir -Force
+    Move-Item -Path (Join-Path $tmpdir 'convco.exe') -Destination (Join-Path $BinDir 'convco.exe') -Force
+    Remove-Item -Path $tmpdir -Recurse -Force
+    Remove-Item -Path $tmpfile -Force
+    Write-Host "[OK] convco $CONVCO_VERSION を $BinDir\convco.exe に配置しました。"
+}
+
+function Install-Lefthook {
+    if (Get-Command lefthook -ErrorAction SilentlyContinue) {
+        Write-Host "[SKIP] lefthook は既にインストール済みです。"
+        Write-Host "バージョン: $((lefthook version) -join ' ')"
+        return
+    }
+    # Windows は .gz ではなく .exe を直接ダウンロードできる asset がある場合があるが、
+    # 統一性のため .gz を使う。Windows でも tar が使えるため gunzip 相当が可能。
+    $asset = "lefthook_${LEFTHOOK_VERSION}_Windows_x86_64.gz"
+    $sha = $LEFTHOOK_SHA256_WINDOWS_X86_64
+    $url = "https://github.com/evilmartians/lefthook/releases/download/v$LEFTHOOK_VERSION/$asset"
+    $tmpfile = Get-DownloadAndVerify -Url $url -ExpectedSha $sha
+    # PowerShell には gunzip 相当の組込みが無いが、System.IO.Compression.GzipStream で展開可能
+    $outPath = Join-Path $BinDir 'lefthook.exe'
+    $inStream = [System.IO.File]::OpenRead($tmpfile)
+    $gzStream = New-Object System.IO.Compression.GzipStream($inStream, [System.IO.Compression.CompressionMode]::Decompress)
+    $outStream = [System.IO.File]::Create($outPath)
+    $gzStream.CopyTo($outStream)
+    $outStream.Close(); $gzStream.Close(); $inStream.Close()
+    Remove-Item -Path $tmpfile -Force
+    Write-Host "[OK] lefthook $LEFTHOOK_VERSION を $outPath に配置しました。"
+}
+
+function Install-Gitleaks {
+    if (Get-Command gitleaks -ErrorAction SilentlyContinue) {
+        Write-Host "[SKIP] gitleaks は既にインストール済みです。"
+        Write-Host "バージョン: $((gitleaks version) -join ' ')"
+        return
+    }
+    $asset = "gitleaks_${GITLEAKS_VERSION}_windows_x64.zip"
+    $sha = $GITLEAKS_SHA256_WINDOWS_X86_64
+    $url = "https://github.com/gitleaks/gitleaks/releases/download/v$GITLEAKS_VERSION/$asset"
+    $tmpfile = Get-DownloadAndVerify -Url $url -ExpectedSha $sha
+    $tmpdir = New-Item -ItemType Directory -Path (Join-Path $env:TEMP "gitleaks-$([Guid]::NewGuid().Guid)")
+    Expand-Archive -Path $tmpfile -DestinationPath $tmpdir -Force
+    Move-Item -Path (Join-Path $tmpdir 'gitleaks.exe') -Destination (Join-Path $BinDir 'gitleaks.exe') -Force
+    Remove-Item -Path $tmpdir -Recurse -Force
+    Remove-Item -Path $tmpfile -Force
+    Write-Host "[OK] gitleaks $GITLEAKS_VERSION を $BinDir\gitleaks.exe に配置しました。"
+}
+
+Install-Uv
+Install-Just
+Install-Convco
+Install-Lefthook
+Install-Gitleaks
+
+# ───────────────────────────────────────────────────────────────
+# Step 11. Python ツール導入（uv tool install、冪等）
+# ───────────────────────────────────────────────────────────────
 function Install-PythonTools {
     if (-not (Get-Command uv -ErrorAction SilentlyContinue)) {
         Write-Error '[FAIL] uv の導入後に再実行してください。'
         exit 1
     }
-    & uv tool install ruff
-    & uv tool install pyright
-    & uv tool install pip-audit
+    foreach ($tool in @('ruff', 'pyright', 'pip-audit')) {
+        if (Get-Command $tool -ErrorAction SilentlyContinue) {
+            Write-Host "[SKIP] $tool は既にインストール済みです。"
+        } else {
+            & uv tool install $tool
+        }
+    }
 }
 
 # Step 12. Node ツール導入
 function Install-NodeTools {
     & corepack enable
-    & pnpm install -g '@biomejs/biome' 'osv-scanner'
+    if (-not $env:PNPM_HOME) {
+        $env:PNPM_HOME = Join-Path $env:USERPROFILE 'AppData\Local\pnpm'
+    }
+    if (-not (Test-Path $env:PNPM_HOME)) {
+        New-Item -ItemType Directory -Path $env:PNPM_HOME -Force | Out-Null
+    }
+    $env:PATH = "$env:PNPM_HOME;$env:PATH"
+    if ($env:GITHUB_PATH) {
+        Add-Content -Path $env:GITHUB_PATH -Value $env:PNPM_HOME
+    }
+    if (Get-Command biome -ErrorAction SilentlyContinue) {
+        Write-Host "[SKIP] biome は既にインストール済みです。"
+    } else {
+        & pnpm install -g '@biomejs/biome'
+    }
 }
 
 # Step 13. lefthook install（--ToolsOnly でなければ）

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -183,39 +183,211 @@ verify_sha256() {
 }
 
 # ───────────────────────────────────────────────────────────────
-# 各ツールの GitHub Releases からの導入は Sub-issue C で実装する。
-# 本スケルトンでは、ピン定数の確定後に以下を実装する想定:
-#
-#   install_uv()       - astral-sh/uv の OS/arch に対応した tar.gz/zip を取得
-#   install_just()     - casey/just
-#   install_convco()   - convco/convco
-#   install_lefthook() - evilmartians/lefthook
-#   install_gitleaks() - gitleaks/gitleaks
-#
-# 各関数は以下を共通実装:
-#   1. command -v で既存検査 → あれば MSG-DW-006 を表示してスキップ
-#   2. プラットフォームに対応した URL を合成
-#   3. curl -sSfL でダウンロード
-#   4. verify_sha256 でピン値と照合
-#   5. tar/unzip で展開し、$BIN_DIR に配置
-#   6. chmod +x
+# GitHub Releases からのバイナリ取得（共通ヘルパ）
 # ───────────────────────────────────────────────────────────────
+download_to_tmp() {
+    # $1=URL, prints tmpfile path on stdout
+    local url=$1 tmpfile
+    tmpfile=$(mktemp)
+    if ! curl -sSfL "$url" -o "$tmpfile"; then
+        rm -f "$tmpfile"
+        echo "[FAIL] ダウンロード失敗: $url" >&2
+        exit 1
+    fi
+    echo "$tmpfile"
+}
 
-# Step 11. Python ツール導入（uv tool install）
+# ───────────────────────────────────────────────────────────────
+# Step 6. uv 導入
+# ───────────────────────────────────────────────────────────────
+install_uv() {
+    if command -v uv >/dev/null 2>&1; then
+        echo "[SKIP] uv は既にインストール済みです。"
+        echo "バージョン: $(uv --version 2>&1 | head -1)"
+        return 0
+    fi
+    local platform asset sha url tmpfile tmpdir
+    platform=$(detect_platform)
+    case "$platform" in
+        LINUX_X86_64)   asset="uv-x86_64-unknown-linux-gnu.tar.gz";   sha=$UV_SHA256_LINUX_X86_64 ;;
+        LINUX_ARM64)    asset="uv-aarch64-unknown-linux-gnu.tar.gz";  sha=$UV_SHA256_LINUX_ARM64 ;;
+        DARWIN_X86_64)  asset="uv-x86_64-apple-darwin.tar.gz";        sha=$UV_SHA256_DARWIN_X86_64 ;;
+        DARWIN_ARM64)   asset="uv-aarch64-apple-darwin.tar.gz";       sha=$UV_SHA256_DARWIN_ARM64 ;;
+    esac
+    url="https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/${asset}"
+    tmpfile=$(download_to_tmp "$url")
+    verify_sha256 "$tmpfile" "$sha"
+    tmpdir=$(mktemp -d)
+    tar -xzf "$tmpfile" -C "$tmpdir"
+    # tar.gz は uv-{platform}/uv の構造
+    find "$tmpdir" -name 'uv' -type f -exec mv {} "$BIN_DIR/uv" \;
+    chmod +x "$BIN_DIR/uv"
+    rm -rf "$tmpdir" "$tmpfile"
+    echo "[OK] uv ${UV_VERSION} を $BIN_DIR/uv に配置しました。"
+}
+
+# ───────────────────────────────────────────────────────────────
+# Step 7. just 導入
+# ───────────────────────────────────────────────────────────────
+install_just() {
+    if command -v just >/dev/null 2>&1; then
+        echo "[SKIP] just は既にインストール済みです。"
+        echo "バージョン: $(just --version 2>&1)"
+        return 0
+    fi
+    local platform asset sha url tmpfile tmpdir
+    platform=$(detect_platform)
+    case "$platform" in
+        LINUX_X86_64)   asset="just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz";   sha=$JUST_SHA256_LINUX_X86_64 ;;
+        LINUX_ARM64)    asset="just-${JUST_VERSION}-aarch64-unknown-linux-musl.tar.gz";  sha=$JUST_SHA256_LINUX_ARM64 ;;
+        DARWIN_X86_64)  asset="just-${JUST_VERSION}-x86_64-apple-darwin.tar.gz";         sha=$JUST_SHA256_DARWIN_X86_64 ;;
+        DARWIN_ARM64)   asset="just-${JUST_VERSION}-aarch64-apple-darwin.tar.gz";        sha=$JUST_SHA256_DARWIN_ARM64 ;;
+    esac
+    url="https://github.com/casey/just/releases/download/${JUST_VERSION}/${asset}"
+    tmpfile=$(download_to_tmp "$url")
+    verify_sha256 "$tmpfile" "$sha"
+    tmpdir=$(mktemp -d)
+    tar -xzf "$tmpfile" -C "$tmpdir"
+    # just の tar.gz は root 直下に just バイナリ
+    mv "$tmpdir/just" "$BIN_DIR/just"
+    chmod +x "$BIN_DIR/just"
+    rm -rf "$tmpdir" "$tmpfile"
+    echo "[OK] just ${JUST_VERSION} を $BIN_DIR/just に配置しました。"
+}
+
+# ───────────────────────────────────────────────────────────────
+# Step 8. convco 導入
+# ───────────────────────────────────────────────────────────────
+install_convco() {
+    if command -v convco >/dev/null 2>&1; then
+        echo "[SKIP] convco は既にインストール済みです。"
+        echo "バージョン: $(convco --version 2>&1)"
+        return 0
+    fi
+    local platform asset sha url tmpfile tmpdir
+    platform=$(detect_platform)
+    case "$platform" in
+        LINUX_X86_64)   asset="convco-ubuntu.zip";          sha=$CONVCO_SHA256_LINUX_X86_64 ;;
+        LINUX_ARM64)    asset="convco-ubuntu-aarch64.zip";  sha=$CONVCO_SHA256_LINUX_ARM64 ;;
+        DARWIN_X86_64)  asset="convco-macos.zip";           sha=$CONVCO_SHA256_DARWIN_X86_64 ;;
+        DARWIN_ARM64)   asset="convco-macos.zip";           sha=$CONVCO_SHA256_DARWIN_ARM64 ;;
+    esac
+    url="https://github.com/convco/convco/releases/download/v${CONVCO_VERSION}/${asset}"
+    tmpfile=$(download_to_tmp "$url")
+    verify_sha256 "$tmpfile" "$sha"
+    tmpdir=$(mktemp -d)
+    unzip -q "$tmpfile" -d "$tmpdir"
+    mv "$tmpdir/convco" "$BIN_DIR/convco"
+    chmod +x "$BIN_DIR/convco"
+    rm -rf "$tmpdir" "$tmpfile"
+    echo "[OK] convco ${CONVCO_VERSION} を $BIN_DIR/convco に配置しました。"
+}
+
+# ───────────────────────────────────────────────────────────────
+# Step 9. lefthook 導入
+# ───────────────────────────────────────────────────────────────
+install_lefthook() {
+    if command -v lefthook >/dev/null 2>&1; then
+        echo "[SKIP] lefthook は既にインストール済みです。"
+        echo "バージョン: $(lefthook version 2>&1)"
+        return 0
+    fi
+    local platform asset sha url tmpfile
+    platform=$(detect_platform)
+    case "$platform" in
+        LINUX_X86_64)   asset="lefthook_${LEFTHOOK_VERSION}_Linux_x86_64.gz";   sha=$LEFTHOOK_SHA256_LINUX_X86_64 ;;
+        LINUX_ARM64)    asset="lefthook_${LEFTHOOK_VERSION}_Linux_arm64.gz";    sha=$LEFTHOOK_SHA256_LINUX_ARM64 ;;
+        DARWIN_X86_64)  asset="lefthook_${LEFTHOOK_VERSION}_MacOS_x86_64.gz";   sha=$LEFTHOOK_SHA256_DARWIN_X86_64 ;;
+        DARWIN_ARM64)   asset="lefthook_${LEFTHOOK_VERSION}_MacOS_arm64.gz";    sha=$LEFTHOOK_SHA256_DARWIN_ARM64 ;;
+    esac
+    url="https://github.com/evilmartians/lefthook/releases/download/v${LEFTHOOK_VERSION}/${asset}"
+    tmpfile=$(download_to_tmp "$url")
+    verify_sha256 "$tmpfile" "$sha"
+    # .gz は単一バイナリの圧縮
+    gunzip -c "$tmpfile" > "$BIN_DIR/lefthook"
+    chmod +x "$BIN_DIR/lefthook"
+    rm -f "$tmpfile"
+    echo "[OK] lefthook ${LEFTHOOK_VERSION} を $BIN_DIR/lefthook に配置しました。"
+}
+
+# ───────────────────────────────────────────────────────────────
+# Step 10. gitleaks 導入
+# ───────────────────────────────────────────────────────────────
+install_gitleaks() {
+    if command -v gitleaks >/dev/null 2>&1; then
+        echo "[SKIP] gitleaks は既にインストール済みです。"
+        echo "バージョン: $(gitleaks version 2>&1)"
+        return 0
+    fi
+    local platform asset sha url tmpfile tmpdir
+    platform=$(detect_platform)
+    case "$platform" in
+        LINUX_X86_64)   asset="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz";    sha=$GITLEAKS_SHA256_LINUX_X86_64 ;;
+        LINUX_ARM64)    asset="gitleaks_${GITLEAKS_VERSION}_linux_arm64.tar.gz";  sha=$GITLEAKS_SHA256_LINUX_ARM64 ;;
+        DARWIN_X86_64)  asset="gitleaks_${GITLEAKS_VERSION}_darwin_x64.tar.gz";   sha=$GITLEAKS_SHA256_DARWIN_X86_64 ;;
+        DARWIN_ARM64)   asset="gitleaks_${GITLEAKS_VERSION}_darwin_arm64.tar.gz"; sha=$GITLEAKS_SHA256_DARWIN_ARM64 ;;
+    esac
+    url="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${asset}"
+    tmpfile=$(download_to_tmp "$url")
+    verify_sha256 "$tmpfile" "$sha"
+    tmpdir=$(mktemp -d)
+    tar -xzf "$tmpfile" -C "$tmpdir"
+    mv "$tmpdir/gitleaks" "$BIN_DIR/gitleaks"
+    chmod +x "$BIN_DIR/gitleaks"
+    rm -rf "$tmpdir" "$tmpfile"
+    echo "[OK] gitleaks ${GITLEAKS_VERSION} を $BIN_DIR/gitleaks に配置しました。"
+}
+
+# ───────────────────────────────────────────────────────────────
+# PATH 拡張（GitHub Actions 互換 + ローカル）
+# ───────────────────────────────────────────────────────────────
+export PATH="$BIN_DIR:$PATH"
+if [[ -n "${GITHUB_PATH:-}" ]]; then
+    echo "$BIN_DIR" >> "$GITHUB_PATH"
+fi
+
+# Step 6-10. GitHub Releases から 5 ツール導入
+install_uv
+install_just
+install_convco
+install_lefthook
+install_gitleaks
+
+# Step 11. Python ツール導入（uv tool install、冪等）
+# 別経路（apt/pip 等）でも導入済みなら uv tool は走らせない。bakufu は
+# 既存 ruff/pyright/pip-audit を尊重する方針（PATH に居れば OK）。
 install_python_tools() {
     if ! command -v uv >/dev/null 2>&1; then
         echo "[FAIL] uv の導入後に再実行してください。" >&2
         exit 1
     fi
-    uv tool install ruff
-    uv tool install pyright
-    uv tool install pip-audit
+    for tool in ruff pyright pip-audit; do
+        if command -v "$tool" >/dev/null 2>&1; then
+            echo "[SKIP] $tool は既にインストール済みです。"
+        else
+            uv tool install "$tool"
+        fi
+    done
 }
 
 # Step 12. Node ツール導入
+# pnpm の global bin を PNPM_HOME に固定（未設定なら ~/.local/share/pnpm）。
 install_node_tools() {
     corepack enable
-    pnpm install -g @biomejs/biome osv-scanner
+    if [[ -z "${PNPM_HOME:-}" ]]; then
+        export PNPM_HOME="${HOME}/.local/share/pnpm"
+    fi
+    mkdir -p "$PNPM_HOME"
+    export PATH="${PNPM_HOME}:$PATH"
+    if [[ -n "${GITHUB_PATH:-}" ]]; then
+        echo "$PNPM_HOME" >> "$GITHUB_PATH"
+    fi
+
+    if command -v biome >/dev/null 2>&1; then
+        echo "[SKIP] biome は既にインストール済みです。"
+    else
+        pnpm install -g @biomejs/biome
+    fi
 }
 
 # Step 13. lefthook install（--tools-only でなければ）
@@ -230,8 +402,6 @@ finalize_lefthook() {
     lefthook install
 }
 
-# 実装の本体（ピン値が空の場合は上記 check_pins で既に exit 済み）
-# 5 ツールのインストール本体は Sub-issue C で実装。本スケルトンではピン未確定により到達しない。
 install_python_tools
 install_node_tools
 finalize_lefthook


### PR DESCRIPTION
## Summary

- 5 ツールの GitHub Releases バイナリ取得 + SHA256 検証 + 配置を実装
- ローカル冪等性確認 OK（2 回連続実行で全 [SKIP] + [OK]）
- osv-scanner は npm 未配布のため一旦 \`pnpm audit\` に置換（後段で 6 ツール目として再導入予定）

## 種別

- [x] feature/* → develop（新機能・改善）

## 関連 Issue

Refs: docs/features/dev-workflow/requirements-analysis.md §Sub-issue 分割計画 (Sub-issue C 続編)

## チェックリスト

- [x] PR タイトルが Conventional Commits に従っている
- [x] ローカル \`bash scripts/setup.sh --tools-only\` が冪等
- [ ] CI（branch-policy / pr-title-check）が緑
- [ ] CI install 経路が動作（フレッシュ環境で 5 ツール導入）

## 残課題（後続 Issue）

- 設計書群の osv-scanner 表記整合（tech-stack.md / requirements-analysis.md / requirements.md / basic-design.md / detailed-design.md / test-design.md）
- bakufu スケルトン（pyproject.toml + package.json + biome.json + tsconfig.json）作成 → biome / tsc / pytest / vitest が動く状態に
- osv-scanner を 6 ツール目として GitHub Releases バイナリ経由で再導入