### PR TITLE
feat(room): Room Aggregate Root (Issue #18)

### DIFF
--- a/backend/src/bakufu/domain/exceptions.py
+++ b/backend/src/bakufu/domain/exceptions.py
@@ -11,11 +11,17 @@ human-readable ``message`` and a ``detail`` dict for programmatic introspection
 * :class:`StageInvariantViolation` — workflow Stage entity-level violation,
   inherits from :class:`WorkflowInvariantViolation` so callers can ``except``
   the parent and still receive the more-specific subclass.
+* :class:`AgentInvariantViolation` — agent feature, see
+  ``docs/features/agent/detailed-design.md`` §Exception.
+* :class:`RoomInvariantViolation` — room feature, see
+  ``docs/features/room/detailed-design.md`` §Exception.
 
-Workflow violations automatically apply :func:`mask_discord_webhook_in` to
-both ``message`` and ``detail`` so a webhook secret can never leak through
-exception text or its diagnostic payload (Workflow §Confirmation G "target の
-シークレット扱い" 例外 message / detail 行).
+Workflow / Agent / Room violations automatically apply
+:func:`mask_discord_webhook_in` to both ``message`` and ``detail`` so a
+webhook secret can never leak through exception text or its diagnostic
+payload — multi-layer defense covering webhook URLs that may slip into
+``NotifyChannel.target`` / ``Persona.prompt_body`` / ``SkillRef.path`` /
+``PromptKit.prefix_markdown`` / ``Room.{name,description}``.
 """
 
 from __future__ import annotations
@@ -212,11 +218,63 @@ class AgentInvariantViolation(Exception):  # noqa: N818
         self.detail: dict[str, object] = masked_detail
 
 
+type RoomViolationKind = Literal[
+    "name_range",
+    "description_too_long",
+    "member_duplicate",
+    "capacity_exceeded",
+    "member_not_found",
+    "room_archived",
+]
+"""Discriminator for :class:`RoomInvariantViolation` per Room detailed-design
+§Exception (§確定 I 例外型統一規約).
+
+The set is **closed at six kinds**: ``prompt_kit_too_long`` is *intentionally
+omitted* because the PromptKit VO raises :class:`pydantic.ValidationError`
+on its own ``model_validator`` before any Room invariant check fires. Adding
+it here would create a dead-code path that ``RoomInvariantViolation`` cannot
+reach by construction — see Room detailed-design §確定 I 2 段階 catch.
+"""
+
+
+# DDD: "Violation" describes an invariant breach, not a programming bug, so
+# the N818 "Error suffix" rule does not apply here.
+class RoomInvariantViolation(Exception):  # noqa: N818
+    """Raised when a :class:`Room` aggregate invariant is violated.
+
+    Mirrors :class:`AgentInvariantViolation` / :class:`WorkflowInvariantViolation`
+    in shape (``kind`` + ``message`` + ``detail`` + immutable copy of detail) and
+    applies the same Discord webhook secret masking. ``Room.name`` /
+    ``Room.description`` / ``PromptKit.prefix_markdown`` may all carry user-pasted
+    text that contains a webhook URL, so masking ``message`` / ``detail`` at
+    construction time means callers cannot leak a token by serializing the
+    exception (multi-layer defense, see Room detailed-design §確定 H).
+    """
+
+    def __init__(
+        self,
+        *,
+        kind: RoomViolationKind,
+        message: str,
+        detail: Mapping[str, object] | None = None,
+    ) -> None:
+        masked_message = mask_discord_webhook(message)
+        masked_detail: dict[str, object] = (
+            {key: mask_discord_webhook_in(value) for key, value in detail.items()} if detail else {}
+        )
+        super().__init__(masked_message)
+        self.kind: RoomViolationKind = kind
+        self.message: str = masked_message
+        self.detail: dict[str, object] = masked_detail
+
+
 __all__ = [
     "AgentInvariantViolation",
     "AgentViolationKind",
     "EmpireInvariantViolation",
     "EmpireViolationKind",
+    "RoomInvariantViolation",
+    "RoomViolationKind",
     "StageInvariantViolation",
     "StageViolationKind",
     "WorkflowInvariantViolation",

--- a/backend/src/bakufu/domain/room/__init__.py
+++ b/backend/src/bakufu/domain/room/__init__.py
@@ -1,0 +1,53 @@
+"""Room Aggregate Root package.
+
+Implements ``REQ-RM-001``〜``REQ-RM-006`` per ``docs/features/room``. Split
+into three sibling modules along the design's responsibility lines so each
+file stays well under the 270-line readability budget and the file-level
+boundary mirrors the agent / workflow precedent:
+
+* :mod:`bakufu.domain.room.value_objects` — :class:`AgentMembership` and
+  :class:`PromptKit` Pydantic VOs with their self-checks.
+* :mod:`bakufu.domain.room.aggregate_validators` — four module-level
+  invariant helpers covering name range / description length / member
+  uniqueness / member capacity.
+* :mod:`bakufu.domain.room.room` — :class:`Room` Aggregate Root that
+  dispatches over the helpers in deterministic order.
+
+This ``__init__`` re-exports the public surface plus the underscore-prefixed
+helpers tests need to invoke directly (same pattern Norman approved for the
+agent package).
+"""
+
+from __future__ import annotations
+
+from bakufu.domain.room.aggregate_validators import (
+    MAX_DESCRIPTION_LENGTH,
+    MAX_MEMBERS,
+    MAX_NAME_LENGTH,
+    MIN_NAME_LENGTH,
+    _validate_description_length,
+    _validate_member_capacity,
+    _validate_member_unique,
+    _validate_name_range,
+)
+from bakufu.domain.room.room import Room
+from bakufu.domain.room.value_objects import (
+    PROMPT_KIT_PREFIX_MAX,
+    AgentMembership,
+    PromptKit,
+)
+
+__all__ = [
+    "MAX_DESCRIPTION_LENGTH",
+    "MAX_MEMBERS",
+    "MAX_NAME_LENGTH",
+    "MIN_NAME_LENGTH",
+    "PROMPT_KIT_PREFIX_MAX",
+    "AgentMembership",
+    "PromptKit",
+    "Room",
+    "_validate_description_length",
+    "_validate_member_capacity",
+    "_validate_member_unique",
+    "_validate_name_range",
+]

--- a/backend/src/bakufu/domain/room/aggregate_validators.py
+++ b/backend/src/bakufu/domain/room/aggregate_validators.py
@@ -1,0 +1,131 @@
+"""Aggregate-level invariant helpers for :class:`Room`.
+
+Each helper is a **module-level pure function** so tests can ``import`` and
+invoke directly — same testability pattern Norman / Steve approved for the
+agent ``aggregate_validators.py`` and the workflow ``dag_validators.py``.
+The Aggregate Root in :mod:`bakufu.domain.room.room` stays a thin dispatch
+over them; rule changes touch only the helper, never the orchestration code.
+
+Helpers (run in this order in :class:`Room.model_validator`):
+
+1. :func:`_validate_name_range` — ``1 ≤ NFC+strip(name) ≤ 80``
+2. :func:`_validate_description_length` — ``0 ≤ NFC+strip(description) ≤ 500``
+3. :func:`_validate_member_unique` — no duplicate ``(agent_id, role)`` pair
+4. :func:`_validate_member_capacity` — ``len(members) ≤ 50``
+
+Naming follows the agent / workflow precedent (``_validate_*_unique`` for
+collection uniqueness checks). Boy Scout: every collection contract that says
+"no duplicate (a, b) pair" gets a dedicated helper so the rule survives
+future refactors (Steve's twin-defense symmetry rule from PR #16).
+"""
+
+from __future__ import annotations
+
+from bakufu.domain.exceptions import RoomInvariantViolation
+from bakufu.domain.room.value_objects import AgentMembership
+
+# Confirmation B: name length bounds (1〜80 after NFC + strip).
+MIN_NAME_LENGTH: int = 1
+MAX_NAME_LENGTH: int = 80
+
+# Confirmation B: description length bounds (0〜500 after NFC + strip).
+MAX_DESCRIPTION_LENGTH: int = 500
+
+# Confirmation C: member capacity (≤ 50).
+MAX_MEMBERS: int = 50
+
+
+def _validate_name_range(name: str) -> None:
+    """``Room.name`` must fall in 1〜80 characters after NFC + strip (MSG-RM-001).
+
+    Length is judged on the *normalized* string (the field validator runs the
+    pipeline before this helper is invoked), so the count reflects what the
+    user will see in audit logs and UI labels.
+    """
+    length = len(name)
+    if not (MIN_NAME_LENGTH <= length <= MAX_NAME_LENGTH):
+        raise RoomInvariantViolation(
+            kind="name_range",
+            message=(
+                f"[FAIL] Room name must be "
+                f"{MIN_NAME_LENGTH}-{MAX_NAME_LENGTH} characters (got {length})\n"
+                f"Next: Provide a name with {MIN_NAME_LENGTH}-{MAX_NAME_LENGTH} "
+                f"NFC-normalized characters; trim leading/trailing whitespace."
+            ),
+            detail={"length": length},
+        )
+
+
+def _validate_description_length(description: str) -> None:
+    """``Room.description`` must fall in 0〜500 characters after NFC + strip (MSG-RM-002)."""
+    length = len(description)
+    if length > MAX_DESCRIPTION_LENGTH:
+        raise RoomInvariantViolation(
+            kind="description_too_long",
+            message=(
+                f"[FAIL] Room description must be 0-{MAX_DESCRIPTION_LENGTH} "
+                f"characters (got {length})\n"
+                f"Next: Shorten the description to <={MAX_DESCRIPTION_LENGTH} "
+                f"characters; move long content to PromptKit.prefix_markdown "
+                f"(10000 char limit)."
+            ),
+            detail={"length": length},
+        )
+
+
+def _validate_member_unique(members: list[AgentMembership]) -> None:
+    """No two memberships may share the same ``(agent_id, role)`` pair (MSG-RM-003).
+
+    Allowing the same agent to hold multiple roles (LEADER + REVIEWER, etc.)
+    is a Room §確定 F design choice — the unique key is the **pair**, not
+    ``agent_id`` alone. ``joined_at`` participates in equality of the VO but
+    is intentionally **not** part of the uniqueness key here, so re-adding
+    the same pair at a later timestamp is still rejected as a duplicate.
+    """
+    seen: set[tuple[object, str]] = set()
+    for membership in members:
+        key = (membership.agent_id, membership.role.value)
+        if key in seen:
+            raise RoomInvariantViolation(
+                kind="member_duplicate",
+                message=(
+                    f"[FAIL] Duplicate member: "
+                    f"agent_id={membership.agent_id}, role={membership.role.value}\n"
+                    f"Next: Either skip this add (already a member) or use a "
+                    f"different role to add the same agent in another capacity "
+                    f"(e.g. leader + reviewer)."
+                ),
+                detail={
+                    "agent_id": str(membership.agent_id),
+                    "role": membership.role.value,
+                },
+            )
+        seen.add(key)
+
+
+def _validate_member_capacity(members: list[AgentMembership]) -> None:
+    """Cap members at :data:`MAX_MEMBERS` (MSG-RM-004 / Room §確定 C)."""
+    count = len(members)
+    if count > MAX_MEMBERS:
+        raise RoomInvariantViolation(
+            kind="capacity_exceeded",
+            message=(
+                f"[FAIL] Room members capacity exceeded "
+                f"(got {count}, max {MAX_MEMBERS})\n"
+                f"Next: Remove unused members (e.g. archived agents) before "
+                f"adding more, or split the work across multiple Rooms."
+            ),
+            detail={"members_count": count, "max_members": MAX_MEMBERS},
+        )
+
+
+__all__ = [
+    "MAX_DESCRIPTION_LENGTH",
+    "MAX_MEMBERS",
+    "MAX_NAME_LENGTH",
+    "MIN_NAME_LENGTH",
+    "_validate_description_length",
+    "_validate_member_capacity",
+    "_validate_member_unique",
+    "_validate_name_range",
+]

--- a/backend/src/bakufu/domain/room/room.py
+++ b/backend/src/bakufu/domain/room/room.py
@@ -1,0 +1,218 @@
+"""Room Aggregate Root (REQ-RM-001〜006).
+
+Implements per ``docs/features/room``. The aggregate dispatches over four
+helpers in :mod:`bakufu.domain.room.aggregate_validators` and composes
+:class:`AgentMembership` + :class:`PromptKit` VOs from
+:mod:`bakufu.domain.room.value_objects`.
+
+Design contracts:
+
+* **Pre-validate rebuild (Confirmation A)** — ``add_member`` /
+  ``remove_member`` / ``update_prompt_kit`` / ``archive`` all go through
+  :meth:`Room._rebuild_with` (``model_dump → swap → model_validate``).
+* **NFC pipeline (Confirmation B)** — ``Room.name`` and ``Room.description``
+  reuse the empire / workflow / agent ``nfc_strip`` helper. Length judgement
+  happens in the aggregate validators so the resulting
+  :class:`RoomInvariantViolation` carries ``kind='name_range'`` /
+  ``'description_too_long'`` with MSG-RM-001 / 002 wording.
+* **archive idempotency (Confirmation D)** — ``archive()`` always returns a
+  *new* instance. Idempotency means "result state matches", not "object
+  identity". Pydantic v2 frozen + ``model_validate`` rebuild guarantees
+  this; the docstring documents the contract so callers do not rely on
+  ``is`` comparisons.
+* **archived terminal (Confirmation E)** — ``add_member`` / ``remove_member``
+  / ``update_prompt_kit`` Fail Fast on archived Rooms with
+  ``kind='room_archived'`` (MSG-RM-006). ``archive()`` itself is idempotent
+  and bypasses this check.
+* **`(agent_id, role)` pair uniqueness (Confirmation F)** — same agent can
+  hold multiple roles; the validator uses the pair as the key.
+* **Application-layer responsibilities** — Workflow existence, Agent
+  existence, leader-required-by-Workflow, and Empire-scoped name uniqueness
+  live in ``RoomService`` / ``EmpireService``. The aggregate trusts only
+  what it can observe locally.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Self
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    field_validator,
+    model_validator,
+)
+
+from bakufu.domain.exceptions import RoomInvariantViolation
+from bakufu.domain.room.aggregate_validators import (
+    _validate_description_length,
+    _validate_member_capacity,
+    _validate_member_unique,
+    _validate_name_range,
+)
+from bakufu.domain.room.value_objects import AgentMembership, PromptKit
+from bakufu.domain.value_objects import (
+    AgentId,
+    Role,
+    RoomId,
+    WorkflowId,
+    nfc_strip,
+)
+
+
+class Room(BaseModel):
+    """Editable composition space within an :class:`Empire` (REQ-RM-001).
+
+    Composes a :class:`PromptKit` preamble and ``list[AgentMembership]`` over
+    a fixed :class:`WorkflowId`. The aggregate enforces structural invariants
+    only — Workflow existence and leader-required-by-Workflow checks belong
+    to the application layer because they require external knowledge.
+    """
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        arbitrary_types_allowed=False,
+    )
+
+    id: RoomId
+    name: str
+    description: str = ""
+    workflow_id: WorkflowId
+    members: list[AgentMembership] = []
+    prompt_kit: PromptKit = PromptKit()
+    archived: bool = False
+
+    # ---- pre-validation -------------------------------------------------
+    @field_validator("name", "description", mode="before")
+    @classmethod
+    def _normalize_short_text(cls, value: object) -> object:
+        # NFC + strip pipeline shared with empire / workflow / agent (Confirmation B).
+        return nfc_strip(value)
+
+    @model_validator(mode="after")
+    def _check_invariants(self) -> Self:
+        """Dispatch over the aggregate-level helpers in deterministic order.
+
+        Order: name range → description length → member uniqueness → member
+        capacity. Earlier failures hide later ones so error messages stay
+        focused on the root cause.
+        """
+        _validate_name_range(self.name)
+        _validate_description_length(self.description)
+        _validate_member_unique(self.members)
+        _validate_member_capacity(self.members)
+        return self
+
+    # ---- behaviors (Tell, Don't Ask) ------------------------------------
+    def add_member(self, membership: AgentMembership) -> Room:
+        """Append ``membership`` to ``members``; aggregate validation catches duplicates.
+
+        Fail Fast on archived Rooms (Confirmation E). The
+        ``(agent_id, role)`` pair-uniqueness check fires inside
+        :meth:`_check_invariants` after the rebuild.
+
+        Raises:
+            RoomInvariantViolation: ``kind='room_archived'`` (MSG-RM-006) if
+                the Room is already archived; ``kind='member_duplicate'``
+                (MSG-RM-003) if the pair already exists; ``kind='capacity_exceeded'``
+                (MSG-RM-004) if adding pushes the count over :data:`MAX_MEMBERS`.
+        """
+        self._reject_if_archived()
+        return self._rebuild_with(members=[*self.members, membership])
+
+    def remove_member(self, agent_id: AgentId, role: Role) -> Room:
+        """Drop the membership matching ``(agent_id, role)``.
+
+        Fail Fast on archived Rooms (Confirmation E) and on missing pair
+        (MSG-RM-005) — the caller cannot blindly retry a remove without
+        observing the current member list.
+
+        Raises:
+            RoomInvariantViolation: ``kind='room_archived'`` (MSG-RM-006);
+                ``kind='member_not_found'`` (MSG-RM-005) when no membership
+                matches the pair.
+        """
+        self._reject_if_archived()
+        if not any(m.agent_id == agent_id and m.role == role for m in self.members):
+            raise RoomInvariantViolation(
+                kind="member_not_found",
+                message=(
+                    f"[FAIL] Member not found: agent_id={agent_id}, role={role.value}\n"
+                    f"Next: Verify the (agent_id, role) pair via "
+                    f"GET /rooms/{{room_id}}/members; the agent may have been "
+                    f"already removed or never had this role."
+                ),
+                detail={"agent_id": str(agent_id), "role": role.value},
+            )
+        return self._rebuild_with(
+            members=[m for m in self.members if not (m.agent_id == agent_id and m.role == role)],
+        )
+
+    def update_prompt_kit(self, prompt_kit: PromptKit) -> Room:
+        """Replace ``prompt_kit`` with ``prompt_kit``.
+
+        Fail Fast on archived Rooms (Confirmation E). PromptKit length
+        violations surface as :class:`pydantic.ValidationError` at VO
+        construction time (Confirmation I two-stage catch), so by the time
+        this method is invoked the VO is already valid.
+
+        Raises:
+            RoomInvariantViolation: ``kind='room_archived'`` (MSG-RM-006).
+        """
+        self._reject_if_archived()
+        return self._rebuild_with(prompt_kit=prompt_kit)
+
+    def archive(self) -> Room:
+        """Return a new :class:`Room` with ``archived=True`` (Confirmation D).
+
+        Idempotent: calling on an already-archived Room yields a fresh Room
+        that is **structurally equal** to the input but has a different
+        ``id()``. Callers must not rely on object identity — always reassign
+        the returned value (``room = room.archive()``). Same contract Norman
+        approved for the agent / empire ``archive()`` behaviors.
+        """
+        return self._rebuild_with_state({"archived": True})
+
+    # ---- internal -------------------------------------------------------
+    def _reject_if_archived(self) -> None:
+        """Raise ``room_archived`` (MSG-RM-006) when the Room is terminal.
+
+        Confirmation E: archived Rooms reject all mutating behaviors except
+        :meth:`archive` itself, which stays idempotent for retry tolerance.
+        """
+        if self.archived:
+            raise RoomInvariantViolation(
+                kind="room_archived",
+                message=(
+                    f"[FAIL] Cannot modify archived Room: room_id={self.id}\n"
+                    f"Next: Create a new Room; unarchive is not supported in "
+                    f"MVP (Phase 2 will add RoomService.unarchive)."
+                ),
+                detail={"room_id": str(self.id)},
+            )
+
+    def _rebuild_with(
+        self,
+        *,
+        members: list[AgentMembership] | None = None,
+        prompt_kit: PromptKit | None = None,
+    ) -> Room:
+        """Re-construct via ``model_validate`` so ``_check_invariants`` re-fires."""
+        state = self.model_dump()
+        if members is not None:
+            state["members"] = [m.model_dump() for m in members]
+        if prompt_kit is not None:
+            state["prompt_kit"] = prompt_kit.model_dump()
+        return Room.model_validate(state)
+
+    def _rebuild_with_state(self, updates: dict[str, Any]) -> Room:
+        """Pre-validate rebuild for scalar attribute updates (e.g. ``archived``)."""
+        state = self.model_dump()
+        state.update(updates)
+        return Room.model_validate(state)
+
+
+__all__ = [
+    "Room",
+]

--- a/backend/src/bakufu/domain/room/value_objects.py
+++ b/backend/src/bakufu/domain/room/value_objects.py
@@ -1,0 +1,117 @@
+"""Room-specific Value Objects (:class:`AgentMembership` / :class:`PromptKit`).
+
+These VOs live in the ``room/`` package rather than the global
+:mod:`bakufu.domain.value_objects` so the file-level boundary mirrors the
+responsibility boundary — same pattern Norman approved for the agent /
+workflow packages. ``Role`` and ``AgentId`` remain in the global module
+because they cross feature boundaries.
+
+``PromptKit.prefix_markdown`` applies **NFC only** (no strip): the field
+holds Markdown text where leading/trailing newlines are semantically
+significant for the downstream prompt renderer. Same rule the agent
+``Persona.prompt_body`` follows (Agent §確定 E / Room §確定 B).
+"""
+
+from __future__ import annotations
+
+import unicodedata
+from datetime import datetime
+from typing import Self
+
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+
+from bakufu.domain.value_objects import AgentId, Role
+
+# ---------------------------------------------------------------------------
+# AgentMembership (Room §確定 F — (agent_id, role) pair as the unique key)
+# ---------------------------------------------------------------------------
+
+
+class AgentMembership(BaseModel):
+    """Frozen membership entry: an :class:`Agent` taking on a :class:`Role`.
+
+    The Room aggregate stores a ``list[AgentMembership]`` and enforces
+    ``(agent_id, role)`` pair uniqueness — **not** ``agent_id`` alone — so a
+    single agent can hold multiple roles (e.g. LEADER + REVIEWER). Storing
+    ``joined_at`` per-role lets the UI surface "joined as LEADER on X, then
+    added REVIEWER on Y" naturally.
+
+    Stored under ``docs/architecture/domain-model/value-objects.md`` §AgentMembership;
+    Room is the only feature that composes this VO today.
+    """
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        arbitrary_types_allowed=False,
+    )
+
+    agent_id: AgentId
+    role: Role
+    joined_at: datetime
+
+
+# ---------------------------------------------------------------------------
+# PromptKit (Room §確定 G — single-attribute VO, retained for Phase-2 growth)
+# ---------------------------------------------------------------------------
+PROMPT_KIT_PREFIX_MAX: int = 10_000
+
+
+class PromptKit(BaseModel):
+    """Room-scoped system-prompt preamble (Markdown text).
+
+    Single-attribute VO today; the structure exists so Phase 2 can extend it
+    with ``variables``, ``role_specific_prefix``, or ``sections`` without
+    forcing a schema migration on :class:`Room` (Room §確定 G).
+
+    The persistence layer applies secret masking to ``prefix_markdown``
+    *before* it lands in the SQLite ``rooms`` row — see
+    ``docs/architecture/domain-model/storage.md`` §シークレットマスキング規則.
+    The aggregate keeps the raw user input so the UI can read it back
+    unchanged; the masking gateway is **only** at the persistence boundary.
+    """
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        arbitrary_types_allowed=False,
+    )
+
+    prefix_markdown: str = ""
+
+    @field_validator("prefix_markdown", mode="before")
+    @classmethod
+    def _normalize_prefix(cls, value: object) -> object:
+        # NFC only — preserves leading/trailing Markdown whitespace (Room §確定 B).
+        if isinstance(value, str):
+            return unicodedata.normalize("NFC", value)
+        return value
+
+    @model_validator(mode="after")
+    def _check_self_invariants(self) -> Self:
+        """Length cap raises :class:`pydantic.ValidationError` (MSG-RM-007).
+
+        Room detailed-design §確定 I freezes that PromptKit length violations
+        surface as ``ValidationError`` — not ``RoomInvariantViolation`` —
+        because the failure happens *before* any Room aggregate is in scope.
+        ``RoomService.update_prompt_kit`` then catches in two layers (VO
+        construction → ``ValidationError``; aggregate behavior → archived
+        terminal etc.).
+        """
+        length = len(self.prefix_markdown)
+        if length > PROMPT_KIT_PREFIX_MAX:
+            raise ValueError(
+                f"[FAIL] PromptKit.prefix_markdown must be 0-{PROMPT_KIT_PREFIX_MAX} "
+                f"characters (got {length})\n"
+                f"Next: Trim PromptKit content to <={PROMPT_KIT_PREFIX_MAX} "
+                f"NFC-normalized characters; for richer prompts use Phase 2 "
+                f"sections (variables / role_specific_prefix / sections)."
+            )
+        return self
+
+
+__all__ = [
+    "PROMPT_KIT_PREFIX_MAX",
+    "AgentMembership",
+    "PromptKit",
+]

