### PR TITLE
chore(domain-model): adopt frozenset[Role] for Stage.required_role

### DIFF
--- a/docs/architecture/domain-model.md
+++ b/docs/architecture/domain-model.md
@@ -58,7 +58,7 @@ classDiagram
         +id: StageId
         +name: str
         +kind: StageKind
-        +required_role: Role
+        +required_role: frozenset~Role~
         +deliverable_template: str
         +completion_policy: CompletionPolicy
     }

--- a/docs/architecture/domain-model/aggregates.md
+++ b/docs/architecture/domain-model/aggregates.md
@@ -61,6 +61,7 @@
 - 終端 Stage（外向き Transition なし）が 1 件以上存在
 - `EXTERNAL_REVIEW` Stage は `notify_channels` を持つ
 - 同じ `from_stage_id` × `condition` の Transition は重複しない（決定論的）
+- 各 Stage の `required_role` は空集合でない（最低 1 件の Role を持つ）— Stage 自身の不変条件だが、Workflow.validate() でも全 Stage を走査して集約検査する
 
 **ふるまい**:
 - `add_stage(stage_data) -> StageId`

--- a/docs/architecture/domain-model/transactions.md
+++ b/docs/architecture/domain-model/transactions.md
@@ -61,19 +61,19 @@
 
 ```
 Workflow: V モデル開発フロー
-├── Stage: 要求分析 (WORK, REQUIRED_ROLE=LEADER)
-├── Stage: 要求分析レビュー (EXTERNAL_REVIEW, notify=[Discord])
-├── Stage: 要件定義 (WORK, REQUIRED_ROLE=LEADER+UX)
-├── Stage: 要件定義レビュー (EXTERNAL_REVIEW, notify=[Discord])
-├── Stage: 基本設計 (WORK, REQUIRED_ROLE=DEVELOPER+UX)
-├── Stage: 基本設計レビュー (EXTERNAL_REVIEW, notify=[Discord])
-├── Stage: 詳細設計 (WORK, REQUIRED_ROLE=DEVELOPER)
-├── Stage: 詳細設計レビュー (EXTERNAL_REVIEW)
-├── Stage: 実装 (WORK, REQUIRED_ROLE=DEVELOPER)
-├── Stage: ユニットテスト (WORK, REQUIRED_ROLE=TESTER)
-├── Stage: 結合テスト (WORK, REQUIRED_ROLE=TESTER)
-├── Stage: E2E テスト (WORK, REQUIRED_ROLE=TESTER)
-└── Stage: 完了レビュー (EXTERNAL_REVIEW, notify=[Discord])
+├── Stage: 要求分析       (WORK, required_role={LEADER})
+├── Stage: 要求分析レビュー (EXTERNAL_REVIEW, required_role={REVIEWER}, notify=[Discord])
+├── Stage: 要件定義       (WORK, required_role={LEADER, UX})
+├── Stage: 要件定義レビュー (EXTERNAL_REVIEW, required_role={REVIEWER}, notify=[Discord])
+├── Stage: 基本設計       (WORK, required_role={DEVELOPER, UX})
+├── Stage: 基本設計レビュー (EXTERNAL_REVIEW, required_role={REVIEWER}, notify=[Discord])
+├── Stage: 詳細設計       (WORK, required_role={DEVELOPER})
+├── Stage: 詳細設計レビュー (EXTERNAL_REVIEW, required_role={REVIEWER})
+├── Stage: 実装           (WORK, required_role={DEVELOPER})
+├── Stage: ユニットテスト  (WORK, required_role={TESTER})
+├── Stage: 結合テスト      (WORK, required_role={TESTER})
+├── Stage: E2E テスト     (WORK, required_role={TESTER})
+└── Stage: 完了レビュー    (EXTERNAL_REVIEW, required_role={REVIEWER}, notify=[Discord])
 
 Transitions:
 - 要求分析 ─APPROVED→ 要件定義

--- a/docs/architecture/domain-model/transactions.md
+++ b/docs/architecture/domain-model/transactions.md
@@ -68,7 +68,7 @@ Workflow: V モデル開発フロー
 ├── Stage: 基本設計       (WORK, required_role={DEVELOPER, UX})
 ├── Stage: 基本設計レビュー (EXTERNAL_REVIEW, required_role={REVIEWER}, notify=[Discord])
 ├── Stage: 詳細設計       (WORK, required_role={DEVELOPER})
-├── Stage: 詳細設計レビュー (EXTERNAL_REVIEW, required_role={REVIEWER})
+├── Stage: 詳細設計レビュー (EXTERNAL_REVIEW, required_role={REVIEWER}, notify=[Discord])
 ├── Stage: 実装           (WORK, required_role={DEVELOPER})
 ├── Stage: ユニットテスト  (WORK, required_role={TESTER})
 ├── Stage: 結合テスト      (WORK, required_role={TESTER})

--- a/docs/architecture/domain-model/value-objects.md
+++ b/docs/architecture/domain-model/value-objects.md
@@ -44,10 +44,16 @@
 | `id` | `StageId` | 不変 |
 | `name` | `str` | 1〜80 文字（例: "要求分析"、"基本設計"、"実装"、"外部レビュー"） |
 | `kind` | `StageKind` | `WORK` / `INTERNAL_REVIEW` / `EXTERNAL_REVIEW` |
-| `required_role` | `Role` | この Stage を担当する Role |
+| `required_role` | `frozenset[Role]` | この Stage を担当する Role の集合。**空集合は不可（最低 1 件）**。複数役割の協業を表現できる（例: `{LEADER, UX}`） |
 | `deliverable_template` | `str` | Markdown テンプレ（成果物の形式） |
 | `completion_policy` | `CompletionPolicy`（VO） | 完了判定ロジック（例: "approved by reviewer" / "all checklist items checked"） |
 | `notify_channels` | `List[NotifyChannel]` | `EXTERNAL_REVIEW` のときのみ必須。Discord / Slack / Email 等の通知先 |
+
+**`required_role` を集合型にした理由**:
+- 業務工程は単一役割で完結しないことが多い（例: 要件定義は LEADER + UX、基本設計は DEVELOPER + UX）
+- 単一 `Role` から複数を表現するために合成 enum 値（`LEADER_AND_UX` 等）を増やすと組合せ爆発する
+- `frozenset[Role]` は不変・順序非依存・集合演算（`is_subset_of` 等）が標準で使える
+- Stage 担当割当時に「Agent の `role` が `required_role` に含まれるか」を `agent.role in stage.required_role` で素直に判定できる
 
 ### Transition（Entity within Workflow Aggregate）
 


### PR DESCRIPTION
Closes #7

## Summary

PR #6（Phase 0 アーキ凍結）レビューで Steve が Boy Scout 観点として残した `Stage.required_role` の型と既存レンダリング例の食い違いを、M1 着手前に解消する。

- 設計書の Stage 定義は **`required_role: Role`（単一型）**
- 既存レンダリング例は **`REQUIRED_ROLE=LEADER+UX` / `DEVELOPER+UX`** と複数 Role を表記
- workflow Issue (#9) がこれに依存するため、本 chore PR で先行解消

## 変更内容

`Stage.required_role` を `Role` から **`frozenset[Role]`** に拡張する。

### 設計判断の理由

| 候補 | 採否 | 理由 |
|----|----|----|
| 単一 `Role` のまま、複数役割は合成 enum 値（`LEADER_AND_UX` 等）で表現 | 不採用 | 組合せ爆発、enum surface が膨張 |
| `List[Role]` | 不採用 | 順序に意味がなく、可変・重複可能性で不変条件チェックが煩雑 |
| `set[Role]`（mutable） | 不採用 | 不変条件「最低 1 件」を破る可能性、frozen dataclass / Pydantic VO に乗せにくい |
| **`frozenset[Role]`** | **採用** | 不変・順序非依存・集合演算（`agent.role in stage.required_role`）が自然、Pydantic v2 frozen model と整合 |

### 不変条件の追加

- Stage 自身の不変条件: `required_role` は **空集合不可（最低 1 件）**
- Workflow.validate() でも全 Stage を走査して集約検査（aggregate-aware な検査の一環）

## 変更ファイル

- `docs/architecture/domain-model.md` — `classDiagram` の Stage を `+required_role: frozenset~Role~` に
- `docs/architecture/domain-model/value-objects.md` — Stage 属性表の型と制約欄を更新、選定理由ブロックを追加
- `docs/architecture/domain-model/aggregates.md` — Workflow Aggregate の不変条件に「各 Stage の `required_role` は空集合不可」を追加
- `docs/architecture/domain-model/transactions.md` — V モデル開発室レンダリング例を `REQUIRED_ROLE=LEADER+UX` から `required_role={LEADER, UX}` 表記に統一、`EXTERNAL_REVIEW` Stage に `required_role={REVIEWER}` を明記（従来は省略されていた）

## 影響しないこと

- `Agent.role` / `AgentMembership.role` は単一 `Role` のまま（Agent は単一役割を持ち、Stage 側で集合包含を判定する設計）
- 他の Aggregate / VO / 列挙型に変更なし
- 500 行ルール維持（最大ファイル 225 行）

## Test plan

ドキュメント変更のみで実行可能なテストはない。レビュー観点：

- [ ] Mermaid `classDiagram` の `frozenset~Role~` 表記が GitHub レンダリングで壊れない
- [ ] `value-objects.md` §Stage の制約欄と aggregates.md §Workflow 不変条件の記述が一致している
- [ ] レンダリング例の `required_role={...}` が全 Stage に明記されている（`EXTERNAL_REVIEW` も含む）
- [ ] workflow Issue (#9) の受入基準と本書の記述が整合する（実装担当が読み始めた際に矛盾を感じない）

## 注意事項

- 本 PR のコミットも **未署名**（agent 環境に GPG/SSH 鍵未設定）。develop の branch protection が `Require signed commits` を要求する場合、マージ前にオーナー対処が必要
- AI 生成フッターを含めない（CONTRIBUTING.md §AI 生成フッターの禁止に準拠）