### PR TITLE
docs(directive): Vモデル design for Directive Aggregate Root

### DIFF
--- a/docs/features/directive/basic-design.md
+++ b/docs/features/directive/basic-design.md
@@ -1,0 +1,194 @@
+# 基本設計書
+
+> feature: `directive`
+> 関連: [requirements.md](requirements.md) / [`docs/architecture/domain-model/aggregates.md`](../../architecture/domain-model/aggregates.md) §Directive
+
+## 記述ルール（必ず守ること）
+
+基本設計に**疑似コード・サンプル実装（python/ts/sh/yaml 等の言語コードブロック）を書かない**。
+ソースコードと二重管理になりメンテナンスコストしか生まない。
+必要なのは構造契約（クラス・モジュール・データの関係）であり、実装の細部は [detailed-design.md](detailed-design.md) で凍結する。
+
+## モジュール構成
+
+| 機能 ID | モジュール | ディレクトリ | 責務 |
+|--------|----------|------------|------|
+| REQ-DR-001〜003 | `Directive` Aggregate Root | `backend/src/bakufu/domain/directive/directive.py` | Directive の属性・不変条件・ふるまい |
+| REQ-DR-003 | 不変条件 helper | `backend/src/bakufu/domain/directive/aggregate_validators.py` | `_validate_text_range` / `_validate_task_link_immutable` |
+| REQ-DR-001 | `DirectiveInvariantViolation` 例外 | `backend/src/bakufu/domain/exceptions.py`（既存ファイル更新） | webhook auto-mask 強制（agent / workflow / room と同パターン） |
+| 公開 API | re-export | `backend/src/bakufu/domain/directive/__init__.py` | `Directive` / `DirectiveInvariantViolation` を re-export |
+
+```
+ディレクトリ構造（本 feature で追加・変更されるファイル）:
+
+.
+├── backend/
+│   ├── src/
+│   │   └── bakufu/
+│   │       └── domain/
+│   │           ├── directive/                    # 新規ディレクトリ（room と同パターン）
+│   │           │   ├── __init__.py               # 新規: 公開 API re-export
+│   │           │   ├── directive.py              # 新規: Directive Aggregate Root
+│   │           │   └── aggregate_validators.py   # 新規: _validate_* helper
+│   │           └── exceptions.py                 # 既存更新: DirectiveInvariantViolation 追加
+│   └── tests/
+│       └── domain/
+│           └── directive/
+│               ├── __init__.py                   # 新規
+│               └── test_directive.py             # 新規: ユニットテスト
+└── docs/
+    └── features/
+        └── directive/                            # 本 feature 設計書 4 本
+```
+
+## クラス設計（概要）
+
+```mermaid
+classDiagram
+    class Directive {
+        +id: DirectiveId
+        +text: str
+        +target_room_id: RoomId
+        +created_at: datetime
+        +task_id: TaskId | None
+        +link_task(task_id) Directive
+    }
+    class DirectiveInvariantViolation
+
+    Directive ..> DirectiveInvariantViolation : raises
+```
+
+**凝集のポイント**:
+
+- Directive 自身は frozen（Pydantic v2 `model_config.frozen=True`）
+- 状態変更ふるまい（`link_task`）は新インスタンスを返す（pre-validate 方式）
+- `text` の長さ・`task_id` の一意遷移は **Aggregate 内部で守る**（構造的不変条件）
+- `target_room_id` 参照整合性 / `$` プレフィックス正規化は **application 層責務**（外部知識を要するため）
+
+## 処理フロー
+
+### ユースケース 1: Directive 発行（DirectiveService.issue）
+
+1. application 層が `DirectiveService.issue(raw_text, target_room_id)` を呼び出す（UI / API 経由）
+2. application 層が `text = raw_text if raw_text.startswith('$') else '$' + raw_text` で正規化（§確定 R1-A）
+3. application 層が `RoomRepository.find_by_id(target_room_id)` で Room 存在検証（不在なら `RoomNotFoundError`）
+4. application 層が `Directive(id=uuid4(), text=text, target_room_id=target_room_id, created_at=datetime.now(timezone.utc), task_id=None)` を構築
+5. Pydantic 型バリデーション → `model_validator(mode='after')` で `_validate_text_range` → `_validate_task_link_immutable` の順に走行
+6. valid なら `DirectiveRepository.save(directive)` で永続化（永続化前に `text` のマスキング適用、Repository 層で TypeDecorator `MaskedText`）
+7. 続けて Task 構築 → TaskRepository.save → directive.link_task(task_id) で紐付け（§確定 R1-B）
+
+### ユースケース 2: Task 紐付け（link_task）
+
+1. application 層が `DirectiveService.issue()` 内で Task 構築完了後に `directive.link_task(task_id)` を呼ぶ
+2. Aggregate 内で `_rebuild_with_state(task_id=new_task_id)` 経由で dict を構築 → `model_validate` で再構築
+3. `_validate_task_link_immutable` が `existing_task_id is not None` を検出した場合 `DirectiveInvariantViolation(kind='task_already_linked')` を Fail Fast
+4. 通過なら新 Directive を返却。application 層が `DirectiveRepository.save(updated_directive)`
+
+## シーケンス図
+
+```mermaid
+sequenceDiagram
+    participant CEO as CEO（UI）
+    participant App as DirectiveService
+    participant Room as RoomRepository
+    participant Dir as Directive Aggregate
+    participant DirRepo as DirectiveRepository
+    participant Task as Task Aggregate
+    participant TaskRepo as TaskRepository
+
+    CEO->>App: issue('$ ブログ分析機能を作って', room_id)
+    App->>Room: find_by_id(room_id)
+    Room-->>App: Room instance（存在）
+    App->>Dir: Directive(id, text, room_id, created_at, task_id=None)
+    Dir-->>App: valid Directive
+    App->>DirRepo: save(directive)
+    DirRepo-->>App: ok
+    App->>Task: Task(directive_id=directive.id, ...)
+    Task-->>App: valid Task
+    App->>TaskRepo: save(task)
+    TaskRepo-->>App: ok
+    App->>Dir: directive.link_task(task.id)
+    Dir-->>App: 新 Directive（task_id=task.id）
+    App->>DirRepo: save(updated_directive)
+    DirRepo-->>App: ok
+    App-->>CEO: directive_id, task_id
+```
+
+## アーキテクチャへの影響
+
+- `docs/architecture/domain-model.md` への変更: なし（`mermaid classDiagram` の Directive は既存）
+- `docs/architecture/domain-model/aggregates.md` への変更: なし（§Directive は既に凍結済み、本 feature は実装の追従）
+- `docs/architecture/domain-model/storage.md` への変更: §シークレットマスキング規則 §逆引き表に `Directive.text` 行が追加される（**ただし本 feature では追記しない**。後続 `feature/directive-repository` PR で永続化テーブル定義と同時に追記する責務分離）
+- `docs/architecture/tech-stack.md` への変更: なし
+- 既存 feature への波及: なし。empire / workflow / agent / room は本 feature を import しない（依存方向: directive → 既存 ID 型のみ）
+
+## 外部連携
+
+該当なし — 理由: domain 層のみのため外部システムへの通信は発生しない。
+
+| 連携先 | 目的 | プロトコル | 認証 | タイムアウト / リトライ |
+|-------|------|----------|-----|--------------------|
+| 該当なし | — | — | — | — |
+
+## UX 設計
+
+該当なし — 理由: domain 層のため UI は持たない。CEO directive 発行 UI は `feature/chat-ui`（Phase 2）で扱う。
+
+| シナリオ | 期待される挙動 |
+|---------|------------|
+| 該当なし | — |
+
+**アクセシビリティ方針**: 該当なし（UI なし）。
+
+## セキュリティ設計
+
+### 脅威モデル
+
+本 feature 範囲では以下の 2 件。詳細な信頼境界は [`docs/architecture/threat-model.md`](../../architecture/threat-model.md)。
+
+| 想定攻撃者 | 攻撃経路 | 保護資産 | 対策 |
+|-----------|---------|---------|------|
+| **T1: Directive.text 経由の secret 漏洩** | CEO がチャット欄で webhook URL / API key を含むメッセージを `$` 付きで送信 → DB 永続化 → ログ・監査経路へ流出 | OAuth トークン / Discord webhook token / API key | Aggregate 内ではマスキングしない（生入力を保持して UI で読み返す経路を確保）。**永続化前の単一ゲートウェイ**（[`storage.md`](../../architecture/domain-model/storage.md) §シークレットマスキング規則）で TypeDecorator `MaskedText` 経由で適用。後続 `feature/directive-repository` PR で `directives.text` カラムを `MaskedText` 型として宣言する責務 |
+| **T2: Directive.text に Discord webhook URL が混入した状態で `DirectiveInvariantViolation` を raise** | text 10001 文字超過 → 例外発生 → 例外 message / detail に webhook URL がそのまま埋め込まれログ / Discord 通知に流出 | Discord webhook token | `DirectiveInvariantViolation` の `__init__` で `mask_discord_webhook` + `mask_discord_webhook_in` を `super().__init__` 前に強制適用。agent / workflow / room と同パターン（多層防御） |
+
+### OWASP Top 10 対応
+
+| # | カテゴリ | 対応状況 |
+|---|---------|---------|
+| A01 | Broken Access Control | 該当なし（domain 層） |
+| A02 | Cryptographic Failures | **適用**: 永続化前マスキング（`Directive.text`、後続 directive-repository PR で配線）+ 例外 auto-mask（DirectiveInvariantViolation） |
+| A03 | Injection | 該当なし（Pydantic 型強制） |
+| A04 | Insecure Design | **適用**: pre-validate 方式 / frozen model / `task_id` 一意遷移の構造的不変条件 |
+| A05 | Security Misconfiguration | 該当なし |
+| A06 | Vulnerable Components | Pydantic v2 / pyright |
+| A07 | Auth Failures | 該当なし |
+| A08 | Data Integrity Failures | **適用**: frozen model / pre-validate による不正状態の窓ゼロ化 |
+| A09 | Logging Failures | **適用**: `DirectiveInvariantViolation` の auto-mask により例外ログから webhook URL が漏洩しない |
+| A10 | SSRF | 該当なし（外部 URL fetch なし） |
+
+## ER 図
+
+該当なし — 理由: 本 feature は domain 層のみで永続化スキーマは含まない。永続化は `feature/directive-repository` で扱う（M2 永続化基盤完了後）。参考の概形:
+
+```mermaid
+erDiagram
+    DIRECTIVE {
+        string id PK
+        string text "MaskedText (storage.md 逆引き表)"
+        string target_room_id FK
+        datetime created_at "UTC"
+        string task_id FK "NULL or 有効 TaskId"
+    }
+    ROOM ||--o{ DIRECTIVE : "委譲先として参照される"
+    DIRECTIVE ||--o| TASK : "1 件の Task を生成（task_id null許容）"
+```
+
+## エラーハンドリング方針
+
+| 例外種別 | 処理方針 | ユーザーへの通知 |
+|---------|---------|----------------|
+| `DirectiveInvariantViolation` | application 層で catch、HTTP API 層で 400 / 422 にマッピング（別 feature） | MSG-DR-001 / MSG-DR-002（kind: `text_range` / `task_already_linked`） |
+| `pydantic.ValidationError` | 構築時の型違反。application 層で catch | MSG-DR-003（型違反全般） |
+| `RoomNotFoundError` | application 層 `DirectiveService.issue()` の参照整合性違反、HTTP 404 にマッピング | MSG-DR-004 |
+| `WorkflowNotFoundError` | 同上、Room の workflow_id を解決できない場合 | MSG-DR-005 |
+| その他 | 握り潰さない、application 層へ伝播 | 汎用エラーメッセージ |