--- a/backend/tests/domain/room/test_application_responsibility.py
+++ b/backend/tests/domain/room/test_application_responsibility.py
@@ -1,0 +1,82 @@
+"""Application-layer responsibility boundary tests (TC-UT-RM-027〜030).
+
+Room §確定 R1-A / R1-D / R1-E freeze that **Aggregate-internal invariants
+are structural only**: ``(agent_id, role)`` uniqueness, capacity, archived
+terminal, name length, description length. Cross-aggregate concerns —
+``name`` Empire-scoped uniqueness, ``workflow_id`` referential integrity,
+``LEADER`` required-by-Workflow, Agent existence — live in
+``RoomService`` / ``EmpireService`` because they require external
+knowledge. These tests freeze that boundary so a future refactor cannot
+silently push aggregate-level checks into the Room aggregate (the regression
+direction Norman PR #16 / Steve PR #16 worked hard to keep clean for the
+agent feature).
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from bakufu.domain.value_objects import Role
+
+from tests.factories.room import (
+    make_agent_membership,
+    make_room,
+)
+
+
+class TestNameUniquenessNotEnforcedByAggregate:
+    """TC-UT-RM-027: Aggregate constructs two Rooms with the same name."""
+
+    def test_two_rooms_with_same_name_both_construct(self) -> None:
+        """TC-UT-RM-027: Empire-scoped name uniqueness is RoomService responsibility.
+
+        The aggregate has no Repository handle, so it can only enforce *local*
+        invariants. Empire-scoped uniqueness is a Repository SELECT pattern
+        in ``RoomService.create()``.
+        """
+        room_a = make_room(name="Vモデル開発室", room_id=uuid4())
+        room_b = make_room(name="Vモデル開発室", room_id=uuid4())
+        assert room_a.name == room_b.name
+        assert room_a.id != room_b.id
+
+
+class TestWorkflowReferentialIntegrityNotEnforcedByAggregate:
+    """TC-UT-RM-028: any UUID is accepted as workflow_id at the aggregate level."""
+
+    def test_arbitrary_workflow_id_constructs(self) -> None:
+        """TC-UT-RM-028: Workflow existence is verified by RoomService, not Room."""
+        # The UUID is arbitrary — no Workflow with this id exists. Aggregate
+        # accepts because referential integrity is application-layer scope.
+        room = make_room(workflow_id=uuid4())
+        assert room.workflow_id is not None
+
+
+class TestLeaderRequirementNotEnforcedByAggregate:
+    """TC-UT-RM-029: Room with zero LEADER role members constructs (chat-room scenario)."""
+
+    def test_room_without_leader_constructs(self) -> None:
+        """TC-UT-RM-029: leader-required-by-Workflow is RoomService responsibility.
+
+        Some Workflows (e.g. casual-chat or discussion-only flows) do not
+        require a LEADER. The aggregate cannot read Workflow.required_role
+        without a Repository, so it skips the check entirely. Same pattern
+        Agent §確定 I uses for ``provider_kind`` MVP gating.
+        """
+        room = make_room(members=[])
+        assert all(m.role != Role.LEADER for m in room.members)
+
+
+class TestAgentExistenceNotEnforcedByAggregate:
+    """TC-UT-RM-030: AgentMembership accepts any UUID as agent_id."""
+
+    def test_room_with_unknown_agent_id_constructs(self) -> None:
+        """TC-UT-RM-030: Agent existence is verified by RoomService.add_member().
+
+        At the aggregate level, ``agent_id`` is a typed UUID slot. Whether it
+        resolves to an actual Agent row is a Repository concern, not an
+        invariant the aggregate can observe.
+        """
+        unknown_agent_id = uuid4()
+        m = make_agent_membership(agent_id=unknown_agent_id, role=Role.DEVELOPER)
+        room = make_room(members=[m])
+        assert room.members[0].agent_id == unknown_agent_id

--- a/backend/tests/domain/room/test_archive.py
+++ b/backend/tests/domain/room/test_archive.py
@@ -1,0 +1,90 @@
+"""archive() idempotency + archived terminal violations (Confirmations D / E).
+
+Covers TC-UT-RM-011 / 012 / 013 / 023. ``archive()`` always returns a new
+instance (Confirmation D — idempotency means *result state matches*, not
+*object identity*), and archived Rooms reject all mutating behaviors except
+``archive`` itself (Confirmation E).
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from bakufu.domain.exceptions import RoomInvariantViolation
+from bakufu.domain.value_objects import Role
+
+from tests.factories.room import (
+    make_agent_membership,
+    make_archived_room,
+    make_prompt_kit,
+    make_room,
+)
+
+
+class TestArchive:
+    """TC-UT-RM-011 / 012 / 023: archive() returns a new instance (idempotent)."""
+
+    def test_archive_returns_archived_room(self) -> None:
+        """TC-UT-RM-011: archive() yields a Room with archived=True."""
+        room = make_room()
+        archived = room.archive()
+        assert archived.archived is True
+
+    def test_archive_does_not_mutate_original(self) -> None:
+        """TC-UT-RM-011: original Room.archived stays False after archive()."""
+        room = make_room()
+        room.archive()
+        assert room.archived is False
+
+    def test_archive_on_already_archived_returns_new_equal_instance(self) -> None:
+        """TC-UT-RM-012: archive() on archived Room returns a *new* equal Room.
+
+        Idempotency means **result state matches**, not **object identity**.
+        ``model_validate`` rebuild always produces a fresh instance with a
+        different ``id()`` but structurally equal attributes.
+        """
+        room = make_archived_room()
+        again = room.archive()
+        assert again.archived is True
+        assert again == room
+        assert again is not room
+
+    def test_consecutive_archive_calls_remain_idempotent(self) -> None:
+        """TC-UT-RM-023: archive() chained 3 times yields the same final state."""
+        room = make_room()
+        a1 = room.archive()
+        a2 = a1.archive()
+        a3 = a2.archive()
+        assert a1.archived is True
+        assert a2.archived is True
+        assert a3.archived is True
+        assert a1 == a2 == a3
+
+
+class TestArchivedTerminalViolation:
+    """TC-UT-RM-013: archived Rooms reject add_member / remove_member / update_prompt_kit."""
+
+    def test_archived_add_member_raises_room_archived(self) -> None:
+        """TC-UT-RM-013: add_member on archived Room raises room_archived."""
+        room = make_archived_room()
+        m = make_agent_membership(agent_id=uuid4(), role=Role.DEVELOPER)
+        with pytest.raises(RoomInvariantViolation) as excinfo:
+            room.add_member(m)
+        assert excinfo.value.kind == "room_archived"
+
+    def test_archived_remove_member_raises_room_archived(self) -> None:
+        """TC-UT-RM-013: remove_member on archived Room raises room_archived."""
+        m = make_agent_membership(agent_id=uuid4(), role=Role.DEVELOPER)
+        room = make_archived_room(members=[m])
+        with pytest.raises(RoomInvariantViolation) as excinfo:
+            room.remove_member(m.agent_id, m.role)
+        assert excinfo.value.kind == "room_archived"
+
+    def test_archived_update_prompt_kit_raises_room_archived(self) -> None:
+        """TC-UT-RM-013: update_prompt_kit on archived Room raises room_archived."""
+        room = make_archived_room()
+        new_kit = make_prompt_kit(prefix_markdown="# attempted")
+        with pytest.raises(RoomInvariantViolation) as excinfo:
+            room.update_prompt_kit(new_kit)
+        assert excinfo.value.kind == "room_archived"

