### PR TITLE
feat(agent): Agent Aggregate Root with H1〜H10 path-traversal defense

### DIFF
--- a/backend/src/bakufu/domain/agent/__init__.py
+++ b/backend/src/bakufu/domain/agent/__init__.py
@@ -1,0 +1,109 @@
+"""Agent Aggregate Root package.
+
+Implements ``REQ-AG-001``〜``REQ-AG-006`` per ``docs/features/agent``.
+Split into four sibling modules along the design's responsibility lines so
+each file stays under the 500-line readability budget and the file-level
+boundary mirrors the design's twin-defense pattern (Stage's self-check vs
+the aggregate's collection check):
+
+* :mod:`bakufu.domain.agent.value_objects` — :class:`Persona` /
+  :class:`ProviderConfig` / :class:`SkillRef` Pydantic VOs with self-checks.
+* :mod:`bakufu.domain.agent.path_validators` — H1〜H10 path traversal
+  defense for ``SkillRef.path`` (Confirmation H), each rule a pure function.
+* :mod:`bakufu.domain.agent.aggregate_validators` — five module-level
+  invariant helpers covering provider capacity / uniqueness / default count
+  and skill capacity / uniqueness.
+* :mod:`bakufu.domain.agent.agent` — :class:`Agent` Aggregate Root that
+  dispatches over the helpers in deterministic order.
+
+This ``__init__`` re-exports the public surface plus the underscore-prefixed
+helpers tests need to invoke directly.
+"""
+
+from __future__ import annotations
+
+from bakufu.domain.agent.agent import (
+    MAX_NAME_LENGTH,
+    MIN_NAME_LENGTH,
+    Agent,
+)
+from bakufu.domain.agent.aggregate_validators import (
+    MAX_PROVIDERS,
+    MAX_SKILLS,
+    MIN_PROVIDERS,
+    _validate_default_provider_count,
+    _validate_provider_capacity,
+    _validate_provider_kind_unique,
+    _validate_skill_capacity,
+    _validate_skill_id_unique,
+)
+from bakufu.domain.agent.path_validators import (
+    MAX_PATH_LENGTH,
+    MIN_PATH_LENGTH,
+    REQUIRED_PARTS_PREFIX,
+    SKILLS_SUBDIR,
+    _h1_nfc_normalize,
+    _h2_check_length,
+    _h3_check_forbidden_chars,
+    _h4_check_leading,
+    _h5_check_traversal_sequences,
+    _h6_parse_parts,
+    _h7_check_prefix,
+    _h8_recheck_parts,
+    _h9_check_windows_reserved,
+    _h10_check_base_escape,
+    validate_skill_path,
+)
+from bakufu.domain.agent.value_objects import (
+    ARCHETYPE_MAX,
+    DISPLAY_NAME_MAX,
+    DISPLAY_NAME_MIN,
+    PROMPT_BODY_MAX,
+    PROVIDER_MODEL_MAX,
+    PROVIDER_MODEL_MIN,
+    SKILL_NAME_MAX,
+    SKILL_NAME_MIN,
+    Persona,
+    ProviderConfig,
+    SkillRef,
+)
+
+__all__ = [
+    "ARCHETYPE_MAX",
+    "DISPLAY_NAME_MAX",
+    "DISPLAY_NAME_MIN",
+    "MAX_NAME_LENGTH",
+    "MAX_PATH_LENGTH",
+    "MAX_PROVIDERS",
+    "MAX_SKILLS",
+    "MIN_NAME_LENGTH",
+    "MIN_PATH_LENGTH",
+    "MIN_PROVIDERS",
+    "PROMPT_BODY_MAX",
+    "PROVIDER_MODEL_MAX",
+    "PROVIDER_MODEL_MIN",
+    "REQUIRED_PARTS_PREFIX",
+    "SKILLS_SUBDIR",
+    "SKILL_NAME_MAX",
+    "SKILL_NAME_MIN",
+    "Agent",
+    "Persona",
+    "ProviderConfig",
+    "SkillRef",
+    "_h1_nfc_normalize",
+    "_h2_check_length",
+    "_h3_check_forbidden_chars",
+    "_h4_check_leading",
+    "_h5_check_traversal_sequences",
+    "_h6_parse_parts",
+    "_h7_check_prefix",
+    "_h8_recheck_parts",
+    "_h9_check_windows_reserved",
+    "_h10_check_base_escape",
+    "_validate_default_provider_count",
+    "_validate_provider_capacity",
+    "_validate_provider_kind_unique",
+    "_validate_skill_capacity",
+    "_validate_skill_id_unique",
+    "validate_skill_path",
+]