--- a/docs/features/directive/detailed-design.md
+++ b/docs/features/directive/detailed-design.md
@@ -1,0 +1,279 @@
+# 詳細設計書
+
+> feature: `directive`
+> 関連: [basic-design.md](basic-design.md) / [`docs/architecture/domain-model/aggregates.md`](../../architecture/domain-model/aggregates.md) §Directive
+
+## 記述ルール（必ず守ること）
+
+詳細設計に**疑似コード・サンプル実装（python/ts/sh/yaml 等の言語コードブロック）を書かない**。
+ソースコードと二重管理になりメンテナンスコストしか生まない。
+必要なのは「構造契約（属性名・型・制約）」と「確定文言（メッセージ文字列）」と「実装の意図」。
+
+## クラス設計（詳細）
+
+```mermaid
+classDiagram
+    class Directive {
+        +id: DirectiveId
+        +text: str
+        +target_room_id: RoomId
+        +created_at: datetime
+        +task_id: TaskId | None
+        +link_task(task_id) Directive
+    }
+```
+
+### Aggregate Root: Directive
+
+| 属性 | 型 | 制約 | 意図 |
+|----|----|----|----|
+| `id` | `DirectiveId`（UUIDv4） | 不変 | 一意識別 |
+| `text` | `str` | 1〜10000 文字（NFC 正規化のみ、strip しない — `Persona.prompt_body` / `PromptKit.prefix_markdown` と同規約） | CEO directive 本文（`$` プレフィックス含む正規化済みテキスト） |
+| `target_room_id` | `RoomId`（UUIDv4） | 不変、参照のみ | 委譲先の部屋（参照整合性は application 層） |
+| `created_at` | `datetime` | UTC、tz-aware（naive datetime は `pydantic.ValidationError`） | 発行時刻（application 層で生成して引数渡し） |
+| `task_id` | `TaskId \| None`（UUIDv4 or None） | 一意遷移（None → 有効 TaskId のみ可、再リンク禁止） | 生成された Task の参照 |
+
+`model_config`:
+- `frozen = True`
+- `arbitrary_types_allowed = False`
+- `extra = 'forbid'`
+
+**不変条件（model_validator(mode='after')）**:
+1. `text` の NFC 正規化後の length が 1〜10000（`_validate_text_range`）
+2. `task_id` 一意遷移（`_validate_task_link_immutable` — 既に有効 TaskId が設定されている状態への上書きは禁止。本不変条件は `link_task` ふるまい呼び出し経路でのみ発動する。コンストラクタ呼び出し時点では `task_id is None` または `任意の有効 TaskId` を許容、属性間の遷移を見るのは pre-validate 経路）
+
+**不変条件（application 層責務、Aggregate 内では守らない）**:
+- `target_room_id` の指す Room の存在 — `DirectiveService.issue()` が `RoomRepository.find_by_id` で確認
+- `text` の `$` プレフィックス正規化 — `DirectiveService.issue()` で `raw_text` を `'$' + raw_text` 形式に統一（既に `$` で始まれば変更なし）
+
+**ふるまい**:
+- `link_task(task_id: TaskId) -> Directive`: `task_id` を有効 TaskId に遷移した**新 Directive インスタンス**を返す。`_validate_task_link_immutable` で既存リンクとの衝突を Fail Fast
+
+### Exception: DirectiveInvariantViolation
+
+| 属性 | 型 | 制約 |
+|----|----|----|
+| `message` | `str` | MSG-DR-NNN 由来の文言（webhook URL は `<REDACTED:DISCORD_WEBHOOK>` 化済み） |
+| `detail` | `dict[str, object]` | 違反の文脈（webhook URL は `mask_discord_webhook_in` で再帰的に伏字化済み） |
+| `kind` | `Literal['text_range', 'task_already_linked']` | 違反種別 |
+
+`Exception` 継承。`domain/exceptions.py` の他の例外（empire / workflow / agent / room）と統一フォーマット。**`super().__init__` 前に `message` を `mask_discord_webhook` で、`detail` を `mask_discord_webhook_in` で伏字化する**（agent / workflow / room と同パターン、多層防御）。
+
+## 確定事項（先送り撤廃）
+
+### 確定 A: pre-validate 方式は Pydantic v2 model_validate 経由
+
+`link_task` の手順:
+
+1. `self.model_dump(mode='python')` で現状を dict 化
+2. dict 内の `task_id` を新 TaskId で更新
+3. `Directive.model_validate(updated_dict)` を呼ぶ — `model_validator` が走る
+4. 失敗時は `ValidationError` を `DirectiveInvariantViolation` に変換して raise
+
+empire / workflow / agent / room と同じパターン。`model_copy(update=...)` は採用しない（Pydantic v2 仕様で `validate=False` が既定のため不変条件再検査が走らない）。
+
+### 確定 B: `text` の正規化パイプラインと長さ判定
+
+`Persona.prompt_body` / `PromptKit.prefix_markdown` と同じく **NFC 正規化のみ、strip しない**:
+
+#### 正規化パイプライン（順序固定）
+
+1. 入力 `raw_text` を受け取る（application 層で `$` プレフィックス正規化済み）
+2. `normalized = unicodedata.normalize('NFC', raw_text)` で NFC 正規化
+3. `length = len(normalized)` で Unicode コードポイント数を計上（**strip は適用しない**）
+4. 範囲判定（`1 <= length <= 10000`）
+5. 通過時のみ属性として `normalized` を保持
+
+#### `text` を strip しない理由
+
+- CEO directive は複数段落 / 末尾改行を含む長文の可能性
+- `'$ ブログ分析機能を作って\n\n要件:\n- GA4 経由\n- 月次集計'` のような構造を保持
+- agent §確定 E §適用範囲表で `Persona.prompt_body` を strip しないと凍結した先例と同方針
+
+### 確定 C: `task_id` 一意遷移の検査
+
+`_validate_task_link_immutable`:
+
+| 入力経路 | 元 `task_id` | 新 `task_id` | 判定 |
+|---|---|---|---|
+| コンストラクタ（初回構築） | （存在しない） | None | OK（未紐付け状態で生成） |
+| コンストラクタ（直接構築、テスト等） | （存在しない） | 有効 TaskId | OK（既に紐付け済み状態で生成、永続化からの復元等） |
+| `link_task(new_task_id)` | None | new_task_id | OK（None → 有効 TaskId への遷移） |
+| `link_task(new_task_id)` | 既存有効 TaskId | new_task_id | NG → `DirectiveInvariantViolation(kind='task_already_linked', detail={'directive_id': self.id, 'existing_task_id': existing, 'attempted_task_id': new_task_id})` |
+
+##### 「コンストラクタ経路では任意の TaskId を許容、`link_task` 経路でのみ再リンクを禁止する」実装方式
+
+`link_task` ふるまい内で **「呼び出し時点の self.task_id が None であること」** を `_validate_task_link_immutable` で守る。コンストラクタ経路（`Directive(task_id=既存TaskId)` での直接構築）は permanent な値の代入であり、`task_id` 値の遷移ではないため許容する。
+
+実装上は `link_task` ふるまいが `self.task_id is None` を直接検査してから `_rebuild_with_state` を呼ぶ:
+
+| 段階 | 動作 |
+|---|---|
+| 1 | `if self.task_id is not None: raise DirectiveInvariantViolation(kind='task_already_linked', ...)` で Fail Fast |
+| 2 | `self.model_dump()` で dict 化 → `task_id = new_task_id` に差し替え |
+| 3 | `Directive.model_validate(updated_dict)` で再構築（`model_validator` が走るが、再リンク違反はもうここでは見ない、ふるまい入口で守った） |
+
+これにより「Directive Repository が永続化済み有効 TaskId 持ちの Directive を復元する」経路と「`link_task` で再リンクを試みる」経路を分離して扱える。
+
+### 確定 D: `link_task` ふるまいの返り値型
+
+`link_task(task_id) -> Directive`（新インスタンス）。empire / workflow / agent / room と同じく frozen の制約上、状態変更は新インスタンス返却。
+
+| 入力 Directive 状態 | 返り値 | オブジェクト同一性 |
+|---|---|---|
+| `task_id is None` | 新 `Directive`（`task_id = new_task_id`） | 別オブジェクト |
+| `task_id == new_task_id`（同じ TaskId で再リンク） | `DirectiveInvariantViolation(kind='task_already_linked')` | 例外 |
+| `task_id == 既存有効 TaskId（new_task_id と異なる）` | `DirectiveInvariantViolation(kind='task_already_linked')` | 例外 |
+
+冪等性は持たない — 「同じ TaskId で 2 回 link_task を呼んでも OK」という設計を採用すると `_validate_task_link_immutable` の不変条件が複雑化する。**1 回のみ許可、2 回目は常に Fail Fast** の clear cut な契約を採用する（再リンクが必要な業務シナリオは MVP 範囲では存在しない、Phase 2 でも別 Directive 発行で対応する）。
+
+### 確定 E: `DirectiveInvariantViolation` の webhook auto-mask
+
+agent / workflow / room と同じく `DirectiveInvariantViolation.__init__` で:
+
+1. `super().__init__` 前に `mask_discord_webhook(message)` を message に適用
+2. `detail` に対し `mask_discord_webhook_in(detail)` を再帰的に適用
+3. `kind` は enum 文字列のため mask 対象外
+4. その後 `super().__init__(masked_message)` を呼ぶ
+
+これにより `DirectiveInvariantViolation` の `str(exc)` / `exc.detail` のいずれを取り出しても webhook URL が伏字化済みであることを物理的に保証する（多層防御）。
+
+#### `DirectiveInvariantViolation` で webhook が混入する経路
+
+| 経路 | 例 |
+|----|----|
+| `Directive.text` の長さ違反 | CEO がチャット欄で webhook URL を含む 10001 文字超過の長文を送信 → 例外 detail に text の prefix が含まれる |
+| `link_task` の再リンク違反 | webhook URL を含む既存 Directive で `link_task` を再呼び出し → 例外 detail に既存 directive 情報（id のみ、text は含めない） |
+
+UI 側でも入力時マスキングを実装するが、本 Aggregate 層では「例外経路で漏れない」ことを単独で保証する責務を持つ。
+
+### 確定 F: 例外型統一規約と「揺れ」の凍結（room §確定 I 踏襲）
+
+| 違反種別 | 例外型 | 発生レイヤ | 凍結する `kind` 値 |
+|---|---|---|---|
+| 構造的不変条件違反 | `DirectiveInvariantViolation` | Aggregate `model_validator(mode='after')` または `link_task` ふるまい入口 | `text_range` / `task_already_linked` |
+| 型違反 / 必須欠落 | `pydantic.ValidationError` | Pydantic 型バリデーション（`mode='after'` より前） | — |
+| application 層の参照整合性違反 | `RoomNotFoundError` / `WorkflowNotFoundError` / `DirectiveNotFoundError` | `DirectiveService` / `RoomService` | — |
+
+##### `link_task` ふるまいの例外型確定
+
+`task_id` の型違反（None or UUIDv4 以外）は **Pydantic 型バリデーション**で `pydantic.ValidationError`（MSG-DR-003）。`link_task` 入口に到達する時点では既に valid な TaskId として渡される。`link_task` 内では `_validate_task_link_immutable` が `DirectiveInvariantViolation(kind='task_already_linked')`（MSG-DR-002）のみ raise する。
+
+##### MSG ID と例外型の対応（凍結）
+
+| MSG ID | 例外型 | kind |
+|---|---|---|
+| MSG-DR-001 | `DirectiveInvariantViolation` | `text_range` |
+| MSG-DR-002 | `DirectiveInvariantViolation` | `task_already_linked` |
+| MSG-DR-003 | `pydantic.ValidationError` | （型違反全般、kind 概念なし） |
+| MSG-DR-004 | `RoomNotFoundError` | （application 層） |
+| MSG-DR-005 | `WorkflowNotFoundError` | （application 層） |
+
+### 確定 G: `target_room_id` 検証の責務分離（application 層、別 Issue）
+
+`DirectiveService.issue(raw_text, target_room_id)` の application 層責務:
+
+1. `text = raw_text if raw_text.startswith('$') else '$' + raw_text` で `$` プレフィックス正規化
+2. `RoomRepository.find_by_id(target_room_id)` で Room 取得（不在なら `RoomNotFoundError(MSG-DR-004)` を Fail Fast）
+3. Room の `archived == True` 検証（archived Room への directive 発行は禁止 — 本 PR スコープ外、`feature/directive-repository` または `feature/directive-application` で凍結）
+4. `WorkflowRepository.find_by_id(room.workflow_id)` で Workflow 取得（不在なら `WorkflowNotFoundError(MSG-DR-005)`）
+5. `Directive(...)` 構築 + `DirectiveRepository.save(directive)`
+6. 同一 Tx 内で Task 構築 → `TaskRepository.save(task)` → `directive.link_task(task.id)` → `DirectiveRepository.save(updated_directive)`
+
+ドメイン層の Directive はこの呼び出し前提で「自身では `target_room_id` の存在を検証しない」契約。
+
+### 確定 H: 「Aggregate 内検査と application 層検査」の責務分離マトリクス
+
+| 検査項目 | Aggregate 内 | application 層 |
+|---|---|---|
+| `text` 1〜10000 文字 | ✓（構造的、`_validate_text_range`） | ✗ |
+| `task_id` 一意遷移 | ✓（構造的、`_validate_task_link_immutable`） | ✗ |
+| `text` の `$` プレフィックス正規化 | ✗ | ✓（`DirectiveService.issue()` で正規化、§確定 R1-A / G） |
+| `target_room_id` の Room 存在 | ✗ | ✓（外部知識、§確定 G） |
+| Room の `workflow_id` の Workflow 存在 | ✗ | ✓（外部知識、§確定 G） |
+| Task 生成と紐付けの 1 トランザクション | ✗ | ✓（複数 Aggregate にまたがるため、§確定 R1-B） |
+
+## 設計判断の補足
+
+### なぜ `target_room_id` 参照整合性を Aggregate 内で守らないか
+
+`target_room_id` が指す Room の存在は Repository SELECT を要する集合知識。Aggregate 内では「`target_room_id` が UUID 型として valid」までしか守らない。Repository 経由で確認する application 層責務（empire の `archive_room` で `room_id` の存在を Aggregate 内で守るのと対称な分離方針、room §確定 R1-D 踏襲）。
+
+### なぜ `spawn_task` ではなく `link_task` か
+
+`aggregates.md` §Directive の「`spawn_task() -> Task`」は概念的な意図で、実装パターンとしては Aggregate 境界違反になる:
+
+- Task は別 Aggregate Root のため、Directive 内で Task インスタンスを直接生成すると 1 Tx で 2 Aggregate 更新になる
+- Aggregate Root のトランザクション境界（1 Tx で 1 Aggregate）を破壊する
+
+`DirectiveService.issue()` の application 層が Task を生成し、Directive には `link_task(task_id)` で「生成済み Task の id を紐付ける」責務だけを残すことで、Aggregate 凝集境界を保つ。これは workflow の `Stage` 内 Entity が Workflow Aggregate に閉じ、Task との関係は別 Aggregate 経由で結ばれる設計と同方針。
+
+### なぜ `task_id` を List にしないか
+
+`aggregates.md` §Directive で「task_id: TaskId | None — 生成された Task（未着手なら None）」と単一参照で凍結済み。複数 Task は別 Directive で発行する設計（CEO が 2 つの directive を発行すれば Task が 2 件生成される）。MVP 範囲で「1 Directive → N Task」の業務シナリオは存在しない（YAGNI）。
+
+### なぜ `created_at` を引数で受け取るか
+
+`datetime.now(timezone.utc)` を Aggregate 内で自動生成すると freezegun 等での test 制御が必要になる。application 層で生成して引数渡しすることで Aggregate 自体は時刻に依存しない pure data になり、test 容易性が向上（`Directive(id=..., text=..., target_room_id=..., created_at=fixed_datetime, task_id=None)` で固定時刻を渡せる）。
+
+### なぜ `task_id` 再リンクを冪等にしないか
+
+「同じ TaskId で 2 回 link_task を呼んでも OK」という冪等設計は `_validate_task_link_immutable` の検査ロジックを複雑化する（既存 task_id と新 task_id を比較して同一なら no-op、異なれば Fail Fast）。**1 回のみ許可、2 回目は常に Fail Fast** の clear cut な契約のほうが構造が単純で、再リンクが必要な業務シナリオは存在しない（CEO が再発行したい場合は新規 Directive を発行する設計）。
+
+## ユーザー向けメッセージの確定文言
+
+### プレフィックス統一
+
+| プレフィックス | 意味 |
+|--------------|-----|
+| `[FAIL]` | 処理中止を伴う失敗 |
+| `[OK]` | 成功完了 |
+
+### MSG 確定文言表
+
+各メッセージは **「失敗内容（What）」+「次に何をすべきか（Next Action）」の 2 行構造**を採用する（§確定 F、room §確定 I 踏襲）。例外 message は改行（`\n`）区切りで 2 行を保持する。
+
+| ID | 例外型 | 文言（1 行目: failure / 2 行目: next action） |
+|----|------|----|
+| MSG-DR-001 | `DirectiveInvariantViolation(kind='text_range')` | `[FAIL] Directive text must be 1-10000 characters (got {length})` / `Next: Trim directive content to <=10000 NFC-normalized characters; for richer prompts use multiple directives or attach a deliverable.` — `{length}` は §確定 B の正規化パイプライン（NFC 正規化のみ、strip しない）適用後の `len()` 値 |
+| MSG-DR-002 | `DirectiveInvariantViolation(kind='task_already_linked')` | `[FAIL] Directive already has a linked Task: directive_id={directive_id}, existing_task_id={existing_task_id}` / `Next: Issue a new Directive instead of re-linking; one Directive maps to one Task by design.` |
+| MSG-DR-003 | `pydantic.ValidationError`（Directive VO 構築時） | `[FAIL] Directive type validation failed: {field}={value!r}` / `Next: Verify field types — id/target_room_id are UUIDv4, created_at is tz-aware UTC datetime, task_id is UUIDv4 or None.` — Pydantic 標準のメッセージに 2 行構造を application 層でラップ |
+| MSG-DR-004 | `RoomNotFoundError`（application 層） | `[FAIL] Target Room not found: room_id={room_id}` / `Next: Verify the room_id via GET /rooms; the room may have been archived or deleted.` |
+| MSG-DR-005 | `WorkflowNotFoundError`（application 層） | `[FAIL] Workflow not found for Room: room_id={room_id}, workflow_id={workflow_id}` / `Next: Verify Room.workflow_id integrity; the Workflow may have been deleted while the Room references it.` |
+
+##### 「Next:」行の役割（フィードバック原則）
+
+- **発行レイヤを跨いで一貫**: 例外 message / API レスポンスの `error.next_action` フィールド / UI の Toast 2 行目 / CLI の stderr 2 行目に**同一文言**を流す
+- **i18n 入口**: Phase 2 で UI 側 i18n を入れる際、`MSG-DR-NNN.failure` / `MSG-DR-NNN.next` の 2 キー × 言語数で翻訳テーブルが作れる
+- **検証可能性**: test-design.md の TC-UT-DR-NNN で `assert "Next:" in str(exc)` を含めることで「hint 必須」を CI で物理保証する
+
+メッセージは ASCII 範囲（プレースホルダ `{...}` は f-string 形式）。日本語化は UI 側 i18n（Phase 2）。本 feature の例外メッセージは英語固定。
+
+## データ構造（永続化キー）
+
+該当なし — 理由: 本 feature は domain 層のみで永続化スキーマは含まない。永続化は `feature/directive-repository` で扱う（M2 永続化基盤完了後）。
+
+参考の概形:
+
+| カラム | 型 | 制約 | 意図 |
+|-------|----|----|----|
+| `directives.id` | `UUIDStr` | PK | DirectiveId |
+| `directives.text` | `MaskedText` | NOT NULL | masking 適用済み（`process_bind_param` で `MaskingGateway.mask()`、storage.md §逆引き表に `Directive.text` 行追加対象） |
+| `directives.target_room_id` | `UUIDStr` | FK to `rooms.id` | 委譲先 Room |
+| `directives.created_at` | `UTCDateTime` | NOT NULL | UTC 発行時刻 |
+| `directives.task_id` | `UUIDStr` | NULL or FK to `tasks.id` | 紐付け済み Task |
+
+## API エンドポイント詳細
+
+該当なし — 理由: 本 feature は domain 層のみ。API は `feature/http-api` で凍結する。
+
+## 出典・参考
+
+- [Pydantic v2 — model_validator / model_validate](https://docs.pydantic.dev/latest/concepts/validators/) — pre-validate 方式の実装根拠
+- [Pydantic v2 — frozen models](https://docs.pydantic.dev/latest/concepts/models/) — 不変モデルの挙動
+- [Unicode Standard Annex #15: Unicode Normalization Forms](https://unicode.org/reports/tr15/) — NFC 正規化の仕様根拠
+- [`docs/architecture/domain-model/aggregates.md`](../../architecture/domain-model/aggregates.md) — Directive 凍結済み設計
+- [`docs/architecture/domain-model/storage.md`](../../architecture/domain-model/storage.md) — シークレットマスキング規則（`Directive.text` の Repository 永続化時に適用、`feature/directive-repository` で配線）
+- [`docs/architecture/threat-model.md`](../../architecture/threat-model.md) — A02 / A04 / A09 対応根拠
+- [`docs/features/agent/detailed-design.md`](../agent/detailed-design.md) §確定 D / E — 名前正規化パイプラインの先例
+- [`docs/features/room/detailed-design.md`](../room/detailed-design.md) §確定 I — 例外型統一規約 + MSG 2 行構造の先例

--- a/docs/features/directive/requirements-analysis.md
+++ b/docs/features/directive/requirements-analysis.md
@@ -1,0 +1,202 @@
+# 要求分析書
+
+> feature: `directive`
+> Issue: [#24 feat(directive): Directive Aggregate Root (M1)](https://github.com/bakufu-dev/bakufu/issues/24)
+> 凍結済み設計: [`docs/architecture/domain-model/aggregates.md`](../../architecture/domain-model/aggregates.md) §Directive / [`value-objects.md`](../../architecture/domain-model/value-objects.md) §ID 型一覧（`DirectiveId` は既存）
+
+## 人間の要求
+
+> Issue #24:
+>
+> bakufu MVP（v0.1.0）M1「ドメイン骨格」の **5 番目の Aggregate** として **Directive Aggregate Root** を実装する。Directive は CEO（リポジトリオーナー）が発行する指令で、`$` プレフィックスから始まるテキストと委譲先 Room を持つ。Directive から Task が生成され、MVP の核心ユースケース「CEO directive → Task 起票 → 各 Stage を Agent が処理 → 外部レビューで人間が承認/差し戻し → DONE」の**起点**を担う。
+
+## 背景・目的
+
+### 現状の痛点
+
+1. M1 ドメイン骨格 4 兄弟（empire / workflow / agent / room）が PR #15 / #16 / #17 / #22 で完走したが、**CEO directive の起点 Aggregate がないため Task 起票経路が宙に浮いている**。`mvp-scope.md` §M7「V モデル E2E」へ至る経路が Directive で塞がれている
+2. M1 後段の `task` Issue は `directive_id` を介して Directive を参照する設計（`aggregates.md` §Task 属性表）。Directive がないと Task 構築の参照整合性検査が成立しない
+3. UI の MVP（普通の Tailwind ダッシュボード）は「Room チャネルで `$` プレフィックスのメッセージを送信 → directive 起票 → Task 生成」を中核ユースケースに据える。Directive の attribute / 不変条件が決まっていないと UI 側のチャット欄入力 → API 経路も着手できない
+
+### 解決されれば変わること
+
+- `task` Issue が Directive 参照を前提に実装可能になる（`directive_id` 必須属性が確定する）
+- UI のチャット欄 → directive 発行 → Task 生成のシーケンスが API 仕様確定前でも domain 契約から逆算できる
+- empire / workflow / agent / room の確立済みパターン（pre-validate / frozen Pydantic v2 / `_validate_*` helper / 例外 auto-mask / ディレクトリ層分離 / 例外型統一規約 / MSG 2 行構造）を **5 例目**として揃え、後続 task / external-review-gate の実装パターンを完全固定する
+
+### ビジネス価値
+
+- bakufu の核心思想「CEO directive → Vモデル工程進行 → 外部レビューで人間が承認」のうち最初の **CEO directive 起点** を Aggregate 単位で表現する。これが揃うと task / external-review-gate を直線消化できる経路が確立される
+- 「`$` プレフィックスで CEO 入力を識別する」ai-team 由来の運用慣習を Aggregate 内で正規化し、UI / API レイヤと application 層の責務を明確に分離する
+
+## 議論結果
+
+### 設計担当による採用前提
+
+- Directive Aggregate は **Pydantic v2 BaseModel + `model_config.frozen=True` + `model_validator(mode='after')`**（empire / workflow / agent / room と同じ規約）
+- `text` は **NFC 正規化のみ、strip しない**（`Persona.prompt_body` / `PromptKit.prefix_markdown` と同規約。CEO の改行を含む長文 directive を保持するため）
+- `target_room_id` の存在検証は **application 層責務**（`DirectiveService.issue()` で `RoomRepository.find_by_id` 確認）。Aggregate 内では UUID 型として valid までしか守らない
+- `task_id is None` から有効 TaskId への遷移は **1 回のみ許可**（Aggregate 内不変条件 `_validate_task_link_immutable`、再リンクは `DirectiveInvariantViolation(kind='task_already_linked')`）
+- ディレクトリ層分離は room と同パターン（`backend/src/bakufu/domain/directive/` 配下に `directive.py` / `aggregate_validators.py` / `__init__.py`）
+- 状態変更ふるまいは新インスタンス返却の pre-validate 方式（agent §確定 D / room §確定 D 踏襲、冪等は「結果状態の同値性」で担保）
+- `DirectiveInvariantViolation` は workflow / agent / room と同じく **`mask_discord_webhook` + `mask_discord_webhook_in` を `super().__init__` 前に強制適用**（`text` フィールドに CEO が webhook URL を貼り付け得る経路の防衛線）
+
+### 却下候補と根拠
+
+| 候補 | 却下理由 |
+|-----|---------|
+| Aggregate 内で `text.startswith('$')` を強制 | UI / API 入力経路で CEO が毎回 `$` を打つ煩雑さを排除する責務は application 層が吸収すべき。agent §確定 I の `provider_kind` MVP gate と同じ責務分離 |
+| `spawn_task() -> Task` を Directive 内で実装し Task インスタンスを直接生成 | **Aggregate 境界違反**（Aggregate Root のトランザクション境界は 1 Tx で 1 Aggregate）。Workflow / Room との結合度が過剰になる。`DirectiveService.issue()` の application 層が Task を生成し `directive.link_task(task_id)` で紐付ける責務に分離 |
+| `task_id` を List に変えて 1 Directive → N Task の関係を許容 | MVP 範囲外。`aggregates.md` §Directive で「task_id: TaskId \| None — 生成された Task（未着手なら None）」と単一参照で凍結済み。複数 Task は別 Directive で発行する設計 |
+| `text` に strip 適用 | CEO の長文 directive で末尾改行や前置詞の改行を保持する必要がある。`Persona.prompt_body` / `PromptKit.prefix_markdown` と同規約で NFC のみ |
+| `created_at` を Aggregate 内で `datetime.now(timezone.utc)` 自動生成 | テスト容易性が下がる（freezegun が要る）。application 層 `DirectiveService.issue()` で生成して引数渡しする方が clean |
+
+### 重要な選定確定（レビュー指摘 R1 応答）
+
+#### 確定 R1-A: `$` プレフィックス検査の責務分離
+
+`aggregates.md` §Directive で「`$` プレフィックスから始まる」と概念定義されているが、**Aggregate 内不変条件として強制しない**。`DirectiveService.issue(raw_text, target_room_id)` の application 層で以下を実行:
+
+1. `text = raw_text if raw_text.startswith('$') else '$' + raw_text` で正規化
+2. `Directive(id=..., text=text, target_room_id=..., created_at=now(), task_id=None)` で構築
+
+理由:
+
+- UI / API 入力経路で CEO が `$` を打ち忘れた場合の自動付加が運用上自然（毎回打つのは煩雑）
+- Aggregate は valid な text しか受け取らない契約で清潔（`$` 付きを保証された状態で扱う）
+- agent §確定 I の `provider_kind` MVP gate を `AgentService.hire()` に押し出した先例と同じ責務分離パターン
+
+#### 確定 R1-B: `spawn_task` ではなく `link_task` に変更（イーロン承認済み）
+
+`aggregates.md` §Directive で「`spawn_task() -> Task`」と記述されているが、**Aggregate 境界違反**のため本 feature では以下に変更する:
+
+1. **Aggregate 内ふるまい**: `link_task(task_id: TaskId) -> Directive` — 生成済み Task の id を関連付ける（pre-validate 方式で新インスタンス返却）
+2. **application 層責務**: `DirectiveService.issue(raw_text, target_room_id)` が
+   - Directive 構築（task_id=None）
+   - DirectiveRepository.save(directive)
+   - 同一 Tx 内で Task 構築 → TaskRepository.save(task)
+   - directive.link_task(task.id) で紐付け → DirectiveRepository.save(updated_directive)
+
+理由:
+
+- Task は別 Aggregate Root のため、Directive 内で Task インスタンスを直接生成すると 1 Tx で 2 Aggregate 更新になり凝集境界が崩れる
+- `link_task` は Aggregate 内不変条件（`task_id` 一意遷移）に閉じる責務
+- `aggregates.md` §Directive の「`spawn_task() -> Task`」記述は概念的な意図で、実装パターンとしては application 層の use case に分解される
+
+#### 確定 R1-C: `task_id` 二重リンク禁止（イーロン承認済み）
+
+`task_id is None` から有効 TaskId への遷移は **1 回のみ許可**:
+
+| 入力 Directive 状態 | `link_task(new_task_id)` 呼び出し結果 |
+|---|---|
+| `task_id is None` | 新 Directive（`task_id = new_task_id`、ペンディング解除）|
+| `task_id == 既存有効 TaskId` | `DirectiveInvariantViolation(kind='task_already_linked', detail={'directive_id': ..., 'existing_task_id': ..., 'attempted_task_id': ...})` を Fail Fast |
+
+`_validate_task_link_immutable` helper で `model_validator(mode='after')` 内で守る。Directive 1 件 → Task 1 件の関係を Aggregate 内で物理保証する。
+
+#### 確定 R1-D: `DirectiveInvariantViolation` の auto-mask
+
+CEO が directive `text` に webhook URL を貼り付け得るため、agent / workflow / room と同パターンで:
+
+1. `super().__init__` 前に `mask_discord_webhook(message)` を message に適用
+2. `detail` に対し `mask_discord_webhook_in(detail)` を再帰的に適用
+3. `kind` は enum 文字列のため mask 対象外
+4. その後 `super().__init__(masked_message)` を呼ぶ
+
+#### 確定 R1-E: 例外型統一規約と MSG 2 行構造（room §確定 I 踏襲）
+
+| 違反種別 | 例外型 | 発生レイヤ | kind |
+|---|---|---|---|
+| 構造的不変条件違反 | `DirectiveInvariantViolation` | Aggregate `model_validator(mode='after')` | `text_range` / `task_already_linked` |
+| 型違反 / 必須欠落 | `pydantic.ValidationError` | Pydantic 型バリデーション | — |
+| application 層の参照整合性違反 | `RoomNotFoundError` / `WorkflowNotFoundError` / `DirectiveNotFoundError` | `DirectiveService` / `RoomService` | — |
+
+MSG-DR-001〜005 は **2 行構造**（`[FAIL] failure` + `Next: action`）で凍結し、test-design.md の TC-UT-DR-NNN で `assert "Next:" in str(exc)` を CI 物理保証する規約（room §確定 I 踏襲）。
+
+## ペルソナ
+
+| ペルソナ名 | 役割 | 技術レベル | 利用文脈 | 達成したいゴール |
+|-----------|------|-----------|---------|----------------|
+| 個人開発者 CEO（堀川さん想定） | bakufu インスタンスのオーナー、リポジトリ所有者 | GitHub / Docker / CLI 日常使用 | UI のチャット欄に `$ ブログのアクセス分析機能を作って` と入力 → Directive 起票 → Vモデル工程が走る | 1 行の指令で Vモデル開発フローを起動する |
+| 後続 Issue 担当（バックエンド開発者） | `feature/task` PR の実装者 | DDD 経験あり、SQLAlchemy 2.x async / Pydantic v2 経験あり | 本 PR の設計書を真実源として読み、Task の `directive_id` 参照経路を実装 | 設計書の確定 R1-B / R1-C を素直に実装するだけで、後段レビューで責務散在を指摘されない |
+
+##### ペルソナ別ジャーニー（個人開発者 CEO）
+
+1. **directive 発行**: UI のチャット欄に `$ ブログのアクセス分析機能を作って` と入力 → Enter
+2. **正規化**: application 層が `$` 付きを保証（既に `$` で始まれば変更なし、なければ自動付加）
+3. **Directive 構築**: `Directive(id=uuid4(), text='$ ブログ...', target_room_id=current_room_id, created_at=now(), task_id=None)`
+4. **永続化**: `DirectiveRepository.save(directive)` で SQLite に書き込み
+5. **Task 生成**: 同一 Tx 内で Task を作り `directive.link_task(task_id)` で紐付け
+6. **Vモデル工程開始**: Room の Workflow から Task が起票され、`current_stage_id` が初期 Stage に設定される
+
+##### ジャーニーから逆算した受入要件
+
+- ジャーニー 1: `text` は CEO の改行・絵文字・複数段落を保持できる必要がある（NFC のみ、strip しない）
+- ジャーニー 3: `task_id is None` で構築できる（Directive 起票時点では Task 未生成）
+- ジャーニー 5: `link_task(task_id)` で 1 回だけ紐付け可能、再リンクは Fail Fast
+- ジャーニー全般: directive `text` に webhook URL が混入しても永続化前にマスキング、例外経路でも auto-mask（agent §確定 D 踏襲）
+
+bakufu システム全体のペルソナは [`docs/architecture/context.md`](../../architecture/context.md) §4 を参照。
+
+## 前提条件・制約
+
+| 区分 | 内容 |
+|-----|------|
+| 既存技術スタック | Python 3.12+ / Pydantic v2 / pyright strict / pytest |
+| 既存 CI | lint / typecheck / test-backend / audit |
+| 既存ブランチ戦略 | GitFlow（CONTRIBUTING.md §ブランチ戦略） |
+| コミット規約 | Conventional Commits |
+| ライセンス | MIT |
+| ネットワーク | 該当なし — domain 層 |
+| 対象 OS | Windows 10 21H2+ / macOS 12+ / Linux glibc 2.35+ |
+
+## 機能一覧
+
+| 機能ID | 機能名 | 概要 | 優先度 |
+|--------|-------|------|--------|
+| REQ-DR-001 | Directive 構築 | コンストラクタで `id` / `text` / `target_room_id` / `created_at` / `task_id`（既定 None）を受け取り、不変条件検査を経て valid な Directive を返す | 必須 |
+| REQ-DR-002 | Task 紐付け | `link_task(task_id)` で `task_id` を有効 TaskId に遷移。既に紐付け済みなら Fail Fast | 必須 |
+| REQ-DR-003 | 不変条件検査 | コンストラクタ末尾と状態変更ふるまい末尾で実行。`text` 1〜10000 文字 / `task_id` 一意遷移 / `target_room_id` UUID 型 | 必須 |
+
+## Sub-issue 分割計画
+
+本 Issue は単一 Aggregate に閉じる粒度のため Sub-issue 分割は不要。1 PR で 4 設計書 + 実装 + ユニットテストを完結させる。
+
+| Sub-issue 名 | 紐付く REQ | スコープ | 依存関係 |
+|------------|-----------|---------|---------|
+| 単一 PR | REQ-DR-001〜003 | Directive Aggregate + ユニットテスト | M1 4 兄弟（PR #15/#16/#17/#22）+ M2 永続化基盤（PR #23）マージ済み |
+
+## 非機能要求
+
+| 区分 | 要求 |
+|-----|------|
+| パフォーマンス | 不変条件検査は O(1)（属性数固定）。1ms 未満 |
+| 可用性 | 該当なし — domain 層 |
+| 保守性 | pyright strict pass / ruff 警告ゼロ / カバレッジ 95% 以上（4 兄弟実績水準） |
+| 可搬性 | 純 Python のみ |
+| セキュリティ | `text` に webhook URL / API key が混入し得る。永続化前にマスキング規則の適用対象（[`storage.md`](../../architecture/domain-model/storage.md) §シークレットマスキング規則）。`DirectiveInvariantViolation` は webhook URL auto-mask（4 兄弟と同パターン）。詳細は [`threat-model.md`](../../architecture/threat-model.md) §A04 |
+
+## 受入基準
+
+| # | 基準 | 検証方法 |
+|---|------|---------|
+| 1 | `Directive(id, text, target_room_id, created_at)` で valid な Directive が構築される（task_id=None 既定） | TC-UT-DR-001 |
+| 2 | text が 0 文字 / 10001 文字以上で `DirectiveInvariantViolation(kind='text_range')` | TC-UT-DR-002 |
+| 3 | text の NFC 正規化が適用される（合成形 / 分解形が同一長で扱われる） | TC-UT-DR-003 |
+| 4 | text の strip が**適用されない**（前後改行を保持） | TC-UT-DR-004 |
+| 5 | `link_task(task_id)` で `task_id` が None → 有効 TaskId に遷移、新 Directive を返す | TC-UT-DR-005 |
+| 6 | 既に紐付け済み（`task_id is not None`）の Directive で `link_task` は `DirectiveInvariantViolation(kind='task_already_linked')` | TC-UT-DR-006 |
+| 7 | `DirectiveInvariantViolation` の `message` / `detail` 内の Discord webhook URL が `<REDACTED:DISCORD_WEBHOOK>` に伏字化される | TC-UT-DR-007 |
+| 8 | Directive は frozen で構造的等価判定 | TC-UT-DR-008 |
+| 9 | エラーメッセージは 2 行構造（`[FAIL] ...` + `Next: ...`）で `assert "Next:" in str(exc)` が pass | TC-UT-DR-001〜007 全件 |
+| 10 | `pyright --strict` および `ruff check` がエラーゼロ | CI lint / typecheck |
+| 11 | カバレッジが `domain/directive/` で 95% 以上 | pytest --cov |
+
+## 扱うデータと機密レベル
+
+| 区分 | 内容 | 機密レベル |
+|-----|------|----------|
+| Directive.text | CEO directive 本文（自然言語、`$` プレフィックス付き） | 中（webhook URL / API key 等が誤って混入し得る、Repository 永続化前マスキング必須、storage.md §逆引き表に追記対象） |
+| Directive.target_room_id | 委譲先 Room の参照 | 低 |
+| Directive.created_at | UTC 発行時刻 | 低 |
+| Directive.task_id | 生成された Task の参照（None or 有効 TaskId） | 低 |

--- a/docs/features/directive/requirements.md
+++ b/docs/features/directive/requirements.md
@@ -1,0 +1,99 @@
+# 要件定義書
+
+> feature: `directive`
+> 関連: [requirements-analysis.md](requirements-analysis.md) / [`docs/architecture/domain-model/aggregates.md`](../../architecture/domain-model/aggregates.md) §Directive
+
+## 機能要件
+
+### REQ-DR-001: Directive 構築
+
+| 項目 | 内容 |
+|------|------|
+| 入力 | `id: DirectiveId` / `text: str` / `target_room_id: RoomId` / `created_at: datetime`（UTC、tz-aware）/ `task_id: TaskId \| None`（既定 None） |
+| 処理 | Pydantic 型バリデーション → `model_validator(mode='after')` で不変条件検査（`text` 1〜10000 文字、NFC 正規化のみ・strip しない / `task_id` UUIDv4 形式 or None / `created_at` tz-aware） |
+| 出力 | valid な `Directive` インスタンス（frozen） |
+| エラー時 | `DirectiveInvariantViolation` を raise。`message` は MSG-DR-001/002（2 行構造、§確定 R1-E）、`kind` は `text_range` / `task_already_linked` のいずれか。型違反は `pydantic.ValidationError`（MSG-DR-003） |
+
+### REQ-DR-002: Task 紐付け
+
+| 項目 | 内容 |
+|------|------|
+| 入力 | `task_id: TaskId`（生成済み Task の id） |
+| 処理 | 現状の `task_id` を確認 → None なら新 `task_id` を設定して dict 化 → `Directive.model_validate(updated_dict)` で再構築 → `model_validator` 走行 → 不変条件通過時のみ新 Directive を返す。既に紐付け済みなら `_validate_task_link_immutable` で Fail Fast |
+| 出力 | 新 `Directive` インスタンス（pre-validate 方式により元 Directive は変化しない） |
+| エラー時 | `DirectiveInvariantViolation(kind='task_already_linked')`。元 Directive は変更されない |
+
+### REQ-DR-003: 不変条件検査
+
+| 項目 | 内容 |
+|------|------|
+| 入力 | Directive の現状属性 |
+| 処理 | `_validate_text_range`（NFC 後の length が 1〜10000）/ `_validate_task_link_immutable`（task_id 一意遷移）を順次実行。命名対称性: empire / workflow / agent / room と並ぶ `_validate_*` helper |
+| 出力 | 違反なしなら return（None）、違反時は `DirectiveInvariantViolation` を raise |
+| エラー時 | `DirectiveInvariantViolation` 単一例外。`kind` で違反種別を識別 |
+
+## 画面・CLI 仕様
+
+### CLI レシピ / コマンド
+
+該当なし — 理由: 本 feature は domain 層のみ。Admin CLI は `feature/admin-cli` で扱う。CEO directive 発行 UI は `feature/chat-ui` 相当（Phase 2）で扱う。
+
+| コマンド | 概要 |
+|---------|------|
+| 該当なし | — |
+
+### Web UI 画面
+
+該当なし — 理由: UI は `feature/chat-ui`（Phase 2）で扱う。
+
+| 画面ID | 画面名 | 主要操作 |
+|-------|-------|---------|
+| 該当なし | — | — |
+
+## API 仕様
+
+該当なし — 理由: API は `feature/http-api` で扱う。本 feature は domain 層のみ。
+
+| メソッド | パス | 用途 | リクエスト | レスポンス |
+|---------|-----|------|----------|----------|
+| 該当なし | — | — | — | — |
+
+## データモデル
+
+`docs/architecture/domain-model/aggregates.md` §Directive の凍結済み定義に従う。本 feature では新規 VO は追加しない（`DirectiveId` は既存）。
+
+| エンティティ | 属性 | 型 | 制約 | 関連 |
+|-------------|------|---|------|------|
+| Directive | `id` | `DirectiveId` | 不変、UUIDv4 | Aggregate Root |
+| Directive | `text` | `str` | 1〜10000 文字（NFC 正規化のみ、strip しない） | — |
+| Directive | `target_room_id` | `RoomId` | UUIDv4。既存 Room を指す（参照整合性は application 層） | Room への参照 |
+| Directive | `created_at` | `datetime` | UTC、tz-aware | — |
+| Directive | `task_id` | `TaskId \| None` | UUIDv4 or None。一意遷移（None → 有効 TaskId のみ可、再リンク禁止） | Task への参照 |
+
+## ユーザー向けメッセージ一覧
+
+全 MSG は **2 行構造**を採用する（§確定 R1-E「フィードバック原則」、確定文言は detailed-design.md §MSG 確定文言表 で凍結）:
+
+- 1 行目: `[FAIL] <failure summary>` — 何が失敗したか
+- 2 行目: `Next: <action>` — 次に何をすべきか
+
+「Next:」必須は test-design.md の TC-UT-DR-NNN で `assert "Next:" in str(exc)` により CI 物理保証する。
+
+| ID | 種別 | 例外型 | kind | 表示条件 |
+|----|------|------|------|---------|
+| MSG-DR-001 | エラー | `DirectiveInvariantViolation` | `text_range` | text の NFC 後 length が 0 または 10001 以上 |
+| MSG-DR-002 | エラー | `DirectiveInvariantViolation` | `task_already_linked` | 既に `task_id is not None` の Directive に `link_task` を実行 |
+| MSG-DR-003 | エラー | `pydantic.ValidationError` | — | 型違反（None 渡し / tz-naive datetime / 不正 UUID 等） |
+| MSG-DR-004 | エラー | `RoomNotFoundError` | — | application 層 `DirectiveService.issue()` で `target_room_id` の Room が存在しない |
+| MSG-DR-005 | エラー | `WorkflowNotFoundError` | — | DirectiveService.issue() で Room の workflow_id を解決できない |
+
+## 依存関係
+
+| 区分 | 依存 | バージョン方針 | 導入経路 | 備考 |
+|-----|------|-------------|---------|------|
+| ランタイム | Python 3.12+ | pyproject.toml | uv | 既存 |
+| Python 依存 | Pydantic v2.x | pyproject.toml（既存） | uv | 既存 |
+| Python 依存 | unicodedata（標準ライブラリ） | — | — | NFC 正規化 |
+| ドメイン | `DirectiveId` / `RoomId` / `TaskId` | `domain/value_objects.py` | 内部 import | 既存 |
+| ドメイン | `mask_discord_webhook` / `mask_discord_webhook_in` | `domain/exceptions.py`（agent / workflow / room と共有） | 内部 import | 既存 |
+| 外部サービス | 該当なし | — | — | domain 層のため外部通信なし |

--- a/docs/features/directive/test-design.md
+++ b/docs/features/directive/test-design.md
@@ -1,0 +1,236 @@
+# テスト設計書
+
+<!-- feature: directive -->
+<!-- 配置先: docs/features/directive/test-design.md -->
+<!-- 対象範囲: REQ-DR-001〜003 / MSG-DR-001〜005 / 受入基準 1〜11 / 詳細設計 確定 A〜H / `link_task` 一意遷移 + auto-mask + 例外型統一 + 2 行構造 MSG -->
+
+本 feature は domain 層の Aggregate Root（Directive）と例外（DirectiveInvariantViolation）に閉じる M1 5 兄弟目（empire / workflow / agent / room の確立済みパターンを継承）。HTTP API / CLI / UI の公開エントリポイントは持たないため、E2E は本 feature 範囲外（後続 `feature/admin-cli` / `feature/http-api` / `feature/chat-ui`（Phase 2）で起票）。本 feature のテストは **ユニット主体 + Aggregate 内 module 連携の往復シナリオ + 責務境界の物理確認** で構成する。
+
+empire / workflow / agent / room の test-design.md と完全に同じ規約を踏襲（外部 I/O ゼロ・factory に `_meta.synthetic = True` の `WeakValueDictionary` レジストリ）。Directive は Aggregate 内 VO を新規追加しない（`DirectiveId` / `RoomId` / `TaskId` は既存）ため、factory 規模は最小。
+
+## テストマトリクス
+
+| 要件ID | 実装アーティファクト | テストケースID | テストレベル | 種別 | 受入基準 |
+|--------|-------------------|---------------|------------|------|---------|
+| REQ-DR-001 | `Directive.__init__` / `model_validator(mode='after')` | TC-UT-DR-001 | ユニット | 正常系 | 1 |
+| REQ-DR-001（text 境界） | `Directive.text` の長さバリデーション | TC-UT-DR-002 | ユニット | 境界値 | 2 |
+| REQ-DR-001（NFC 正規化） | `Directive.text` の NFC 正規化（確定 B） | TC-UT-DR-003 | ユニット | 正常系 | 3 |
+| REQ-DR-001（strip しない） | `Directive.text` の前後改行・空白保持（確定 B） | TC-UT-DR-004 | ユニット | 正常系 | 4 |
+| REQ-DR-001（task_id 直接構築） | コンストラクタで `task_id=既存有効TaskId` を渡せる（永続化からの復元経路） | TC-UT-DR-014 | ユニット | 正常系 | （確定 C） |
+| REQ-DR-001（created_at tz-aware） | naive datetime を渡すと `pydantic.ValidationError` | TC-UT-DR-015 | ユニット | 異常系 | （MSG-DR-003） |
+| REQ-DR-002 | `Directive.link_task` 正常系 | TC-UT-DR-005 | ユニット | 正常系 | 5 |
+| REQ-DR-002（再リンク禁止） | 既に紐付け済みの Directive で `link_task` 再呼び出し | TC-UT-DR-006 | ユニット | 異常系 | 6 |
+| REQ-DR-002（同一 TaskId 再リンク） | `task_id == new_task_id` でも Fail Fast（確定 D の冪等性なし契約） | TC-UT-DR-016 | ユニット | 異常系 | （確定 D） |
+| REQ-DR-003-① | text 1〜10000 文字 | TC-UT-DR-002 | ユニット | 境界値 | 2 |
+| REQ-DR-003-② | task_id 一意遷移 | TC-UT-DR-006 | ユニット | 異常系 | 6 |
+| 確定 A（pre-validate） | `link_task` 失敗時の元 Directive 不変 | TC-UT-DR-017 | ユニット | 異常系 | — |
+| 確定 B（NFC + strip しない） | NFC 合成形 / 分解形が同一視される | TC-UT-DR-003 | ユニット | 正常系 | 3 |
+| 確定 B（strip しない） | 前後改行・空白を保持 | TC-UT-DR-004 | ユニット | 正常系 | 4 |
+| 確定 C（一意遷移検査） | `link_task` ふるまい入口で `self.task_id is None` を検査 | TC-UT-DR-006, TC-UT-DR-016 | ユニット | 異常系 | 6 |
+| 確定 D（冪等性なし） | 同 TaskId 再リンクも Fail Fast | TC-UT-DR-016 | ユニット | 異常系 | （確定 D） |
+| 確定 E（webhook auto-mask） | `DirectiveInvariantViolation` の auto-mask | TC-UT-DR-007 | ユニット | 異常系 | 7 |
+| 確定 F（例外型統一） | text 違反は `DirectiveInvariantViolation`、型違反は `pydantic.ValidationError` | TC-UT-DR-002, TC-UT-DR-015 | ユニット | 異常系 | （確定 F） |
+| 確定 G（target_room_id 検証） | Aggregate 内では `target_room_id` の Room 存在を検証しない（責務境界） | TC-UT-DR-018 | ユニット | 正常系 | （責務境界） |
+| 確定 G（$ プレフィックス） | Aggregate 内では `$` プレフィックスを正規化しない（application 層責務） | TC-UT-DR-019 | ユニット | 正常系 | （責務境界） |
+| 確定 H（責務分離マトリクス） | application 層責務 4 件すべてが Aggregate 内で強制されないことを物理確認 | TC-UT-DR-018, TC-UT-DR-019 | ユニット | 正常系 | （責務境界） |
+| frozen 不変性 | `Directive.text = 'X'` 等の直接代入拒否 | TC-UT-DR-020 | ユニット | 異常系 | 8 |
+| frozen 構造的等価 | 同一属性の Directive 2 インスタンスが `==` True / `hash()` 一致 | TC-UT-DR-008 | ユニット | 正常系 | 8 |
+| `extra='forbid'` | 未知フィールド拒否 | TC-UT-DR-021 | ユニット | 異常系 | （T1 防御） |
+| MSG-DR-001（2 行構造） | `[FAIL] Directive text must be 1-10000 characters (got {length})` + `Next:` hint | TC-UT-DR-022 | ユニット | 異常系 | 2, 9 |
+| MSG-DR-002（2 行構造） | `[FAIL] Directive already has a linked Task: directive_id={...}, existing_task_id={...}` + `Next:` hint | TC-UT-DR-023 | ユニット | 異常系 | 6, 9 |
+| MSG-DR-003 | 型違反は `pydantic.ValidationError` 経由（kind 概念なし） | TC-UT-DR-015 | ユニット | 異常系 | （確定 F） |
+| **Next: hint 物理保証**（確定 F） | 全 MSG-DR-001/002 で `assert "Next:" in str(exc)` を CI 強制 | TC-UT-DR-022, TC-UT-DR-023 | ユニット | 異常系 | 9（room §確定 I 踏襲） |
+| AC-10（lint/typecheck） | `pyright --strict` / `ruff check` | （CI ジョブ） | — | — | 10 |
+| AC-11（カバレッジ） | `pytest --cov=bakufu.domain.directive` | （CI ジョブ） | — | — | 11 |
+| 結合シナリオ 1 | `Directive` + `DirectiveInvariantViolation` 往復 | TC-IT-DR-001 | 結合 | 正常系/異常系 | 1, 5 |
+| 結合シナリオ 2 | `link_task` 失敗 → 同一 Directive で再リンク不可（pre-validate 連続安全性） | TC-IT-DR-002 | 結合 | 異常系 | 5, 6 |
+
+**マトリクス充足の証拠**:
+
+- REQ-DR-001〜003 すべてに最低 1 件のテストケース
+- **`task_id` 一意遷移検査（確定 C / D）**: None → 有効 TaskId は OK（TC-UT-DR-005）+ 有効 TaskId への上書きは raise（TC-UT-DR-006）+ 同一 TaskId 再リンクも raise（TC-UT-DR-016）の 3 経路で「冪等性なし、1 回のみ許可」契約を物理確認
+- **責務境界 4 件**（`target_room_id` Room 存在 / `$` プレフィックス正規化 / Workflow 解決 / Task 生成と紐付けの 1 Tx）すべてに「Aggregate 層で強制しない」ことを物理確認する unit ケース（TC-UT-DR-018, TC-UT-DR-019）。room §確定 R1-A 系と同パターンで責務境界を test で凍結し将来の誤った Aggregate 内強制への退行を防ぐ
+- **DirectiveInvariantViolation auto-mask（確定 E）**: webhook URL を含む 10001 文字超過の text で例外発生 → message と detail の両方が伏字化されていることを TC-UT-DR-007 で確認
+- **MSG 2 行構造 + Next: hint 物理保証（確定 F、room §確定 I 踏襲）**: 全 MSG-DR-001/002 で `assert "Next:" in str(exc)` を CI 強制（TC-UT-DR-022, TC-UT-DR-023）。「hint が抜けたら CI で落ちる」を test 層で凍結
+- MSG-DR-001〜005 すべてに静的文字列照合（MSG-DR-003〜005 は application 層 / `pydantic.ValidationError` 経由のため範囲外注意書きあり）
+- 受入基準 1〜9 すべてに unit/integration ケース（10/11 は CI ジョブ）
+- 確定 A（pre-validate）/ B（NFC + strip しない）/ C（一意遷移）/ D（冪等性なし）/ E（auto-mask）/ F（例外型統一 + 2 行 MSG）/ G（responsibility 分離）/ H（責務分離マトリクス）すべてに証拠ケース
+- 孤児要件ゼロ
+
+## 外部 I/O 依存マップ
+
+| 外部 I/O | 用途 | raw fixture | factory | characterization 状態 |
+|--------|-----|------------|---------|---------------------|
+| **該当なし** | Directive は domain 層単独で外部 I/O を持たない（HTTP / DB / ファイル / 時刻 / LLM / Discord いずれも未依存）。`text` は文字列バリデーションのみで実 LLM 送信は `feature/llm-adapter` 責務。`target_room_id` / `task_id` も VO 型として保持のみで、参照先 Aggregate の存在検証は application 層責務（`DirectiveService.issue()`） | — | — | **不要（外部 I/O ゼロ）** |
+| `unicodedata.normalize('NFC', ...)` | text 正規化 | — | — | 不要（CPython 標準ライブラリ仕様で固定、empire / workflow / agent / room と同方針） |
+| `datetime.now(UTC)` | `Directive.created_at`（呼び出し側 application 層で生成して引数渡し、Aggregate 内では受け取るのみ） | — | — | 不要（Aggregate 内で時刻を取得しない、§確定設計判断「なぜ created_at を引数で受け取るか」） |
+
+**根拠**:
+- [`basic-design.md`](basic-design.md) §外部連携 で「該当なし — domain 層のみのため外部システムへの通信は発生しない」と凍結
+- [`requirements-analysis.md`](requirements-analysis.md) §前提条件・制約 で「ネットワーク: 該当なし」と凍結
+- 本 feature では assumed mock 問題は構造上発生しない（モック対象なし）
+
+**factory（合成データ）の扱い**:
+
+| factory | 出力 | `_meta.synthetic` 付与 |
+|--------|-----|------------------|
+| `DirectiveFactory` | `Directive`（valid デフォルト = `task_id=None`、`created_at=datetime.now(UTC)`、短文 text） | `True` |
+| `LinkedDirectiveFactory` | `Directive`（valid デフォルト + `task_id=既存有効TaskId`、永続化復元シナリオ用） | `True` |
+| `LongTextDirectiveFactory` | `Directive`（text 10000 文字、上限境界） | `True` |
+
+`_meta.synthetic = True` は empire / workflow / agent / room と同じく **`tests/factories/directive.py` モジュールスコープ `WeakValueDictionary[int, BaseModel]` レジストリ + `id(instance)` をキーに `is_synthetic()` で判定** 方式を踏襲する。frozen + `extra='forbid'` を尊重してインスタンスに属性追加は試みない。本番コード（`backend/src/bakufu/`）からは `tests/factories/directive.py` を import しない（CI で `tests/` から `src/` への向きのみ許可）。
+
+## E2E テストケース
+
+**該当なし** — 理由:
+
+- 本 feature は domain 層の純粋ライブラリで、CLI / HTTP API / UI のいずれの公開エントリポイントも持たない（[`requirements.md`](requirements.md) §画面・CLI 仕様 / §API 仕様 で「該当なし」と凍結）
+- 戦略ガイド §E2E対象の判断「内部API・ライブラリなどエンドユーザー操作がない場合は結合テストで代替可」に従い、E2E は本 feature 範囲外
+- 後続 `feature/admin-cli` / `feature/http-api`（Directive 発行 API） / `feature/chat-ui`（Phase 2 CEO directive 発行 UI）が公開 I/F を実装した時点で E2E を起票
+- 受入基準 1〜9 はすべて unit/integration テストで検証可能（10/11 は CI ジョブ）
+
+| テストID | ペルソナ | シナリオ | 操作手順 | 期待結果 |
+|---------|---------|---------|---------|---------|
+| （N/A） | — | 該当なし — domain 層のため公開 I/F なし | — | — |
+
+## 結合テストケース
+
+domain 層単独の本 feature では「結合」を **Aggregate 内 module 連携（Directive + DirectiveInvariantViolation の往復シナリオ）+ pre-validate 連続シナリオ**と定義する。外部 LLM / Discord / GitHub / DB は本 feature では使わないためモック不要。
+
+| テストID | 対象モジュール連携 | 使用 fixture | 前提条件 | 操作 | 期待結果 |
+|---------|------------------|--------------|---------|------|---------|
+| TC-IT-DR-001 | `Directive` + `DirectiveInvariantViolation` 往復 | factory（`DirectiveFactory`） | task_id=None の最小 Directive | 1) `link_task(task_id_1)` で None → 有効 TaskId 遷移 → 新 Directive、元 Directive は task_id=None のまま → 2) 新 Directive で `link_task(task_id_2)` を試行 → MSG-DR-002 で raise → 3) 元 Directive と新 Directive の構造的等価判定（`==` False、task_id が異なる） | 受入基準 1, 5 を一連で確認、Pydantic frozen 不変性を経路全体で確認 |
+| TC-IT-DR-002 | `Directive.link_task`（失敗）+ pre-validate 連続安全性 | factory | 既に紐付け済み Directive（task_id=既存有効TaskId） | 1) 同一 Directive で `link_task(new_task_id)` → MSG-DR-002 で raise → 2) 元 Directive の task_id が unchanged であることを確認（pre-validate 確定 A）→ 3) 別の新規 task_id_3 でも `link_task` → 同様に raise（再リンク禁止は永続的） | 失敗の独立性（pre-validate 確定 A）が連続操作で破綻しないこと、受入基準 5, 6 |
+
+**注**: 本 feature では結合テストも `tests/integration/test_directive.py` ではなく `tests/domain/directive/test_directive.py` 内の「往復シナリオ」セクションとして実装してよい（empire / workflow / agent / room と同方針）。
+
+## ユニットテストケース
+
+`tests/factories/directive.py` の factory 経由で入力を生成する。raw fixture は本 feature では外部 I/O ゼロのため存在しない。
+
+### Directive Aggregate Root（不変条件 2 種、受入基準 1〜8）
+
+| テストID | 対象 | 種別 | 入力（factory） | 期待結果 |
+|---------|-----|------|---------------|---------|
+| TC-UT-DR-001 | `Directive(id, text, target_room_id, created_at)` task_id=None 既定 | 正常系 | factory デフォルト | 構築成功、`task_id=None`、`text` は NFC 正規化済み、`created_at` は tz-aware UTC |
+| TC-UT-DR-002 | `Directive.text` 境界値（確定 B） | 境界値 | text 0 / 1 / 10000 / 10001 文字、NFC 分解形混入 | 0/10001 は `DirectiveInvariantViolation(kind='text_range')` + MSG-DR-001、1/10000 は成功 |
+| TC-UT-DR-003 | NFC 正規化（確定 B） | 正常系 | 合成形 `'ダリオ要件'` / 分解形 `'ダリオ要件'`（カタカナ NFD） | 両 Directive の `text` が NFC 正規化済みで同一値、構造的等価が成立 |
+| TC-UT-DR-004 | strip しない（確定 B） | 正常系 | `text='\n# Directive\n\nbody\n\n'`（前後改行を含む） | `Directive.text == '\n# Directive\n\nbody\n\n'`（改行が保持される）。CEO directive の段落構造を保持する設計判断の物理確認 |
+| TC-UT-DR-005 | `Directive.link_task(task_id)` 正常系 | 正常系 | task_id=None の Directive + 有効 TaskId | 新 Directive の `task_id` が有効 TaskId に遷移、元 Directive は task_id=None のまま（frozen） |
+| TC-UT-DR-006 | `link_task` 再リンク禁止（確定 C / D） | 異常系 | 既に紐付け済み Directive（task_id=既存有効TaskId） + 別の new_task_id | `DirectiveInvariantViolation(kind='task_already_linked')` + MSG-DR-002、detail に `directive_id` / `existing_task_id` / `attempted_task_id` を含む |
+| TC-UT-DR-007 | T2: `DirectiveInvariantViolation` の webhook auto-mask（確定 E） | 異常系 | webhook URL を含む 10001 文字超過 text を構築試行 | 例外の `str(exc)` および `exc.detail` の両方で webhook URL の token 部分が `<REDACTED:DISCORD_WEBHOOK>` に伏字化されていること（agent / workflow / room と同パターン） |
+| TC-UT-DR-008 | frozen 構造的等価 / hash（受入基準 8） | 正常系 | 全属性同値の Directive を 2 インスタンス | `==` True、`hash()` 一致。frozen + `model_config.frozen=True` 起因 |
+| TC-UT-DR-014 | コンストラクタで task_id=既存有効TaskId（確定 C） | 正常系 | `Directive(task_id=既存TaskId)` での直接構築 | 構築成功（永続化からの復元経路、`_validate_task_link_immutable` は link_task 経路でのみ発動、コンストラクタ経路は許容） |
+| TC-UT-DR-015 | created_at tz-aware 必須（MSG-DR-003） | 異常系 | `created_at=datetime.now()`（naive、tz 情報なし） | `pydantic.ValidationError`（kind 概念なし、確定 F の例外型統一規約）、message に tz / timezone / aware 等のキーワード含む |
+| TC-UT-DR-016 | 同一 TaskId 再リンク（確定 D 冪等性なし） | 異常系 | 既存 task_id == new_task_id（同じ TaskId で 2 回 link_task） | `DirectiveInvariantViolation(kind='task_already_linked')`、冪等にしない設計の物理確認（確定 D「1 回のみ許可、2 回目は常に Fail Fast」） |
+
+### pre-validate 方式（確定 A）の元 Directive 不変性
+
+| テストID | 対象 | 種別 | 入力 | 期待結果 |
+|---------|-----|------|------|---------|
+| TC-UT-DR-017 | `link_task` 失敗時の元 Directive 不変 | 異常系 | 既に紐付け済み Directive で `link_task` を試行（再リンク違反） | 失敗後、元 Directive の `task_id` が完全に変化なし（pre-validate 確定 A）。さらに別の new_task_id でも繰り返し失敗するため、状態破損が連続操作で進まないことを確認 |
+
+### frozen / extra='forbid' / VO 構造的等価（受入基準 8、T1 防御）
+
+| テストID | 対象 | 種別 | 入力 | 期待結果 |
+|---------|-----|------|------|---------|
+| TC-UT-DR-020 | frozen 不変性 | 異常系 | `directive.text = 'X'` / `directive.task_id = ...` 等の直接代入 | `pydantic.ValidationError`（frozen instance への代入拒否）、Directive の全属性で確認 |
+| TC-UT-DR-021 | `extra='forbid'` 未知フィールド拒否 | 異常系 | `Directive.model_validate({...,'unknown': 'x'})` | `pydantic.ValidationError`、`extra` 違反（T1 関連の入力境界防御） |
+
+### application 層責務メタ（責務境界の物理確認、確定 G / H）
+
+| テストID | 対象 | 種別 | 入力 | 期待結果 |
+|---------|-----|------|------|---------|
+| TC-UT-DR-018 | Directive Aggregate は `target_room_id` の Room 存在を**検証しない**（確定 G） | 正常系 | 存在しない room_id（任意の UUIDv4 を生成）で Directive を構築 | 構築成功（Aggregate は target_room_id を VO 型として保持するのみ）。Room 存在検証は `DirectiveService.issue()` の `RoomRepository.find_by_id` 経由（room §確定 R1-A 系と同パターン） |
+| TC-UT-DR-019 | Directive Aggregate は `text` の `$` プレフィックスを**正規化しない**（確定 G） | 正常系 | `text='ブログ分析機能を作って'`（`$` 無し）で Directive を構築 | 構築成功、`text` は `$` プレフィックス無しのまま保持される。`$` 正規化は `DirectiveService.issue()` 責務（agent §確定 I の `provider_kind` MVP gate と同パターン） |
+
+これら 2 件は「将来の誤った Aggregate 内強制への退行を test で物理的に防ぐ」境界凍結ケース。
+
+### MSG 文言照合 + Next: hint 物理保証（確定 F、受入基準 9）
+
+**フィードバック原則の物理保証**（room §確定 I 踏襲、Norman R1 対応）: 全 MSG は **2 行構造**（1 行目 = 失敗事実 `[FAIL] ...`、2 行目 = 次の行動 `Next: ...`）。test 側で **`assert "Next:" in str(exc)`** を必須とし、hint 行が抜けたら CI で落ちる構造で凍結する。
+
+| テストID | MSG ID | 例外型 | 入力 | 期待結果（1 行目: failure 完全一致 / 2 行目: hint 部分一致） |
+|---------|--------|--------|------|---------|
+| TC-UT-DR-022 | MSG-DR-001 | `DirectiveInvariantViolation(kind='text_range')` | text='a'*10001 | 1 行目: `[FAIL] Directive text must be 1-10000 characters (got 10001)` で始まる、2 行目: **`assert "Next:" in str(exc)`** + `assert "Trim" in str(exc)` または `"multiple directives" in str(exc)`（複数 directive 提案 hint） |
+| TC-UT-DR-023 | MSG-DR-002 | `DirectiveInvariantViolation(kind='task_already_linked')` | 既に紐付け済み Directive で `link_task` 再呼び出し | 1 行目: `[FAIL] Directive already has a linked Task: directive_id=<id>, existing_task_id=<id>` 形式、2 行目: **`assert "Next:" in str(exc)`** + `assert "Issue a new Directive" in str(exc)`（新規 directive 発行 hint） + `assert "one Directive maps to one Task" in str(exc)`（1:1 設計言明） |
+
+## カバレッジ基準
+
+- REQ-DR-001 〜 003 の各要件が**最低 1 件**のテストケースで検証されている（マトリクス参照）
+- 不変条件 2 種それぞれが独立した unit ケースで検証されている（`text` 範囲 / `task_id` 一意遷移）
+- **`task_id` 一意遷移検査（確定 C / D）**: None → 有効 TaskId は OK（TC-UT-DR-005）+ 既存有効 TaskId への上書き禁止（TC-UT-DR-006）+ 同一 TaskId 再リンクも raise（TC-UT-DR-016）の 3 経路で「冪等性なし、1 回のみ許可」を物理確認
+- **責務境界 2 件**（`target_room_id` Room 存在 / `$` プレフィックス正規化）すべてに「Aggregate 層で強制しない」ことを物理確認する unit ケース（TC-UT-DR-018, TC-UT-DR-019）。責務境界を test で凍結し将来の誤った Aggregate 内強制への退行を防ぐ
+- **DirectiveInvariantViolation auto-mask（T2 防御、確定 E）**: webhook URL 含む入力で例外発生時に message と detail の両方が伏字化されていることを TC-UT-DR-007 で確認
+- MSG-DR-001 / 002 の各文言が**静的文字列で照合**されており、加えて **`assert "Next:" in str(exc)` の hint 物理保証**を全 2 ケースで実施（TC-UT-DR-022, TC-UT-DR-023、確定 F / room §確定 I 踏襲）。「hint が抜けたら CI で落ちる」物理層でフィードバック原則を凍結
+- MSG-DR-003 は `pydantic.ValidationError` 経路として TC-UT-DR-015 で確認（kind 概念なし、確定 F 例外型統一規約）
+- MSG-DR-004 / 005 は application 層 `DirectiveService.issue()` の責務、本 feature 範囲外（後続 `feature/directive-application` で起票）
+- 受入基準 1 〜 9 の各々が**最低 1 件のユニット/結合ケース**で検証されている（E2E 不在のため戦略ガイドの「結合代替可」に従う）
+- 受入基準 10（pyright/ruff）/ 11（カバレッジ 95%）は CI ジョブで担保
+- 確定 A〜H すべてに証拠ケース
+- C0 目標: `domain/directive/` 配下で **95% 以上**（domain 層基準、要件分析書 §非機能要求準拠）
+
+## 人間が動作確認できるタイミング
+
+本 feature は domain 層単独のため、人間が UI / CLI で触れるタイミングは無い。レビュワー / オーナーは以下で動作確認する。
+
+- CI 統合後: `gh pr checks` で 7 ジョブ緑（lint / typecheck / test-backend / audit / fmt / commit-msg / no-ai-footer）
+- ローカル: `bash scripts/setup.sh` → `cd backend && uv run pytest tests/domain/directive/test_directive.py -v` → 全テスト緑
+- カバレッジ確認: `cd backend && uv run pytest --cov=bakufu.domain.directive --cov-report=term-missing tests/domain/directive/test_directive.py` → `domain/directive/` 95% 以上
+- 不変条件違反の実観測: 不正入力で MSG-DR-001/002 が出ることを目視（実装担当が PR 説明欄に貼り付け）
+- `link_task` 再リンク禁止の実観測: `uv run python -c "from tests.factories.directive import DirectiveFactory; from uuid import uuid4; d = DirectiveFactory(); d2 = d.link_task(uuid4()); d2.link_task(uuid4())"` で MSG-DR-002 が出ることを目視
+- webhook auto-mask の実観測: `text='https://discord.com/api/webhooks/123/secret-token-..' + 'a'*10000` の形で webhook URL を含む長文を構築試行 → 例外 message / detail に `<REDACTED:DISCORD_WEBHOOK>` が出ることを目視
+
+後段で `feature/admin-cli`（`bakufu admin directive issue`）/ `feature/http-api`（Directive 発行 API）/ `feature/chat-ui`（Phase 2）が完成したら、本 feature の Directive を経由して `curl` 経由の手動シナリオで E2E 観測可能になる。
+
+## テストディレクトリ構造
+
+```
+backend/
+  tests/
+    factories/
+      __init__.py
+      directive.py             # DirectiveFactory / LinkedDirectiveFactory /
+                               # LongTextDirectiveFactory
+                               # （empire / workflow / agent / room 流の
+                               # WeakValueDictionary レジストリ + is_synthetic()）
+    domain/
+      directive/
+        __init__.py
+        test_directive.py      # TC-UT-DR-001〜023 + TC-IT-DR-001〜002（往復シナリオ section）
+```
+
+**配置の根拠**:
+- empire / workflow / agent / room と同方針: domain 層単独・外部 I/O ゼロのため `tests/integration/` ディレクトリは作らない
+- characterization / raw / schema は本 feature では生成しない（外部 I/O ゼロ）
+- factory のみは生成する（unit テストの入力バリエーション網羅のため）
+- 本 feature では agent / room と同じく helper module-level 独立化（`_validate_text_range` / `_validate_task_link_immutable`）を `aggregate_validators.py` に持つ。test 側は `Directive` を構築 / メソッド呼び出しすることで間接的に helper を経路網羅する
+
+## 未決課題・要起票 characterization task
+
+| # | タスク | 起票先 | 備考 |
+|---|-------|--------|------|
+| （N/A） | 該当なし — 外部 I/O ゼロのため characterization 不要 | — | 後続 `feature/directive-repository` の Repository 実装（DB 永続化、`directives.text` を `MaskedText` 列で配線、`storage.md` §逆引き表に Directive 行追加対象）/ `feature/chat-ui`（Web UI）が起票時に Directive 起点の characterization が発生する見込み |
+
+**Schneier 申し送り（前 PR レビューより継承）**:
+
+- **`Directive.text` の secret マスキング**: 本 feature では文字列保持のみ。永続化前マスキング規則（[`storage.md`](../../architecture/domain-model/storage.md) §シークレットマスキング規則）の適用は `feature/directive-repository` 責務として明示申し送り（detailed-design §データ構造（永続化キー）に `MaskedText` 列指定済）。本 feature では「domain VO は raw 保持、Repository 層で適用」という適用先指定を凍結
+- **本 feature 固有の申し送り**:
+  - `target_room_id` 参照整合性 / Workflow 解決 / Task 生成と紐付けの 1 Tx は `DirectiveService.issue()` 責務（確定 G / H）。`feature/directive-application` 実装時に MSG-DR-004 / 005 + 1 Tx 内 Task 生成 + link_task の順序を漏れなく実装する申し送り
+  - prompt injection 対策（敵対的 directive text 検出 / ユーザー入力境界 escape）は `feature/llm-adapter` および `feature/http-api` の入力境界責務として残す。本 feature は長さ制約（10000 文字）のみを Pydantic field validator + `_validate_text_range` で Fail Fast
+  - `link_task` の冪等性なし契約（確定 D）: 業務シナリオで再リンクが必要な場合は新規 Directive 発行で対応する設計。Phase 2 で「Directive update」業務要求が出た場合のみ unarchive と並ぶ拡張ポイントとして再検討
+
+## レビュー観点（テスト設計レビュー時）
+
+- [ ] REQ-DR-001〜003 すべてに 1 件以上のテストケースがあり、不変条件 2 種が独立 unit で検証されている
+- [ ] **`task_id` 一意遷移検査**が「None → 有効 TaskId（TC-UT-DR-005）+ 既存 → new で raise（TC-UT-DR-006）+ 同一 TaskId でも raise（TC-UT-DR-016）」の 3 経路で確定 C / D を物理確認している
+- [ ] **責務境界 2 件**（`target_room_id` Room 存在 / `$` プレフィックス正規化）すべてが「Aggregate 内で強制しない」ことを TC-UT-DR-018 / 019 で物理確認している
+- [ ] **DirectiveInvariantViolation auto-mask（確定 E）**が webhook URL 含む長文での例外発生時に message + detail 両方で伏字化されることを TC-UT-DR-007 で確認している
+- [ ] **MSG 2 行構造 + Next: hint（確定 F、room §確定 I 踏襲）**: TC-UT-DR-022 / 023 で全 2 MSG-DR で `assert "Next:" in str(exc)` を CI 強制
+- [ ] MSG-DR-003 が `pydantic.ValidationError` 経路として TC-UT-DR-015 で確認されている（例外型統一規約）
+- [ ] MSG-DR-004 / 005 が application 層責務として明示され、本 feature テスト範囲外であることが明確
+- [ ] 確定 A〜H（pre-validate / NFC + strip しない / 一意遷移 / 冪等性なし / auto-mask / 例外型統一 + 2 行 MSG / responsibility 分離 / 責務分離マトリクス）すべてに証拠ケースが含まれる
+- [ ] frozen 不変性（TC-UT-DR-020）+ 構造的等価（TC-UT-DR-008）+ extra='forbid'（TC-UT-DR-021）が独立して検証されている
+- [ ] empire / workflow / agent / room の WeakValueDictionary レジストリ方式と整合した factory 設計になっている
+- [ ] 外部 I/O ゼロの主張が basic-design.md / requirements-analysis.md と整合している
+- [ ] Schneier 申し送り（`Directive.text` の persistence-foundation 経由マスキング配線 / `DirectiveService.issue()` の Tx 境界 / prompt injection は別 feature 責務）が次レビュー時に確認可能な形で test-design および設計書に記録されている