--- a/backend/tests/domain/room/test_construction.py
+++ b/backend/tests/domain/room/test_construction.py
@@ -1,0 +1,116 @@
+"""Room construction + boundary value tests (TC-UT-RM-001 / 002 / 003 / 018).
+
+Covers REQ-RM-001 (construction) + name / description boundary values + the
+NFC + strip pipeline (Confirmation B). Each boundary value lives in its own
+``Test*`` class so failures cluster by which length contract was violated.
+"""
+
+from __future__ import annotations
+
+import pytest
+from bakufu.domain.exceptions import RoomInvariantViolation
+
+from tests.factories.room import make_room
+
+
+class TestMinimalConstruction:
+    """TC-UT-RM-001: zero members, empty PromptKit, archived=False default."""
+
+    def test_default_room_has_no_members(self) -> None:
+        """TC-UT-RM-001: factory default constructs with members=[]."""
+        room = make_room()
+        assert room.members == []
+
+    def test_default_room_is_not_archived(self) -> None:
+        """TC-UT-RM-001: factory default constructs with archived=False."""
+        room = make_room()
+        assert room.archived is False
+
+    def test_default_prompt_kit_is_empty(self) -> None:
+        """TC-UT-RM-001: factory default constructs with empty prefix_markdown."""
+        room = make_room()
+        assert room.prompt_kit.prefix_markdown == ""
+
+
+class TestNameBoundary:
+    """TC-UT-RM-002: name length boundary 0 / 1 / 80 / 81 + whitespace."""
+
+    @pytest.mark.parametrize("length", [1, 80])
+    def test_valid_lengths_succeed(self, length: int) -> None:
+        """TC-UT-RM-002: name lengths 1 and 80 (after NFC + strip) succeed."""
+        room = make_room(name="a" * length)
+        assert len(room.name) == length
+
+    def test_empty_name_raises_name_range(self) -> None:
+        """TC-UT-RM-002: name length 0 raises name_range with detail.length=0."""
+        with pytest.raises(RoomInvariantViolation) as excinfo:
+            make_room(name="")
+        assert excinfo.value.kind == "name_range"
+        assert excinfo.value.detail.get("length") == 0
+
+    def test_oversized_name_raises_name_range(self) -> None:
+        """TC-UT-RM-002: name length 81 raises name_range with detail.length=81."""
+        with pytest.raises(RoomInvariantViolation) as excinfo:
+            make_room(name="a" * 81)
+        assert excinfo.value.kind == "name_range"
+        assert excinfo.value.detail.get("length") == 81
+
+    def test_whitespace_only_name_raises_name_range(self) -> None:
+        """TC-UT-RM-002: whitespace-only name (post-strip length=0) raises."""
+        with pytest.raises(RoomInvariantViolation) as excinfo:
+            make_room(name="   ")
+        assert excinfo.value.kind == "name_range"
+
+
+class TestDescriptionBoundary:
+    """TC-UT-RM-003: description length boundary 0 / 500 / 501."""
+
+    @pytest.mark.parametrize("length", [0, 500])
+    def test_valid_lengths_succeed(self, length: int) -> None:
+        """TC-UT-RM-003: description lengths 0 and 500 succeed."""
+        room = make_room(description="a" * length)
+        assert len(room.description) == length
+
+    def test_oversized_description_raises_description_too_long(self) -> None:
+        """TC-UT-RM-003: description length 501 raises description_too_long."""
+        with pytest.raises(RoomInvariantViolation) as excinfo:
+            make_room(description="a" * 501)
+        assert excinfo.value.kind == "description_too_long"
+        assert excinfo.value.detail.get("length") == 501
+
+
+class TestNfcStripPipeline:
+    """TC-UT-RM-018: name / description NFC + strip; PromptKit NFC only (Confirmation B)."""
+
+    def test_name_strips_leading_and_trailing_whitespace(self) -> None:
+        """TC-UT-RM-018: '  Vモデル開発室  ' is held as 'Vモデル開発室' after NFC + strip."""
+        room = make_room(name="  Vモデル開発室  ")
+        assert room.name == "Vモデル開発室"
+
+    def test_description_strips_whitespace(self) -> None:
+        """TC-UT-RM-018: description leading/trailing whitespace is stripped."""
+        room = make_room(description="  hello  ")
+        assert room.description == "hello"
+
+    def test_name_nfc_normalization_unifies_decomposed_form(self) -> None:
+        """TC-UT-RM-018: composed and decomposed forms collapse to the same NFC string."""
+        # The decomposed form (NFD) of "ダ" splits to "タ" + combining dakuten.
+        composed = "ダリオ"
+        decomposed = "ダリオ"
+        room_composed = make_room(name=composed)
+        room_decomposed = make_room(name=decomposed)
+        assert room_composed.name == room_decomposed.name
+
+    def test_prompt_kit_preserves_leading_and_trailing_newlines(self) -> None:
+        """TC-UT-RM-018: PromptKit applies NFC only — leading/trailing newlines kept.
+
+        agent §確定 E / Room §確定 B: ``prefix_markdown`` is Markdown body
+        text where leading/trailing newlines are semantically significant.
+        ``strip()`` is *not* applied at the field validator.
+        """
+        from tests.factories.room import make_prompt_kit
+
+        text = "\n# Heading\n\nbody\n\n"
+        room = make_room()
+        room2 = room.update_prompt_kit(make_prompt_kit(prefix_markdown=text))
+        assert room2.prompt_kit.prefix_markdown == text