--- a/backend/src/bakufu/domain/agent/__init__.py
+++ b/backend/src/bakufu/domain/agent/__init__.py
@@ -52,7 +52,7 @@ from bakufu.domain.agent.path_validators import (
     _h8_recheck_parts,
     _h9_check_windows_reserved,
     _h10_check_base_escape,
-    validate_skill_path,
+    _validate_skill_path,
 )
 from bakufu.domain.agent.value_objects import (
     ARCHETYPE_MAX,
@@ -105,5 +105,5 @@ __all__ = [
     "_validate_provider_kind_unique",
     "_validate_skill_capacity",
     "_validate_skill_id_unique",
-    "validate_skill_path",
+    "_validate_skill_path",
 ]

--- a/backend/src/bakufu/domain/agent/agent.py
+++ b/backend/src/bakufu/domain/agent/agent.py
@@ -1,0 +1,201 @@
+"""Agent Aggregate Root (REQ-AG-001〜006).
+
+Implements per ``docs/features/agent``. The aggregate dispatches over five
+helpers in :mod:`bakufu.domain.agent.aggregate_validators` and delegates
+SkillRef.path traversal defense (H1〜H10) to
+:mod:`bakufu.domain.agent.path_validators`.
+
+Design contracts:
+
+* **Pre-validate rebuild (Confirmation A)** — ``set_default_provider`` /
+  ``add_skill`` / ``remove_skill`` / ``archive`` all go through
+  :meth:`Agent._rebuild_with` (``model_dump → swap → model_validate``).
+* **NFC pipeline (Confirmation E)** — ``Agent.name`` reuses the empire /
+  workflow ``nfc_strip`` helper. Length judgement happens in the model
+  validator so the resulting :class:`AgentInvariantViolation` carries
+  ``kind='name_range'`` with MSG-AG-001 wording.
+* **archive idempotency (Confirmation D)** — ``archive()`` always returns a
+  *new* instance. Idempotency means "result state matches", not "object
+  identity". Pydantic v2 frozen + ``model_validate`` rebuild guarantees this
+  by construction; the docstring/tests document the contract so users do not
+  rely on ``is`` comparisons.
+* **provider_kind MVP gate (Confirmation I)** — *not* implemented in the
+  aggregate. ``AgentService.hire()`` (a Phase-2 application service) is the
+  responsibility owner; the aggregate trusts that the enum value is well
+  formed and lets the service decide whether the Adapter exists.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Self
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    field_validator,
+    model_validator,
+)
+
+from bakufu.domain.agent.aggregate_validators import (
+    _validate_default_provider_count,
+    _validate_provider_capacity,
+    _validate_provider_kind_unique,
+    _validate_skill_capacity,
+    _validate_skill_id_unique,
+)
+from bakufu.domain.agent.value_objects import (
+    Persona,
+    ProviderConfig,
+    SkillRef,
+)
+from bakufu.domain.exceptions import AgentInvariantViolation
+from bakufu.domain.value_objects import (
+    AgentId,
+    ProviderKind,
+    Role,
+    SkillId,
+    nfc_strip,
+)
+
+# Confirmation E: name length bounds (1〜40 after NFC + strip).
+MIN_NAME_LENGTH: int = 1
+MAX_NAME_LENGTH: int = 40
+
+
+class Agent(BaseModel):
+    """Hireable LLM agent owned by an :class:`Empire`."""
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        arbitrary_types_allowed=False,
+    )
+
+    id: AgentId
+    name: str
+    persona: Persona
+    role: Role
+    providers: list[ProviderConfig]
+    skills: list[SkillRef] = []
+    archived: bool = False
+
+    # ---- pre-validation -------------------------------------------------
+    @field_validator("name", mode="before")
+    @classmethod
+    def _normalize_name(cls, value: object) -> object:
+        return nfc_strip(value)
+
+    @model_validator(mode="after")
+    def _check_invariants(self) -> Self:
+        """Dispatch over the aggregate-level helpers in deterministic order.
+
+        Order: name range → provider capacity / uniqueness / default count
+        → skill capacity / uniqueness. Earlier failures hide later ones so
+        error messages stay focused on the root cause.
+        """
+        self._check_name_range()
+        _validate_provider_capacity(self.providers)
+        _validate_provider_kind_unique(self.providers)
+        _validate_default_provider_count(self.providers)
+        _validate_skill_capacity(self.skills)
+        _validate_skill_id_unique(self.skills)
+        return self
+
+    def _check_name_range(self) -> None:
+        length = len(self.name)
+        if not (MIN_NAME_LENGTH <= length <= MAX_NAME_LENGTH):
+            raise AgentInvariantViolation(
+                kind="name_range",
+                message=(
+                    f"[FAIL] Agent name must be "
+                    f"{MIN_NAME_LENGTH}-{MAX_NAME_LENGTH} characters "
+                    f"(got {length})"
+                ),
+                detail={"length": length},
+            )
+
+    # ---- behaviors (Tell, Don't Ask) ------------------------------------
+    def set_default_provider(self, provider_kind: ProviderKind) -> Agent:
+        """Switch the default provider to the entry whose ``provider_kind`` matches.
+
+        Linear scan over ``providers`` (small N ≤ 10). Raises if the kind is
+        not registered — the caller cannot mark a never-configured provider
+        as default.
+
+        Raises:
+            AgentInvariantViolation: ``kind='provider_not_found'`` when no
+                ``ProviderConfig`` matches ``provider_kind``.
+        """
+        if not any(provider.provider_kind == provider_kind for provider in self.providers):
+            raise AgentInvariantViolation(
+                kind="provider_not_found",
+                message=f"[FAIL] provider_kind not registered: {provider_kind}",
+                detail={"provider_kind": str(provider_kind)},
+            )
+        new_providers = [
+            ProviderConfig(
+                provider_kind=provider.provider_kind,
+                model=provider.model,
+                is_default=(provider.provider_kind == provider_kind),
+            )
+            for provider in self.providers
+        ]
+        return self._rebuild_with(providers=new_providers)
+
+    def add_skill(self, skill_ref: SkillRef) -> Agent:
+        """Append ``skill_ref`` to ``skills``; aggregate validation catches duplicates."""
+        return self._rebuild_with(skills=[*self.skills, skill_ref])
+
+    def remove_skill(self, skill_id: SkillId) -> Agent:
+        """Drop the SkillRef whose ``skill_id`` matches.
+
+        Raises:
+            AgentInvariantViolation: ``kind='skill_not_found'`` (MSG-AG-008).
+        """
+        if not any(skill.skill_id == skill_id for skill in self.skills):
+            raise AgentInvariantViolation(
+                kind="skill_not_found",
+                message=f"[FAIL] Skill not found in agent: skill_id={skill_id}",
+                detail={"skill_id": str(skill_id)},
+            )
+        return self._rebuild_with(
+            skills=[skill for skill in self.skills if skill.skill_id != skill_id],
+        )
+
+    def archive(self) -> Agent:
+        """Return a new :class:`Agent` with ``archived=True`` (Confirmation D).
+
+        Idempotent: calling on an already-archived Agent yields a fresh
+        Agent that is **structurally equal** to the input but has a
+        different ``id()``. Callers must not rely on object identity —
+        always reassign the returned value (``agent = agent.archive()``).
+        """
+        return self._rebuild_with_state({"archived": True})
+
+    # ---- internal: pre-validate rebuild (Confirmation A) ----------------
+    def _rebuild_with(
+        self,
+        *,
+        providers: list[ProviderConfig] | None = None,
+        skills: list[SkillRef] | None = None,
+    ) -> Agent:
+        """Re-construct via ``model_validate`` so ``_check_invariants`` re-fires."""
+        state = self.model_dump()
+        if providers is not None:
+            state["providers"] = [provider.model_dump() for provider in providers]
+        if skills is not None:
+            state["skills"] = [skill.model_dump() for skill in skills]
+        return Agent.model_validate(state)
+
+    def _rebuild_with_state(self, updates: dict[str, Any]) -> Agent:
+        """Pre-validate rebuild for scalar attribute updates (e.g. ``archived``)."""
+        state = self.model_dump()
+        state.update(updates)
+        return Agent.model_validate(state)
+
+
+__all__ = [
+    "MAX_NAME_LENGTH",
+    "MIN_NAME_LENGTH",
+    "Agent",
+]

--- a/backend/src/bakufu/domain/agent/aggregate_validators.py
+++ b/backend/src/bakufu/domain/agent/aggregate_validators.py
@@ -1,0 +1,120 @@
+"""Aggregate-level invariant helpers for :class:`Agent`.
+
+Each helper is a **module-level pure function** so tests can ``import`` and
+invoke directly — same testability pattern Norman / Steve approved for the
+workflow package's ``dag_validators.py``. The Aggregate Root in
+:mod:`bakufu.domain.agent.agent` stays a thin dispatch over them; rule
+changes touch only the helper, never the orchestration code.
+
+Helpers (run in this order in :class:`Agent.model_validator`):
+
+1. :func:`_validate_provider_capacity` — ``1 ≤ len(providers) ≤ 10``
+2. :func:`_validate_provider_kind_unique` — no duplicate ``provider_kind``
+3. :func:`_validate_default_provider_count` — exactly one ``is_default=True``
+4. :func:`_validate_skill_capacity` — ``len(skills) ≤ 20``
+5. :func:`_validate_skill_id_unique` — no duplicate ``skill_id``
+
+Naming follows the workflow precedent ``_validate_*_unique`` for collection
+uniqueness checks (Steve's twin-defense symmetry rule from PR #16).
+"""
+
+from __future__ import annotations
+
+from bakufu.domain.agent.value_objects import ProviderConfig, SkillRef
+from bakufu.domain.exceptions import AgentInvariantViolation
+from bakufu.domain.value_objects import ProviderKind, SkillId
+
+# Confirmation C: capacity bounds.
+MIN_PROVIDERS: int = 1
+MAX_PROVIDERS: int = 10
+MAX_SKILLS: int = 20
+
+
+def _validate_provider_capacity(providers: list[ProviderConfig]) -> None:
+    """T2-DoS guard + REQ-AG-001 contract (1 件以上、上限 10 件)."""
+    count = len(providers)
+    if count < MIN_PROVIDERS:
+        raise AgentInvariantViolation(
+            kind="no_provider",
+            message="[FAIL] Agent must have at least one provider",
+            detail={"providers_count": count, "min_providers": MIN_PROVIDERS},
+        )
+    if count > MAX_PROVIDERS:
+        raise AgentInvariantViolation(
+            kind="provider_capacity_exceeded",
+            message=(
+                f"[FAIL] Agent invariant violation: providers capacity "
+                f"{MAX_PROVIDERS} exceeded (got {count})"
+            ),
+            detail={"providers_count": count, "max_providers": MAX_PROVIDERS},
+        )
+
+
+def _validate_provider_kind_unique(providers: list[ProviderConfig]) -> None:
+    """No two ProviderConfig may share ``provider_kind`` (MSG-AG-004)."""
+    seen: set[ProviderKind] = set()
+    for provider in providers:
+        if provider.provider_kind in seen:
+            raise AgentInvariantViolation(
+                kind="provider_duplicate",
+                message=f"[FAIL] Duplicate provider_kind: {provider.provider_kind}",
+                detail={"provider_kind": str(provider.provider_kind)},
+            )
+        seen.add(provider.provider_kind)
+
+
+def _validate_default_provider_count(providers: list[ProviderConfig]) -> None:
+    """Exactly one provider must be marked ``is_default=True`` (MSG-AG-003)."""
+    count = sum(1 for provider in providers if provider.is_default)
+    if count != 1:
+        raise AgentInvariantViolation(
+            kind="default_not_unique",
+            message=(f"[FAIL] Exactly one provider must have is_default=True (got {count})"),
+            detail={"default_count": count},
+        )
+
+
+def _validate_skill_capacity(skills: list[SkillRef]) -> None:
+    """Cap skills at 20 (REQ-AG-001 / Confirmation C)."""
+    count = len(skills)
+    if count > MAX_SKILLS:
+        raise AgentInvariantViolation(
+            kind="skill_capacity_exceeded",
+            message=(
+                f"[FAIL] Agent invariant violation: skills capacity "
+                f"{MAX_SKILLS} exceeded (got {count})"
+            ),
+            detail={"skills_count": count, "max_skills": MAX_SKILLS},
+        )
+
+
+def _validate_skill_id_unique(skills: list[SkillRef]) -> None:
+    """No two SkillRef may share ``skill_id`` (MSG-AG-007).
+
+    Naming mirrors workflow's ``_validate_stage_id_unique`` /
+    ``_validate_transition_id_unique`` symmetry that Steve required in
+    PR #16: every collection contract that says "no duplicate id" gets a
+    dedicated helper so the Boy Scout rule ("first leak breaks all") never
+    catches us off-guard on the next aggregate.
+    """
+    seen: set[SkillId] = set()
+    for skill in skills:
+        if skill.skill_id in seen:
+            raise AgentInvariantViolation(
+                kind="skill_duplicate",
+                message=f"[FAIL] Skill already added: skill_id={skill.skill_id}",
+                detail={"skill_id": str(skill.skill_id)},
+            )
+        seen.add(skill.skill_id)
+
+
+__all__ = [
+    "MAX_PROVIDERS",
+    "MAX_SKILLS",
+    "MIN_PROVIDERS",
+    "_validate_default_provider_count",
+    "_validate_provider_capacity",
+    "_validate_provider_kind_unique",
+    "_validate_skill_capacity",
+    "_validate_skill_id_unique",
+]

--- a/backend/src/bakufu/domain/agent/path_validators.py
+++ b/backend/src/bakufu/domain/agent/path_validators.py
@@ -5,7 +5,7 @@ Each Hx check is a **module-level pure function** so:
 1. Tests can ``import`` them and invoke directly to prove each rule works
    independently — same testability pattern as Workflow's
    :mod:`bakufu.domain.workflow.dag_validators` (Confirmation F).
-2. :func:`validate_skill_path` stays a thin sequencer over the ten checks,
+2. :func:`_validate_skill_path` stays a thin sequencer over the ten checks,
    with order locked by the design document.
 3. Future ``feature/skill-loader`` Phase-2 work that adds a runtime I/O
    recheck can re-use the exact same helpers — single source of truth for
@@ -226,7 +226,7 @@ def _h10_check_base_escape(path: str) -> None:
 # ---------------------------------------------------------------------------
 # Orchestrator (used by SkillRef.field_validator)
 # ---------------------------------------------------------------------------
-def validate_skill_path(raw_path: str) -> str:
+def _validate_skill_path(raw_path: str) -> str:
     """Run H1〜H10 in the design's locked order and return the NFC-normalized form.
 
     The returned value is what :class:`SkillRef` stores as ``path`` — callers
@@ -267,5 +267,5 @@ __all__ = [
     "_h8_recheck_parts",
     "_h9_check_windows_reserved",
     "_h10_check_base_escape",
-    "validate_skill_path",
+    "_validate_skill_path",
 ]

--- a/backend/src/bakufu/domain/agent/path_validators.py
+++ b/backend/src/bakufu/domain/agent/path_validators.py
@@ -1,0 +1,271 @@
+"""SkillRef.path traversal defense (Agent feature §確定 H, H1〜H10).
+
+Each Hx check is a **module-level pure function** so:
+
+1. Tests can ``import`` them and invoke directly to prove each rule works
+   independently — same testability pattern as Workflow's
+   :mod:`bakufu.domain.workflow.dag_validators` (Confirmation F).
+2. :func:`validate_skill_path` stays a thin sequencer over the ten checks,
+   with order locked by the design document.
+3. Future ``feature/skill-loader`` Phase-2 work that adds a runtime I/O
+   recheck can re-use the exact same helpers — single source of truth for
+   path policy, no rule drift.
+
+The functions raise :class:`AgentInvariantViolation` directly so callers
+(``SkillRef`` field validator) get the structured ``kind='skill_path_invalid'``
+discriminator without going through Pydantic's ``ValidationError`` wrapping.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import unicodedata
+from pathlib import Path, PurePosixPath
+
+from bakufu.domain.exceptions import AgentInvariantViolation
+
+# H2: 1〜500 chars (NFC-normalized form).
+MIN_PATH_LENGTH: int = 1
+MAX_PATH_LENGTH: int = 500
+
+# H7: required prefix segments. Anything not under bakufu-data/skills/* is
+# rejected at the VO boundary, regardless of what the file system says.
+REQUIRED_PARTS_PREFIX: tuple[str, str] = ("bakufu-data", "skills")
+SKILLS_SUBDIR: str = "skills"
+
+# H4: leading-character rejections.
+_WINDOWS_ABSOLUTE_RE = re.compile(r"^[A-Za-z]:[\\/]")
+
+# H9: Windows reserved device names. Compared case-insensitive on the part
+# stem (without extension) so "CON.md" is rejected too.
+_WINDOWS_RESERVED_NAMES: frozenset[str] = frozenset(
+    {
+        "CON",
+        "PRN",
+        "AUX",
+        "NUL",
+        *(f"COM{i}" for i in range(1, 10)),
+        *(f"LPT{i}" for i in range(1, 10)),
+    }
+)
+
+# H3: forbidden characters — NUL, ASCII C0/C1 control, backslash.
+_ASCII_CONTROL_RANGE = frozenset(chr(c) for c in range(0x00, 0x20)) | {chr(0x7F)}
+_FORBIDDEN_CHARS: frozenset[str] = _ASCII_CONTROL_RANGE | {"\\"}
+
+
+def _violation(check_id: str, detail_extra: dict[str, object]) -> AgentInvariantViolation:
+    """Centralize the ``AgentInvariantViolation`` shape used by every Hx helper.
+
+    Keeps the message format and ``kind`` consistent so callers can switch on
+    ``detail['check']`` to attribute the failure without parsing strings.
+    """
+    detail = {"check": check_id, **detail_extra}
+    return AgentInvariantViolation(
+        kind="skill_path_invalid",
+        message=f"[FAIL] SkillRef.path validation failed (check {check_id}): {detail}",
+        detail=detail,
+    )
+
+
+# ---------------------------------------------------------------------------
+# H1: NFC normalization
+# ---------------------------------------------------------------------------
+def _h1_nfc_normalize(raw_path: str) -> str:
+    """Apply NFC. Returned string is what every subsequent helper inspects."""
+    return unicodedata.normalize("NFC", raw_path)
+
+
+# ---------------------------------------------------------------------------
+# H2: length 1〜500
+# ---------------------------------------------------------------------------
+def _h2_check_length(path: str) -> None:
+    length = len(path)
+    if not (MIN_PATH_LENGTH <= length <= MAX_PATH_LENGTH):
+        raise _violation(
+            "H2",
+            {
+                "length": length,
+                "min": MIN_PATH_LENGTH,
+                "max": MAX_PATH_LENGTH,
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# H3: forbidden chars (NUL / control / backslash)
+# ---------------------------------------------------------------------------
+def _h3_check_forbidden_chars(path: str) -> None:
+    for ch in path:
+        if ch in _FORBIDDEN_CHARS:
+            raise _violation("H3", {"forbidden_char_codepoint": ord(ch)})
+
+
+# ---------------------------------------------------------------------------
+# H4: leading-character rejection (POSIX abs / Windows abs / home tilde)
+# ---------------------------------------------------------------------------
+def _h4_check_leading(path: str) -> None:
+    if path.startswith("/"):
+        raise _violation("H4", {"reason": "leading slash (POSIX absolute)"})
+    if path.startswith("~"):
+        raise _violation("H4", {"reason": "leading tilde (home expansion)"})
+    if _WINDOWS_ABSOLUTE_RE.match(path):
+        raise _violation("H4", {"reason": "Windows absolute path"})
+
+
+# ---------------------------------------------------------------------------
+# H5: traversal sequences and surrounding whitespace
+# ---------------------------------------------------------------------------
+def _h5_check_traversal_sequences(path: str) -> None:
+    if path != path.strip():
+        raise _violation("H5", {"reason": "leading or trailing whitespace"})
+    # ``path == '.'`` / ``path == '..'`` / leading ``./`` or ``../`` are
+    # current-dir or parent-dir aliases that round-trip through
+    # PurePosixPath silently — reject them at this layer.
+    if path in {".", ".."} or path.startswith(("./", "../")):
+        raise _violation("H5", {"reason": "path starts with '.' or '..'"})
+    if path.endswith(("/.", "/..", "/")):
+        raise _violation("H5", {"reason": "path ends with '.' or '..' or trailing slash"})
+    # Two-dot traversal anywhere — most common attack form.
+    if ".." in path.split("/"):
+        raise _violation("H5", {"reason": "'..' parent-dir traversal in path"})
+
+
+# ---------------------------------------------------------------------------
+# H6: parse via PurePosixPath, return parts
+# ---------------------------------------------------------------------------
+def _h6_parse_parts(path: str) -> tuple[str, ...]:
+    return PurePosixPath(path).parts
+
+
+# ---------------------------------------------------------------------------
+# H7: prefix must be ('bakufu-data', 'skills', <rest>)
+# ---------------------------------------------------------------------------
+def _h7_check_prefix(parts: tuple[str, ...]) -> None:
+    if len(parts) < 3:
+        raise _violation(
+            "H7",
+            {"reason": "path needs at least 3 components", "parts_count": len(parts)},
+        )
+    if parts[0] != REQUIRED_PARTS_PREFIX[0] or parts[1] != REQUIRED_PARTS_PREFIX[1]:
+        raise _violation(
+            "H7",
+            {
+                "reason": "prefix must be 'bakufu-data/skills/'",
+                "actual_prefix": list(parts[:2]),
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# H8: re-check every part for forbidden chars (defense in depth post-parse)
+# ---------------------------------------------------------------------------
+def _h8_recheck_parts(parts: tuple[str, ...]) -> None:
+    for index, part in enumerate(parts):
+        for ch in part:
+            if ch in _FORBIDDEN_CHARS:
+                raise _violation(
+                    "H8",
+                    {"part_index": index, "forbidden_char_codepoint": ord(ch)},
+                )
+
+
+# ---------------------------------------------------------------------------
+# H9: Windows reserved names
+# ---------------------------------------------------------------------------
+def _h9_check_windows_reserved(parts: tuple[str, ...]) -> None:
+    for index, part in enumerate(parts):
+        # Strip extension for the comparison: "CON.md" → "CON".
+        stem = part.split(".", 1)[0].upper()
+        if stem in _WINDOWS_RESERVED_NAMES:
+            raise _violation(
+                "H9",
+                {
+                    "part_index": index,
+                    "reserved_name": stem,
+                },
+            )
+
+
+# ---------------------------------------------------------------------------
+# H10: filesystem-grounded base-escape verification
+# ---------------------------------------------------------------------------
+def _h10_check_base_escape(path: str) -> None:
+    """Resolve ``BAKUFU_DATA_DIR / path`` and require it to live under
+    ``BAKUFU_DATA_DIR / 'bakufu-data' / 'skills'`` (the canonical skills root).
+
+    The relative path ``bakufu-data/skills/<rest>`` is resolved against
+    ``BAKUFU_DATA_DIR``; the joined absolute path must stay under the
+    skills root. ``Path.resolve()`` follows symlinks, so symlink-via-skills-subdir
+    escape is detected here — the final defensive line. If
+    ``BAKUFU_DATA_DIR`` is unset we raise a structured failure rather than
+    silently skipping (defense in depth).
+    """
+    base_dir_str = os.environ.get("BAKUFU_DATA_DIR")
+    if not base_dir_str:
+        raise _violation(
+            "H10",
+            {"reason": "BAKUFU_DATA_DIR not set"},
+        )
+    base_dir = Path(base_dir_str)
+    # ``REQUIRED_PARTS_PREFIX`` is ``('bakufu-data', 'skills')``, so the
+    # canonical skills root is exactly that prefix joined under the env var.
+    skills_root = base_dir.joinpath(*REQUIRED_PARTS_PREFIX).resolve()
+    candidate = (base_dir / path).resolve()
+    if not candidate.is_relative_to(skills_root):
+        raise _violation(
+            "H10",
+            {
+                "reason": "resolved path escapes BAKUFU_DATA_DIR/bakufu-data/skills/",
+                "skills_root": str(skills_root),
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator (used by SkillRef.field_validator)
+# ---------------------------------------------------------------------------
+def validate_skill_path(raw_path: str) -> str:
+    """Run H1〜H10 in the design's locked order and return the NFC-normalized form.
+
+    The returned value is what :class:`SkillRef` stores as ``path`` — callers
+    must always replace their input with the function's output so downstream
+    consumers never see un-normalized strings.
+
+    Raises:
+        AgentInvariantViolation: with ``kind='skill_path_invalid'`` on any
+            failure. ``detail['check']`` carries the Hx identifier (``'H1'``
+            ... ``'H10'``) so HTTP/API layers can localize without parsing
+            the message string.
+    """
+    normalized = _h1_nfc_normalize(raw_path)
+    _h2_check_length(normalized)
+    _h3_check_forbidden_chars(normalized)
+    _h4_check_leading(normalized)
+    _h5_check_traversal_sequences(normalized)
+    parts = _h6_parse_parts(normalized)
+    _h7_check_prefix(parts)
+    _h8_recheck_parts(parts)
+    _h9_check_windows_reserved(parts)
+    _h10_check_base_escape(normalized)
+    return normalized
+
+
+__all__ = [
+    "MAX_PATH_LENGTH",
+    "MIN_PATH_LENGTH",
+    "REQUIRED_PARTS_PREFIX",
+    "SKILLS_SUBDIR",
+    "_h1_nfc_normalize",
+    "_h2_check_length",
+    "_h3_check_forbidden_chars",
+    "_h4_check_leading",
+    "_h5_check_traversal_sequences",
+    "_h6_parse_parts",
+    "_h7_check_prefix",
+    "_h8_recheck_parts",
+    "_h9_check_windows_reserved",
+    "_h10_check_base_escape",
+    "validate_skill_path",
+]

--- a/backend/src/bakufu/domain/agent/value_objects.py
+++ b/backend/src/bakufu/domain/agent/value_objects.py
@@ -23,7 +23,7 @@ from typing import Self
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-from bakufu.domain.agent.path_validators import validate_skill_path
+from bakufu.domain.agent.path_validators import _validate_skill_path
 from bakufu.domain.exceptions import AgentInvariantViolation
 from bakufu.domain.value_objects import ProviderKind, SkillId, nfc_strip
 
@@ -150,7 +150,7 @@ class SkillRef(BaseModel):
     """Reference to a Skill markdown file inside ``BAKUFU_DATA_DIR/skills/``.
 
     The path validation contract is comprehensive (10 separate checks); see
-    :func:`bakufu.domain.agent.path_validators.validate_skill_path` for the
+    :func:`bakufu.domain.agent.path_validators._validate_skill_path` for the
     full ordered policy.
     """
 
@@ -174,7 +174,7 @@ class SkillRef(BaseModel):
     def _validate_path(cls, value: str) -> str:
         # H1〜H10 in one shot. Returns the NFC-normalized form so the stored
         # value is canonical (no later code paths see an un-normalized string).
-        return validate_skill_path(value)
+        return _validate_skill_path(value)
 
 
 __all__ = [

--- a/backend/src/bakufu/domain/agent/value_objects.py
+++ b/backend/src/bakufu/domain/agent/value_objects.py
@@ -1,0 +1,192 @@
+"""Agent-specific Value Objects (Persona / ProviderConfig / SkillRef).
+
+These VOs live in the ``agent/`` package rather than the global
+:mod:`bakufu.domain.value_objects` so the file-level boundary mirrors the
+responsibility boundary — same pattern Norman approved for the workflow
+package. ``SkillId`` and ``ProviderKind`` remain in the global module
+because they cross feature boundaries (Skill loader, LLM Adapter).
+
+The Persona / archetype / display_name validations all share the
+:func:`bakufu.domain.value_objects.nfc_strip` pipeline (Confirmation B
+shared policy carried forward from empire / workflow). ``prompt_body``
+applies NFC only — Markdown leading/trailing newlines must be preserved
+because downstream renderers depend on them (Confirmation E).
+
+``SkillRef.path`` runs the full H1〜H10 traversal-defense pipeline from
+:mod:`bakufu.domain.agent.path_validators`.
+"""
+
+from __future__ import annotations
+
+import unicodedata
+from typing import Self
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from bakufu.domain.agent.path_validators import validate_skill_path
+from bakufu.domain.exceptions import AgentInvariantViolation
+from bakufu.domain.value_objects import ProviderKind, SkillId, nfc_strip
+
+# ---------------------------------------------------------------------------
+# Persona (Agent feature §確定 E length policy)
+# ---------------------------------------------------------------------------
+DISPLAY_NAME_MIN: int = 1
+DISPLAY_NAME_MAX: int = 40
+ARCHETYPE_MAX: int = 80
+PROMPT_BODY_MAX: int = 10_000
+
+
+class Persona(BaseModel):
+    """Character / authoring profile attached to an :class:`Agent`.
+
+    ``display_name`` and ``archetype`` go through NFC + strip (Confirmation E).
+    ``prompt_body`` only goes through NFC — strip would eat the Markdown
+    leading/trailing whitespace that downstream prompt rendering relies on.
+    """
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        arbitrary_types_allowed=False,
+    )
+
+    display_name: str
+    archetype: str = ""
+    prompt_body: str = ""
+
+    @field_validator("display_name", "archetype", mode="before")
+    @classmethod
+    def _normalize_short_name(cls, value: object) -> object:
+        return nfc_strip(value)
+
+    @field_validator("prompt_body", mode="before")
+    @classmethod
+    def _normalize_prompt_body(cls, value: object) -> object:
+        # NFC only — preserves Markdown leading/trailing whitespace.
+        if isinstance(value, str):
+            return unicodedata.normalize("NFC", value)
+        return value
+
+    @model_validator(mode="after")
+    def _check_self_invariants(self) -> Self:
+        display_name_len = len(self.display_name)
+        if not (DISPLAY_NAME_MIN <= display_name_len <= DISPLAY_NAME_MAX):
+            raise AgentInvariantViolation(
+                kind="display_name_range",
+                message=(
+                    f"[FAIL] Persona.display_name must be "
+                    f"{DISPLAY_NAME_MIN}-{DISPLAY_NAME_MAX} characters "
+                    f"(got {display_name_len})"
+                ),
+                detail={"length": display_name_len},
+            )
+        archetype_len = len(self.archetype)
+        if archetype_len > ARCHETYPE_MAX:
+            raise AgentInvariantViolation(
+                kind="archetype_too_long",
+                message=(
+                    f"[FAIL] Persona.archetype must be 0-{ARCHETYPE_MAX} characters "
+                    f"(got {archetype_len})"
+                ),
+                detail={"length": archetype_len},
+            )
+        prompt_body_len = len(self.prompt_body)
+        if prompt_body_len > PROMPT_BODY_MAX:
+            raise AgentInvariantViolation(
+                kind="persona_too_long",
+                message=(
+                    f"[FAIL] Persona.prompt_body must be 0-{PROMPT_BODY_MAX} "
+                    f"characters (got {prompt_body_len})"
+                ),
+                detail={"length": prompt_body_len},
+            )
+        return self
+
+
+# ---------------------------------------------------------------------------
+# ProviderConfig
+# ---------------------------------------------------------------------------
+PROVIDER_MODEL_MIN: int = 1
+PROVIDER_MODEL_MAX: int = 80
+
+
+class ProviderConfig(BaseModel):
+    """LLM provider configuration entry inside an :class:`Agent`.
+
+    ``provider_kind`` enum ensures only known providers slip through; the
+    "is this provider's Adapter implemented in MVP" check belongs to the
+    application layer (``AgentService.hire``), not the VO — see Agent
+    detailed-design §確定 I for responsibility split.
+    """
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        arbitrary_types_allowed=False,
+    )
+
+    provider_kind: ProviderKind
+    model: str = Field(min_length=PROVIDER_MODEL_MIN, max_length=PROVIDER_MODEL_MAX)
+    is_default: bool = False
+
+    @field_validator("model", mode="before")
+    @classmethod
+    def _strip_model(cls, value: object) -> object:
+        # Strip-only (no NFC) per Confirmation E — model names are ASCII
+        # identifiers in practice and applying NFC has no behavioral effect.
+        if isinstance(value, str):
+            return value.strip()
+        return value
+
+
+# ---------------------------------------------------------------------------
+# SkillRef (H1〜H10 path traversal defense delegated to path_validators)
+# ---------------------------------------------------------------------------
+SKILL_NAME_MIN: int = 1
+SKILL_NAME_MAX: int = 80
+
+
+class SkillRef(BaseModel):
+    """Reference to a Skill markdown file inside ``BAKUFU_DATA_DIR/skills/``.
+
+    The path validation contract is comprehensive (10 separate checks); see
+    :func:`bakufu.domain.agent.path_validators.validate_skill_path` for the
+    full ordered policy.
+    """
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        arbitrary_types_allowed=False,
+    )
+
+    skill_id: SkillId
+    name: str = Field(min_length=SKILL_NAME_MIN, max_length=SKILL_NAME_MAX)
+    path: str
+
+    @field_validator("name", mode="before")
+    @classmethod
+    def _normalize_name(cls, value: object) -> object:
+        return nfc_strip(value)
+
+    @field_validator("path", mode="after")
+    @classmethod
+    def _validate_path(cls, value: str) -> str:
+        # H1〜H10 in one shot. Returns the NFC-normalized form so the stored
+        # value is canonical (no later code paths see an un-normalized string).
+        return validate_skill_path(value)
+
+
+__all__ = [
+    "ARCHETYPE_MAX",
+    "DISPLAY_NAME_MAX",
+    "DISPLAY_NAME_MIN",
+    "PROMPT_BODY_MAX",
+    "PROVIDER_MODEL_MAX",
+    "PROVIDER_MODEL_MIN",
+    "SKILL_NAME_MAX",
+    "SKILL_NAME_MIN",
+    "Persona",
+    "ProviderConfig",
+    "SkillRef",
+]

--- a/backend/src/bakufu/domain/exceptions.py
+++ b/backend/src/bakufu/domain/exceptions.py
@@ -160,7 +160,61 @@ class StageInvariantViolation(WorkflowInvariantViolation):
         self.kind: StageViolationKind = kind  # type: ignore[assignment]
 
 
+type AgentViolationKind = Literal[
+    "name_range",
+    "no_provider",
+    "default_not_unique",
+    "provider_duplicate",
+    "persona_too_long",
+    "provider_not_found",
+    "skill_duplicate",
+    "skill_not_found",
+    "skill_path_invalid",
+    "archetype_too_long",
+    "display_name_range",
+    "provider_not_implemented",
+    "skill_capacity_exceeded",
+    "provider_capacity_exceeded",
+]
+"""Discriminator for :class:`AgentInvariantViolation` per Agent detailed-design
+§Exception. Extends the design's 12 documented kinds with two operational
+``*_capacity_exceeded`` discriminators that surface the §確定 C bounds
+(providers ≤ 10, skills ≤ 20) — without them the same MSG would have to
+double up an existing kind and lose discrimination at the HTTP API layer."""
+
+
+# DDD: "Violation" describes an invariant breach, not a programming bug, so
+# the N818 "Error suffix" rule does not apply here.
+class AgentInvariantViolation(Exception):  # noqa: N818
+    """Raised when an :class:`Agent` aggregate invariant is violated.
+
+    Mirrors :class:`EmpireInvariantViolation` in shape (``kind`` + ``message``
+    + ``detail`` + immutable copy of detail) and applies the same Discord
+    webhook secret masking that :class:`WorkflowInvariantViolation` uses, so
+    if a SkillRef.path or Persona.prompt_body ever happens to contain a
+    Discord webhook URL fragment it cannot leak through exception text.
+    """
+
+    def __init__(
+        self,
+        *,
+        kind: AgentViolationKind,
+        message: str,
+        detail: Mapping[str, object] | None = None,
+    ) -> None:
+        masked_message = mask_discord_webhook(message)
+        masked_detail: dict[str, object] = (
+            {key: mask_discord_webhook_in(value) for key, value in detail.items()} if detail else {}
+        )
+        super().__init__(masked_message)
+        self.kind: AgentViolationKind = kind
+        self.message: str = masked_message
+        self.detail: dict[str, object] = masked_detail
+
+
 __all__ = [
+    "AgentInvariantViolation",
+    "AgentViolationKind",
     "EmpireInvariantViolation",
     "EmpireViolationKind",
     "StageInvariantViolation",

--- a/backend/src/bakufu/domain/value_objects.py
+++ b/backend/src/bakufu/domain/value_objects.py
@@ -58,6 +58,9 @@ type StageId = UUID
 type TransitionId = UUID
 """Transition entity identifier (within Workflow aggregate)."""
 
+type SkillId = UUID
+"""Skill identifier (referenced by :class:`SkillRef` inside Agent aggregate)."""
+
 
 # ---------------------------------------------------------------------------
 # Role enum
@@ -97,6 +100,23 @@ class TransitionCondition(StrEnum):
     REJECTED = "REJECTED"
     CONDITIONAL = "CONDITIONAL"
     TIMEOUT = "TIMEOUT"
+
+
+class ProviderKind(StrEnum):
+    """LLM provider per ``domain-model/value-objects.md`` §列挙型一覧.
+
+    All six values are defined upfront so adding a new provider in Phase 2
+    requires only an Adapter implementation + a ``BAKUFU_IMPLEMENTED_PROVIDERS``
+    update — never an enum migration that would force every persisted Agent
+    to be rebuilt (Agent feature §確定 I).
+    """
+
+    CLAUDE_CODE = "CLAUDE_CODE"
+    CODEX = "CODEX"
+    GEMINI = "GEMINI"
+    OPENCODE = "OPENCODE"
+    KIMI = "KIMI"
+    COPILOT = "COPILOT"
 
 
 # ---------------------------------------------------------------------------
@@ -339,9 +359,11 @@ __all__ = [
     "NormalizedShortName",
     "NotifyChannel",
     "NotifyChannelKind",
+    "ProviderKind",
     "Role",
     "RoomId",
     "RoomRef",
+    "SkillId",
     "StageId",
     "StageKind",
     "TransitionCondition",

--- a/backend/tests/domain/agent/__init__.py
+++ b/backend/tests/domain/agent/__init__.py
@@ -1,0 +1,1 @@
+"""Agent aggregate tests, split per feature surface (Norman §file-split rule)."""

--- a/backend/tests/domain/agent/conftest.py
+++ b/backend/tests/domain/agent/conftest.py
@@ -1,0 +1,23 @@
+"""Pytest fixtures shared across agent aggregate tests.
+
+The ``BAKUFU_DATA_DIR`` env var is mandatory for ``SkillRef.path`` H10
+(:func:`bakufu.domain.agent.path_validators._h10_check_base_escape`). In
+production the launcher sets it; in unit tests we autouse-fixture a stable
+fake directory string so every SkillRef construction can complete H10
+without relying on the actual filesystem (``Path.resolve(strict=False)``
+on a non-existent path simply returns the lexically-resolved form).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _bakufu_data_dir(monkeypatch: pytest.MonkeyPatch) -> None:  # pyright: ignore[reportUnusedFunction]
+    """Set ``BAKUFU_DATA_DIR`` for the duration of every agent test.
+
+    Autouse fixture — pytest invokes it via dependency injection, so the
+    function appears unused to pyright. The pragma below silences that.
+    """
+    monkeypatch.setenv("BAKUFU_DATA_DIR", "/tmp/bakufu-test-root")

--- a/backend/tests/domain/agent/test_application_responsibility.py
+++ b/backend/tests/domain/agent/test_application_responsibility.py
@@ -1,0 +1,26 @@
+"""Application-layer responsibility lock (TC-UT-AG-029 / REQ-AG R1-B).
+
+Confirmation R1-B in the requirements analysis says **name uniqueness inside
+an Empire is the application service's job**, not the aggregate's. Two
+Agents with identical names but different ids must construct cleanly at the
+domain layer; the duplicate check belongs in ``AgentService.hire``.
+
+These tests lock that contract so a future refactor cannot silently move the
+check into the aggregate (which would give a false sense of "name uniqueness
+is now defended at multiple layers" while breaking the layered design).
+"""
+
+from __future__ import annotations
+
+from tests.factories.agent import make_agent
+
+
+class TestNameUniquenessLeftToApplicationLayer:
+    """TC-UT-AG-029 — Agent aggregate does NOT enforce intra-Empire name uniqueness."""
+
+    def test_two_agents_with_same_name_but_different_ids_construct(self) -> None:
+        """REQ-AG R1-B: Aggregate accepts duplicate names — uniqueness lives in AgentService."""
+        a1 = make_agent(name="ダリオ")
+        a2 = make_agent(name="ダリオ")
+        # Both Agents construct successfully and carry distinct ids.
+        assert a1.name == a2.name and a1.id != a2.id

--- a/backend/tests/domain/agent/test_archive.py
+++ b/backend/tests/domain/agent/test_archive.py
@@ -1,0 +1,70 @@
+"""Archive idempotency (REQ-AG-005 / Confirmation D).
+
+Covers TC-UT-AG-010 / 020 / 025. The contract that ``archive()`` always
+returns a *new* instance is verified explicitly with ``is`` comparison so
+that future "skip if already archived" optimizations cannot reintroduce
+identity-based caching without breaking these tests.
+"""
+
+from __future__ import annotations
+
+from tests.factories.agent import make_agent, make_archived_agent
+
+
+class TestArchiveBasic:
+    """TC-UT-AG-010 — archive flips archived=True."""
+
+    def test_archive_returns_archived_true(self) -> None:
+        """TC-UT-AG-010: archive() flips archived to True on the returned Agent."""
+        agent = make_agent()
+        archived = agent.archive()
+        assert archived.archived is True
+
+    def test_archive_does_not_mutate_original(self) -> None:
+        """TC-UT-AG-010: original Agent stays archived=False."""
+        agent = make_agent()
+        agent.archive()
+        assert agent.archived is False
+
+
+class TestArchiveIdempotency:
+    """TC-UT-AG-020 / 025 — idempotency = state equality, NOT object identity."""
+
+    def test_archive_on_already_archived_does_not_raise(self) -> None:
+        """TC-UT-AG-020: archive() on archived=True Agent succeeds (no exception)."""
+        agent = make_archived_agent()
+        result = agent.archive()  # must not raise
+        assert result.archived is True
+
+    def test_archive_on_already_archived_returns_new_instance(self) -> None:
+        """TC-UT-AG-020 / Confirmation D: archive() ALWAYS returns a new instance.
+
+        ``a1 is a2`` must be False — Confirmation D forbids object-identity
+        caching. Idempotency is defined as "result state matches", proven by
+        the structural-equality assertion in the next test.
+        """
+        agent = make_archived_agent()
+        result = agent.archive()
+        assert result is not agent
+
+    def test_archive_on_already_archived_is_structurally_equal(self) -> None:
+        """TC-UT-AG-020: result of redundant archive() is == the original archived Agent."""
+        agent = make_archived_agent()
+        result = agent.archive()
+        assert result == agent  # same fields, different identity
+
+    def test_three_consecutive_archive_calls_yield_archived_true(self) -> None:
+        """TC-UT-AG-025: archive().archive().archive() all keep archived=True."""
+        agent = make_agent()
+        a1 = agent.archive()
+        a2 = a1.archive()
+        a3 = a2.archive()
+        assert a1.archived is True and a2.archived is True and a3.archived is True
+
+    def test_three_consecutive_archive_calls_each_yield_distinct_instance(self) -> None:
+        """TC-UT-AG-025: each archive() call returns a distinct object identity."""
+        agent = make_agent()
+        a1 = agent.archive()
+        a2 = a1.archive()
+        a3 = a2.archive()
+        assert a1 is not a2 and a2 is not a3 and a1 is not a3

--- a/backend/tests/domain/agent/test_construction.py
+++ b/backend/tests/domain/agent/test_construction.py
@@ -1,0 +1,57 @@
+"""Construction & name normalization (TC-UT-AG-001 / 002 / 012 / 030).
+
+Covers REQ-AG-001 minimal contracts and the NFC + strip pipeline shared with
+empire / workflow.
+"""
+
+from __future__ import annotations
+
+import unicodedata
+
+import pytest
+from bakufu.domain.exceptions import AgentInvariantViolation
+
+from tests.factories.agent import make_agent
+
+
+class TestAgentConstruction:
+    """REQ-AG-001 / TC-UT-AG-001 — minimal Agent contract."""
+
+    def test_default_factory_yields_one_provider_no_skills(self) -> None:
+        """TC-UT-AG-001: Agent built via factory has 1 provider, 0 skills, archived=False."""
+        agent = make_agent()
+        assert len(agent.providers) == 1 and len(agent.skills) == 0 and agent.archived is False
+
+
+class TestAgentNameBoundaries:
+    """REQ-AG-001 / TC-UT-AG-002 — name length 1〜40."""
+
+    @pytest.mark.parametrize("valid_length", [1, 40])
+    def test_accepts_lower_and_upper_boundary(self, valid_length: int) -> None:
+        """TC-UT-AG-002: 1-char and 40-char names construct successfully."""
+        agent = make_agent(name="a" * valid_length)
+        assert len(agent.name) == valid_length
+
+    @pytest.mark.parametrize("invalid_name", ["", "a" * 41, "   "])
+    def test_rejects_zero_fortyone_or_whitespace_only(self, invalid_name: str) -> None:
+        """TC-UT-AG-002: 0-char / 41-char / whitespace-only names raise."""
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            make_agent(name=invalid_name)
+        assert excinfo.value.kind == "name_range"
+
+
+class TestAgentNameNormalization:
+    """TC-UT-AG-012 — NFC + strip pipeline shared with empire / workflow."""
+
+    def test_decomposed_kana_normalized_to_nfc(self) -> None:
+        """TC-UT-AG-012: decomposed kana with dakuten (e.g. 'がが') is normalized."""
+        composed = "がが"
+        decomposed = unicodedata.normalize("NFD", composed)
+        assert decomposed != composed  # sanity
+        agent = make_agent(name=decomposed)
+        assert agent.name == composed
+
+    def test_surrounding_whitespace_stripped(self) -> None:
+        """TC-UT-AG-012: leading/trailing whitespace is stripped."""
+        agent = make_agent(name="  ダリオ  ")
+        assert agent.name == "ダリオ"

--- a/backend/tests/domain/agent/test_frozen_extra.py
+++ b/backend/tests/domain/agent/test_frozen_extra.py
@@ -1,0 +1,111 @@
+"""frozen=True / extra='forbid' invariants (TC-UT-AG-026 / 027 / 011).
+
+Verifies that the Pydantic v2 frozen contract physically prevents post-
+construction mutation across all aggregate / VO surfaces, and that unknown
+fields in payloads are rejected before any aggregate validation runs.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from bakufu.domain.agent import Agent, ProviderConfig, SkillRef
+from bakufu.domain.value_objects import ProviderKind, Role
+from pydantic import ValidationError
+
+from tests.factories.agent import (
+    make_agent,
+    make_persona,
+    make_provider_config,
+    make_skill_ref,
+)
+
+
+class TestFrozenContract:
+    """TC-UT-AG-026 — Agent / Persona / ProviderConfig / SkillRef frozen."""
+
+    def test_agent_rejects_attribute_assignment(self) -> None:
+        agent = make_agent()
+        with pytest.raises(ValidationError):
+            agent.name = "改竄"  # type: ignore[misc]
+
+    def test_persona_rejects_attribute_assignment(self) -> None:
+        persona = make_persona()
+        with pytest.raises(ValidationError):
+            persona.archetype = "違う"  # type: ignore[misc]
+
+    def test_provider_config_rejects_attribute_assignment(self) -> None:
+        config = make_provider_config()
+        with pytest.raises(ValidationError):
+            config.is_default = False  # type: ignore[misc]
+
+    def test_skill_ref_rejects_attribute_assignment(self) -> None:
+        skill = make_skill_ref()
+        with pytest.raises(ValidationError):
+            skill.name = "改竄"  # type: ignore[misc]
+
+
+class TestStructuralEquality:
+    """TC-UT-AG-011 — VOs use structural equality and hashing."""
+
+    def test_two_personas_with_identical_fields_compare_equal(self) -> None:
+        a = make_persona(display_name="reviewer", archetype="r", prompt_body="p")
+        b = make_persona(display_name="reviewer", archetype="r", prompt_body="p")
+        assert a == b
+
+    def test_two_provider_configs_with_identical_fields_compare_equal(self) -> None:
+        a = make_provider_config(provider_kind=ProviderKind.CLAUDE_CODE, model="x", is_default=True)
+        b = make_provider_config(provider_kind=ProviderKind.CLAUDE_CODE, model="x", is_default=True)
+        assert a == b
+
+
+class TestExtraForbid:
+    """TC-UT-AG-027 — extra='forbid' rejects unknown fields."""
+
+    def test_agent_model_validate_rejects_unknown_field(self) -> None:
+        """Agent.model_validate refuses payloads with unknown keys."""
+        payload: dict[str, object] = {
+            "id": str(uuid4()),
+            "name": "ok",
+            "persona": {
+                "display_name": "p",
+                "archetype": "",
+                "prompt_body": "",
+            },
+            "role": Role.DEVELOPER.value,
+            "providers": [
+                {
+                    "provider_kind": ProviderKind.CLAUDE_CODE.value,
+                    "model": "sonnet",
+                    "is_default": True,
+                }
+            ],
+            "skills": [],
+            "archived": False,
+            "unknown_field": "should-be-rejected",
+        }
+        with pytest.raises(ValidationError):
+            Agent.model_validate(payload)
+
+    def test_provider_config_rejects_unknown_field(self) -> None:
+        with pytest.raises(ValidationError):
+            ProviderConfig.model_validate(
+                {
+                    "provider_kind": ProviderKind.CLAUDE_CODE.value,
+                    "model": "x",
+                    "is_default": True,
+                    "unknown": "x",
+                }
+            )
+
+    def test_skill_ref_rejects_unknown_field(self) -> None:
+        with pytest.raises(ValidationError):
+            SkillRef.model_validate(
+                {
+                    "skill_id": str(uuid4()),
+                    "name": "x",
+                    "path": "bakufu-data/skills/x.md",
+                    "unknown": "x",
+                }
+            )

--- a/backend/tests/domain/agent/test_helpers_independence.py
+++ b/backend/tests/domain/agent/test_helpers_independence.py
@@ -1,0 +1,164 @@
+"""Aggregate + path helpers invoked independently (Confirmation F equivalent).
+
+The 5 ``_validate_*`` helpers in ``aggregate_validators.py`` and the 10
+``_h*_check_*`` helpers in ``path_validators.py`` are module-level pure
+functions — tests can import and call them directly without first
+constructing an Agent. This proves the aggregate path does not share code
+with the VO self-checks (twin-defense from workflow Confirmation F carried
+forward to agent).
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from bakufu.domain.agent import (
+    Persona,
+    ProviderConfig,
+    SkillRef,
+    _h1_nfc_normalize,
+    _h2_check_length,
+    _h3_check_forbidden_chars,
+    _h4_check_leading,
+    _h5_check_traversal_sequences,
+    _h6_parse_parts,
+    _h7_check_prefix,
+    _h8_recheck_parts,
+    _h9_check_windows_reserved,
+    _validate_default_provider_count,
+    _validate_provider_capacity,
+    _validate_provider_kind_unique,
+    _validate_skill_capacity,
+    _validate_skill_id_unique,
+)
+from bakufu.domain.agent.aggregate_validators import MAX_PROVIDERS, MAX_SKILLS
+from bakufu.domain.exceptions import AgentInvariantViolation
+from bakufu.domain.value_objects import ProviderKind
+
+from tests.factories.agent import make_provider_config, make_skill_ref
+
+
+class TestAggregateHelpersIndependent:
+    """Each ``_validate_*`` is invokable directly and raises the right kind."""
+
+    def test_provider_capacity_rejects_zero(self) -> None:
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            _validate_provider_capacity([])
+        assert excinfo.value.kind == "no_provider"
+
+    def test_provider_capacity_rejects_overflow(self) -> None:
+        many = [
+            ProviderConfig.model_construct(
+                provider_kind=ProviderKind.CLAUDE_CODE,
+                model=f"m-{i}",
+                is_default=False,
+            )
+            for i in range(MAX_PROVIDERS + 1)
+        ]
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            _validate_provider_capacity(many)
+        assert excinfo.value.kind == "provider_capacity_exceeded"
+
+    def test_provider_kind_unique_rejects_duplicate(self) -> None:
+        p1 = make_provider_config(provider_kind=ProviderKind.CLAUDE_CODE, is_default=True)
+        p2 = make_provider_config(
+            provider_kind=ProviderKind.CLAUDE_CODE, model="opus", is_default=False
+        )
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            _validate_provider_kind_unique([p1, p2])
+        assert excinfo.value.kind == "provider_duplicate"
+
+    def test_default_provider_count_rejects_zero(self) -> None:
+        providers = [make_provider_config(provider_kind=ProviderKind.CLAUDE_CODE, is_default=False)]
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            _validate_default_provider_count(providers)
+        assert excinfo.value.kind == "default_not_unique"
+
+    def test_skill_capacity_rejects_overflow(self) -> None:
+        skills = [
+            make_skill_ref(name=f"s-{i:02d}", path=f"bakufu-data/skills/s{i:02d}.md")
+            for i in range(MAX_SKILLS + 1)
+        ]
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            _validate_skill_capacity(skills)
+        assert excinfo.value.kind == "skill_capacity_exceeded"
+
+    def test_skill_id_unique_rejects_duplicate(self) -> None:
+        s1 = make_skill_ref()
+        s2 = SkillRef.model_construct(skill_id=s1.skill_id, name="dup", path=s1.path)
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            _validate_skill_id_unique([s1, s2])
+        assert excinfo.value.kind == "skill_duplicate"
+
+
+class TestPathHelpersIndependent:
+    """Each Hx helper raises with the corresponding ``check`` discriminator."""
+
+    def test_h1_normalizes(self) -> None:
+        import unicodedata
+
+        composed = "がが"
+        decomposed = unicodedata.normalize("NFD", composed)
+        assert _h1_nfc_normalize(decomposed) == composed
+
+    def test_h2_rejects_oversize(self) -> None:
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            _h2_check_length("a" * 501)
+        assert excinfo.value.detail.get("check") == "H2"
+
+    def test_h3_rejects_nul(self) -> None:
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            _h3_check_forbidden_chars("foo\x00bar")
+        assert excinfo.value.detail.get("check") == "H3"
+
+    def test_h4_rejects_leading_slash(self) -> None:
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            _h4_check_leading("/etc/passwd")
+        assert excinfo.value.detail.get("check") == "H4"
+
+    def test_h5_rejects_traversal(self) -> None:
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            _h5_check_traversal_sequences("foo/../bar")
+        assert excinfo.value.detail.get("check") == "H5"
+
+    def test_h6_returns_parts_tuple(self) -> None:
+        parts = _h6_parse_parts("bakufu-data/skills/f.md")
+        assert parts == ("bakufu-data", "skills", "f.md")
+
+    def test_h7_rejects_wrong_prefix(self) -> None:
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            _h7_check_prefix(("other", "skills", "f.md"))
+        assert excinfo.value.detail.get("check") == "H7"
+
+    def test_h8_rejects_forbidden_in_part(self) -> None:
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            _h8_recheck_parts(("bakufu-data", "skills", "foo\x00.md"))
+        assert excinfo.value.detail.get("check") == "H8"
+
+    def test_h9_rejects_reserved_name(self) -> None:
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            _h9_check_windows_reserved(("bakufu-data", "skills", "CON.md"))
+        assert excinfo.value.detail.get("check") == "H9"
+
+
+class TestValueObjectFactoryRegistry:
+    """Synthetic-vs-real bookkeeping (cross-cutting smoke)."""
+
+    def test_factory_built_persona_is_synthetic(self) -> None:
+        from tests.factories.agent import is_synthetic
+
+        persona = Persona(display_name="raw")
+        assert is_synthetic(persona) is False
+
+    def test_factory_built_skill_ref_is_synthetic(self) -> None:
+        from tests.factories.agent import is_synthetic, make_skill_ref
+
+        ref = make_skill_ref()
+        assert is_synthetic(ref) is True
+
+    def test_directly_constructed_skill_ref_is_not_synthetic(self) -> None:
+        from tests.factories.agent import is_synthetic
+
+        ref = SkillRef(skill_id=uuid4(), name="raw", path="bakufu-data/skills/r.md")
+        assert is_synthetic(ref) is False

--- a/backend/tests/domain/agent/test_integration.py
+++ b/backend/tests/domain/agent/test_integration.py
@@ -1,0 +1,74 @@
+"""Aggregate-internal lifecycle integration (TC-IT-AG-001 / 002).
+
+Same pattern as ``empire`` / ``workflow`` integration suites: domain layer
+has no public entry point, so we validate the round-trip behavior across
+the Aggregate's mutator chain (set_default_provider → add_skill →
+remove_skill → archive) plus the resilience scenario where a mid-chain
+failure leaves the original aggregate intact.
+"""
+
+from __future__ import annotations
+
+import pytest
+from bakufu.domain.exceptions import AgentInvariantViolation
+from bakufu.domain.value_objects import ProviderKind
+
+from tests.factories.agent import (
+    make_agent,
+    make_provider_config,
+    make_skill_ref,
+)
+
+
+class TestAgentLifecycleIntegration:
+    """TC-IT-AG-001 / 002 — full lifecycle + resilience."""
+
+    def test_full_lifecycle_round_trip(self) -> None:
+        """TC-IT-AG-001: hire → add_skill → switch default → remove_skill → archive.
+
+        Pre-state: 2-provider Agent (CLAUDE_CODE default + CODEX non-default),
+        1 skill. Walk the full mutator chain and verify the final shape.
+        """
+        providers = [
+            make_provider_config(provider_kind=ProviderKind.CLAUDE_CODE, is_default=True),
+            make_provider_config(provider_kind=ProviderKind.CODEX, is_default=False),
+        ]
+        skill = make_skill_ref()
+        agent = make_agent(providers=providers, skills=[skill])
+
+        # 1) Switch the default to CODEX.
+        switched = agent.set_default_provider(ProviderKind.CODEX)
+        codex = next(p for p in switched.providers if p.provider_kind is ProviderKind.CODEX)
+        assert codex.is_default is True
+
+        # 2) Add a second skill.
+        new_skill = make_skill_ref(name="planner", path="bakufu-data/skills/planner.md")
+        with_two_skills = switched.add_skill(new_skill)
+        assert len(with_two_skills.skills) == 2
+
+        # 3) Remove the original skill.
+        with_one_skill = with_two_skills.remove_skill(skill.skill_id)
+        assert len(with_one_skill.skills) == 1
+        assert with_one_skill.skills[0].skill_id == new_skill.skill_id
+
+        # 4) Archive the agent — Confirmation D returns a *new* instance.
+        archived = with_one_skill.archive()
+        assert archived.archived is True and archived is not with_one_skill
+
+    def test_failed_set_default_does_not_block_subsequent_operations(self) -> None:
+        """TC-IT-AG-002: a failed set_default_provider leaves Agent ready for further changes."""
+        agent = make_agent()
+
+        # 1) Switching to an unregistered kind fails; original stays unchanged.
+        with pytest.raises(AgentInvariantViolation):
+            agent.set_default_provider(ProviderKind.GEMINI)
+        assert len(agent.providers) == 1
+
+        # 2) add_skill then succeeds against the unchanged aggregate.
+        new_skill = make_skill_ref()
+        with_skill = agent.add_skill(new_skill)
+        assert len(with_skill.skills) == 1
+
+        # 3) archive() then succeeds against that further-mutated aggregate.
+        archived = with_skill.archive()
+        assert archived.archived is True

--- a/backend/tests/domain/agent/test_invariants.py
+++ b/backend/tests/domain/agent/test_invariants.py
@@ -1,0 +1,161 @@
+"""Aggregate-level invariants (REQ-AG-001 / 005 / 006).
+
+Covers TC-UT-AG-003 / 004 / 013〜015 / 018 / 021. Each invariant lives in its
+own ``Test*`` class so failures cluster by which collection contract was
+violated. Capacity overflow paths use ``model_construct`` to bypass the Agent
+constructor's eager Pydantic validation when the test needs to feed the
+helper an already-built collection.
+"""
+
+from __future__ import annotations
+
+import pytest
+from bakufu.domain.agent.aggregate_validators import MAX_PROVIDERS, MAX_SKILLS
+from bakufu.domain.exceptions import AgentInvariantViolation
+from bakufu.domain.value_objects import ProviderKind
+
+from tests.factories.agent import (
+    make_agent,
+    make_provider_config,
+    make_skill_ref,
+)
+
+
+class TestProvidersRequired:
+    """TC-UT-AG-013 — providers must contain at least one entry."""
+
+    def test_empty_providers_raises_no_provider(self) -> None:
+        """TC-UT-AG-013: providers=[] raises no_provider."""
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            make_agent(providers=[])
+        assert excinfo.value.kind == "no_provider"
+
+
+class TestProviderCapacity:
+    """TC-UT-AG-014 — providers ≤ MAX_PROVIDERS (Confirmation C)."""
+
+    def test_overflow_raises_provider_capacity_exceeded(self) -> None:
+        """TC-UT-AG-014: 11 providers raises provider_capacity_exceeded."""
+        # 10 with is_default=False + 1 with is_default=True so the
+        # default-count helper would pass (it runs after capacity).
+        providers = [
+            make_provider_config(provider_kind=kind, is_default=False)
+            for kind in list(ProviderKind)[:6]
+        ]
+        # Append duplicates beyond MAX_PROVIDERS by varying model strings
+        # (we just need >MAX_PROVIDERS entries; provider_kind uniqueness
+        # check would catch it but capacity runs first).
+        providers.extend(
+            make_provider_config(
+                provider_kind=ProviderKind.CLAUDE_CODE,
+                model=f"sonnet-{i}",
+                is_default=False,
+            )
+            for i in range(MAX_PROVIDERS - 5)  # tops out beyond MAX
+        )
+        # Need at least one default — append one more.
+        providers.append(make_provider_config(is_default=True))
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            make_agent(providers=providers)
+        assert excinfo.value.kind == "provider_capacity_exceeded"
+
+
+class TestProviderKindUnique:
+    """TC-UT-AG-015 — provider_kind must be unique across providers."""
+
+    def test_duplicate_provider_kind_raises_provider_duplicate(self) -> None:
+        """TC-UT-AG-015: two ProviderConfigs with same provider_kind raises."""
+        p1 = make_provider_config(provider_kind=ProviderKind.CLAUDE_CODE, is_default=True)
+        p2 = make_provider_config(
+            provider_kind=ProviderKind.CLAUDE_CODE, model="opus", is_default=False
+        )
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            make_agent(providers=[p1, p2])
+        assert excinfo.value.kind == "provider_duplicate"
+
+
+class TestDefaultProviderCount:
+    """TC-UT-AG-003 / 004 / 021 — exactly one is_default=True."""
+
+    def test_zero_defaults_raises_default_not_unique(self) -> None:
+        """TC-UT-AG-003: all is_default=False raises default_not_unique with count=0."""
+        providers = [
+            make_provider_config(provider_kind=ProviderKind.CLAUDE_CODE, is_default=False),
+            make_provider_config(provider_kind=ProviderKind.CODEX, is_default=False),
+        ]
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            make_agent(providers=providers)
+        assert excinfo.value.kind == "default_not_unique"
+        assert excinfo.value.detail.get("default_count") == 0
+
+    def test_two_defaults_raises_default_not_unique(self) -> None:
+        """TC-UT-AG-004: two is_default=True raises default_not_unique with count=2."""
+        providers = [
+            make_provider_config(provider_kind=ProviderKind.CLAUDE_CODE, is_default=True),
+            make_provider_config(provider_kind=ProviderKind.CODEX, is_default=True),
+        ]
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            make_agent(providers=providers)
+        assert excinfo.value.kind == "default_not_unique"
+        assert excinfo.value.detail.get("default_count") == 2
+
+    @pytest.mark.parametrize(
+        ("default_flags", "expected_count"),
+        [
+            ([False, False, False], 0),
+            ([True, True, False], 2),
+            ([True, True, True], 3),
+        ],
+    )
+    def test_count_outside_one_raises(self, default_flags: list[bool], expected_count: int) -> None:
+        """TC-UT-AG-021: 0 / 2 / 3 default counts all raise (boundary all sweep)."""
+        kinds = [ProviderKind.CLAUDE_CODE, ProviderKind.CODEX, ProviderKind.GEMINI]
+        providers = [
+            make_provider_config(provider_kind=kind, is_default=flag)
+            for kind, flag in zip(kinds, default_flags, strict=True)
+        ]
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            make_agent(providers=providers)
+        assert excinfo.value.kind == "default_not_unique"
+        assert excinfo.value.detail.get("default_count") == expected_count
+
+    def test_exactly_one_default_succeeds(self) -> None:
+        """TC-UT-AG-021: exactly one is_default=True (boundary success case)."""
+        providers = [
+            make_provider_config(provider_kind=ProviderKind.CLAUDE_CODE, is_default=True),
+            make_provider_config(provider_kind=ProviderKind.CODEX, is_default=False),
+            make_provider_config(provider_kind=ProviderKind.GEMINI, is_default=False),
+        ]
+        agent = make_agent(providers=providers)
+        defaults = [p for p in agent.providers if p.is_default]
+        assert len(defaults) == 1
+
+
+class TestSkillCapacity:
+    """TC-UT-AG-018 — skills ≤ MAX_SKILLS (Confirmation C)."""
+
+    def test_overflow_raises_skill_capacity_exceeded(self) -> None:
+        """TC-UT-AG-018: MAX_SKILLS+1 skills raises skill_capacity_exceeded."""
+        skills = [
+            make_skill_ref(name=f"skill-{i:02d}", path=f"bakufu-data/skills/s{i:02d}.md")
+            for i in range(MAX_SKILLS + 1)
+        ]
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            make_agent(skills=skills)
+        assert excinfo.value.kind == "skill_capacity_exceeded"
+
+
+class TestSkillIdUnique:
+    """TC-UT-AG-008 — skill_id must be unique (mirrors stage / transition rule).
+
+    Steve PR #16 symmetry: every "no duplicate id" collection contract gets a
+    dedicated helper. The Agent ``_validate_skill_id_unique`` mirrors that.
+    """
+
+    def test_duplicate_skill_id_raises_skill_duplicate(self) -> None:
+        """TC-UT-AG-008: two SkillRef sharing skill_id raises skill_duplicate."""
+        s1 = make_skill_ref()
+        s2 = make_skill_ref(skill_id=s1.skill_id, name="another")
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            make_agent(skills=[s1, s2])
+        assert excinfo.value.kind == "skill_duplicate"

--- a/backend/tests/domain/agent/test_msg_wording.py
+++ b/backend/tests/domain/agent/test_msg_wording.py
@@ -1,0 +1,116 @@
+"""MSG-AG-001〜012 exact wording (TC-UT-AG-030〜037 / 045).
+
+Each violation kind maps to a static string template in detailed-design.md
+§MSG. Tests assert the message **exactly** so future i18n / refactoring
+cannot silently drift the operator-visible wording.
+"""
+
+from __future__ import annotations
+
+import pytest
+from bakufu.domain.agent import Persona
+from bakufu.domain.exceptions import AgentInvariantViolation
+from bakufu.domain.value_objects import ProviderKind
+
+from tests.factories.agent import (
+    make_agent,
+    make_provider_config,
+    make_skill_ref,
+)
+
+
+class TestMessageWording:
+    """MSG-AG exact wording (TC-UT-AG-030〜037 / 045)."""
+
+    def test_msg_ag_001_for_oversized_name(self) -> None:
+        """TC-UT-AG-030: MSG-AG-001 wording matches '[FAIL] Agent name ...'."""
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            make_agent(name="a" * 41)
+        assert excinfo.value.message == "[FAIL] Agent name must be 1-40 characters (got 41)"
+
+    def test_msg_ag_002_for_no_provider(self) -> None:
+        """TC-UT-AG-031: MSG-AG-002 'Agent must have at least one provider'."""
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            make_agent(providers=[])
+        assert excinfo.value.message == "[FAIL] Agent must have at least one provider"
+
+    def test_msg_ag_003_for_zero_defaults(self) -> None:
+        """TC-UT-AG-032 (count=0): MSG-AG-003 wording reports got 0."""
+        providers = [
+            make_provider_config(provider_kind=ProviderKind.CLAUDE_CODE, is_default=False),
+        ]
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            make_agent(providers=providers)
+        assert (
+            excinfo.value.message == "[FAIL] Exactly one provider must have is_default=True (got 0)"
+        )
+
+    def test_msg_ag_003_for_two_defaults(self) -> None:
+        """TC-UT-AG-032 (count=2): MSG-AG-003 wording reports got 2."""
+        providers = [
+            make_provider_config(provider_kind=ProviderKind.CLAUDE_CODE, is_default=True),
+            make_provider_config(provider_kind=ProviderKind.CODEX, is_default=True),
+        ]
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            make_agent(providers=providers)
+        assert (
+            excinfo.value.message == "[FAIL] Exactly one provider must have is_default=True (got 2)"
+        )
+
+    def test_msg_ag_004_for_duplicate_provider_kind(self) -> None:
+        """TC-UT-AG-033: MSG-AG-004 wording carries the duplicate provider_kind."""
+        providers = [
+            make_provider_config(provider_kind=ProviderKind.CLAUDE_CODE, is_default=True),
+            make_provider_config(
+                provider_kind=ProviderKind.CLAUDE_CODE, model="opus", is_default=False
+            ),
+        ]
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            make_agent(providers=providers)
+        assert "Duplicate provider_kind" in excinfo.value.message
+        assert "CLAUDE_CODE" in excinfo.value.message
+
+    def test_msg_ag_005_for_oversized_prompt_body(self) -> None:
+        """TC-UT-AG-034: MSG-AG-005 wording reports 10001-char prompt_body."""
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            Persona(display_name="p", prompt_body="a" * 10_001)
+        assert (
+            excinfo.value.message
+            == "[FAIL] Persona.prompt_body must be 0-10000 characters (got 10001)"
+        )
+
+    def test_msg_ag_006_for_unknown_provider_in_set_default(self) -> None:
+        """TC-UT-AG-035: MSG-AG-006 wording carries the unregistered provider_kind."""
+        agent = make_agent()
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            agent.set_default_provider(ProviderKind.GEMINI)
+        assert excinfo.value.message == "[FAIL] provider_kind not registered: GEMINI"
+
+    def test_msg_ag_007_for_duplicate_skill_id(self) -> None:
+        """TC-UT-AG-036: MSG-AG-007 wording carries the duplicate skill_id."""
+        skill = make_skill_ref()
+        agent = make_agent(skills=[skill])
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            agent.add_skill(make_skill_ref(skill_id=skill.skill_id, name="dup"))
+        assert excinfo.value.message == f"[FAIL] Skill already added: skill_id={skill.skill_id}"
+
+    def test_msg_ag_008_for_remove_unknown_skill(self) -> None:
+        """TC-UT-AG-037: MSG-AG-008 wording carries the missing skill_id."""
+        from uuid import uuid4
+
+        agent = make_agent()
+        unknown = uuid4()
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            agent.remove_skill(unknown)
+        assert excinfo.value.message == f"[FAIL] Skill not found in agent: skill_id={unknown}"
+
+    def test_msg_ag_skill_path_invalid_prefix(self) -> None:
+        """TC-UT-AG-045: skill_path_invalid messages start with the consistent prefix."""
+        from uuid import uuid4
+
+        from bakufu.domain.agent import SkillRef
+
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            SkillRef(skill_id=uuid4(), name="x", path="/etc/passwd")
+        assert excinfo.value.message.startswith("[FAIL] SkillRef.path validation failed")
+        assert excinfo.value.kind == "skill_path_invalid"

--- a/backend/tests/domain/agent/test_mutators.py
+++ b/backend/tests/domain/agent/test_mutators.py
@@ -1,0 +1,129 @@
+"""Mutators (REQ-AG-002 / 003 / 004) + pre-validate rollback.
+
+Covers TC-UT-AG-005 / 006 / 007 / 008 / 009 / 017 / 019 / 022〜024.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from bakufu.domain.exceptions import AgentInvariantViolation
+from bakufu.domain.value_objects import ProviderKind
+
+from tests.factories.agent import (
+    make_agent,
+    make_provider_config,
+    make_skill_ref,
+)
+
+
+class TestSetDefaultProvider:
+    """REQ-AG-002 / TC-UT-AG-005 / 006 / 017."""
+
+    def test_switches_default_to_target_kind(self) -> None:
+        """TC-UT-AG-005: set_default_provider promotes the target to default."""
+        providers = [
+            make_provider_config(provider_kind=ProviderKind.CLAUDE_CODE, is_default=True),
+            make_provider_config(provider_kind=ProviderKind.CODEX, is_default=False),
+        ]
+        agent = make_agent(providers=providers)
+        updated = agent.set_default_provider(ProviderKind.CODEX)
+        codex = next(p for p in updated.providers if p.provider_kind is ProviderKind.CODEX)
+        assert codex.is_default is True
+
+    def test_demotes_previously_default_provider(self) -> None:
+        """TC-UT-AG-017: switching default flips the previously-default flag to False."""
+        providers = [
+            make_provider_config(provider_kind=ProviderKind.CLAUDE_CODE, is_default=True),
+            make_provider_config(provider_kind=ProviderKind.CODEX, is_default=False),
+            make_provider_config(provider_kind=ProviderKind.GEMINI, is_default=False),
+        ]
+        agent = make_agent(providers=providers)
+        updated = agent.set_default_provider(ProviderKind.CODEX)
+        non_codex_defaults = [
+            p
+            for p in updated.providers
+            if p.provider_kind is not ProviderKind.CODEX and p.is_default
+        ]
+        assert non_codex_defaults == []
+
+    def test_unknown_kind_raises_provider_not_found(self) -> None:
+        """TC-UT-AG-006: switching to a non-registered kind raises provider_not_found."""
+        agent = make_agent()
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            agent.set_default_provider(ProviderKind.GEMINI)
+        assert excinfo.value.kind == "provider_not_found"
+
+
+class TestAddSkill:
+    """REQ-AG-003 / TC-UT-AG-007 / 008."""
+
+    def test_appends_to_skills_list(self) -> None:
+        """TC-UT-AG-007: add_skill returns a new Agent with the skill appended."""
+        agent = make_agent()
+        skill = make_skill_ref(name="reviewer", path="bakufu-data/skills/reviewer.md")
+        updated = agent.add_skill(skill)
+        assert len(updated.skills) == 1 and updated.skills[0].skill_id == skill.skill_id
+
+    def test_does_not_mutate_original(self) -> None:
+        """TC-UT-AG-007: caller's Agent stays empty after add_skill path."""
+        agent = make_agent()
+        agent.add_skill(make_skill_ref())
+        assert agent.skills == []
+
+    def test_duplicate_skill_id_raises_skill_duplicate(self) -> None:
+        """TC-UT-AG-008: add_skill with existing skill_id raises skill_duplicate."""
+        skill = make_skill_ref()
+        agent = make_agent(skills=[skill])
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            agent.add_skill(make_skill_ref(skill_id=skill.skill_id, name="dup"))
+        assert excinfo.value.kind == "skill_duplicate"
+
+
+class TestRemoveSkill:
+    """REQ-AG-004 / TC-UT-AG-009 / 019."""
+
+    def test_drops_target_skill(self) -> None:
+        """TC-UT-AG-009: remove_skill returns a new Agent without the target skill."""
+        s1 = make_skill_ref(name="a", path="bakufu-data/skills/a.md")
+        s2 = make_skill_ref(name="b", path="bakufu-data/skills/b.md")
+        agent = make_agent(skills=[s1, s2])
+        updated = agent.remove_skill(s1.skill_id)
+        assert len(updated.skills) == 1 and updated.skills[0].skill_id == s2.skill_id
+
+    def test_unknown_skill_id_raises_skill_not_found(self) -> None:
+        """TC-UT-AG-019: remove_skill with unregistered skill_id raises skill_not_found."""
+        agent = make_agent()
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            agent.remove_skill(uuid4())
+        assert excinfo.value.kind == "skill_not_found"
+
+
+class TestPreValidateRollback:
+    """Confirmation A / TC-UT-AG-022〜024 — failed mutators leave caller unchanged."""
+
+    def test_failed_set_default_provider_keeps_original(self) -> None:
+        """TC-UT-AG-022: failed set_default_provider does not mutate caller's Agent."""
+        agent = make_agent()
+        original_defaults = [p.provider_kind for p in agent.providers if p.is_default]
+        with pytest.raises(AgentInvariantViolation):
+            agent.set_default_provider(ProviderKind.GEMINI)
+        unchanged = [p.provider_kind for p in agent.providers if p.is_default]
+        assert unchanged == original_defaults
+
+    def test_failed_add_skill_keeps_original(self) -> None:
+        """TC-UT-AG-023: failed add_skill does not grow caller's skills."""
+        skill = make_skill_ref()
+        agent = make_agent(skills=[skill])
+        with pytest.raises(AgentInvariantViolation):
+            agent.add_skill(make_skill_ref(skill_id=skill.skill_id, name="dup"))
+        assert len(agent.skills) == 1
+
+    def test_failed_remove_skill_keeps_original(self) -> None:
+        """TC-UT-AG-024: failed remove_skill does not shrink caller's skills."""
+        skill = make_skill_ref()
+        agent = make_agent(skills=[skill])
+        with pytest.raises(AgentInvariantViolation):
+            agent.remove_skill(uuid4())
+        assert len(agent.skills) == 1

--- a/backend/tests/domain/agent/test_persona.py
+++ b/backend/tests/domain/agent/test_persona.py
@@ -1,0 +1,76 @@
+"""Persona VO contract (TC-UT-AG-016 / TC-UT-VO-AG-001 / 002 / 007).
+
+Verifies the display_name / archetype / prompt_body length boundaries plus
+the special rule that ``prompt_body`` is NFC-normalized **without** strip
+(Confirmation E) so Markdown leading/trailing whitespace survives intact.
+"""
+
+from __future__ import annotations
+
+import unicodedata
+
+import pytest
+from bakufu.domain.agent import Persona
+from bakufu.domain.exceptions import AgentInvariantViolation
+
+
+class TestPersonaDisplayName:
+    """TC-UT-VO-AG-001 / 002 — display_name length 1〜40."""
+
+    @pytest.mark.parametrize("valid_length", [1, 40])
+    def test_accepts_lower_and_upper_boundary(self, valid_length: int) -> None:
+        """TC-UT-VO-AG-001: 1-char and 40-char display_name construct."""
+        persona = Persona(display_name="a" * valid_length)
+        assert len(persona.display_name) == valid_length
+
+    @pytest.mark.parametrize("invalid_length", [0, 41])
+    def test_rejects_outside_boundary(self, invalid_length: int) -> None:
+        """TC-UT-VO-AG-002: 0 / 41 display_name raises display_name_range."""
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            Persona(display_name="a" * invalid_length)
+        assert excinfo.value.kind == "display_name_range"
+
+
+class TestPersonaArchetype:
+    """TC-UT-VO-AG-007 — archetype 0〜80 (Boy Scout补完)."""
+
+    @pytest.mark.parametrize("valid_length", [0, 80])
+    def test_accepts_zero_or_eighty(self, valid_length: int) -> None:
+        """TC-UT-VO-AG-007: 0-char and 80-char archetype construct."""
+        persona = Persona(display_name="p", archetype="a" * valid_length)
+        assert len(persona.archetype) == valid_length
+
+    def test_rejects_eightyone_chars(self) -> None:
+        """TC-UT-VO-AG-007: 81-char archetype raises archetype_too_long."""
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            Persona(display_name="p", archetype="a" * 81)
+        assert excinfo.value.kind == "archetype_too_long"
+
+
+class TestPersonaPromptBody:
+    """TC-UT-AG-016 — prompt_body 0〜10000 + NFC only (no strip)."""
+
+    @pytest.mark.parametrize("valid_length", [0, 10_000])
+    def test_accepts_zero_or_ten_thousand_chars(self, valid_length: int) -> None:
+        """TC-UT-AG-016: 0-char and 10000-char prompt_body construct."""
+        persona = Persona(display_name="p", prompt_body="a" * valid_length)
+        assert len(persona.prompt_body) == valid_length
+
+    def test_rejects_ten_thousand_one_chars(self) -> None:
+        """TC-UT-AG-016: 10001-char prompt_body raises persona_too_long."""
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            Persona(display_name="p", prompt_body="a" * 10_001)
+        assert excinfo.value.kind == "persona_too_long"
+
+    def test_prompt_body_preserves_leading_and_trailing_whitespace(self) -> None:
+        """Confirmation E: prompt_body is NFC-only, NOT strip — Markdown whitespace survives."""
+        markdown = "\n\n  # heading  \nbody\n  \n"
+        persona = Persona(display_name="p", prompt_body=markdown)
+        assert persona.prompt_body == unicodedata.normalize("NFC", markdown)
+
+    def test_prompt_body_normalizes_decomposed_kana(self) -> None:
+        """Confirmation E: prompt_body still goes through NFC for canonical equality."""
+        composed = "がが"
+        decomposed = unicodedata.normalize("NFD", composed)
+        persona = Persona(display_name="p", prompt_body=decomposed)
+        assert persona.prompt_body == composed

--- a/backend/tests/domain/agent/test_provider_config.py
+++ b/backend/tests/domain/agent/test_provider_config.py
@@ -1,0 +1,61 @@
+"""ProviderConfig VO contract (TC-UT-VO-AG-003 / 004 / 028).
+
+Confirmation I leaves "Adapter implemented in MVP" enforcement to the
+application service ``AgentService.hire`` — the VO only checks structural
+shape (enum value, model length). The MVP-implementation gate is verified at
+the application layer in a future ``feature/agent-service`` test.
+"""
+
+from __future__ import annotations
+
+import pytest
+from bakufu.domain.agent import ProviderConfig
+from bakufu.domain.value_objects import ProviderKind
+from pydantic import ValidationError
+
+
+class TestProviderConfigKindEnum:
+    """TC-UT-VO-AG-003 / TC-UT-AG-028 — provider_kind must be a known ProviderKind."""
+
+    @pytest.mark.parametrize("kind", list(ProviderKind))
+    def test_accepts_each_canonical_kind(self, kind: ProviderKind) -> None:
+        """TC-UT-VO-AG-003: every ProviderKind enum value constructs."""
+        config = ProviderConfig(provider_kind=kind, model="x", is_default=True)
+        assert config.provider_kind is kind
+
+    def test_rejects_unknown_kind_string(self) -> None:
+        """TC-UT-AG-028: provider_kind='UNKNOWN' raises ValidationError."""
+        with pytest.raises(ValidationError):
+            ProviderConfig.model_validate(
+                {"provider_kind": "UNKNOWN_PROVIDER", "model": "x", "is_default": True}
+            )
+
+
+class TestProviderConfigModelBoundary:
+    """TC-UT-VO-AG-004 — model length 1〜80."""
+
+    @pytest.mark.parametrize("valid_length", [1, 80])
+    def test_accepts_lower_and_upper_boundary(self, valid_length: int) -> None:
+        """TC-UT-VO-AG-004: 1-char and 80-char model construct."""
+        config = ProviderConfig(
+            provider_kind=ProviderKind.CLAUDE_CODE,
+            model="a" * valid_length,
+        )
+        assert len(config.model) == valid_length
+
+    @pytest.mark.parametrize("invalid_length", [0, 81])
+    def test_rejects_outside_boundary(self, invalid_length: int) -> None:
+        """TC-UT-VO-AG-004: 0 / 81 model raises ValidationError."""
+        with pytest.raises(ValidationError):
+            ProviderConfig(
+                provider_kind=ProviderKind.CLAUDE_CODE,
+                model="a" * invalid_length,
+            )
+
+    def test_model_strips_surrounding_whitespace(self) -> None:
+        """Confirmation E: model is strip-only (NFC has no behavioral effect on ASCII)."""
+        config = ProviderConfig(
+            provider_kind=ProviderKind.CLAUDE_CODE,
+            model="  sonnet  ",
+        )
+        assert config.model == "sonnet"

--- a/backend/tests/domain/agent/test_skillref_path.py
+++ b/backend/tests/domain/agent/test_skillref_path.py
@@ -1,0 +1,212 @@
+"""SkillRef.path traversal defense H1〜H10 (Confirmation H / TC-UT-AG-038〜044).
+
+Each ``Test*`` class targets one Hx rule. Failures cluster by which rule was
+violated, mirroring the workflow ``test_notify_channel_ssrf.py`` structure
+that Norman / Schneier approved for SSRF G1〜G10.
+
+The aggregate-side path goes through ``SkillRef.field_validator`` which
+delegates to :func:`validate_skill_path`. We exercise the public surface
+(constructor + ``model_validate``) so future refactors of the orchestrator
+internals do not silently drop coverage.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from bakufu.domain.agent import SkillRef
+from bakufu.domain.exceptions import AgentInvariantViolation
+
+
+def _ref(path: str) -> SkillRef:
+    """Build a SkillRef with arbitrary id/name and the given path."""
+    return SkillRef(skill_id=uuid4(), name="test-skill", path=path)
+
+
+class TestH1NFCNormalization:
+    """H1 / TC-UT-AG-038 — NFC normalization of the path string."""
+
+    def test_decomposed_kana_in_path_is_normalized(self) -> None:
+        """H1: 'がが' decomposed in path is stored as the composed form."""
+        import unicodedata
+
+        composed_filename = "がが.md"
+        decomposed_filename = unicodedata.normalize("NFD", composed_filename)
+        path = f"bakufu-data/skills/{decomposed_filename}"
+        ref = _ref(path)
+        assert ref.path == f"bakufu-data/skills/{composed_filename}"
+
+
+class TestH3ForbiddenChars:
+    """H3 / TC-UT-AG-039 — NUL / control / backslash forbidden in path."""
+
+    @pytest.mark.parametrize(
+        "bad_path",
+        [
+            "bakufu-data/skills/foo\\bar.md",  # backslash
+            "bakufu-data/skills/foo\x00.md",  # NUL
+            "bakufu-data/skills/foo\x01.md",  # ASCII control
+            "bakufu-data/skills/foo\x7f.md",  # DEL
+        ],
+    )
+    def test_forbidden_chars_rejected(self, bad_path: str) -> None:
+        """H3: backslash / NUL / control / DEL all raise skill_path_invalid."""
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            _ref(bad_path)
+        assert excinfo.value.kind == "skill_path_invalid"
+        assert excinfo.value.detail.get("check") == "H3"
+
+
+class TestH4LeadingChar:
+    """H4 / TC-UT-AG-039 — POSIX abs / Windows abs / tilde rejected."""
+
+    @pytest.mark.parametrize(
+        "bad_path",
+        [
+            "/etc/passwd",  # POSIX absolute
+            "~/secret",  # tilde home expansion
+            "C:\\Windows\\system32",  # Windows absolute backslash
+            "D:/foo/bar",  # Windows absolute forward slash
+        ],
+    )
+    def test_leading_char_rejected(self, bad_path: str) -> None:
+        """H4: leading slash / tilde / Windows-drive prefix raise."""
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            _ref(bad_path)
+        assert excinfo.value.kind == "skill_path_invalid"
+        # Backslash inside the path also trips H3; we just verify rejection
+        # against a stable check identifier from the H3+H4 pair.
+        assert excinfo.value.detail.get("check") in {"H3", "H4"}
+
+
+class TestH5TraversalSequences:
+    """H5 / TC-UT-AG-040 — '..' traversal and surrounding whitespace rejected."""
+
+    @pytest.mark.parametrize(
+        "bad_path",
+        [
+            "bakufu-data/skills/../../../etc/passwd",  # classic traversal
+            "bakufu-data/skills/sub/../escape",  # mid-path traversal
+            "bakufu-data/skills/legitimate/../../../escape",  # multi-up
+            "..",  # bare parent
+            "./relative",  # current-dir prefix
+            "../escape",  # parent prefix
+        ],
+    )
+    def test_traversal_or_dot_prefix_rejected(self, bad_path: str) -> None:
+        """H5: any '..' segment in the path raises skill_path_invalid."""
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            _ref(bad_path)
+        assert excinfo.value.kind == "skill_path_invalid"
+
+    @pytest.mark.parametrize(
+        "bad_path",
+        [
+            " bakufu-data/skills/file.md",  # leading space
+            "bakufu-data/skills/file.md ",  # trailing space
+        ],
+    )
+    def test_surrounding_whitespace_rejected(self, bad_path: str) -> None:
+        """H5: leading or trailing whitespace raises skill_path_invalid."""
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            _ref(bad_path)
+        assert excinfo.value.kind == "skill_path_invalid"
+        assert excinfo.value.detail.get("check") == "H5"
+
+
+class TestH7PrefixEnforcement:
+    """H7 / TC-UT-AG-041 — path must start with 'bakufu-data/skills/<rest>'."""
+
+    @pytest.mark.parametrize(
+        "bad_path",
+        [
+            "other/path/file.md",  # wrong root
+            "bakufu-data/other/file.md",  # second segment wrong
+            "skills/file.md",  # missing 'bakufu-data'
+            "bakufu-data/skills",  # too short (no <rest>)
+        ],
+    )
+    def test_wrong_prefix_rejected(self, bad_path: str) -> None:
+        """H7: prefix not matching ('bakufu-data', 'skills') raises."""
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            _ref(bad_path)
+        assert excinfo.value.kind == "skill_path_invalid"
+        assert excinfo.value.detail.get("check") == "H7"
+
+
+class TestH9WindowsReserved:
+    """H9 / TC-UT-AG-043 — Windows reserved device names (CON / NUL / etc.)."""
+
+    @pytest.mark.parametrize(
+        "bad_path",
+        [
+            "bakufu-data/skills/CON.md",
+            "bakufu-data/skills/prn.txt",  # case-insensitive
+            "bakufu-data/skills/AUX",  # no extension
+            "bakufu-data/skills/NUL.markdown",
+            "bakufu-data/skills/COM1.md",
+            "bakufu-data/skills/LPT9.md",
+            "bakufu-data/skills/con",  # bare lowercase
+        ],
+    )
+    def test_windows_reserved_name_rejected(self, bad_path: str) -> None:
+        """H9: every Windows reserved device name (case-insensitive) raises."""
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            _ref(bad_path)
+        assert excinfo.value.kind == "skill_path_invalid"
+        assert excinfo.value.detail.get("check") == "H9"
+
+
+class TestH10BaseEscape:
+    """H10 / TC-UT-AG-042 — resolved path must stay under BAKUFU_DATA_DIR/skills/."""
+
+    def test_unset_bakufu_data_dir_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """H10: missing BAKUFU_DATA_DIR is a structured failure (not a silent skip)."""
+        monkeypatch.delenv("BAKUFU_DATA_DIR", raising=False)
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            _ref("bakufu-data/skills/sample.md")
+        assert excinfo.value.kind == "skill_path_invalid"
+        assert excinfo.value.detail.get("check") == "H10"
+
+
+class TestPathLengthBoundary:
+    """H2 / TC-UT-AG-044 — path length 1〜500 (lower bound enforced via H4 / structural)."""
+
+    def test_500_char_valid_path_succeeds(self) -> None:
+        """H2: a structurally-valid 500-char path constructs."""
+        # Build "bakufu-data/skills/" (19 chars) + (some extra prefix) + filename
+        # to total exactly 500 chars.
+        prefix = "bakufu-data/skills/"
+        remaining = 500 - len(prefix)
+        # Use a long filename of 'a'*remaining; H9 stem is 'a'*remaining minus
+        # extension which is fine (not a reserved name).
+        path = prefix + "a" * remaining
+        assert len(path) == 500
+        ref = _ref(path)
+        assert ref.path == path
+
+    def test_501_char_path_rejected(self) -> None:
+        """H2: a 501-char path raises skill_path_invalid (H2)."""
+        prefix = "bakufu-data/skills/"
+        remaining = 501 - len(prefix)
+        path = prefix + "a" * remaining
+        assert len(path) == 501
+        with pytest.raises(AgentInvariantViolation) as excinfo:
+            _ref(path)
+        assert excinfo.value.kind == "skill_path_invalid"
+        assert excinfo.value.detail.get("check") == "H2"
+
+
+class TestValidPathHappyPath:
+    """Sanity: a fully valid SkillRef.path constructs and is stored normalized."""
+
+    def test_canonical_path_constructs(self) -> None:
+        """Happy path: 'bakufu-data/skills/reviewer.md' goes through all H1〜H10."""
+        ref = _ref("bakufu-data/skills/reviewer.md")
+        assert ref.path == "bakufu-data/skills/reviewer.md"
+
+    def test_nested_subdir_constructs(self) -> None:
+        """Happy path: nested subdir under skills/ is permitted."""
+        ref = _ref("bakufu-data/skills/sub/sub2/file.md")
+        assert ref.path == "bakufu-data/skills/sub/sub2/file.md"

--- a/backend/tests/domain/agent/test_skillref_path.py
+++ b/backend/tests/domain/agent/test_skillref_path.py
@@ -5,9 +5,11 @@ violated, mirroring the workflow ``test_notify_channel_ssrf.py`` structure
 that Norman / Schneier approved for SSRF G1〜G10.
 
 The aggregate-side path goes through ``SkillRef.field_validator`` which
-delegates to :func:`validate_skill_path`. We exercise the public surface
+delegates to :func:`_validate_skill_path`. We exercise the public surface
 (constructor + ``model_validate``) so future refactors of the orchestrator
-internals do not silently drop coverage.
+internals do not silently drop coverage. The orchestrator function carries a
+leading underscore (Steve PR #17 naming-symmetry rule): all path / aggregate
+helpers are module-private until a real cross-feature consumer arrives.
 """
 
 from __future__ import annotations

--- a/backend/tests/factories/agent.py
+++ b/backend/tests/factories/agent.py
@@ -1,0 +1,158 @@
+"""Factories for the Agent aggregate, its entities, and its VOs.
+
+Per ``docs/features/agent/test-design.md``. Mirrors the empire / workflow
+pattern: every factory returns a *valid* default instance built through the
+production constructor, allows keyword overrides, and registers the result
+in a :class:`WeakValueDictionary` so :func:`is_synthetic` can later flag
+test-built objects without mutating the frozen Pydantic models.
+
+``DEFAULT_SKILL_PATH`` and the ``BAKUFU_DATA_DIR`` env var (set by
+``conftest.py``) together make every default ``SkillRef`` pass H1〜H10 so
+tests focused on Agent behavior do not have to thread path payloads through
+their setup.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID, uuid4
+from weakref import WeakValueDictionary
+
+from bakufu.domain.agent import (
+    Agent,
+    Persona,
+    ProviderConfig,
+    SkillRef,
+)
+from bakufu.domain.value_objects import ProviderKind, Role
+from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+# Module-scope registry. Values are kept weakly so GC pressure stays neutral.
+_SYNTHETIC_REGISTRY: WeakValueDictionary[int, BaseModel] = WeakValueDictionary()
+
+# Default SkillRef.path that satisfies H1〜H10 when ``BAKUFU_DATA_DIR`` is set.
+DEFAULT_SKILL_PATH: str = "bakufu-data/skills/sample-skill.md"
+
+
+def is_synthetic(instance: BaseModel) -> bool:
+    """Return ``True`` when ``instance`` was created by a factory in this module."""
+    cached = _SYNTHETIC_REGISTRY.get(id(instance))
+    return cached is instance
+
+
+def _register(instance: BaseModel) -> None:
+    """Record ``instance`` in the synthetic registry."""
+    _SYNTHETIC_REGISTRY[id(instance)] = instance
+
+
+# ---------------------------------------------------------------------------
+# Persona
+# ---------------------------------------------------------------------------
+def make_persona(
+    *,
+    display_name: str = "テストペルソナ",
+    archetype: str = "review-focused",
+    prompt_body: str = "You are a thorough reviewer.",
+) -> Persona:
+    """Build a valid :class:`Persona`."""
+    persona = Persona(
+        display_name=display_name,
+        archetype=archetype,
+        prompt_body=prompt_body,
+    )
+    _register(persona)
+    return persona
+
+
+# ---------------------------------------------------------------------------
+# ProviderConfig
+# ---------------------------------------------------------------------------
+def make_provider_config(
+    *,
+    provider_kind: ProviderKind = ProviderKind.CLAUDE_CODE,
+    model: str = "sonnet-4.5",
+    is_default: bool = True,
+) -> ProviderConfig:
+    """Build a valid :class:`ProviderConfig` with ``is_default=True`` by default."""
+    config = ProviderConfig(
+        provider_kind=provider_kind,
+        model=model,
+        is_default=is_default,
+    )
+    _register(config)
+    return config
+
+
+# ---------------------------------------------------------------------------
+# SkillRef
+# ---------------------------------------------------------------------------
+def make_skill_ref(
+    *,
+    skill_id: UUID | None = None,
+    name: str = "sample-skill",
+    path: str = DEFAULT_SKILL_PATH,
+) -> SkillRef:
+    """Build a valid :class:`SkillRef`. Requires ``BAKUFU_DATA_DIR`` env var (H10)."""
+    ref = SkillRef(
+        skill_id=skill_id if skill_id is not None else uuid4(),
+        name=name,
+        path=path,
+    )
+    _register(ref)
+    return ref
+
+
+# ---------------------------------------------------------------------------
+# Agent
+# ---------------------------------------------------------------------------
+def make_agent(
+    *,
+    agent_id: UUID | None = None,
+    name: str = "テストエージェント",
+    persona: Persona | None = None,
+    role: Role = Role.DEVELOPER,
+    providers: Sequence[ProviderConfig] | None = None,
+    skills: Sequence[SkillRef] | None = None,
+    archived: bool = False,
+) -> Agent:
+    """Build a valid :class:`Agent`.
+
+    With no overrides yields the simplest valid Agent: 1 ProviderConfig with
+    ``is_default=True``, no skills, ``archived=False``.
+    """
+    if persona is None:
+        persona = make_persona()
+    if providers is None:
+        providers = [make_provider_config()]
+    if skills is None:
+        skills = []
+    agent = Agent(
+        id=agent_id if agent_id is not None else uuid4(),
+        name=name,
+        persona=persona,
+        role=role,
+        providers=list(providers),
+        skills=list(skills),
+        archived=archived,
+    )
+    _register(agent)
+    return agent
+
+
+def make_archived_agent(**overrides: object) -> Agent:
+    """Build an Agent with ``archived=True`` for idempotency test setups."""
+    return make_agent(archived=True, **overrides)  # pyright: ignore[reportArgumentType]
+
+
+__all__ = [
+    "DEFAULT_SKILL_PATH",
+    "is_synthetic",
+    "make_agent",
+    "make_archived_agent",
+    "make_persona",
+    "make_provider_config",
+    "make_skill_ref",
+]


### PR DESCRIPTION
## Summary

`Agent` Aggregate Root + `Persona` / `ProviderConfig` / `SkillRef` VO の実装 (Issue #10 / **M1 ドメイン骨格 3/3 本目・最終**)。
[detailed-design.md](../blob/develop/docs/features/agent/detailed-design.md) §確定 A〜I を全部守った。empire / workflow お手本を踏襲。

### パッケージ構成 (Norman の workflow パターン踏襲)

| ファイル | 行数 | 責務 |
|---------|----:|------|
| `agent/__init__.py` | 109 | public re-exports + `_h1〜_h10` + `_validate_*` |
| `agent/agent.py` | 201 | `Agent` Aggregate Root |
| `agent/aggregate_validators.py` | 123 | 5 module-level invariant helpers |
| `agent/path_validators.py` | 270 | **H1〜H10** 各々独立 helper + `validate_skill_path` |
| `agent/value_objects.py` | 192 | `Persona` / `ProviderConfig` / `SkillRef` |

全ファイル < 500 行（最大 270）。各 helper を独立させたことで Stage 自身検査と aggregate 検査がコード共有しない物理保証 (ディレクトリ層の twin-defense)。

### 確定事項の遵守

- **確定 A (pre-validate)**: `_rebuild_with` で `model_dump → swap → model_validate`。`archive()` は `_rebuild_with_state` で scalar 更新
- **確定 C (容量)**: `MAX_PROVIDERS=10`, `MAX_SKILLS=20`。`provider_capacity_exceeded` / `skill_capacity_exceeded` 専用 kind を新設し、HTTP API での discrimination を維持
- **確定 D (archive 冪等性)**: `archive()` は常に**新インスタンス**を返す。`a1 is a2 == False` かつ `a1.archived == a2.archived == True` をスモークテストで物理証明。`model_copy` 不採用理由を docstring 明記
- **確定 E (NFC パイプライン)**:
  - `Agent.name` / `Persona.display_name` / `Persona.archetype` → NFC + strip
  - `Persona.prompt_body` → NFC のみ (Markdown 改行保持)
  - `ProviderConfig.model` → strip のみ (ASCII 想定)
- **確定 H (SkillRef.path traversal 防御)**: H1〜H10 を 10 独立 module-level pure function として実装、テストから直接 import 可能。順序固定:
  - H1: NFC 正規化
  - H2: 1〜500 文字
  - H3: 拒否文字 (NUL / 制御 / バックスラッシュ)
  - H4: 先頭文字 (POSIX 絶対 / Windows 絶対 / `~`)
  - H5: traversal 列 (`..`, `.`, 前後空白, 末尾 `/`)
  - H6: `PurePosixPath` parse
  - H7: prefix `bakufu-data/skills/...` 強制
  - H8: 各 part 再検査
  - H9: Windows 予約名 (case-insensitive、拡張子有無問わず)
  - H10: `BAKUFU_DATA_DIR` 経由の `is_relative_to()` 物理確認 (symlink escape も検出)
- **確定 I**: `provider_kind` MVP gate は domain 範囲外。`AgentService.hire()` 責務として明示、`provider_not_implemented` kind を Literal に予約済み
- **MSG-AG-001〜012 完全一致**: `[FAIL] ...` 接頭辞、`{length}` は NFC + strip 後の Unicode コードポイント数

### 設計原則の遵守

- **DRY**: `nfc_strip` を `value_objects` から import 1 行で再利用 (empire / workflow と同パターン)、`mask_discord_webhook[_in]` を `AgentInvariantViolation` でも再利用
- **対称性**: `_validate_skill_id_unique` を `_validate_stage_id_unique` / `_validate_transition_id_unique` と対称配置 (Steve の PR #16 ルール踏襲)
- **Tell, Don't Ask**: 状態変更は Agent メソッド経由のみ、frozen で物理保証
- **公開関数禁止**: 全ロジックはクラスメソッドまたは module-level helper に閉じる
- **Fail Fast**: 容量・型・H1〜H10 を VO レベル第一防衛線で即拒否

### 変更ファイル

| ファイル | 役割 |
|---------|------|
| `backend/src/bakufu/domain/agent/` (新規 5 ファイル) | Agent パッケージ |
| `backend/src/bakufu/domain/value_objects.py` | `SkillId` / `ProviderKind` 追加 |
| `backend/src/bakufu/domain/exceptions.py` | `AgentInvariantViolation` 追加 (auto-mask 適用) |

### ローカル品質ゲート

- `ruff format/check` — clean
- `uv run pyright` strict — 0 errors, 0 warnings
- `uv run pytest backend/` — **163 passed** (empire 64 + workflow 99 維持、回帰なし)
- 動作確認 17 系統 (Persona / SkillRef / H1-H10 全 13 拒否ケース / Agent 構築 / `is_default==0/2` / provider duplicate / `set_default_provider` switch & not_found / `add_skill` duplicate / `remove_skill` not_found / **archive 冪等性 `a1 is a2 == False`** / frozen / extra forbid / helper 独立性) を `BAKUFU_DATA_DIR=/tmp/test-bakufu-data` でワンライナー全 PASS

ユニット / 結合テストはテスト担当 (ジェフ) が後段で TC-UT-AG-001〜060 + TC-UT-VO-AG-001〜007 を追加。本 PR は実装のみ。

## Test plan

- [ ] CI 7 ジョブ全 Green
- [ ] テスト担当による H1〜H10 13 拒否ケース + Agent invariants + archive idempotency 検証
- [ ] レビュー担当 (スティーブ / ノーマン / シュナイアー) による設計原則照合 — 特に確定 H (10 helper 独立性) と確定 I (provider_kind MVP gate の責務分離)

Closes #10