### PR DESCRIPTION
## Summary

Issue #24 工程2: Directive Aggregate Root のVモデル左側 4 設計書（要求分析 / 要件定義 / 基本設計 / 詳細設計）を新規作成。M1 ドメイン骨格 5 兄弟目（empire / workflow / agent / room の確立済みパターンを継承）。

## 設計ハイライト

- **`$` プレフィックス検査を application 層責務に分離**: `DirectiveService.issue()` で `raw_text` を `'$' + raw_text` 形式に正規化、Aggregate は valid な text しか受け取らない契約（agent §確定 I 同パターン）
- **`spawn_task` → `link_task` に変更（イーロン承認）**: Aggregate 境界違反（1 Tx で 2 Aggregate 更新）を回避、Task 生成は `DirectiveService.issue()` 責務、Directive 内では生成済み Task の id を紐付けるだけ
- **`task_id` 二重リンク禁止**: None → 有効 TaskId の遷移は 1 回のみ、再リンクは `DirectiveInvariantViolation(kind='task_already_linked')` で Fail Fast。`_validate_task_link_immutable` で守る
- **冪等性なし**: 同じ TaskId での再リンクも Fail Fast（再リンクが必要な業務シナリオは MVP に存在しない、新規 Directive 発行で対応）
- **`text` の正規化規約**: NFC のみ・strip しない（Persona.prompt_body / PromptKit.prefix_markdown と同規約、CEO の改行・絵文字・複数段落を保持）
- **`DirectiveInvariantViolation` auto-mask**: agent / workflow / room と同パターン（webhook URL 多層防御）
- **MSG 2 行構造**: MSG-DR-001〜005 を `[FAIL] ...` + `Next: ...` で凍結、`assert "Next:" in str(exc)` で CI 物理保証（room §確定 I 踏襲）
- **ディレクトリ層分離**: `domain/directive/` 配下に 3 ファイル（room と同パターン）