--- a/backend/tests/domain/room/test_frozen_extra.py
+++ b/backend/tests/domain/room/test_frozen_extra.py
@@ -1,0 +1,63 @@
+"""Frozen + extra='forbid' contract tests (TC-UT-RM-025 / 026).
+
+Pydantic v2 ``frozen=True`` rejects attribute assignment; ``extra='forbid'``
+rejects unknown fields at construction. Both contracts are checked here so
+future model_config tweaks cannot silently weaken them.
+"""
+
+from __future__ import annotations
+
+import pytest
+from bakufu.domain.room import PromptKit, Room
+from pydantic import ValidationError
+
+from tests.factories.room import make_prompt_kit, make_room
+
+
+class TestFrozenAssignmentRejected:
+    """TC-UT-RM-025: direct attribute assignment raises ValidationError."""
+
+    def test_assigning_room_name_raises(self) -> None:
+        """TC-UT-RM-025: room.name = ... raises ValidationError (frozen)."""
+        room = make_room()
+        with pytest.raises(ValidationError):
+            room.name = "X"  # type: ignore[misc] # frozen, must raise at runtime
+
+    def test_assigning_room_archived_raises(self) -> None:
+        """TC-UT-RM-025: room.archived = True raises ValidationError (frozen)."""
+        room = make_room()
+        with pytest.raises(ValidationError):
+            room.archived = True  # type: ignore[misc] # frozen, must raise at runtime
+
+    def test_assigning_prompt_kit_attr_raises(self) -> None:
+        """TC-UT-RM-025: prompt_kit.prefix_markdown = ... raises ValidationError."""
+        kit = make_prompt_kit()
+        with pytest.raises(ValidationError):
+            kit.prefix_markdown = "# new"  # type: ignore[misc] # frozen, must raise at runtime
+
+
+class TestExtraForbidden:
+    """TC-UT-RM-026: unknown fields rejected at construction."""
+
+    def test_unknown_field_on_room_raises(self) -> None:
+        """TC-UT-RM-026: Room.model_validate({...,'unknown':'x'}) raises."""
+        from uuid import uuid4
+
+        with pytest.raises(ValidationError):
+            Room.model_validate(
+                {
+                    "id": str(uuid4()),
+                    "name": "test",
+                    "description": "",
+                    "workflow_id": str(uuid4()),
+                    "members": [],
+                    "prompt_kit": {"prefix_markdown": ""},
+                    "archived": False,
+                    "unknown": "x",
+                }
+            )
+
+    def test_unknown_field_on_prompt_kit_raises(self) -> None:
+        """TC-UT-RM-026: PromptKit.model_validate({'prefix_markdown': '', 'unknown': 1}) raises."""
+        with pytest.raises(ValidationError):
+            PromptKit.model_validate({"prefix_markdown": "", "unknown": 1})

--- a/backend/tests/domain/room/test_helpers_independence.py
+++ b/backend/tests/domain/room/test_helpers_independence.py
@@ -1,0 +1,118 @@
+"""Module-level helper independence (Boy Scout twin-defense symmetry).
+
+Steve PR #16 / Norman PR #16 approved: every aggregate-level invariant
+helper lives at module scope so tests can ``import`` and invoke directly.
+Mirrors the agent ``test_helpers_independence.py`` pattern. These tests
+freeze the helper signatures and entry-point contract — the Aggregate stays
+a thin dispatch over them, and a refactor that inlines a helper back into
+the model_validator has to update this test file too.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from bakufu.domain.exceptions import RoomInvariantViolation
+from bakufu.domain.room import (
+    MAX_DESCRIPTION_LENGTH,
+    MAX_MEMBERS,
+    MAX_NAME_LENGTH,
+    MIN_NAME_LENGTH,
+    _validate_description_length,
+    _validate_member_capacity,
+    _validate_member_unique,
+    _validate_name_range,
+)
+from bakufu.domain.value_objects import Role
+
+from tests.factories.room import make_agent_membership, make_leader_membership
+
+
+class TestValidateNameRange:
+    """``_validate_name_range`` is a module-level pure function."""
+
+    @pytest.mark.parametrize("length", [MIN_NAME_LENGTH, MAX_NAME_LENGTH])
+    def test_valid_lengths_return_none(self, length: int) -> None:
+        """Valid lengths return ``None`` without raising."""
+        result = _validate_name_range("a" * length)
+        assert result is None
+
+    @pytest.mark.parametrize("length", [0, MAX_NAME_LENGTH + 1])
+    def test_invalid_lengths_raise_name_range(self, length: int) -> None:
+        """Out-of-range lengths raise ``RoomInvariantViolation(kind='name_range')``."""
+        with pytest.raises(RoomInvariantViolation) as excinfo:
+            _validate_name_range("a" * length)
+        assert excinfo.value.kind == "name_range"
+
+
+class TestValidateDescriptionLength:
+    """``_validate_description_length`` is a module-level pure function."""
+
+    def test_valid_lengths_return_none(self) -> None:
+        """0 and MAX_DESCRIPTION_LENGTH return ``None``."""
+        assert _validate_description_length("") is None
+        assert _validate_description_length("a" * MAX_DESCRIPTION_LENGTH) is None
+
+    def test_oversized_raises_description_too_long(self) -> None:
+        """501 chars raises ``description_too_long``."""
+        with pytest.raises(RoomInvariantViolation) as excinfo:
+            _validate_description_length("a" * (MAX_DESCRIPTION_LENGTH + 1))
+        assert excinfo.value.kind == "description_too_long"
+
+
+class TestValidateMemberUnique:
+    """``_validate_member_unique`` is a module-level pure function (Confirmation F)."""
+
+    def test_empty_members_returns_none(self) -> None:
+        """An empty member list passes vacuously."""
+        assert _validate_member_unique([]) is None
+
+    def test_unique_pairs_pass(self) -> None:
+        """Distinct ``(agent_id, role)`` pairs pass."""
+        members = [
+            make_leader_membership(agent_id=uuid4()),
+            make_agent_membership(agent_id=uuid4(), role=Role.DEVELOPER),
+        ]
+        assert _validate_member_unique(members) is None
+
+    def test_same_agent_different_role_passes(self) -> None:
+        """Confirmation F: same agent_id under different roles is allowed."""
+        agent_id = uuid4()
+        members = [
+            make_leader_membership(agent_id=agent_id),
+            make_agent_membership(agent_id=agent_id, role=Role.REVIEWER),
+        ]
+        assert _validate_member_unique(members) is None
+
+    def test_duplicate_pair_raises_member_duplicate(self) -> None:
+        """Same ``(agent_id, role)`` raises ``member_duplicate``."""
+        agent_id = uuid4()
+        members = [
+            make_leader_membership(agent_id=agent_id),
+            make_leader_membership(agent_id=agent_id),
+        ]
+        with pytest.raises(RoomInvariantViolation) as excinfo:
+            _validate_member_unique(members)
+        assert excinfo.value.kind == "member_duplicate"
+
+
+class TestValidateMemberCapacity:
+    """``_validate_member_capacity`` is a module-level pure function (Confirmation C)."""
+
+    def test_at_capacity_returns_none(self) -> None:
+        """``MAX_MEMBERS`` entries pass."""
+        members = [
+            make_agent_membership(agent_id=uuid4(), role=Role.DEVELOPER) for _ in range(MAX_MEMBERS)
+        ]
+        assert _validate_member_capacity(members) is None
+
+    def test_overflow_raises_capacity_exceeded(self) -> None:
+        """``MAX_MEMBERS + 1`` raises ``capacity_exceeded``."""
+        members = [
+            make_agent_membership(agent_id=uuid4(), role=Role.DEVELOPER)
+            for _ in range(MAX_MEMBERS + 1)
+        ]
+        with pytest.raises(RoomInvariantViolation) as excinfo:
+            _validate_member_capacity(members)
+        assert excinfo.value.kind == "capacity_exceeded"

--- a/backend/tests/domain/room/test_integration.py
+++ b/backend/tests/domain/room/test_integration.py
@@ -1,0 +1,94 @@
+"""Round-trip scenarios across Room + PromptKit + AgentMembership + Exception (TC-IT-RM-001 / 002).
+
+The room feature is domain-only with zero external I/O, so "integration" here
+means *aggregate-internal module integration*: chained behaviors over a
+non-empty member list, with the original Room observed unchanged at each
+step (frozen + pre-validate rebuild, Confirmation A).
+
+These tests intentionally compose the production constructors / behaviors
+directly — no mocks, no test-only back doors — and exercise the documented
+acceptance criteria 1, 4, 7, 10, 11 in a single sequence.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from bakufu.domain.exceptions import RoomInvariantViolation
+from bakufu.domain.value_objects import Role
+
+from tests.factories.room import (
+    make_agent_membership,
+    make_leader_membership,
+    make_prompt_kit,
+    make_room,
+)
+
+
+class TestRoomLifecycleRoundTrip:
+    """TC-IT-RM-001: full Room lifecycle exercise across all behaviors."""
+
+    def test_full_lifecycle_preserves_immutability(self) -> None:
+        """TC-IT-RM-001: add → add → update → remove → archive sequence."""
+        # Step 1: empty Room.
+        room0 = make_room(members=[])
+        assert room0.members == []
+        assert room0.archived is False
+
+        # Step 2: add a leader.
+        leader = make_leader_membership(agent_id=uuid4())
+        room1 = room0.add_member(leader)
+        assert len(room1.members) == 1
+
+        # Step 3: add a developer.
+        developer = make_agent_membership(agent_id=uuid4(), role=Role.DEVELOPER)
+        room2 = room1.add_member(developer)
+        assert len(room2.members) == 2
+
+        # Step 4: replace PromptKit.
+        new_kit = make_prompt_kit(prefix_markdown="# V-Model Room policy\n\nbe rigorous")
+        room3 = room2.update_prompt_kit(new_kit)
+        assert "V-Model Room policy" in room3.prompt_kit.prefix_markdown
+
+        # Step 5: remove the developer.
+        room4 = room3.remove_member(developer.agent_id, developer.role)
+        assert len(room4.members) == 1
+        assert room4.members[0].agent_id == leader.agent_id
+
+        # Step 6: archive.
+        room5 = room4.archive()
+        assert room5.archived is True
+
+        # Frozen contract: each earlier Room stays unchanged across steps.
+        assert room0.members == []
+        assert len(room1.members) == 1
+        assert len(room2.members) == 2
+        assert "V-Model Room policy" not in room2.prompt_kit.prefix_markdown
+        assert room4.archived is False
+
+
+class TestAddMemberFailureThenSuccess:
+    """TC-IT-RM-002: add_member fails on duplicate, succeeds on a different pair."""
+
+    def test_failure_does_not_block_subsequent_success(self) -> None:
+        """TC-IT-RM-002: pre-validate isolation lets the next add proceed cleanly."""
+        leader = make_leader_membership(agent_id=uuid4())
+        room = make_room(members=[leader])
+
+        # First call: duplicate pair fails.
+        with pytest.raises(RoomInvariantViolation) as excinfo:
+            room.add_member(make_leader_membership(agent_id=leader.agent_id))
+        assert excinfo.value.kind == "member_duplicate"
+
+        # Original Room is unchanged.
+        assert len(room.members) == 1
+
+        # Second call: different pair succeeds.
+        new_developer = make_agent_membership(agent_id=uuid4(), role=Role.DEVELOPER)
+        new_room = room.add_member(new_developer)
+        assert len(new_room.members) == 2
+        # Pair set is what we expect.
+        pairs = {(m.agent_id, m.role) for m in new_room.members}
+        assert (leader.agent_id, Role.LEADER) in pairs
+        assert (new_developer.agent_id, Role.DEVELOPER) in pairs