## 設計判断の責務分離マトリクス

| 検査項目 | Aggregate 内 | application 層 |
|---|---|---|
| `text` 1〜10000 文字 | ✓ | ✗ |
| `task_id` 一意遷移 | ✓ | ✗ |
| `text` の `$` プレフィックス正規化 | ✗ | ✓（`DirectiveService.issue()`）|
| `target_room_id` の Room 存在 | ✗ | ✓（外部知識）|
| Room の `workflow_id` の Workflow 存在 | ✗ | ✓（外部知識）|
| Task 生成と紐付けの 1 Tx | ✗ | ✓（複数 Aggregate にまたがる、§確定 R1-B）|

## 後続 PR

`feature/directive-repository`（M2 永続化基盤完了済み、Track 2 が `feature/empire-repository` で先行中）で `directives` テーブル定義 + `MaskedText` カラム配線 + storage.md §逆引き表に `Directive.text` 行追加。

## Test plan

- [ ] テスト担当（@ジェフ）が `docs/features/directive/test-design.md` を作成
- [ ] 内部レビュー担当（@スティーブ / @Norman / @Schneier）が設計書をレビュー
- [ ] 受入基準 11 項目（TC-UT-DR-001〜008 + 9〜11 は CI ジョブ）に紐づくユニットテスト観点が test-design.md で具体化

Closes #24（上流マージ後の Aggregate 実装 PR で完全クローズ）