--- a/backend/tests/domain/room/test_invariants.py
+++ b/backend/tests/domain/room/test_invariants.py
@@ -1,0 +1,76 @@
+"""Aggregate-level invariants (TC-UT-RM-005 / 006 / 009).
+
+Covers REQ-RM-006 (invariants ①〜⑤). Each invariant lives in its own
+``Test*`` class so failures cluster by which collection contract was violated.
+``(agent_id, role)`` pair uniqueness (Confirmation F) is exercised with both
+the duplicate-pair raise path and the **same agent + different role** allowed
+path so the test suite freezes the design's responsibility boundary.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from bakufu.domain.exceptions import RoomInvariantViolation
+from bakufu.domain.room import MAX_MEMBERS
+from bakufu.domain.value_objects import Role
+
+from tests.factories.room import (
+    make_agent_membership,
+    make_leader_membership,
+    make_room,
+)
+
+
+class TestMemberPairUniqueness:
+    """TC-UT-RM-005: same (agent_id, role) twice raises member_duplicate."""
+
+    def test_duplicate_pair_raises_member_duplicate(self) -> None:
+        """TC-UT-RM-005: two memberships sharing (agent_id, role) raises."""
+        agent_id = uuid4()
+        m1 = make_agent_membership(agent_id=agent_id, role=Role.DEVELOPER)
+        m2 = make_agent_membership(agent_id=agent_id, role=Role.DEVELOPER)
+        with pytest.raises(RoomInvariantViolation) as excinfo:
+            make_room(members=[m1, m2])
+        assert excinfo.value.kind == "member_duplicate"
+        assert excinfo.value.detail.get("agent_id") == str(agent_id)
+        assert excinfo.value.detail.get("role") == Role.DEVELOPER.value
+
+
+class TestSameAgentDifferentRoleAllowed:
+    """TC-UT-RM-006 (Confirmation F): same agent_id under different roles is allowed."""
+
+    def test_same_agent_two_roles_succeeds(self) -> None:
+        """TC-UT-RM-006: leader + reviewer for same agent is a valid Room."""
+        agent_id = uuid4()
+        m_leader = make_leader_membership(agent_id=agent_id)
+        m_reviewer = make_agent_membership(agent_id=agent_id, role=Role.REVIEWER)
+        room = make_room(members=[m_leader, m_reviewer])
+        assert len(room.members) == 2
+        roles = {m.role for m in room.members}
+        assert roles == {Role.LEADER, Role.REVIEWER}
+
+
+class TestMemberCapacity:
+    """TC-UT-RM-009: members ≤ MAX_MEMBERS (Confirmation C)."""
+
+    def test_at_capacity_succeeds(self) -> None:
+        """TC-UT-RM-009 boundary: exactly MAX_MEMBERS=50 succeeds."""
+        members = [
+            make_agent_membership(agent_id=uuid4(), role=Role.DEVELOPER) for _ in range(MAX_MEMBERS)
+        ]
+        room = make_room(members=members)
+        assert len(room.members) == MAX_MEMBERS
+
+    def test_overflow_raises_capacity_exceeded(self) -> None:
+        """TC-UT-RM-009: MAX_MEMBERS+1 raises capacity_exceeded with count detail."""
+        members = [
+            make_agent_membership(agent_id=uuid4(), role=Role.DEVELOPER)
+            for _ in range(MAX_MEMBERS + 1)
+        ]
+        with pytest.raises(RoomInvariantViolation) as excinfo:
+            make_room(members=members)
+        assert excinfo.value.kind == "capacity_exceeded"
+        assert excinfo.value.detail.get("members_count") == MAX_MEMBERS + 1
+        assert excinfo.value.detail.get("max_members") == MAX_MEMBERS

--- a/backend/tests/domain/room/test_msg_wording.py
+++ b/backend/tests/domain/room/test_msg_wording.py
@@ -1,0 +1,199 @@
+"""MSG-RM-001〜007 wording + Next: hint physical guarantee (TC-UT-RM-031〜037).
+
+Each MSG follows a 2-line structure (Confirmation I, Norman R1):
+
+    [FAIL] <failure fact>
+    Next: <recommended next action>
+
+The first line is asserted **exactly** so future i18n / refactoring cannot
+silently drift the operator-visible failure fact. The second line is
+asserted via substring on the leading ``Next:`` token *and* a topic phrase
+so the design-time hint contract survives cosmetic edits while the
+"hint exists" property is locked in by CI.
+
+MSG-RM-007 travels the :class:`pydantic.ValidationError` path (PromptKit VO
+construction) per Confirmation I two-stage catch — *not* the
+:class:`RoomInvariantViolation` path. The test below pins that contract.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from bakufu.domain.exceptions import RoomInvariantViolation
+from bakufu.domain.room import MAX_MEMBERS, PROMPT_KIT_PREFIX_MAX, PromptKit
+from bakufu.domain.value_objects import Role
+from pydantic import ValidationError
+
+from tests.factories.room import (
+    make_agent_membership,
+    make_archived_room,
+    make_leader_membership,
+    make_room,
+)
+
+
+class TestMsgRm001NameRange:
+    """TC-UT-RM-031: MSG-RM-001 + Next: hint."""
+
+    def test_failure_line_matches_exact_wording(self) -> None:
+        """TC-UT-RM-031: failure line '[FAIL] Room name must be 1-80 ...' exact."""
+        with pytest.raises(RoomInvariantViolation) as excinfo:
+            make_room(name="a" * 81)
+        assert excinfo.value.message.startswith("[FAIL] Room name must be 1-80 characters (got 81)")
+
+    def test_next_hint_present(self) -> None:
+        """TC-UT-RM-031: 'Next:' hint exists with NFC-normalized topic phrase."""
+        with pytest.raises(RoomInvariantViolation) as excinfo:
+            make_room(name="a" * 81)
+        assert "Next:" in excinfo.value.message
+        assert "1-80 NFC-normalized" in excinfo.value.message
+
+
+class TestMsgRm002DescriptionTooLong:
+    """TC-UT-RM-032: MSG-RM-002 + Next: hint."""
+
+    def test_failure_line_matches_exact_wording(self) -> None:
+        """TC-UT-RM-032: failure line '[FAIL] Room description must be 0-500 ...' exact."""
+        with pytest.raises(RoomInvariantViolation) as excinfo:
+            make_room(description="a" * 501)
+        assert excinfo.value.message.startswith(
+            "[FAIL] Room description must be 0-500 characters (got 501)"
+        )
+
+    def test_next_hint_routes_overflow_to_prompt_kit(self) -> None:
+        """TC-UT-RM-032: 'Next:' hint mentions PromptKit.prefix_markdown overflow path."""
+        with pytest.raises(RoomInvariantViolation) as excinfo:
+            make_room(description="a" * 501)
+        assert "Next:" in excinfo.value.message
+        assert "PromptKit.prefix_markdown" in excinfo.value.message
+
+
+class TestMsgRm003MemberDuplicate:
+    """TC-UT-RM-033: MSG-RM-003 + Next: hint (different role suggestion)."""
+
+    def test_failure_line_includes_pair_identifiers(self) -> None:
+        """TC-UT-RM-033: '[FAIL] Duplicate member: agent_id=..., role=LEADER' format."""
+        agent_id = uuid4()
+        m1 = make_leader_membership(agent_id=agent_id)
+        m2 = make_leader_membership(agent_id=agent_id)
+        with pytest.raises(RoomInvariantViolation) as excinfo:
+            make_room(members=[m1, m2])
+        assert "[FAIL] Duplicate member" in excinfo.value.message
+        assert f"agent_id={agent_id}" in excinfo.value.message
+        assert "role=LEADER" in excinfo.value.message
+
+    def test_next_hint_recommends_different_role(self) -> None:
+        """TC-UT-RM-033: 'Next:' hint mentions different role (leader + reviewer)."""
+        agent_id = uuid4()
+        m1 = make_leader_membership(agent_id=agent_id)
+        m2 = make_leader_membership(agent_id=agent_id)
+        with pytest.raises(RoomInvariantViolation) as excinfo:
+            make_room(members=[m1, m2])
+        assert "Next:" in excinfo.value.message
+        assert "different role" in excinfo.value.message
+
+
+class TestMsgRm004CapacityExceeded:
+    """TC-UT-RM-034: MSG-RM-004 + Next: hint (remove or split)."""
+
+    def test_failure_line_matches_exact_wording(self) -> None:
+        """TC-UT-RM-034: '[FAIL] Room members capacity exceeded (got 51, max 50)' exact."""
+        members = [
+            make_agent_membership(agent_id=uuid4(), role=Role.DEVELOPER)
+            for _ in range(MAX_MEMBERS + 1)
+        ]
+        with pytest.raises(RoomInvariantViolation) as excinfo:
+            make_room(members=members)
+        assert excinfo.value.message.startswith(
+            f"[FAIL] Room members capacity exceeded (got {MAX_MEMBERS + 1}, max {MAX_MEMBERS})"
+        )
+
+    def test_next_hint_routes_to_remove_or_split(self) -> None:
+        """TC-UT-RM-034: 'Next:' hint suggests remove unused members or split work."""
+        members = [
+            make_agent_membership(agent_id=uuid4(), role=Role.DEVELOPER)
+            for _ in range(MAX_MEMBERS + 1)
+        ]
+        with pytest.raises(RoomInvariantViolation) as excinfo:
+            make_room(members=members)
+        assert "Next:" in excinfo.value.message
+        assert ("Remove unused members" in excinfo.value.message) or (
+            "split the work" in excinfo.value.message
+        )
+
+
+class TestMsgRm005MemberNotFound:
+    """TC-UT-RM-035: MSG-RM-005 + Next: hint."""
+
+    def test_failure_line_matches_format(self) -> None:
+        """TC-UT-RM-035: '[FAIL] Member not found: agent_id=..., role=DEVELOPER' format."""
+        room = make_room(members=[])
+        unknown = uuid4()
+        with pytest.raises(RoomInvariantViolation) as excinfo:
+            room.remove_member(unknown, Role.DEVELOPER)
+        assert "[FAIL] Member not found" in excinfo.value.message
+        assert f"agent_id={unknown}" in excinfo.value.message
+        assert "role=DEVELOPER" in excinfo.value.message
+
+    def test_next_hint_routes_to_get_members_endpoint(self) -> None:
+        """TC-UT-RM-035: 'Next:' hint routes operator to GET /rooms or 'already removed'."""
+        room = make_room(members=[])
+        with pytest.raises(RoomInvariantViolation) as excinfo:
+            room.remove_member(uuid4(), Role.DEVELOPER)
+        assert "Next:" in excinfo.value.message
+        assert ("GET /rooms/" in excinfo.value.message) or (
+            "already removed" in excinfo.value.message
+        )
+
+
+class TestMsgRm006RoomArchived:
+    """TC-UT-RM-036: MSG-RM-006 + Next: hint (Phase 2 unarchive)."""
+
+    def test_failure_line_includes_room_id(self) -> None:
+        """TC-UT-RM-036: '[FAIL] Cannot modify archived Room: room_id=...' format."""
+        room_id = uuid4()
+        room = make_archived_room(room_id=room_id)
+        with pytest.raises(RoomInvariantViolation) as excinfo:
+            room.add_member(make_agent_membership(agent_id=uuid4(), role=Role.DEVELOPER))
+        assert "[FAIL] Cannot modify archived Room" in excinfo.value.message
+        assert f"room_id={room_id}" in excinfo.value.message
+
+    def test_next_hint_mentions_create_new_room_and_phase_2(self) -> None:
+        """TC-UT-RM-036: 'Next:' hint advises creating a new Room and notes Phase 2."""
+        room = make_archived_room()
+        with pytest.raises(RoomInvariantViolation) as excinfo:
+            room.add_member(make_agent_membership(agent_id=uuid4(), role=Role.DEVELOPER))
+        assert "Next:" in excinfo.value.message
+        assert "Create a new Room" in excinfo.value.message
+        assert "Phase 2" in excinfo.value.message
+
+
+class TestMsgRm007PromptKitTooLong:
+    """TC-UT-RM-037: MSG-RM-007 via pydantic.ValidationError (Confirmation I).
+
+    Length violations on PromptKit fail at VO construction with
+    :class:`ValidationError` — *not* :class:`RoomInvariantViolation`. The
+    aggregate's ``kind`` Literal intentionally omits ``prompt_kit_too_long``
+    so the dead-code path is closed by construction (Norman R2 / §確定 I).
+    """
+
+    def test_failure_line_includes_get_length(self) -> None:
+        """TC-UT-RM-037: ValidationError carries '[FAIL] PromptKit.prefix_markdown ...'."""
+        with pytest.raises(ValidationError) as excinfo:
+            PromptKit(prefix_markdown="a" * (PROMPT_KIT_PREFIX_MAX + 1))
+        msg = str(excinfo.value)
+        assert (
+            f"[FAIL] PromptKit.prefix_markdown must be 0-{PROMPT_KIT_PREFIX_MAX} "
+            f"characters (got {PROMPT_KIT_PREFIX_MAX + 1})"
+        ) in msg
+
+    def test_next_hint_mentions_phase_2_extensions(self) -> None:
+        """TC-UT-RM-037: 'Next:' hint references Phase 2 sections / variables."""
+        with pytest.raises(ValidationError) as excinfo:
+            PromptKit(prefix_markdown="a" * (PROMPT_KIT_PREFIX_MAX + 1))
+        msg = str(excinfo.value)
+        assert "Next:" in msg
+        # Phase 2 extension keywords from detailed-design.md §確定 I.
+        assert "variables" in msg or "role_specific_prefix" in msg or "sections" in msg

--- a/backend/tests/domain/room/test_mutators.py
+++ b/backend/tests/domain/room/test_mutators.py
@@ -1,0 +1,121 @@
+"""Mutator behaviors with pre-validate rebuild semantics (Confirmation A).
+
+Covers TC-UT-RM-004 / 007 / 008 / 010 / 020 / 021 / 022. Each behavior
+returns a *new* :class:`Room` instance and the original stays unchanged on
+both success and failure paths — the test suite freezes that immutability
+contract so future refactors that mutate-in-place are caught immediately.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from bakufu.domain.exceptions import RoomInvariantViolation
+from bakufu.domain.value_objects import Role
+
+from tests.factories.room import (
+    make_agent_membership,
+    make_archived_room,
+    make_leader_membership,
+    make_prompt_kit,
+    make_room,
+)
+
+
+class TestAddMember:
+    """TC-UT-RM-004: add_member appends without mutating the original."""
+
+    def test_add_member_appends_to_new_room(self) -> None:
+        """TC-UT-RM-004: members count grows by 1 on the returned Room."""
+        room = make_room(members=[])
+        m = make_agent_membership(agent_id=uuid4(), role=Role.DEVELOPER)
+        new_room = room.add_member(m)
+        assert len(new_room.members) == 1
+        assert new_room.members[0] == m
+
+    def test_add_member_does_not_mutate_original(self) -> None:
+        """TC-UT-RM-004: the original Room.members stays empty after add."""
+        room = make_room(members=[])
+        m = make_agent_membership(agent_id=uuid4(), role=Role.DEVELOPER)
+        room.add_member(m)
+        assert room.members == []
+
+
+class TestRemoveMember:
+    """TC-UT-RM-007 / 008: remove_member success + missing-pair Fail Fast."""
+
+    def test_remove_member_drops_matching_pair(self) -> None:
+        """TC-UT-RM-007: removing one of two members yields a 1-member Room."""
+        agent_id = uuid4()
+        m1 = make_leader_membership(agent_id=agent_id)
+        m2 = make_agent_membership(agent_id=uuid4(), role=Role.DEVELOPER)
+        room = make_room(members=[m1, m2])
+        new_room = room.remove_member(m1.agent_id, m1.role)
+        assert len(new_room.members) == 1
+        assert new_room.members[0].agent_id == m2.agent_id
+
+    def test_remove_unknown_pair_raises_member_not_found(self) -> None:
+        """TC-UT-RM-008: remove_member with absent (agent_id, role) raises."""
+        room = make_room(members=[])
+        with pytest.raises(RoomInvariantViolation) as excinfo:
+            room.remove_member(uuid4(), Role.DEVELOPER)
+        assert excinfo.value.kind == "member_not_found"
+
+    def test_remove_keeps_original_unchanged(self) -> None:
+        """TC-UT-RM-007: the original Room.members stays at 2 after remove."""
+        m1 = make_leader_membership(agent_id=uuid4())
+        m2 = make_agent_membership(agent_id=uuid4(), role=Role.DEVELOPER)
+        room = make_room(members=[m1, m2])
+        room.remove_member(m1.agent_id, m1.role)
+        assert len(room.members) == 2
+
+
+class TestUpdatePromptKit:
+    """TC-UT-RM-010: update_prompt_kit replaces without mutating the original."""
+
+    def test_update_prompt_kit_replaces_on_new_instance(self) -> None:
+        """TC-UT-RM-010: returned Room carries the new prefix_markdown."""
+        room = make_room()
+        new_kit = make_prompt_kit(prefix_markdown="# Updated")
+        new_room = room.update_prompt_kit(new_kit)
+        assert new_room.prompt_kit.prefix_markdown == "# Updated"
+
+    def test_update_prompt_kit_does_not_mutate_original(self) -> None:
+        """TC-UT-RM-010: the original Room.prompt_kit stays empty."""
+        room = make_room()
+        new_kit = make_prompt_kit(prefix_markdown="# Updated")
+        room.update_prompt_kit(new_kit)
+        assert room.prompt_kit.prefix_markdown == ""
+
+
+class TestPreValidateRollback:
+    """Confirmation A: failed mutators leave the original Room intact."""
+
+    def test_add_member_failure_does_not_mutate_original(self) -> None:
+        """TC-UT-RM-020: duplicate-pair add_member leaves room.members unchanged."""
+        agent_id = uuid4()
+        m = make_leader_membership(agent_id=agent_id)
+        room = make_room(members=[m])
+        dup = make_leader_membership(agent_id=agent_id)
+        with pytest.raises(RoomInvariantViolation):
+            room.add_member(dup)
+        assert len(room.members) == 1
+        assert room.members[0].agent_id == agent_id
+
+    def test_remove_member_failure_does_not_mutate_original(self) -> None:
+        """TC-UT-RM-021: missing-pair remove_member leaves room.members unchanged."""
+        m = make_leader_membership(agent_id=uuid4())
+        room = make_room(members=[m])
+        with pytest.raises(RoomInvariantViolation):
+            room.remove_member(uuid4(), Role.DEVELOPER)
+        assert len(room.members) == 1
+        assert room.members[0] == m
+
+    def test_update_prompt_kit_failure_does_not_mutate_original(self) -> None:
+        """TC-UT-RM-022: archived Room update fails; original prompt_kit unchanged."""
+        original_kit = make_prompt_kit(prefix_markdown="# Original")
+        room = make_archived_room(prompt_kit=original_kit)
+        with pytest.raises(RoomInvariantViolation):
+            room.update_prompt_kit(make_prompt_kit(prefix_markdown="# Changed"))
+        assert room.prompt_kit.prefix_markdown == "# Original"

--- a/backend/tests/domain/room/test_prompt_kit.py
+++ b/backend/tests/domain/room/test_prompt_kit.py
@@ -1,0 +1,71 @@
+"""PromptKit Value Object tests (TC-UT-RM-019 / 024, Confirmations B / G).
+
+PromptKit is a single-attribute frozen VO held to NFC normalization (no
+strip — Markdown body retains leading/trailing whitespace) and a 10000-char
+upper bound. Length violations surface as :class:`pydantic.ValidationError`
+*not* :class:`RoomInvariantViolation` per Room §確定 I two-stage catch.
+"""
+
+from __future__ import annotations
+
+import pytest
+from bakufu.domain.room import PROMPT_KIT_PREFIX_MAX, PromptKit
+from pydantic import ValidationError
+
+from tests.factories.room import make_prompt_kit, make_room
+
+
+class TestPromptKitBoundary:
+    """TC-UT-RM-019: 0 / 10000 / 10001 + leading/trailing newline preservation."""
+
+    @pytest.mark.parametrize("length", [0, PROMPT_KIT_PREFIX_MAX])
+    def test_valid_lengths_succeed(self, length: int) -> None:
+        """TC-UT-RM-019: prefix_markdown of length 0 and 10000 succeed."""
+        kit = make_prompt_kit(prefix_markdown="a" * length)
+        assert len(kit.prefix_markdown) == length
+
+    def test_oversized_prefix_raises_validation_error(self) -> None:
+        """TC-UT-RM-019: 10001 chars raises pydantic.ValidationError per §確定 I."""
+        with pytest.raises(ValidationError) as excinfo:
+            make_prompt_kit(prefix_markdown="a" * (PROMPT_KIT_PREFIX_MAX + 1))
+        # Confirmation I freezes that PromptKit length errors do *not* travel
+        # the RoomInvariantViolation path. The MSG-RM-007 wording is asserted
+        # in test_msg_wording.py.
+        assert "PromptKit.prefix_markdown" in str(excinfo.value)
+
+    def test_prompt_kit_preserves_leading_and_trailing_newlines(self) -> None:
+        """TC-UT-RM-019 + 018: PromptKit applies NFC only — newlines kept.
+
+        Markdown semantics: ``\\n# Heading\\n\\nbody\\n\\n`` retains the
+        wrapping newlines because the body's trailing whitespace is part of
+        the prompt template.
+        """
+        text = "\n# Heading\n\nbody\n\n"
+        kit = make_prompt_kit(prefix_markdown=text)
+        assert kit.prefix_markdown == text
+
+
+class TestPromptKitStructuralEquality:
+    """TC-UT-RM-024: PromptKit / Room frozen → structural equality + hashable."""
+
+    def test_two_prompt_kits_with_same_attrs_compare_equal(self) -> None:
+        """TC-UT-RM-024: two PromptKits with identical prefix compare equal."""
+        a = PromptKit(prefix_markdown="hello")
+        b = PromptKit(prefix_markdown="hello")
+        assert a == b
+
+    def test_two_prompt_kits_with_same_attrs_hash_equal(self) -> None:
+        """TC-UT-RM-024: structurally equal PromptKits share hash."""
+        a = PromptKit(prefix_markdown="hello")
+        b = PromptKit(prefix_markdown="hello")
+        assert hash(a) == hash(b)
+
+    def test_two_rooms_with_same_attrs_compare_equal(self) -> None:
+        """TC-UT-RM-024: two Rooms with identical attributes compare equal."""
+        from uuid import uuid4
+
+        room_id = uuid4()
+        workflow_id = uuid4()
+        a = make_room(room_id=room_id, workflow_id=workflow_id)
+        b = make_room(room_id=room_id, workflow_id=workflow_id)
+        assert a == b

--- a/backend/tests/domain/room/test_webhook_masking.py
+++ b/backend/tests/domain/room/test_webhook_masking.py
@@ -1,0 +1,78 @@
+"""Discord webhook secret masking on RoomInvariantViolation (TC-UT-RM-014).
+
+Confirmation H: ``RoomInvariantViolation`` masks webhook URLs in both
+``message`` and ``detail`` at construction time. ``Room.name`` /
+``Room.description`` / ``PromptKit.prefix_markdown`` may all carry user-
+pasted text containing a webhook URL, so the exception path is the *last*
+defense before that secret would be serialized into a log line or HTTP
+response body.
+"""
+
+from __future__ import annotations
+
+import pytest
+from bakufu.domain.exceptions import RoomInvariantViolation
+
+from tests.factories.room import make_room
+
+# A webhook URL designed to fail the description length check (>500 chars).
+# The id segment (numeric) stays visible; the token segment must be redacted.
+_WEBHOOK_ID = "1234567890123456789"
+_WEBHOOK_TOKEN = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWX"
+_WEBHOOK_URL = f"https://discord.com/api/webhooks/{_WEBHOOK_ID}/{_WEBHOOK_TOKEN}"
+_REDACTED = "<REDACTED:DISCORD_WEBHOOK>"
+
+
+class TestWebhookMaskingOnDescriptionViolation:
+    """TC-UT-RM-014: webhook URL in oversize description is redacted in exception text."""
+
+    def test_token_segment_is_redacted_in_message(self) -> None:
+        """TC-UT-RM-014: exception.message contains the redacted token marker."""
+        # Build a description >500 chars that *contains* the webhook URL.
+        description = _WEBHOOK_URL + ("a" * 600)
+        with pytest.raises(RoomInvariantViolation) as excinfo:
+            make_room(description=description)
+        assert _WEBHOOK_TOKEN not in excinfo.value.message
+        # The webhook id stays for traceability; only token is redacted.
+
+    def test_token_segment_does_not_leak_into_str_exc(self) -> None:
+        """TC-UT-RM-014: str(exc) (used by default logging) carries no token."""
+        description = _WEBHOOK_URL + ("a" * 600)
+        with pytest.raises(RoomInvariantViolation) as excinfo:
+            make_room(description=description)
+        assert _WEBHOOK_TOKEN not in str(excinfo.value)
+
+
+class TestWebhookMaskingOnDetail:
+    """TC-UT-RM-014: webhook URL embedded in detail dict is also redacted."""
+
+    def test_redacted_marker_substitutes_token_in_detail(self) -> None:
+        """TC-UT-RM-014: detail values produced by exception path are masked.
+
+        We trigger a name_range violation with an oversized name carrying a
+        webhook URL. The aggregate validators only put structural data in
+        ``detail`` (length / count), but the masking pass walks the whole
+        dict so any string-valued context is run through
+        :func:`mask_discord_webhook_in`. The contract is that no detail
+        value contains the raw token segment.
+        """
+        # Build an oversize name (>80 chars) carrying the webhook URL.
+        name = _WEBHOOK_URL + "x"
+        with pytest.raises(RoomInvariantViolation) as excinfo:
+            make_room(name=name)
+        # Walk all string values in detail; none should expose the token.
+        for value in excinfo.value.detail.values():
+            assert _WEBHOOK_TOKEN not in str(value)
+
+
+class TestWebhookMaskingIdempotent:
+    """Confirmation H supplemental: masking applied twice yields the same string."""
+
+    def test_already_masked_url_is_not_re_substituted(self) -> None:
+        """``mask_discord_webhook`` is idempotent so re-application is a no-op."""
+        from bakufu.domain.value_objects import mask_discord_webhook
+
+        once = mask_discord_webhook(_WEBHOOK_URL)
+        twice = mask_discord_webhook(once)
+        assert once == twice
+        assert _REDACTED in once

--- a/backend/tests/factories/room.py
+++ b/backend/tests/factories/room.py
@@ -1,0 +1,168 @@
+"""Factories for the Room aggregate, its entities, and its VOs.
+
+Per ``docs/features/room/test-design.md``. Mirrors the empire / workflow /
+agent pattern: every factory returns a *valid* default instance built through
+the production constructor, allows keyword overrides, and registers the
+result in a :class:`WeakValueDictionary` so :func:`is_synthetic` can later
+flag test-built objects without mutating the frozen Pydantic models.
+
+Default Room composes one ``LeaderMembership`` and zero PromptKit prefix
+content so the simplest construction path covers TC-UT-RM-001 with no extra
+setup. Tests that need an empty members list pass ``members=[]`` explicitly,
+which is allowed (Aggregate-level invariants accept 0〜:data:`MAX_MEMBERS`
+entries — leader-required is an application-layer responsibility, see
+TC-UT-RM-029).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from uuid import UUID, uuid4
+from weakref import WeakValueDictionary
+
+from bakufu.domain.room import (
+    AgentMembership,
+    PromptKit,
+    Room,
+)
+from bakufu.domain.value_objects import Role
+from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+# Module-scope registry. Values are kept weakly so GC pressure stays neutral.
+_SYNTHETIC_REGISTRY: WeakValueDictionary[int, BaseModel] = WeakValueDictionary()
+
+
+def is_synthetic(instance: BaseModel) -> bool:
+    """Return ``True`` when ``instance`` was created by a factory in this module."""
+    cached = _SYNTHETIC_REGISTRY.get(id(instance))
+    return cached is instance
+
+
+def _register(instance: BaseModel) -> None:
+    """Record ``instance`` in the synthetic registry."""
+    _SYNTHETIC_REGISTRY[id(instance)] = instance
+
+
+# ---------------------------------------------------------------------------
+# AgentMembership
+# ---------------------------------------------------------------------------
+def make_agent_membership(
+    *,
+    agent_id: UUID | None = None,
+    role: Role = Role.DEVELOPER,
+    joined_at: datetime | None = None,
+) -> AgentMembership:
+    """Build a valid :class:`AgentMembership` (default role DEVELOPER)."""
+    membership = AgentMembership(
+        agent_id=agent_id if agent_id is not None else uuid4(),
+        role=role,
+        joined_at=joined_at if joined_at is not None else datetime.now(UTC),
+    )
+    _register(membership)
+    return membership
+
+
+def make_leader_membership(
+    *,
+    agent_id: UUID | None = None,
+    joined_at: datetime | None = None,
+) -> AgentMembership:
+    """Build a LEADER-role :class:`AgentMembership` for populated Room scenarios."""
+    return make_agent_membership(
+        agent_id=agent_id,
+        role=Role.LEADER,
+        joined_at=joined_at,
+    )
+
+
+# ---------------------------------------------------------------------------
+# PromptKit
+# ---------------------------------------------------------------------------
+def make_prompt_kit(
+    *,
+    prefix_markdown: str = "",
+) -> PromptKit:
+    """Build a valid :class:`PromptKit` (default empty prefix_markdown)."""
+    kit = PromptKit(prefix_markdown=prefix_markdown)
+    _register(kit)
+    return kit
+
+
+def make_long_prompt_kit() -> PromptKit:
+    """Build a :class:`PromptKit` at the upper boundary (10000 chars)."""
+    return make_prompt_kit(prefix_markdown="a" * 10_000)
+
+
+# ---------------------------------------------------------------------------
+# Room
+# ---------------------------------------------------------------------------
+def make_room(
+    *,
+    room_id: UUID | None = None,
+    name: str = "Vモデル開発室",
+    description: str = "",
+    workflow_id: UUID | None = None,
+    members: Sequence[AgentMembership] | None = None,
+    prompt_kit: PromptKit | None = None,
+    archived: bool = False,
+) -> Room:
+    """Build a valid :class:`Room`.
+
+    With no overrides yields the simplest valid Room: zero members, empty
+    description, default empty PromptKit, ``archived=False``. Tests that need
+    populated members pass them explicitly via ``members=[...]``.
+    """
+    if prompt_kit is None:
+        prompt_kit = make_prompt_kit()
+    room = Room(
+        id=room_id if room_id is not None else uuid4(),
+        name=name,
+        description=description,
+        workflow_id=workflow_id if workflow_id is not None else uuid4(),
+        members=list(members) if members is not None else [],
+        prompt_kit=prompt_kit,
+        archived=archived,
+    )
+    _register(room)
+    return room
+
+
+def make_archived_room(**overrides: object) -> Room:
+    """Build a Room with ``archived=True`` for idempotency / terminal-violation setups."""
+    return make_room(archived=True, **overrides)  # pyright: ignore[reportArgumentType]
+
+
+def make_populated_room(
+    *,
+    room_id: UUID | None = None,
+    leader_agent_id: UUID | None = None,
+    developer_agent_id: UUID | None = None,
+) -> Room:
+    """Build a Room with one LEADER + one DEVELOPER membership.
+
+    Useful for TC-IT-RM-001 / 002 round-trip scenarios that exercise add /
+    remove / update / archive transitions over a non-empty member list.
+    """
+    return make_room(
+        room_id=room_id,
+        members=[
+            make_leader_membership(agent_id=leader_agent_id),
+            make_agent_membership(agent_id=developer_agent_id, role=Role.DEVELOPER),
+        ],
+    )
+
+
+__all__ = [
+    "is_synthetic",
+    "make_agent_membership",
+    "make_archived_room",
+    "make_leader_membership",
+    "make_long_prompt_kit",
+    "make_populated_room",
+    "make_prompt_kit",
+    "make_room",
+]


### PR DESCRIPTION
## Summary

- M1 ドメイン骨格 4 番目の Aggregate として **Room Aggregate Root** 実装
- `docs/features/room/` 設計書（develop 取込済み、PR #20）の §確定 A〜H に完全準拠
- M1 三本柱（empire / workflow / agent）と同パターンのディレクトリ層分離

## Implementation

### `domain/room/` — 4 sibling modules

| ファイル | 行数 | 責務 |
|---------|------|------|
| `room.py` | 218 | Room Aggregate Root + behaviors |
| `value_objects.py` | 117 | `AgentMembership` / `PromptKit` |
| `aggregate_validators.py` | 131 | 4 helpers (`_validate_*`) |
| `__init__.py` | 53 | public re-export |

すべて 270 行目安以内。agent と同じファイル分割方針。

### `domain/exceptions.py` 更新

`RoomInvariantViolation` を追加。`__init__` で `mask_discord_webhook` + `mask_discord_webhook_in` を `super().__init__` 前に強制適用（§確定 H、agent / workflow 同パターン）。

`kind` は **6 種固定**: `name_range` / `description_too_long` / `member_duplicate` / `capacity_exceeded` / `member_not_found` / `room_archived`。`prompt_kit_too_long` は **意図的に含めない**（VO 経由で `pydantic.ValidationError` として raise されるため、`RoomInvariantViolation` には到達しない構造、§確定 I）。

## Design contracts honored

- **§確定 A** pre-validate rebuild: `model_dump → swap → model_validate` で `_check_invariants` を再走させる
- **§確定 B** NFC + strip パイプライン共有（empire / workflow / agent と同一）。`PromptKit.prefix_markdown` のみ NFC のみで strip 抜き（Markdown 改行保持）
- **§確定 C** member capacity ≤ 50
- **§確定 D** `archive()` は常に新インスタンスを返す。冪等性は構造的等価で担保、オブジェクト同一性ではない
- **§確定 E** archived Room は `add_member` / `remove_member` / `update_prompt_kit` を Fail Fast で拒否。`archive()` 自身は通過（冪等）
- **§確定 F** `(agent_id, role)` ペアで一意。同一 Agent の複数 Role 兼任を許容
- **§確定 G** `PromptKit` を単一属性 VO のまま維持（Phase 2 拡張余地）
- **§確定 H** `RoomInvariantViolation` の auto-mask
- **§確定 I** 例外型統一規約と 2 段階 catch（`RoomInvariantViolation` × `pydantic.ValidationError`）
- **MSG-RM-001〜006** 2 行構造（failure / `Next: ...`）。Norman R1「フィードバック原則」物理保証

## Application-layer responsibilities (intentionally NOT enforced here)

| 検査項目 | レイヤ |
|---------|-------|
| Workflow 参照整合性 | `RoomService.create()` / `add_member()` |
| Agent 存在検証 | 同上 |
| Workflow が要求する LEADER 必須性 | 同上 |
| Empire 内 `name` 一意 | `EmpireService.establish_room()` |

agent §確定 R1-B / §確定 I と同じ責務分離方針。

## Quality gates (local)

- `pyright --strict`: **0 errors, 0 warnings**
- `ruff check backend/`: **All checks passed**
- `ruff format --check backend/`: **53 files already formatted**
- `pytest backend/`: **297 passed** (no regression on empire / workflow / agent)

## Tests

本 PR は **実装のみ**（agent PR #17 と同パターン）。`docs/features/room/test-design.md` の TC-UT-RM-001〜037 + TC-IT-RM-001〜002 はテスト担当が `test(room):` コミットで追加する。

## Test plan

- [ ] `pyright --strict` 0 errors
- [ ] `ruff check` clean
- [ ] `ruff format --check` clean
- [ ] 既存 297 テスト無回帰
- [ ] テスト担当による TC-UT-RM-001〜037 + TC-IT-RM-001〜002 実装後にカバレッジ確認

## Refs

- Issue: #18
- 設計書: `docs/features/room/{requirements-analysis,requirements,basic-design,detailed-design,test-design}.md`
- 凍結済み: `docs/architecture/domain-model/aggregates.md` §Room
- 先行 PR: #20 (Room 設計), #17 (Agent 実装パターン)