### PR TITLE
docs(empire-repository): Vモデル design for Empire SQLite Repository

### DIFF
--- a/docs/architecture/domain-model/storage.md
+++ b/docs/architecture/domain-model/storage.md
@@ -188,6 +188,7 @@ LLM subprocess の stdout / stderr、Outbox の `payload_json` / `last_error`、
 | `PromptKit.prefix_markdown` | `rooms` | `tables/rooms.py` | `MaskedText` | `feature/room-repository`（後続） |
 | `bakufu_pid_registry.cmd` | `bakufu_pid_registry` | `tables/pid_registry.py` | `MaskedText` | **本 PR** |
 | 構造化ログ | （ファイル） | `infrastructure/logging/structured.py` | log filter（TypeDecorator 対象外、ログ層で `MaskingGateway.mask()` 呼び出し） | `feature/logging` |
+| **Empire 関連カラム（`empires` / `empire_room_refs` / `empire_agent_refs`）** | 同左 3 テーブル | `infrastructure/persistence/sqlite/repositories/empire_repository.py` + `tables/empires.py` 等 | **masking 対象なし**（`String` / `UUIDStr` / `Boolean` のみ。後続 Repository PR が誤って `MaskedText` を追加しないテンプレート、CI 三層防衛 Layer 1+2 で物理保証） | `feature/empire-repository`（PR #25） |
 
 ##### 逆引き表の運用ルール
 

--- a/docs/features/empire-repository/basic-design.md
+++ b/docs/features/empire-repository/basic-design.md
@@ -1,0 +1,274 @@
+# 基本設計書
+
+> feature: `empire-repository`
+> 関連: [requirements.md](requirements.md) / [`docs/features/persistence-foundation/`](../persistence-foundation/) / [`docs/features/empire/`](../empire/)
+
+## 記述ルール（必ず守ること）
+
+基本設計に**疑似コード・サンプル実装（python/ts/sh/yaml 等の言語コードブロック）を書かない**。
+ソースコードと二重管理になりメンテナンスコストしか生まない。
+必要なのは構造契約（クラス・モジュール・データの関係）であり、実装の細部は [detailed-design.md](detailed-design.md) で凍結する。
+
+## モジュール構成
+
+| 機能 ID | モジュール | ディレクトリ | 責務 |
+|--------|----------|------------|------|
+| REQ-EMR-001 | `EmpireRepository` Protocol | `backend/src/bakufu/application/ports/empire_repository.py` | Repository ポート定義（application 層、外側を知らない） |
+| REQ-EMR-002 | `SqliteEmpireRepository` | `backend/src/bakufu/infrastructure/persistence/sqlite/repositories/empire_repository.py` | SQLite 実装（infrastructure 層、Protocol を満たす） |
+| REQ-EMR-003 | Alembic 2nd revision | `backend/alembic/versions/0002_empire_aggregate.py` | 3 テーブル + INDEX 追加 |
+| REQ-EMR-004 | CI 三層防衛拡張（Layer 1） | `scripts/ci/check_masking_columns.sh`（既存ファイル更新） | Empire 3 テーブルを「masking 対象なし」で明示登録 |
+| REQ-EMR-004 | CI 三層防衛拡張（Layer 2） | `backend/tests/architecture/test_masking_columns.py`（既存ファイル更新） | Empire 3 テーブルを parametrize に追加、masking 対象なし assert |
+| REQ-EMR-005 | storage.md 逆引き表更新 | `docs/architecture/domain-model/storage.md`（既存ファイル更新） | Empire 関連カラム「masking 対象なし」行を追加 |
+| 共通 | application/__init__.py | `backend/src/bakufu/application/__init__.py` | 新規（最初の application 層ファイル）|
+| 共通 | application/ports/__init__.py | `backend/src/bakufu/application/ports/__init__.py` | 新規 |
+| 共通 | repositories/__init__.py | `backend/src/bakufu/infrastructure/persistence/sqlite/repositories/__init__.py` | 新規 |
+
+```
+ディレクトリ構造（本 feature で追加・変更されるファイル）:
+
+.
+├── backend/
+│   ├── alembic/
+│   │   └── versions/
+│   │       └── 0002_empire_aggregate.py             # 新規: 3 テーブル + INDEX 追加
+│   ├── src/
+│   │   └── bakufu/
+│   │       ├── application/                          # 新規ディレクトリ（最初の application 層）
+│   │       │   ├── __init__.py                       # 新規
+│   │       │   └── ports/
+│   │       │       ├── __init__.py                   # 新規
+│   │       │       └── empire_repository.py          # 新規: EmpireRepository Protocol
+│   │       └── infrastructure/
+│   │           └── persistence/
+│   │               └── sqlite/
+│   │                   └── repositories/             # 新規ディレクトリ
+│   │                       ├── __init__.py           # 新規
+│   │                       └── empire_repository.py  # 新規: SqliteEmpireRepository
+│   └── tests/
+│       └── infrastructure/
+│           └── persistence/
+│               └── sqlite/
+│                   └── repositories/                 # 新規ディレクトリ
+│                       ├── __init__.py               # 新規
+│                       └── test_empire_repository.py # 新規: 結合テスト
+├── scripts/
+│   └── ci/
+│       └── check_masking_columns.sh                  # 既存更新: Empire 3 テーブル追加
+└── docs/
+    ├── architecture/
+    │   └── domain-model/
+    │       └── storage.md                            # 既存更新: 逆引き表に Empire 行追加
+    └── features/
+        └── empire-repository/                        # 本 feature 設計書 4 本
+```
+
+## クラス設計（概要）
+
+```mermaid
+classDiagram
+    class EmpireRepository {
+        <<Protocol>>
+        +find_by_id(empire_id) Empire | None
+        +count() int
+        +save(empire) None
+    }
+    class SqliteEmpireRepository {
+        +session: AsyncSession
+        +find_by_id(empire_id) Empire | None
+        +count() int
+        +save(empire) None
+        -_to_row(empire) dict
+        -_from_row(empire_row, room_refs, agent_refs) Empire
+    }
+    class Empire {
+        <<Aggregate Root>>
+        +id: EmpireId
+        +name: str
+        +rooms: list~RoomRef~
+        +agents: list~AgentRef~
+    }
+
+    SqliteEmpireRepository ..|> EmpireRepository : implements
+    SqliteEmpireRepository --> Empire : returns
+    EmpireRepository ..> Empire : returns
+```
+
+**凝集のポイント**:
+
+- `EmpireRepository` Protocol は application 層に配置、domain は知らない
+- `SqliteEmpireRepository` は infrastructure 層、Protocol を**型レベルで満たす**（`@runtime_checkable` なし、duck typing）
+- domain ↔ row 変換は private method `_to_row()` / `_from_row()` で Repository に閉じる
+- `save()` は同一 Tx 内で 3 テーブル（empires + empire_room_refs + empire_agent_refs）を delete-then-insert で更新（§確定 R1-B）
+- 呼び出し側 service が `async with session.begin():` で UoW 境界を管理、Repository は session を受け取るのみ
+
+## 処理フロー
+
+### ユースケース 1: Empire の新規作成（save 経路）
+
+1. application 層 `EmpireService.create(name)` が以下を実行（本 PR スコープ外、別 PR）
+   - `EmpireRepository.count()` を呼び `count > 0` なら `EmpireAlreadyExistsError`（empire feature §確定 R1-B）
+   - `Empire(id=uuid4(), name=name, rooms=[], agents=[])` を構築
+2. service が `async with session.begin():` で UoW 境界を開く
+3. service が `EmpireRepository.save(empire)` を呼ぶ
+4. `SqliteEmpireRepository.save(empire)` が以下を順次実行（同一 Tx 内）:
+   - `_to_row(empire)` で `empires_row: dict`、`room_refs: list[dict]`、`agent_refs: list[dict]` に分離
+   - `INSERT INTO empires (id, name) VALUES (...)` または UPSERT
+   - `DELETE FROM empire_room_refs WHERE empire_id = :empire_id` で全削除
+   - `INSERT INTO empire_room_refs (...) VALUES (...)` を `room_refs` 件数分 bulk INSERT
+   - `DELETE FROM empire_agent_refs WHERE empire_id = :empire_id` で全削除
+   - `INSERT INTO empire_agent_refs (...) VALUES (...)` を `agent_refs` 件数分 bulk INSERT
+5. `session.begin()` ブロック退出で commit、例外なら rollback
+
+### ユースケース 2: Empire の取得（find_by_id 経路）
+
+1. application 層 `EmpireService` が `EmpireRepository.find_by_id(empire_id)` を呼ぶ
+2. `SqliteEmpireRepository.find_by_id(empire_id)` が以下を実行:
+   - `SELECT * FROM empires WHERE id = :empire_id` で empire_row を取得（不在なら None を返す）
+   - `SELECT * FROM empire_room_refs WHERE empire_id = :empire_id ORDER BY room_id` で room_refs を取得
+   - `SELECT * FROM empire_agent_refs WHERE empire_id = :empire_id ORDER BY agent_id` で agent_refs を取得
+   - `_from_row(empire_row, room_refs, agent_refs)` で `Empire` を構築（VO 構造で復元）
+3. valid な Empire を返却
+
+### ユースケース 3: Empire の更新（save 経路、既存 Empire の rooms / agents 変更）
+
+1. application 層が `find_by_id(empire_id)` で既存 Empire を取得
+2. service が Empire のドメイン操作（例: `empire.hire_agent(agent_ref)`）で新 Empire を構築（pre-validate 方式、empire #8 で凍結）
+3. service が `EmpireRepository.save(updated_empire)` を呼ぶ
+4. `SqliteEmpireRepository.save()` がユースケース 1 と同じ手順で同一 Tx 内に delete-then-insert（§確定 R1-B）
+5. **delete-then-insert の利点**: 差分計算なし、子テーブル全件を一度削除して全件再挿入するため race condition なし、常に元 Aggregate と DB が同期
+
+### ユースケース 4: Empire のシングルトン強制（count 経路、application 層から利用）
+
+1. application 層 `EmpireService.create(name)` が `EmpireRepository.count()` を呼ぶ
+2. `SqliteEmpireRepository.count()` が `SELECT COUNT(*) FROM empires` を実行
+3. service が `count > 0` なら `EmpireAlreadyExistsError` を raise（empire feature §確定 R1-B、本 PR スコープ外）
+
+## シーケンス図
+
+```mermaid
+sequenceDiagram
+    participant Svc as EmpireService（別 PR）
+    participant Repo as SqliteEmpireRepository
+    participant Sess as AsyncSession
+    participant DB as SQLite
+
+    Svc->>Sess: async with session.begin():
+    Svc->>Repo: save(empire)
+    Repo->>Repo: _to_row(empire)
+    Repo->>Sess: INSERT INTO empires(id, name)
+    Sess->>DB: SQL
+    DB-->>Sess: ok
+    Repo->>Sess: DELETE FROM empire_room_refs WHERE empire_id=:id
+    Sess->>DB: SQL
+    DB-->>Sess: ok
+    Repo->>Sess: INSERT INTO empire_room_refs(...) bulk
+    Sess->>DB: SQL
+    DB-->>Sess: ok
+    Repo->>Sess: DELETE FROM empire_agent_refs WHERE empire_id=:id
+    Sess->>DB: SQL
+    DB-->>Sess: ok
+    Repo->>Sess: INSERT INTO empire_agent_refs(...) bulk
+    Sess->>DB: SQL
+    DB-->>Sess: ok
+    Repo-->>Svc: ok（例外なし）
+    Svc->>Sess: session.begin() 退出 → commit
+    Sess->>DB: COMMIT
+    DB-->>Sess: ok
+    Sess-->>Svc: Tx success
+```
+
+## アーキテクチャへの影響
+
+- `docs/architecture/domain-model.md` への変更: なし（モジュール配置案の `application/ports/` / `infrastructure/persistence/sqlite/repositories/` は既に概念定義済み、本 PR で実体化）
+- `docs/architecture/domain-model/storage.md` への変更: **§逆引き表に「Empire 関連カラム: masking 対象なし」行を追加**（§確定 R1-E、本 PR で同一コミット）
+- `docs/architecture/tech-stack.md` への変更: なし
+- 既存 feature への波及:
+  - `feature/persistence-foundation`（PR #23）の上に乗る、追加要件なし
+  - `feature/empire`（PR #15）の domain 層 Empire を import するのみ、empire 設計書は変更しない
+
+## 外部連携
+
+該当なし — 理由: infrastructure 層（SQLite Repository）に閉じる。外部システムへの通信は発生しない。
+
+| 連携先 | 目的 | プロトコル | 認証 | タイムアウト / リトライ |
+|-------|------|----------|-----|--------------------|
+| 該当なし | — | — | — | — |
+
+## UX 設計
+
+該当なし — 理由: UI を持たない infrastructure 層。
+
+| シナリオ | 期待される挙動 |
+|---------|------------|
+| 該当なし | — |
+
+**アクセシビリティ方針**: 該当なし（UI なし）。
+
+## セキュリティ設計
+
+### 脅威モデル
+
+詳細な信頼境界は [`docs/architecture/threat-model.md`](../../architecture/threat-model.md)。本 feature 範囲では以下の 2 件。
+
+| 想定攻撃者 | 攻撃経路 | 保護資産 | 対策 |
+|-----------|---------|---------|------|
+| **T1: Empire テーブルへの masking 対象カラム誤追加（後続 Repository PR の事故）** | 後続 PR の実装者が「Empire の例があるから」と masking 対象漏れに気づかず、`empires.name` を `MaskedText` 不要なのに、別 Aggregate のカラムを `String` で宣言してしまう | 全 Aggregate の masking 整合性 | CI 三層防衛 Layer 1（grep guard）+ Layer 2（arch test）で Empire 3 テーブルを「masking 対象なし」として明示登録、後続 PR が誤って `MaskedText` を Empire に追加すると Layer 2 で検出（§確定 R1-E） |
+| **T2: 永続化 Tx の半端終了による参照整合性破損** | `save()` 中に SQLite クラッシュ → `empires` 行のみ INSERT されて `empire_room_refs` / `empire_agent_refs` が DELETE のみで終了 | Empire の整合性 | 同一 Tx 内の delete-then-insert（§確定 R1-B）+ M2 永続化基盤の WAL crash safety + foreign_keys ON。Tx 全体が ATOMIC、半端終了で rollback |
+
+### OWASP Top 10 対応
+
+| # | カテゴリ | 対応状況 |
+|---|---------|---------|
+| A01 | Broken Access Control | 該当なし（infrastructure 層、認可は別 feature） |
+| A02 | Cryptographic Failures | 該当なし（Empire には masking 対象カラムなし、§確定 R1-E で物理保証） |
+| A03 | Injection | **適用**: SQLAlchemy ORM 経由で SQL injection 防御。raw SQL は使わない |
+| A04 | Insecure Design | **適用**: Repository ポート分離（依存方向 domain ← application ← infrastructure）+ delete-then-insert 戦略で Tx 原子性 |
+| A05 | Security Misconfiguration | M2 永続化基盤の PRAGMA 強制（defensive=ON 等）の上に乗る、追加要件なし |
+| A06 | Vulnerable Components | SQLAlchemy 2.x / Alembic / aiosqlite（pip-audit で監視） |
+| A07 | Auth Failures | 該当なし |
+| A08 | Data Integrity Failures | **適用**: foreign_keys ON + ON DELETE CASCADE で参照整合性、Tx 原子性で半端更新を防止 |
+| A09 | Logging Failures | M2 永続化基盤の構造化ログ + masking gateway の上に乗る、追加要件なし |
+| A10 | SSRF | 該当なし |
+
+## ER 図
+
+```mermaid
+erDiagram
+    EMPIRES {
+        UUIDStr id PK
+        String name "1〜80 文字"
+    }
+    EMPIRE_ROOM_REFS {
+        UUIDStr empire_id FK
+        UUIDStr room_id "Room.id への参照"
+        String name "RoomRef.name"
+        Boolean archived "RoomRef.archived"
+    }
+    EMPIRE_AGENT_REFS {
+        UUIDStr empire_id FK
+        UUIDStr agent_id "Agent.id への参照"
+        String name "AgentRef.name"
+        String role "AgentRef.role (enum)"
+    }
+
+    EMPIRES ||--o{ EMPIRE_ROOM_REFS : "has 0..N rooms (CASCADE)"
+    EMPIRES ||--o{ EMPIRE_AGENT_REFS : "has 0..N agents (CASCADE)"
+```
+
+UNIQUE 制約:
+
+- `empire_room_refs(empire_id, room_id)`: 同一 Empire 内で同 room_id の重複参照を禁止
+- `empire_agent_refs(empire_id, agent_id)`: 同一 Empire 内で同 agent_id の重複参照を禁止
+
+masking 対象カラム: **なし**（§確定 R1-E、storage.md §逆引き表で物理保証）。
+
+## エラーハンドリング方針
+
+| 例外種別 | 処理方針 | ユーザーへの通知 |
+|---------|---------|----------------|
+| `sqlalchemy.IntegrityError`（FK 違反、UNIQUE 違反） | application 層に伝播、HTTP API 層で 409 Conflict にマッピング | application 層 / HTTP API の MSG（別 feature） |
+| `sqlalchemy.OperationalError`（接続切断、ロック timeout） | application 層に伝播、HTTP API 層で 503 にマッピング | 同上 |
+| `pydantic.ValidationError`（domain Empire 構築時、`_from_row` 内で発生し得る） | Repository 内で catch せず application 層に伝播、データ破損として扱う | application 層 / HTTP API の MSG |
+| その他 | 握り潰さない、application 層へ伝播 | 汎用エラーメッセージ |
+
+**Repository 内で明示的な commit / rollback はしない**: 呼び出し側 service が `async with session.begin():` で UoW 境界を管理。これにより 1 Tx 内で複数 Repository を呼ぶシナリオ（例: directive + task の同時保存）に対応。

--- a/docs/features/empire-repository/detailed-design.md
+++ b/docs/features/empire-repository/detailed-design.md
@@ -1,0 +1,341 @@
+# 詳細設計書
+
+> feature: `empire-repository`
+> 関連: [basic-design.md](basic-design.md) / [`docs/features/persistence-foundation/detailed-design.md`](../persistence-foundation/detailed-design.md)
+
+## 記述ルール（必ず守ること）
+
+詳細設計に**疑似コード・サンプル実装（python/ts/sh/yaml 等の言語コードブロック）を書かない**。
+ソースコードと二重管理になりメンテナンスコストしか生まない。
+必要なのは「構造契約（属性名・型・制約）」と「確定文言（メッセージ文字列）」と「実装の意図」。
+
+## クラス設計（詳細）
+
+```mermaid
+classDiagram
+    class EmpireRepository {
+        <<Protocol>>
+        +async find_by_id(empire_id: EmpireId) Empire | None
+        +async count() int
+        +async save(empire: Empire) None
+    }
+    class SqliteEmpireRepository {
+        +session: AsyncSession
+        +async find_by_id(empire_id: EmpireId) Empire | None
+        +async count() int
+        +async save(empire: Empire) None
+        -_to_row(empire: Empire) tuple
+        -_from_row(empire_row, room_refs, agent_refs) Empire
+    }
+```
+
+### Protocol: EmpireRepository（`application/ports/empire_repository.py`）
+
+| メソッド | 引数 | 戻り値 | 制約 |
+|----|----|----|----|
+| `find_by_id(empire_id: EmpireId)` | EmpireId | `Empire \| None` | 不在時 None。SQLAlchemy 例外は上位伝播 |
+| `count()` | なし | `int` | 全 Empire 数（シングルトン強制 application 層が利用、§確定 R1-D） |
+| `save(empire: Empire)` | Empire | None | 同一 Tx 内で empires + empire_room_refs + empire_agent_refs を delete-then-insert（§確定 R1-B） |
+
+`@runtime_checkable` は付与しない（Python 3.12 typing.Protocol の duck typing で十分）。
+
+### Class: SqliteEmpireRepository（`infrastructure/persistence/sqlite/repositories/empire_repository.py`）
+
+| 属性 | 型 | 制約 |
+|----|----|----|
+| `session` | `AsyncSession` | コンストラクタで注入、Tx 境界は外側 service が管理 |
+
+| 関数 | 引数 | 戻り値 | 制約 |
+|----|----|----|----|
+| `__init__(session: AsyncSession)` | session | None | session を保持するだけ、Tx は開かない |
+| `find_by_id(empire_id)` | EmpireId | `Empire \| None` | empires SELECT → 不在なら None。存在すれば empire_room_refs / empire_agent_refs を SELECT → `_from_row` で構築 |
+| `count()` | なし | int | `SELECT COUNT(*) FROM empires` の結果 |
+| `save(empire)` | Empire | None | §確定 R1-B の delete-then-insert |
+| `_to_row(empire)` | Empire | `tuple[dict, list[dict], list[dict]]` | (empires_row, room_refs, agent_refs) に分離（§確定 R1-C） |
+| `_from_row(empire_row, room_refs, agent_refs)` | dict, list[dict], list[dict] | Empire | VO 構造で復元（§確定 R1-C） |
+
+### Tables（既存 M2 永続化基盤の table モジュール群に追加）
+
+| テーブル | モジュール | カラム |
+|----|----|----|
+| `empires` | `infrastructure/persistence/sqlite/tables/empires.py`（新規） | `id: UUIDStr PK` / `name: String(80) NOT NULL` |
+| `empire_room_refs` | `infrastructure/persistence/sqlite/tables/empire_room_refs.py`（新規） | `empire_id: UUIDStr FK CASCADE` / `room_id: UUIDStr` / `name: String(80)` / `archived: Boolean` / UNIQUE(empire_id, room_id) |
+| `empire_agent_refs` | `infrastructure/persistence/sqlite/tables/empire_agent_refs.py`（新規） | `empire_id: UUIDStr FK CASCADE` / `agent_id: UUIDStr` / `name: String(40)` / `role: String(32)` / UNIQUE(empire_id, agent_id) |
+
+すべて `bakufu.infrastructure.persistence.sqlite.base.Base` を継承。
+
+## 確定事項（先送り撤廃）
+
+### 確定 A: Repository ポート配置 — Aggregate 別ファイル分離（イーロン承認済み）
+
+`application/ports/{aggregate}_repository.py` で各 Aggregate に独立した Protocol ファイルを配置する。
+
+##### 配置ルール
+
+| Aggregate | Protocol ファイル | 担当 PR |
+|---|---|---|
+| Empire | `application/ports/empire_repository.py` | **本 PR** |
+| Workflow | `application/ports/workflow_repository.py` | `feature/workflow-repository`（後続）|
+| Agent | `application/ports/agent_repository.py` | `feature/agent-repository`（後続）|
+| Room | `application/ports/room_repository.py` | `feature/room-repository`（後続）|
+| Directive | `application/ports/directive_repository.py` | `feature/directive-repository`（後続）|
+| Task | `application/ports/task_repository.py` | `feature/task-repository`（後続）|
+| ExternalReviewGate | `application/ports/external_review_gate_repository.py` | `feature/external-review-gate-repository`（後続）|
+
+##### Protocol 定義の規約
+
+- `class {Aggregate}Repository(typing.Protocol):` の形（`@runtime_checkable` なし）
+- すべてのメソッドを `async def` で宣言（async-first）
+- 戻り値型は `domain` 層の型のみ（infrastructure を import しない、依存方向の物理保証）
+- 引数型は `domain` 層の VO（EmpireId / RoomRef / AgentRef 等）のみ
+
+##### 後続 Repository PR のテンプレート責務
+
+本確定 A は本 PR で凍結する**真実源**。後続 6 件 Repository PR は本確定を直接参照して同パターンで Protocol を追加する（同設計判断を再議論しない）。
+
+### 確定 B: `save()` 戦略 — delete-then-insert（イーロン承認済み）
+
+参照型カラム（`empire_room_refs` / `empire_agent_refs`）の更新は **同一 Tx 内で `DELETE WHERE empire_id=?` → 全件 `INSERT`**。
+
+##### 手順（凍結、`SqliteEmpireRepository.save()` の内部）
+
+| 順 | 操作 | SQL（概要） |
+|---|---|---|
+| 1 | empires UPSERT | `INSERT INTO empires (id, name) VALUES (...) ON CONFLICT (id) DO UPDATE SET name=EXCLUDED.name` |
+| 2 | empire_room_refs DELETE | `DELETE FROM empire_room_refs WHERE empire_id = :empire_id` |
+| 3 | empire_room_refs bulk INSERT | `INSERT INTO empire_room_refs (empire_id, room_id, name, archived) VALUES ...`（empire.rooms 件数分） |
+| 4 | empire_agent_refs DELETE | `DELETE FROM empire_agent_refs WHERE empire_id = :empire_id` |
+| 5 | empire_agent_refs bulk INSERT | `INSERT INTO empire_agent_refs (empire_id, agent_id, name, role) VALUES ...`（empire.agents 件数分） |
+
+##### Tx 境界の責務分離
+
+`SqliteEmpireRepository.save()` は **明示的な commit / rollback をしない**。呼び出し側 service が `async with session.begin():` で UoW 境界を管理する。これにより:
+
+1. 複数 Repository を 1 Tx 内で呼ぶシナリオ（例: directive + task の同時保存）に対応
+2. service 層がエラーハンドリングと Tx ライフサイクルを集約管理
+3. Repository は session を受け取って SQL 発行するだけの単機能
+
+##### 後続 Repository PR のテンプレート責務
+
+本戦略は workflow / agent / room / directive / task / external-review-gate Repository でも採用する（**同パターン**）。各 Repository は自分の Aggregate Root に紐づく子テーブル（room_members / workflow_stages / workflow_transitions / agent_providers / agent_skills 等）を delete-then-insert で更新する。
+
+### 確定 C: domain ↔ row 変換 — Repository クラス内 private method
+
+`SqliteEmpireRepository` クラス内に `_to_row()` / `_from_row()` を private method として配置する。
+
+##### `_to_row(empire: Empire)` 契約
+
+| 入力 | 出力 |
+|---|---|
+| `Empire`（Aggregate Root インスタンス） | `tuple[dict, list[dict], list[dict]]` |
+
+戻り値:
+1. `empires_row: dict[str, Any]` — `{'id': ..., 'name': ...}`
+2. `room_refs: list[dict[str, Any]]` — `[{'empire_id': ..., 'room_id': ..., 'name': ..., 'archived': ...}, ...]`
+3. `agent_refs: list[dict[str, Any]]` — `[{'empire_id': ..., 'agent_id': ..., 'name': ..., 'role': ...}, ...]`
+
+##### `_from_row(empire_row, room_refs, agent_refs)` 契約
+
+| 入力 | 出力 |
+|---|---|
+| `empire_row: dict` / `room_refs: list[dict]` / `agent_refs: list[dict]` | `Empire` |
+
+戻り値: `Empire(id=..., name=..., rooms=[RoomRef(...) for ...], agents=[AgentRef(...) for ...])`
+
+Aggregate Root の不変条件は Empire 構築時の `model_validator(mode='after')` で再走（Repository は再 validate しない契約だが、構築は valid な状態で行われる）。
+
+##### pyright strict pass のための型注釈
+
+`_to_row` / `_from_row` の戻り値は明示的な型注釈を付与（`dict[str, Any]` / `Empire`）。SQLAlchemy の `Row` オブジェクトを直接返さず、dict に変換してから受け渡す（domain 層が SQLAlchemy に依存しないため）。
+
+### 確定 D: シングルトン強制の責務分離（empire feature §確定 R1-B 踏襲）
+
+Empire のシングルトン制約（bakufu インスタンスにつき 1 件）は **`EmpireService.create()` の application 層責務**（本 PR スコープ外、別 PR `feature/empire-application` で実装）。
+
+本 PR では `EmpireRepository.count() -> int` メソッドを提供するのみ:
+
+| 状況 | `count()` 戻り値 | application 層の判定 |
+|---|---|---|
+| Empire 0 件（初回起動） | 0 | OK、`save(new_empire)` を実行 |
+| Empire 1 件（既存） | 1 | `EmpireAlreadyExistsError` を raise |
+| Empire 2 件以上（不正状態） | 2+ | データ破損、Critical エラー |
+
+「2 件以上」の検出は本 PR の `count()` で可能だが、検査ロジックは application 層に閉じる。
+
+### 確定 E: CI 三層防衛の Empire 拡張
+
+##### Layer 1: grep guard（`scripts/ci/check_masking_columns.sh`）
+
+既存スクリプトに Empire テーブル群を**明示登録**:
+
+| 登録内容 | 期待結果 |
+|---|---|
+| `empires` テーブルの宣言ファイル（`tables/empires.py`）に `MaskedJSONEncoded` / `MaskedText` が登場しないこと | grep でゼロヒット → pass |
+| `empire_room_refs` 同上 | 同上 |
+| `empire_agent_refs` 同上 | 同上 |
+
+##### Layer 2: arch test（`backend/tests/architecture/test_masking_columns.py`）
+
+既存 parametrize に 3 テーブル追加:
+
+| 入力 | 期待 assertion |
+|---|---|
+| `Base.metadata.tables['empires']` | 全カラムの `column.type.__class__` が `MaskedJSONEncoded` でも `MaskedText` でもない（= `String` / `UUIDStr` のみ） |
+| `Base.metadata.tables['empire_room_refs']` | 同上（`String` / `UUIDStr` / `Boolean` のみ） |
+| `Base.metadata.tables['empire_agent_refs']` | 同上 |
+
+##### Layer 3: storage.md 逆引き表更新（REQ-EMR-005）
+
+`docs/architecture/domain-model/storage.md` §逆引き表に「Empire 関連カラム: masking 対象なし」行を追加（後続 Repository PR が誤って `MaskedText` を Empire に追加しないテンプレート）。
+
+##### 後続 Repository PR のテンプレート責務
+
+各 Aggregate Repository PR は本確定 E と同様、自分の Aggregate のテーブル群を Layer 1 + Layer 2 + Layer 3 に登録する責務を持つ。masking 対象カラムが**ある**場合は `MaskedJSONEncoded` / `MaskedText` を指定し、Layer 2 が assert する。masking 対象カラムが**ない**場合は本 PR と同様「対象なし」を明示登録する。
+
+### 確定 F: テンプレート責務の凍結（後続 6 件 Repository PR の参照源）
+
+本 PR は最小 Aggregate（Empire）でパターンを確立する**最適なテンプレート**。後続 6 件 Repository PR は本 PR の確定 A〜E を直接参照して実装する。
+
+##### 後続 PR が参照するチェックリスト
+
+| チェック項目 | 参照確定 |
+|---|---|
+| Repository ポートを `application/ports/{aggregate}_repository.py` で定義 | 確定 A |
+| Protocol の各メソッドを `async def` で宣言 | 確定 A |
+| `@runtime_checkable` を付与しない | 確定 A |
+| SQLite 実装を `infrastructure/persistence/sqlite/repositories/{aggregate}_repository.py` で実装 | 確定 A / B |
+| `save()` で参照型カラムを delete-then-insert で更新 | 確定 B |
+| Tx 境界は service 層の責務、Repository 内で commit / rollback しない | 確定 B |
+| domain ↔ row 変換は Repository クラス内 private method | 確定 C |
+| Aggregate 集合知識の検査（シングルトン / 一意性等）は service 層責務 | 確定 D |
+| CI 三層防衛 Layer 1 + Layer 2 に新テーブルを parametrize 追加 | 確定 E |
+| storage.md §逆引き表に新テーブル行を追加（masking 対象あり / なしを明示） | 確定 E |
+| Alembic revision を 1 つ追加（initial revision に含めない、各 Aggregate Repository PR が個別 revision を積む） | 確定 F |
+
+##### Alembic revision の段階追加方針
+
+| revision | 内容 | 担当 PR |
+|---|---|---|
+| `0001_init_audit_pid_outbox.py` | M2 永続化基盤の 3 テーブル + 2 トリガ | persistence-foundation #19（マージ済み） |
+| `0002_empire_aggregate.py` | Empire 3 テーブル | **本 PR** |
+| `0003_workflow_aggregate.py` | Workflow + Stage + Transition テーブル | `feature/workflow-repository`（後続） |
+| `0004_agent_aggregate.py` | Agent + provider + skill テーブル | `feature/agent-repository`（後続） |
+| `0005_room_aggregate.py` | Room + room_members テーブル | `feature/room-repository`（後続） |
+| `0006_directive_aggregate.py` | Directive テーブル | `feature/directive-repository`（後続） |
+| `0007_task_aggregate.py` | Task + Conversation + Deliverable テーブル | `feature/task-repository`（後続） |
+| `0008_external_review_gate_aggregate.py` | ExternalReviewGate + AuditEntry テーブル | `feature/external-review-gate-repository`（後続） |
+
+各 revision は前 revision に対する down_revision を明示し、Alembic head が一直線になるよう順序管理する（CI で head が分岐していないか検査）。
+
+## 設計判断の補足
+
+### なぜ Repository ポートを application 層に置くか
+
+clean architecture / DDD の依存方向は `domain ← application ← infrastructure`（外側が内側を知り、内側は外側を知らない）。Repository ポート（Protocol）を:
+
+- **domain 層**に置くと、domain が永続化の存在を知ることになり依存方向違反
+- **application 層**に置くと、domain は何も知らず、application が「永続化能力を抽象化したインターフェース」として Protocol を持ち、infrastructure が実装を提供する清潔な構造
+
+これは Hexagonal Architecture の「ports and adapters」パターンと同じ（ports = Protocol、adapters = SqliteEmpireRepository）。
+
+### なぜ `save()` を delete-then-insert にするか
+
+差分計算（in-place 更新）は実装複雑性が高く、楽観排他なしではデータ破損のリスクがある。delete-then-insert は:
+
+- 同一 Tx 内なら ATOMIC（half-update なし）
+- 差分計算ロジック不要、シンプル
+- N=100 程度のパフォーマンス劣化は MVP 範囲で無視できる
+- 後続 Repository PR にも同パターンで適用可能
+
+event sourcing は MVP 範囲外（YAGNI）、Outbox は別レイヤで結果整合を実現している。
+
+### なぜ Repository 内で commit / rollback しないか
+
+`async with session.begin():` を Repository 内で持つと:
+
+- 1 Tx 内で複数 Repository を呼べない（Empire 保存 + Outbox 行追加を同一 Tx で行う場合等）
+- service 層がエラーハンドリングを集約できない
+- Repository が「自分の責務以外」を持つことになり、責務散在
+
+呼び出し側 service が UoW 境界を管理することで、Repository は単機能（CRUD のみ）に閉じる。
+
+### なぜ Empire テーブル群を CI 三層防衛に明示登録するか
+
+Empire は masking 対象カラムを持たないため、**何もしないと CI が「Empire を検査していない」状態**になる。後続 PR が同 Aggregate に新カラムを追加した場合、masking 対象であるべきカラムを `String` で宣言しても検出できない。
+
+明示登録により:
+
+1. Empire 3 テーブルが grep / arch test の検査対象になる
+2. 「対象なし」を期待結果として assert
+3. 後続 PR が誤って `MaskedText` を Empire に追加すると Layer 2 で検出 → CI 落下
+
+これは「明示的な空リスト」の防衛パターンで、後続 Aggregate Repository PR にも同方針で適用する。
+
+## ユーザー向けメッセージの確定文言
+
+該当なし — 理由: Repository は内部 API、ユーザー向けメッセージは application 層 / HTTP API 層が定義する。Repository は SQLAlchemy 例外（IntegrityError 等）を上位伝播するのみ。
+
+## データ構造（永続化キー）
+
+### `empires` テーブル
+
+| カラム | 型 | 制約 | 意図 |
+|----|----|----|----|
+| `id` | `UUIDStr` | PK, NOT NULL | EmpireId |
+| `name` | `String(80)` | NOT NULL | 表示名（Empire 内一意は application 層責務） |
+
+### `empire_room_refs` テーブル
+
+| カラム | 型 | 制約 | 意図 |
+|----|----|----|----|
+| `empire_id` | `UUIDStr` | FK → `empires.id` ON DELETE CASCADE, NOT NULL | 所属 Empire |
+| `room_id` | `UUIDStr` | NOT NULL | Room への参照（FK は意図的に張らない、Room テーブルは別 Repository PR で追加） |
+| `name` | `String(80)` | NOT NULL | RoomRef.name（表示用キャッシュ） |
+| `archived` | `Boolean` | NOT NULL DEFAULT FALSE | RoomRef.archived |
+| UNIQUE | `(empire_id, room_id)` | — | 同一 Empire 内で同 room_id の重複参照を禁止 |
+
+##### Room テーブルへの FK を張らない理由
+
+`empire_room_refs.room_id` を `rooms.id` への FK にすると、本 PR より先に rooms テーブルが存在する必要がある。room-repository は本 PR と並列着手中（room domain は #18 完了済みだが Repository は別 PR `feature/room-repository`）のため、本 PR では FK を張らず参照のみとする。
+
+`feature/room-repository` PR で room テーブル定義時に **migration で FK を追加する**責務分離（後続 PR の Alembic revision で `op.create_foreign_key(...)` を実行）。
+
+### `empire_agent_refs` テーブル
+
+| カラム | 型 | 制約 | 意図 |
+|----|----|----|----|
+| `empire_id` | `UUIDStr` | FK → `empires.id` ON DELETE CASCADE, NOT NULL | 所属 Empire |
+| `agent_id` | `UUIDStr` | NOT NULL | Agent への参照（FK は意図的に張らない、agent-repository PR で追加） |
+| `name` | `String(40)` | NOT NULL | AgentRef.name（表示用キャッシュ） |
+| `role` | `String(32)` | NOT NULL | AgentRef.role の enum string |
+| UNIQUE | `(empire_id, agent_id)` | — | 同一 Empire 内で同 agent_id の重複参照を禁止 |
+
+### Alembic 2nd revision キー構造（`0002_empire_aggregate.py`）
+
+revision id: `0002_empire_aggregate`（固定）
+down_revision: `0001_init_audit_pid_outbox`
+
+| 操作 | 対象 |
+|----|----|
+| `op.create_table('empires', ...)` | 2 カラム |
+| `op.create_table('empire_room_refs', ...)` | 4 カラム + UNIQUE |
+| `op.create_table('empire_agent_refs', ...)` | 4 カラム + UNIQUE |
+
+`downgrade()` は `op.drop_table` で逆順実行（CASCADE で子テーブルから先に削除）。
+
+## API エンドポイント詳細
+
+該当なし — 理由: 本 feature は infrastructure 層のみ。HTTP API は `feature/http-api` で凍結する。
+
+## 出典・参考
+
+- [SQLAlchemy 2.0 — async / AsyncEngine / AsyncSession](https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html)
+- [SQLAlchemy 2.0 — Imperative Mapping / Core](https://docs.sqlalchemy.org/en/20/orm/mapping_styles.html)
+- [Alembic Tutorial](https://alembic.sqlalchemy.org/en/latest/tutorial.html) — migration / revision 管理
+- [Python typing.Protocol](https://docs.python.org/3/library/typing.html#typing.Protocol) — `@runtime_checkable` なしの duck typing
+- [Hexagonal Architecture (Ports and Adapters)](https://alistair.cockburn.us/hexagonal-architecture/) — Repository ポート配置の根拠
+- [`docs/features/persistence-foundation/`](../persistence-foundation/) — M2 永続化基盤（PR #23 マージ済み）
+- [`docs/features/empire/`](../empire/) — Empire domain 設計（PR #15 マージ済み）
+- [`docs/architecture/domain-model/aggregates.md`](../../architecture/domain-model/aggregates.md) — Empire 凍結済み設計
+- [`docs/architecture/domain-model/storage.md`](../../architecture/domain-model/storage.md) — 逆引き表（本 PR で Empire 行追加）
+- [`docs/architecture/threat-model.md`](../../architecture/threat-model.md) — A04 / A08 対応根拠

--- a/docs/features/empire-repository/requirements-analysis.md
+++ b/docs/features/empire-repository/requirements-analysis.md
@@ -1,0 +1,227 @@
+# 要求分析書
+
+> feature: `empire-repository`
+> Issue: [#25 feat(empire-repository): Empire SQLite Repository (M2)](https://github.com/bakufu-dev/bakufu/issues/25)
+> 凍結済み設計: [`docs/architecture/domain-model/aggregates.md`](../../architecture/domain-model/aggregates.md) §Empire / [`docs/features/persistence-foundation/requirements-analysis.md`](../persistence-foundation/requirements-analysis.md) §確定 R1-D（TypeDecorator 採用 + CI 三層防衛）/ [`docs/features/empire/`](../empire/) （domain 設計済み）
+
+## 人間の要求
+
+> Issue #25:
+>
+> bakufu MVP（v0.1.0）M2「SQLite 永続化」の **最初の Aggregate Repository PR** として **Empire Repository** を実装する。M2 永続化基盤（PR #23、`persistence-foundation`）の上に乗る最初の Aggregate 別 Repository で、後続 6 件（workflow / agent / room / directive / task / external-review-gate）の **Repository 実装パターンを確立する**責務を持つ。Empire は最小 Aggregate（属性 4 件、参照型 RoomRef / AgentRef のみ、masking 対象カラムなし）のため、CI 三層防衛 + Repository ↔ domain 変換 + Alembic revision 拡張のテンプレートを最小コストで凍結できる。
+
+## 背景・目的
+
+### 現状の痛点
+
+1. M2 永続化基盤（PR #23）が完了したが、**Aggregate 別 Repository が一切実装されていない**。`mvp-scope.md` 受入基準 #8「再起動後も Empire / Room / Agent / Task / Gate の状態が SQLite から復元される」を満たす経路が存在しない
+2. 後続 Repository PR（workflow / agent / room / directive / task / external-review-gate）は **Repository 実装パターンの真実源**を必要としている。最初の PR が確立しないと 6 件の PR 並列着手で実装方針が分散する
+3. M3 HTTP API は全 Aggregate の Repository を前提とする（`POST /empires` / `GET /empires/{id}` 等）。Repository が揃わないと M3 着手不可
+
+### 解決されれば変わること
+
+- Repository 実装パターンの真実源（Protocol 配置 / SQLite 実装配置 / domain ↔ row 変換 / `save()` 戦略 / Alembic revision 段階追加 / CI 三層防衛拡張）が確立、後続 6 件 PR が本 PR の確定 A〜F を直接参照して実装可能
+- Empire の永続化が動作することで、Empire のシングルトン強制（application 層 `EmpireService.create()` が `count() == 0` を確認）が動作可能になる
+- M3 HTTP API の Empire endpoint が着手可能になる
+
+### ビジネス価値
+
+- bakufu MVP の**永続化レイヤの起点**を確保。Empire は最上位 Aggregate のため、これが永続化されれば後続 Repository の参照整合性検査（`empire_id` FK）も成立する
+- 「最小 Aggregate でテンプレートを確立する」アプローチにより、後続 Repository PR の実装コストを大幅に削減（同パターンをコピー&ペーストできる）
+
+## 議論結果
+
+### 設計担当による採用前提
+
+- **Repository ポート配置**: `application/ports/{aggregate}_repository.py` で **Aggregate 別ファイル分離**（単一ファイル集約は肥大化、domain 配置は依存方向違反、§確定 R1-A）
+- **`save()` 戦略**: **delete-then-insert**（同一 Tx 内で `DELETE FROM empire_room_refs WHERE empire_id=?` → 全件 `INSERT`、§確定 R1-B、イーロン承認済み）
+- **domain ↔ row 変換**: `SqliteEmpireRepository` クラス内 private method `_to_row()` / `_from_row()`（§確定 R1-C）
+- **シングルトン強制**: `EmpireService.create()` 責務（本 PR スコープ外）、Repository は `count()` メソッド提供のみ
+- **CI 三層防衛の Empire 拡張**: Empire は **masking 対象カラムを持たない**ため、grep guard / arch test に Empire テーブル群を**明示登録**して「対象なし」を assertion（後続 Repository PR の漏れ防止テンプレート）
+
+### 却下候補と根拠
+
+| 候補 | 却下理由 |
+|-----|---------|
+| 全 Aggregate Repository を `application/ports/repositories.py` 単一ファイルに集約 | ファイル肥大化（7 Aggregate × 各 5〜10 メソッド = 50〜70 メソッドが 1 ファイル）、Aggregate 追加時の merge conflict が頻発 |
+| Repository ポート（Protocol）を domain 層に配置（`domain/empire/repository.py`） | **依存方向違反**（domain は外側を知らない、Repository ポートは application 層、SQLite 実装は infrastructure 層）。clean architecture / DDD の依存方向（domain ← application ← infrastructure）と相容れない |
+| `save()` 戦略を in-place 更新（差分計算 + INSERT/UPDATE/DELETE） | 差分計算が複雑、楽観排他なしでは race condition、シングルトン前提では不要な複雑性 |
+| `save()` 戦略を event sourcing | MVP 範囲外（YAGNI）、永続化基盤 PR #23 が `domain_event_outbox` で結果整合を実現しており、Aggregate 内部状態は CRUD で十分 |
+| domain ↔ row 変換を SQLAlchemy `composite()` / `class_mapper` の column_property 経由 | Aggregate Root の VO 構造（`RoomRef` / `AgentRef`）が複雑、SQLAlchemy 内部に閉じ込めると変換ロジックが見えにくい、テスト容易性が下がる |
+| domain ↔ row 変換を別 module（`empire_mapper.py`）の free function で分離 | ファイル数増加、Repository に閉じる責務（外部から呼ばれない）のため private method で十分 |
+| シングルトン強制ロジックを Repository に配置 | Aggregate 集合知識（同 bakufu インスタンスに Empire は 1 件）は Repository 単独では判定できない（Repository は CRUD のみ）。application 層 `EmpireService.create()` の責務（empire feature §確定 R1-B 既凍結） |
+
+### 重要な選定確定（レビュー指摘 R1 応答）
+
+#### 確定 R1-A: Repository ポート配置 — Aggregate 別ファイル分離（イーロン承認済み）
+
+`application/ports/{aggregate}_repository.py` で各 Aggregate に独立した Protocol ファイルを配置する。本 PR では `application/ports/empire_repository.py` のみ追加、後続 Repository PR が同パターンで `workflow_repository.py` / `agent_repository.py` 等を追加する。
+
+ディレクトリ構造（テンプレートとして凍結）:
+
+```
+backend/src/bakufu/
+└── application/
+    ├── __init__.py            # 新規（最初の application 層ファイル）
+    └── ports/
+        ├── __init__.py        # 新規
+        └── empire_repository.py  # 新規（本 PR）
+```
+
+`@runtime_checkable` は付与しない（Python 3.12 typing.Protocol の duck typing で十分、isinstance チェックは不要）。
+
+#### 確定 R1-B: `save()` 戦略 — delete-then-insert（イーロン承認済み）
+
+参照型カラム（`empire_room_refs` / `empire_agent_refs`）の更新は **同一 Tx 内で `DELETE WHERE empire_id=?` → 全件 `INSERT`** で実装する。
+
+| 段階 | 動作 |
+|---|---|
+| 1 | `async with session.begin():` で UoW 境界（呼び出し側 service 層が管理） |
+| 2 | `empires` 行を UPSERT（id 主キーで INSERT or UPDATE） |
+| 3 | `DELETE FROM empire_room_refs WHERE empire_id = :empire_id` で全削除 |
+| 4 | `empire.rooms` 全件を `INSERT INTO empire_room_refs ...` |
+| 5 | `DELETE FROM empire_agent_refs WHERE empire_id = :empire_id` で全削除 |
+| 6 | `empire.agents` 全件を `INSERT INTO empire_agent_refs ...` |
+
+##### delete-then-insert 採用根拠
+
+| 検討事項 | delete-then-insert | 差分計算 | event sourcing |
+|---|---|---|---|
+| 実装複雑性 | ✓ シンプル（DELETE + INSERT） | ✗ 差分計算ロジック | ✗ 別パラダイム |
+| Tx 原子性 | ✓ 同一 Tx で完結 | △ 複雑な順序制御 | ✓ append-only |
+| 楽観排他 | ✓ 不要（シングルトン前提） | ✗ version 列必要 | ✓ event_id |
+| race condition | ✓ なし（シングルトン + 同一 Tx） | ✗ 並行更新でデッドロック可 | ✓ なし |
+| パフォーマンス | △ 全件 DELETE/INSERT（Empire は MVP で N≤100 なので問題なし） | ✓ 差分のみ | △ event 圧縮必要 |
+| 後続 Repository への適用性 | ✓ 同パターンで他 Aggregate にも転用可（room の members 等） | △ Aggregate ごとに差分計算ロジックを書く必要 | ✗ 別パラダイム |
+
+MVP 範囲（N ≤ 100）でのパフォーマンス劣化は無視できる。後続 Repository PR（room の members、workflow の stages / transitions 等）が同パターンで実装可能なため、テンプレートとしての価値が最大。
+
+#### 確定 R1-C: domain ↔ row 変換 — Repository クラス内 private method
+
+`SqliteEmpireRepository` クラス内に `_to_row(empire: Empire) -> dict` / `_from_row(empire_row, room_refs, agent_refs) -> Empire` を private method として配置する。
+
+理由:
+
+- Repository に閉じる責務（外部から呼ばれない、テストは Repository を介して間接的に検証）
+- Aggregate Root の VO 構造（`RoomRef` / `AgentRef`）を SQLAlchemy mapping から分離、domain 層が SQLAlchemy に依存しない
+- pyright strict pass のため戻り値型を明示（`dict[str, Any]` / `Empire`）
+
+#### 確定 R1-D: シングルトン強制の責務分離（empire feature §確定 R1-B 踏襲）
+
+Empire の「bakufu インスタンスにつき Empire は 1 件」というシングルトン制約は**集合知識**であり Repository 単独では判定できない。`EmpireService.create()` の application 層が `EmpireRepository.count()` を呼び `count > 0` なら `EmpireAlreadyExistsError` を raise する責務（既に empire feature §確定 R1-B で凍結済み）。
+
+本 PR では Repository に `count() -> int` メソッドを提供するのみ、シングルトン強制ロジックは別 PR `feature/empire-application` に分離。
+
+#### 確定 R1-E: CI 三層防衛の Empire 拡張
+
+Empire テーブル群（`empires` / `empire_room_refs` / `empire_agent_refs`）は **masking 対象カラムを持たない**。後続 Repository PR が「Empire の例があるから masking 対象漏れに気づかない」という事故を防ぐため、CI 三層防衛に**明示登録**する:
+
+| Layer | 拡張内容 |
+|---|---|
+| Layer 1（grep guard） | `scripts/ci/check_masking_columns.sh` の対象テーブルリストに Empire 関連 3 テーブルを **明示登録**し、masking 対象カラムが存在しないことを検証（追加されたら違反）|
+| Layer 2（arch test） | `backend/tests/architecture/test_masking_columns.py` の parametrize に 3 テーブル追加、各カラムが `MaskedJSONEncoded` / `MaskedText` **でない**（= 通常 String / Boolean / UUIDStr のみ）を assert |
+| Layer 3（逆引き表） | `storage.md` §逆引き表に「Empire 関連カラム: masking 対象なし」行を追加（後続 Repository PR が誤って `MaskedText` を指定しないよう注記） |
+
+#### 確定 R1-F: 後続 Repository PR のテンプレート責務
+
+本 PR は最小 Aggregate（Empire は属性 4 件、masking 対象ゼロ、Domain Event なし）のため、Repository 実装パターンを最小コストで凍結できる**最適なテンプレート**。後続 Repository PR（workflow / agent / room / directive / task / external-review-gate）は本 PR の確定 A〜F を直接参照して実装する。
+
+確立する設計判断:
+
+- `application/ports/{aggregate}_repository.py` の Protocol 定義方式（§確定 R1-A）
+- `infrastructure/persistence/sqlite/repositories/{aggregate}_repository.py` の SQLite 実装
+- `_to_row` / `_from_row` の private method による domain ↔ row 変換（§確定 R1-C）
+- delete-then-insert 戦略による参照型カラムの save 実装（§確定 R1-B）
+- Alembic revision の段階的追加（initial revision に Aggregate を含めない、各 Aggregate Repository PR が個別 revision を積む）
+- CI 三層防衛の parametrize 拡張義務（§確定 R1-E）
+
+## ペルソナ
+
+| ペルソナ名 | 役割 | 技術レベル | 利用文脈 | 達成したいゴール |
+|-----------|------|-----------|---------|----------------|
+| 後続 Repository PR 担当（バックエンド開発者） | `feature/workflow-repository` / `feature/agent-repository` 等の実装者 | DDD 経験あり、SQLAlchemy 2.x async / Pydantic v2 経験あり | 本 PR の設計書を真実源として読み、Aggregate Repository を 1 件積む | 本 PR の確定 A〜F を素直に踏襲するだけで、後段レビューで責務散在を指摘されない |
+| 個人開発者 CEO（堀川さん想定） | bakufu インスタンスのオーナー | GitHub / Docker / CLI 日常使用 | bakufu Backend を起動し、UI で Empire を作成、再起動後も Empire 状態が復元される | 永続化を意識せずに UI で Empire を扱える |
+
+##### ペルソナ別ジャーニー（後続 Repository PR 担当）
+
+1. **本 PR の設計書を読む**: `docs/features/empire-repository/` の 4 本を読み、確定 A〜F を理解する
+2. **Aggregate Repository PR の起票**: `feat(workflow-repository): Workflow SQLite Repository (M2)` を起票
+3. **設計書 4 本作成**: 本 PR の構造を踏襲、Aggregate 固有の差分（masking 対象カラム / 子 Entity 構造）のみ記述
+4. **実装**: `application/ports/workflow_repository.py` Protocol 追加、`infrastructure/persistence/sqlite/repositories/workflow_repository.py` で SqliteWorkflowRepository 実装、`alembic/versions/0003_workflow_aggregate.py` 追加、CI 三層防衛の parametrize 拡張
+5. **テスト**: 本 PR の `test_empire_repository.py` 構造を踏襲、Workflow 固有のテストケースを追加
+
+##### ジャーニーから逆算した受入要件
+
+- ジャーニー 1: 設計書が「テンプレートとして読める」構造（確定 A〜F が独立して凍結、Aggregate 固有部分が明確に分離）
+- ジャーニー 4: ファイル配置・命名規則が機械的に follow できる
+- ジャーニー 5: テスト構造が `test_empire_repository.py` を雛形にできる
+
+bakufu システム全体のペルソナは [`docs/architecture/context.md`](../../architecture/context.md) §4 を参照。
+
+## 前提条件・制約
+
+| 区分 | 内容 |
+|-----|------|
+| 既存技術スタック | Python 3.12+ / SQLAlchemy 2.x async / Alembic / Pydantic v2 / pyright strict / pytest（M2 永続化基盤 #23 で確立） |
+| 既存 CI | lint / typecheck / test-backend / audit / **CI 三層防衛 Layer 1 (check_masking_columns.sh) + Layer 2 (test_masking_columns.py)**（M2 で確立） |
+| 既存ブランチ戦略 | GitFlow（CONTRIBUTING.md §ブランチ戦略） |
+| コミット規約 | Conventional Commits |
+| ライセンス | MIT |
+| ネットワーク | 該当なし — infrastructure 層（local SQLite） |
+| 対象 OS | Windows 10 21H2+ / macOS 12+ / Linux glibc 2.35+ |
+
+## 機能一覧
+
+| 機能ID | 機能名 | 概要 | 優先度 |
+|--------|-------|------|--------|
+| REQ-EMR-001 | EmpireRepository Protocol 定義 | `application/ports/empire_repository.py` で Protocol を定義（`find_by_id` / `count` / `save`） | 必須 |
+| REQ-EMR-002 | SqliteEmpireRepository 実装 | `infrastructure/persistence/sqlite/repositories/empire_repository.py` で SQLite 実装 | 必須 |
+| REQ-EMR-003 | Alembic 2nd revision | `0002_empire_aggregate.py` で 3 テーブル追加（`empires` / `empire_room_refs` / `empire_agent_refs`） | 必須 |
+| REQ-EMR-004 | CI 三層防衛の Empire 拡張 | grep guard + arch test に Empire テーブル群を明示登録（masking 対象なし assertion） | 必須 |
+| REQ-EMR-005 | storage.md 逆引き表更新 | Empire 関連カラムが masking 対象なしを明示する行を追加 | 必須 |
+
+## Sub-issue 分割計画
+
+本 Issue は意図的に**Repository 実装パターン確立に絞った 1 PR**であり、後続 Aggregate Repository（6 件）を別 PR に分離することで既に分割済み。本 Issue 自体をさらに分割すると Alembic revision が複数 PR に跨がり head 管理が壊れる。
+
+| Sub-issue 名 | 紐付く REQ | スコープ | 依存関係 |
+|------------|-----------|---------|---------|
+| 単一 PR | REQ-EMR-001〜005 | 設計書 4 本 + application/ports/ + infrastructure/persistence/sqlite/repositories/ + alembic/versions/0002_*.py + CI 三層防衛拡張 + storage.md 更新 + ユニット / 結合テスト | M2 永続化基盤（PR #23）+ M1 empire (#8) マージ済み |
+
+## 非機能要求
+
+| 区分 | 要求 |
+|-----|------|
+| パフォーマンス | `find_by_id` < 10ms（Empire は MVP で N≤100、JOIN 込みでも問題なし）、`save()` < 50ms（delete-then-insert で 100 件 INSERT 含む） |
+| 可用性 | M2 永続化基盤（WAL モード + crash safety + masking gateway）の上に乗る、追加要件なし |
+| 保守性 | pyright strict pass / ruff 警告ゼロ / カバレッジ 90% 以上（基盤に近いコードのため高カバレッジ目標、persistence-foundation 実績水準） |
+| 可搬性 | M2 と同じ（POSIX 限定機能なし、純 SQLAlchemy） |
+| セキュリティ | Empire には masking 対象カラムなし。CI 三層防衛で「対象なし」を明示登録（後続 Repository PR の漏れ防止）。詳細は [`threat-model.md`](../../architecture/threat-model.md) §A4 |
+
+## 受入基準
+
+| # | 基準 | 検証方法 |
+|---|------|---------|
+| 1 | `EmpireRepository` Protocol が `application/ports/empire_repository.py` で定義される（`find_by_id` / `count` / `save` の 3 メソッド） | TC-IT-EMR-001 |
+| 2 | `SqliteEmpireRepository` が Protocol を満たす（pyright strict pass） | CI typecheck |
+| 3 | `find_by_id(empire_id)` が新規 Empire を取得できる | TC-IT-EMR-002 |
+| 4 | `find_by_id(unknown_id)` が `None` を返す | TC-IT-EMR-003 |
+| 5 | `count()` が 0 件 / 1 件で正しい値を返す | TC-IT-EMR-004 |
+| 6 | `save(empire)` が新規 Empire を挿入する（empires + empire_room_refs + empire_agent_refs の 3 テーブルに行が入る） | TC-IT-EMR-005 |
+| 7 | `save(empire)` が既存 Empire の `rooms` / `agents` 変更を反映する（delete-then-insert 戦略、§確定 R1-B） | TC-IT-EMR-006 |
+| 8 | domain ↔ row のラウンドトリップで構造的等価が保たれる（`save(empire)` → `find_by_id(empire.id)` → 復元 Empire == 元 Empire） | TC-IT-EMR-007 |
+| 9 | Alembic 2nd revision で 3 テーブルが追加され、`alembic upgrade head` / `downgrade base` 双方が緑 | TC-IT-EMR-008 |
+| 10 | CI 三層防衛 Layer 1（grep guard）が Empire 3 テーブルで「masking 対象なし」を pass | TC-CI-EMR-001 |
+| 11 | CI 三層防衛 Layer 2（arch test）が Empire 3 テーブルで `column.type.__class__` が `MaskedJSONEncoded` / `MaskedText` でないことを assert | TC-IT-EMR-009 |
+| 12 | `domain` 層から `application` / `infrastructure` への import がゼロ件（既存 CI 検査で確認） | CI script |
+| 13 | `pyright --strict` および `ruff check` がエラーゼロ | CI lint / typecheck |
+| 14 | カバレッジが `application/ports/empire_repository.py` / `infrastructure/persistence/sqlite/repositories/empire_repository.py` で 90% 以上 | pytest --cov |
+
+## 扱うデータと機密レベル
+
+| 区分 | 内容 | 機密レベル |
+|-----|------|----------|
+| `empires.id` / `empires.name` | Empire の表示名（CEO 任意の文字列、例: "山田の幕府"） | 低 |
+| `empire_room_refs.*` | Room 参照（id / name / archived） | 低 |
+| `empire_agent_refs.*` | Agent 参照（id / name / role） | 低 |
+| **masking 対象カラム** | **なし**（Empire 関連 3 テーブルすべて、storage.md §逆引き表で凍結） | — |

--- a/docs/features/empire-repository/requirements.md
+++ b/docs/features/empire-repository/requirements.md
@@ -1,0 +1,119 @@
+# 要件定義書
+
+> feature: `empire-repository`
+> 関連: [requirements-analysis.md](requirements-analysis.md) / [`docs/features/persistence-foundation/`](../persistence-foundation/) / [`docs/features/empire/`](../empire/)
+
+## 機能要件
+
+### REQ-EMR-001: EmpireRepository Protocol 定義
+
+| 項目 | 内容 |
+|------|------|
+| 入力 | 該当なし（Protocol 定義のため抽象） |
+| 処理 | `application/ports/empire_repository.py` で `EmpireRepository(Protocol)` を定義。3 メソッド: `find_by_id(empire_id: EmpireId) -> Empire \| None` / `count() -> int` / `save(empire: Empire) -> None`。すべて `async def` |
+| 出力 | Protocol 定義（`@runtime_checkable` なし）。pyright strict で SqliteEmpireRepository が Protocol を満たすことを型レベル検証 |
+| エラー時 | 該当なし（Protocol は実行時例外を持たない） |
+
+### REQ-EMR-002: SqliteEmpireRepository 実装
+
+| 項目 | 内容 |
+|------|------|
+| 入力 | `AsyncSession`（コンストラクタ引数）、各メソッドに応じた引数（`empire_id` / `empire`） |
+| 処理 | `find_by_id`: `empires` + `empire_room_refs` + `empire_agent_refs` を JOIN して取得 → `_from_row()` で Empire 復元。`count`: `SELECT COUNT(*) FROM empires`。`save`: §確定 R1-B の delete-then-insert 戦略（empires UPSERT → empire_room_refs DELETE+INSERT → empire_agent_refs DELETE+INSERT、すべて呼び出し側 service の同一 Tx 内で実行） |
+| 出力 | `find_by_id`: `Empire \| None`、`count`: `int`、`save`: `None` |
+| エラー時 | SQLAlchemy `IntegrityError`（FK 違反等）→ application 層に伝播。SQLite 接続切断 → `OperationalError` を上位伝播。`save` 中の Tx は呼び出し側 service が `async with session.begin():` で管理、Repository 内では明示的な commit / rollback はしない |
+
+### REQ-EMR-003: Alembic 2nd revision
+
+| 項目 | 内容 |
+|------|------|
+| 入力 | M2 永続化基盤（PR #23）の initial revision（`0001_init_audit_pid_outbox.py`）|
+| 処理 | `0002_empire_aggregate.py` で 3 テーブル追加: (a) `empires`（id PK、name String(80) NOT NULL）、(b) `empire_room_refs`（empire_id FK → empires.id CASCADE、room_id UUIDStr、name String(80)、archived Boolean、UNIQUE(empire_id, room_id)）、(c) `empire_agent_refs`（empire_id FK → empires.id CASCADE、agent_id UUIDStr、name String(40)、role String(32)、UNIQUE(empire_id, agent_id)）|
+| 出力 | 3 テーブル + 関連 INDEX が SQLite に存在する状態 |
+| エラー時 | migration 失敗 → `BakufuMigrationError(MSG-PF-004)`、Bootstrap stage 3 で Fail Fast（M2 永続化基盤の規約） |
+
+### REQ-EMR-004: CI 三層防衛の Empire 拡張
+
+| 項目 | 内容 |
+|------|------|
+| 入力 | M2 永続化基盤の `scripts/ci/check_masking_columns.sh`（Layer 1）と `backend/tests/architecture/test_masking_columns.py`（Layer 2）|
+| 処理 | (a) Layer 1 grep guard: 対象テーブルリストに `empires` / `empire_room_refs` / `empire_agent_refs` の 3 テーブルを **明示登録**し、masking 対象カラムが存在しないことを strict 検証。(b) Layer 2 arch test: parametrize に 3 テーブル追加、各カラムが `MaskedJSONEncoded` / `MaskedText` **でない**ことを assert |
+| 出力 | CI が Empire 3 テーブルで「masking 対象なし」を物理保証する状態 |
+| エラー時 | 後続 Repository PR が誤って `MaskedText` を Empire カラムに指定 → CI で Layer 2 arch test が落下、PR ブロック |
+
+### REQ-EMR-005: storage.md 逆引き表更新
+
+| 項目 | 内容 |
+|------|------|
+| 入力 | `docs/architecture/domain-model/storage.md` の §逆引き表（11 行、persistence-foundation で凍結済み）|
+| 処理 | §逆引き表に「Empire 関連カラム: masking 対象なし」を明示する行を追加（後続 Repository PR が誤って `MaskedText` を指定しないテンプレート） |
+| 出力 | storage.md §逆引き表に Empire 行が追加された状態（テキスト更新のみ）|
+| エラー時 | 該当なし（ドキュメント更新） |
+
+## 画面・CLI 仕様
+
+### CLI レシピ / コマンド
+
+該当なし — 理由: 本 feature は infrastructure 層（Repository 実装）。Admin CLI は `feature/admin-cli` で扱う。
+
+| コマンド | 概要 |
+|---------|------|
+| 該当なし | — |
+
+### Web UI 画面
+
+該当なし — 理由: UI を持たない。
+
+| 画面ID | 画面名 | 主要操作 |
+|-------|-------|---------|
+| 該当なし | — | — |
+
+## API 仕様
+
+該当なし — 理由: HTTP API は `feature/http-api` で扱う。本 PR は内部 API（Python module-level の Protocol / Class）のみ提供する。
+
+| メソッド | パス | 用途 | リクエスト | レスポンス |
+|---------|-----|------|----------|----------|
+| 該当なし | — | — | — | — |
+
+## データモデル
+
+本 Issue で導入する 3 テーブル + 関連 INDEX。
+
+| エンティティ | 属性 | 型 | 制約 | 関連 |
+|-------------|------|---|------|------|
+| `empires` | `id` | `UUIDStr` | PK, NOT NULL | EmpireId |
+| `empires` | `name` | `String(80)` | NOT NULL | 表示名 |
+| `empire_room_refs` | `empire_id` | `UUIDStr` | FK → `empires.id` ON DELETE CASCADE, NOT NULL | 所属 Empire |
+| `empire_room_refs` | `room_id` | `UUIDStr` | NOT NULL | Room への参照 |
+| `empire_room_refs` | `name` | `String(80)` | NOT NULL | RoomRef.name |
+| `empire_room_refs` | `archived` | `Boolean` | NOT NULL DEFAULT FALSE | RoomRef.archived |
+| `empire_room_refs` UNIQUE | `(empire_id, room_id)` | — | — | DB 制約で `RoomRef.room_id` 一意性を担保 |
+| `empire_agent_refs` | `empire_id` | `UUIDStr` | FK → `empires.id` ON DELETE CASCADE, NOT NULL | 所属 Empire |
+| `empire_agent_refs` | `agent_id` | `UUIDStr` | NOT NULL | Agent への参照 |
+| `empire_agent_refs` | `name` | `String(40)` | NOT NULL | AgentRef.name |
+| `empire_agent_refs` | `role` | `String(32)` | NOT NULL | AgentRef.role（enum string） |
+| `empire_agent_refs` UNIQUE | `(empire_id, agent_id)` | — | — | DB 制約で `AgentRef.agent_id` 一意性を担保 |
+
+**masking 対象カラム**: **なし**（storage.md §逆引き表で凍結、§確定 R1-E で CI 三層防衛が物理保証）。
+
+## ユーザー向けメッセージ一覧
+
+該当なし — 理由: Repository は内部 API のみ提供、ユーザー向けメッセージは application 層 / HTTP API 層が定義する。
+
+| ID | 種別 | メッセージ（要旨） | 表示条件 |
+|----|------|----------------|---------|
+| 該当なし | — | — | — |
+
+## 依存関係
+
+| 区分 | 依存 | バージョン方針 | 導入経路 | 備考 |
+|-----|------|-------------|---------|------|
+| ランタイム | Python 3.12+ | pyproject.toml | uv | 既存 |
+| Python 依存 | SQLAlchemy 2.x | pyproject.toml | uv | 既存（M2 永続化基盤で導入済み）|
+| Python 依存 | Alembic | pyproject.toml | uv | 既存 |
+| Python 依存 | typing.Protocol | 標準ライブラリ | — | Python 3.12 標準 |
+| ドメイン | `Empire` / `EmpireId` / `RoomRef` / `AgentRef` | `domain/empire.py` / `domain/value_objects.py` | 内部 import | 既存（empire feature #8）|
+| インフラ | `Base` / `UUIDStr` / `UTCDateTime` | `infrastructure/persistence/sqlite/base.py` | 内部 import | 既存（M2 永続化基盤）|
+| インフラ | `AsyncSession` / `async_sessionmaker` | `infrastructure/persistence/sqlite/session.py` | 内部 import | 既存 |
+| 外部サービス | 該当なし | — | — | infrastructure 層のため外部通信なし |

--- a/docs/features/empire-repository/test-design.md
+++ b/docs/features/empire-repository/test-design.md
@@ -1,0 +1,280 @@
+# テスト設計書
+
+<!-- feature: empire-repository -->
+<!-- 配置先: docs/features/empire-repository/test-design.md -->
+<!-- 対象範囲: REQ-EMR-001〜005 / 受入基準 1〜14 / 詳細設計 確定 A〜F / Repository ポート + delete-then-insert + domain↔row 変換 + シングルトン強制責務分離 + CI 三層防衛 + テンプレート責務 -->
+
+本 feature は M2 Repository **最初の Aggregate Repository PR**であり、後続 6 件（workflow / agent / room / directive / task / external-review-gate）の**実装パターンを test 層でも凍結する**責務を持つ。テストの主役は **integration**（実 SQLite + 実 Alembic + 実 SQLAlchemy AsyncSession）であり、unit は domain ↔ row 変換 / Protocol 充足チェックなど契約周辺に絞る。
+
+戦略ガイド §結合テスト方針「DB は実接続」「外部 API のみモック」に従い、本 feature のテストは:
+
+- **integration test 主導**: Alembic 2nd revision 適用 → AsyncSession で `find_by_id` / `count` / `save` の 3 メソッド契約検証（`tmp_path` で実 SQLite ファイル）
+- **CI 三層防衛の物理保証**: Layer 1（grep guard）+ Layer 2（arch test）の両方を本 PR で同時起票し、後続 Repository PR の masking 対象漏れを構造で塞ぐ
+- **assumed mock 禁止規約**: `mock.return_value` インライン辞書は禁止、Empire / RoomRef / AgentRef は既存 `tests/factories/empire.py`（empire feature #8 で確立）から取得
+
+外部 I/O は SQLite + ファイルシステム + Alembic が本物。masking gateway（M2 永続化基盤の Layer 1〜3）は Empire スコープでは「対象なし」だが、グローバル init は実行されるため実 init 経路で動作確認する。
+
+## テストマトリクス
+
+| 要件ID | 実装アーティファクト | テストケースID | テストレベル | 種別 | 受入基準 |
+|--------|-------------------|---------------|------------|------|---------|
+| REQ-EMR-001 | `EmpireRepository(Protocol)` 定義 | TC-IT-EMR-001 | 結合 | 正常系 | 1 |
+| REQ-EMR-001 | Protocol 充足（pyright 型レベル + isinstance 風 duck typing） | TC-IT-EMR-010 | 結合 | 正常系 | 2 |
+| REQ-EMR-002 | `find_by_id(empire_id)` 既存 Empire 取得 | TC-IT-EMR-002 | 結合 | 正常系 | 3 |
+| REQ-EMR-002 | `find_by_id(unknown_id)` で None | TC-IT-EMR-003 | 結合 | 異常系 | 4 |
+| REQ-EMR-002 | `count()` 0 件 / 1 件 | TC-IT-EMR-004 | 結合 | 正常系 | 5 |
+| REQ-EMR-002 | `save(empire)` 新規挿入（3 テーブルに行が入る） | TC-IT-EMR-005 | 結合 | 正常系 | 6 |
+| REQ-EMR-002 | `save(empire)` 既存更新（delete-then-insert で rooms / agents 反映、確定 B） | TC-IT-EMR-006 | 結合 | 正常系 | 7 |
+| REQ-EMR-002（ラウンドトリップ） | `save(empire)` → `find_by_id(empire.id)` の構造的等価 | TC-IT-EMR-007 | 結合 | 正常系 | 8 |
+| REQ-EMR-002（delete-then-insert 5 段階） | save 内で empires UPSERT → empire_room_refs DELETE → INSERT → empire_agent_refs DELETE → INSERT の順序検証 | TC-IT-EMR-011 | 結合 | 正常系 | 7（確定 B） |
+| REQ-EMR-002（Tx 境界） | service 側で `async with session.begin()` を持つ正常 commit / 例外時 rollback で Empire 永続化が原子的 | TC-IT-EMR-012 | 結合 | 正常系/異常系 | （確定 B Tx 境界） |
+| REQ-EMR-002（FK CASCADE） | `DELETE FROM empires WHERE id=...` で empire_room_refs / empire_agent_refs が CASCADE 削除される | TC-IT-EMR-013 | 結合 | 正常系 | （データモデル制約） |
+| REQ-EMR-002（UNIQUE 制約） | `(empire_id, room_id)` / `(empire_id, agent_id)` の重複 INSERT で `IntegrityError` | TC-IT-EMR-014 | 結合 | 異常系 | （データモデル制約） |
+| REQ-EMR-002（domain↔row 変換、確定 C） | `_to_row(empire)` が tuple[dict, list, list] を返す | TC-UT-EMR-001 | ユニット | 正常系 | （確定 C） |
+| REQ-EMR-002（domain↔row 変換、確定 C） | `_from_row(empire_row, room_refs, agent_refs)` が valid Empire を構築 | TC-UT-EMR-002 | ユニット | 正常系 | （確定 C） |
+| REQ-EMR-002（domain↔row 双方向） | `_from_row(_to_row(e)) == e` の構造的等価 | TC-UT-EMR-003 | ユニット | 正常系 | 8（確定 C） |
+| REQ-EMR-003 | Alembic 2nd revision で 3 テーブル + INDEX が追加される | TC-IT-EMR-008 | 結合 | 正常系 | 9 |
+| REQ-EMR-003 | `alembic upgrade head` → `downgrade base` 双方が緑（idempotent） | TC-IT-EMR-015 | 結合 | 正常系 | 9 |
+| REQ-EMR-003（chain 完整性） | revision 0001 → 0002 の down_revision が一直線（CI 検査で head 分岐なし） | TC-IT-EMR-016 | 結合 | 正常系 | 9（確定 F） |
+| REQ-EMR-004（Layer 1 grep） | `scripts/ci/check_masking_columns.sh` で Empire 3 テーブルが「masking 対象なし」を pass | TC-CI-EMR-001 | CI script | 正常系 | 10 |
+| REQ-EMR-004（Layer 2 arch） | `tests/architecture/test_masking_columns.py` で Empire 3 テーブルの全カラムが MaskedJSONEncoded / MaskedText でないことを assert | TC-IT-EMR-009 | 結合 | 正常系 | 11 |
+| REQ-EMR-004（後続 PR テンプレート） | 「対象なし」を明示登録できる構造で Layer 1 / 2 が parametrize されている | TC-IT-EMR-017 | 結合 | 正常系 | 11（確定 E / F） |
+| REQ-EMR-005（storage.md 逆引き表） | §逆引き表に「Empire 関連カラム: masking 対象なし」行が存在 | TC-DOC-EMR-001 | doc 検証 | 正常系 | （確定 E Layer 3） |
+| 確定 D（シングルトン責務分離） | `count()` 単体で 0 / 1 / 2+ を返すのみ、Aggregate 内 / Repository 内でシングルトン強制しない | TC-IT-EMR-018 | 結合 | 正常系 | （責務境界） |
+| 確定 F（テンプレート責務） | チェックリスト 11 項目（A〜E）を本 PR が満たすことを test-design.md で凍結 | （本マトリクス全体） | — | — | 11 項目 |
+| AC-12（依存方向） | `domain` 層から `application` / `infrastructure` への import がゼロ件 | （既存 CI script） | — | — | 12 |
+| AC-13（lint/typecheck） | `pyright --strict` / `ruff check` | （CI ジョブ） | — | — | 13 |
+| AC-14（カバレッジ） | `pytest --cov=bakufu.application.ports.empire_repository --cov=bakufu.infrastructure.persistence.sqlite.repositories.empire_repository` で 90% 以上 | （CI ジョブ） | — | — | 14 |
+
+**マトリクス充足の証拠**:
+
+- REQ-EMR-001〜005 すべてに最低 1 件のテストケース
+- **delete-then-insert 5 段階順序（確定 B）**: TC-IT-EMR-011 で実 SQLite に対し UPSERT → DELETE → INSERT の順序を物理確認（`sqlalchemy.event.listen(engine, "after_cursor_execute", ...)` で SQL 発行順を観測する経路）
+- **domain↔row ラウンドトリップ（確定 C）**: TC-UT-EMR-003（unit 純粋ロジック）+ TC-IT-EMR-007（実 DB 経由）の 2 経路で構造的等価を物理確認
+- **Aggregate 集合知識の責務分離（確定 D）**: TC-IT-EMR-018 で「Repository 自身はシングルトン強制しない、`count()` は事実報告のみ」を物理確認
+- **CI 三層防衛の物理保証（確定 E）**: Layer 1 grep（TC-CI-EMR-001）+ Layer 2 arch test（TC-IT-EMR-009）+ Layer 3 storage.md（TC-DOC-EMR-001）の 3 つすべてで Empire テーブル群が「masking 対象なし」を凍結。後続 Repository PR が誤って `MaskedText` 指定 → CI で arch test 落下、PR ブロック
+- **テンプレート責務（確定 F）**: 後続 6 件 Repository PR が確定 A〜E を直接参照して実装する旨を test-design.md レビュー観点で凍結
+- **Tx 境界の正常系/異常系（確定 B）**: TC-IT-EMR-012 で `async with session.begin()` の commit / rollback 両経路を物理確認、Repository が明示的 commit / rollback しないことを assert
+- **DB 制約**: FK CASCADE（TC-IT-EMR-013）+ UNIQUE 制約（TC-IT-EMR-014）で Alembic 2nd revision の DDL が正しいことを物理確認
+- 受入基準 1〜11 すべてに unit/integration ケース（12〜14 は CI ジョブ）
+- 確定 A（Protocol 配置）/ B（delete-then-insert + Tx 境界）/ C（domain↔row 変換）/ D（シングルトン責務分離）/ E（CI 三層防衛）/ F（テンプレート責務）すべてに証拠ケース
+- 孤児要件ゼロ
+
+## 外部 I/O 依存マップ
+
+本 feature は infrastructure 層の Repository 実装であり、本物の SQLite + 本物の Alembic + 本物の SQLAlchemy AsyncSession を使う（M2 永続化基盤と同方針）。
+
+| 外部 I/O | 用途 | raw fixture | factory | characterization 状態 |
+|--------|-----|------------|---------|---------------------|
+| **SQLite (sqlite+aiosqlite)** | engine / session / 3 テーブル / Alembic migration | 不要（実 DB を `tmp_path` 配下の bakufu.db で起動、テストごとに使い捨て） | 不要（DB は本物） | **済（本物使用、persistence-foundation conftest.py の app_engine / session_factory fixture を再利用）** |
+| **ファイルシステム** | `BAKUFU_DATA_DIR` / `bakufu.db` / WAL/SHM | 不要（`pytest.tmp_path`） | 不要（FS は本物） | **済（本物使用）** |
+| **Alembic** | 2nd revision の `upgrade head` / `downgrade base` | 不要（本物の `alembic upgrade` を実 SQLite に対し実行） | 不要 | **済（本物使用、persistence-foundation の `run_upgrade_head` を再利用）** |
+| **SQLAlchemy 2.x AsyncSession** | UoW 境界 / Repository メソッド経由の SQL 発行 | 不要 | 不要 | **済（本物使用）** |
+| **環境変数** | `BAKUFU_DATA_DIR` / `BAKUFU_DB_PATH` | 不要 | 不要 | **済（`monkeypatch.setenv` で test 用 tmp_path）** |
+
+**factory（合成データ）の扱い**:
+
+| factory | 出力 | `_meta.synthetic` 付与 |
+|--------|-----|------------------|
+| `EmpireFactory`（既存、empire feature #8 由来） | `Empire`（valid デフォルト = name="bakufu-empire"、rooms=[], agents=[]） | `True` |
+| `PopulatedEmpireFactory`（新規） | `Empire`（rooms 2 件 + agents 3 件、ラウンドトリップ test 用） | `True` |
+| `RoomRefFactory`（既存） | `RoomRef` | `True` |
+| `AgentRefFactory`（既存） | `AgentRef` | `True` |
+
+`tests/factories/empire.py` は empire feature #8 で確立済み、本 PR では `PopulatedEmpireFactory` を 1 件追加するのみ（rooms / agents 含む Empire の実 DB ラウンドトリップ test 用）。
+
+**raw fixture / characterization は不要**: SQLite + SQLAlchemy + Alembic の挙動は標準ライブラリ仕様で固定、外部観測（実 DB ファイル）が真実源として常時使える。M2 永続化基盤と同じ判断。
+
+## E2E テストケース
+
+**該当なし** — 理由:
+
+- 本 feature は infrastructure 層単独で、CLI / HTTP API / UI のいずれの公開エントリポイントも持たない（[`requirements.md`](requirements.md) §画面・CLI 仕様 / §API 仕様 で「該当なし」と凍結）
+- Repository は内部 API（Python module-level の Protocol / Class）のみ提供
+- 戦略ガイド §E2E対象の判断「内部 API・ライブラリなどエンドユーザー操作がない場合は結合テストで代替可」に従い、E2E は本 feature 範囲外
+- 後続 `feature/admin-cli`（`bakufu admin empire show` 等）/ `feature/http-api`（Empire CRUD）が公開 I/F を実装した時点で E2E を起票
+- 受入基準 1〜11 はすべて unit/integration テストで検証可能（12〜14 は CI ジョブ）
+
+| テストID | ペルソナ | シナリオ | 操作手順 | 期待結果 |
+|---------|---------|---------|---------|---------|
+| （N/A） | — | 該当なし — infrastructure 層のため公開 I/F なし | — | — |
+
+## 結合テストケース
+
+**「Repository 契約 + 実 SQLite + 実 Alembic」を contract testing する**層。M2 永続化基盤の `app_engine` / `session_factory` fixture を再利用。
+
+### Protocol 定義 + 充足（受入基準 1, 2、確定 A）
+
+| テストID | 対象モジュール連携 | 使用 fixture | 前提条件 | 操作 | 期待結果 |
+|---------|------------------|--------------|---------|------|---------|
+| TC-IT-EMR-001 | `EmpireRepository(Protocol)` 定義 | — | `application/ports/empire_repository.py` がインポート可能 | `from bakufu.application.ports.empire_repository import EmpireRepository` | Protocol が `find_by_id` / `count` / `save` の 3 メソッドを宣言、すべて `async def`。`@runtime_checkable` なし（duck typing） |
+| TC-IT-EMR-010 | `SqliteEmpireRepository` の Protocol 充足 | `app_engine` + `session_factory` | engine + Alembic 適用済み | `repo: EmpireRepository = SqliteEmpireRepository(session)` で型代入が pyright で通る | pyright strict pass。さらに duck typing で `hasattr(repo, 'find_by_id') and hasattr(repo, 'count') and hasattr(repo, 'save')` 全 True |
+
+### 基本 CRUD（受入基準 3〜8、確定 B / C）
+
+| テストID | 対象モジュール連携 | 使用 fixture | 前提条件 | 操作 | 期待結果 |
+|---------|------------------|--------------|---------|------|---------|
+| TC-IT-EMR-002 | `find_by_id(existing_empire_id)` | `session_factory` + `EmpireFactory` | `save(empire)` で 1 件保存済み | 同 session_factory で別 session を開き `find_by_id(empire.id)` | 保存した Empire と構造的等価な Empire を返す（`==` True、frozen 構造体）。rooms / agents 件数も一致 |
+| TC-IT-EMR-003 | `find_by_id(unknown_id)` | `session_factory` | DB 空 | `find_by_id(uuid4())` を呼ぶ | `None` を返す。例外を raise しない |
+| TC-IT-EMR-004 | `count()` 0 → 1 遷移 | `session_factory` + `EmpireFactory` | DB 空 | (1) `count()` → 0 を確認、(2) `save(empire)` 後に `count()` → 1 を確認 | 遷移が正しく観測される（contract: シングルトン強制は application 層、本 PR は事実報告のみ） |
+| TC-IT-EMR-005 | `save(empire)` 新規挿入で 3 テーブルに行が入る | `session_factory` + `PopulatedEmpireFactory` | rooms 2 件 + agents 3 件の Empire | `save(empire)` 後、別 session で 3 テーブル直接 SELECT | `empires` 1 行（id, name）+ `empire_room_refs` 2 行 + `empire_agent_refs` 3 行が存在、各カラムが Empire VO の値と一致 |
+| TC-IT-EMR-006 | `save(empire)` 既存更新（rooms / agents 変更） | `session_factory` | 1 度 save 済みの Empire（rooms 2 件 + agents 3 件） | (1) Empire を `add_room` / `archive_room` / `add_agent` で更新（empire feature #8 のふるまい）、(2) 再度 `save(updated_empire)` を呼ぶ | empire_room_refs / empire_agent_refs が **delete-then-insert** で全置換される（確定 B 戦略）。古い RoomRef / AgentRef は残らず、新 VO が SELECT で取得される |
+| TC-IT-EMR-007 | ラウンドトリップ（save → find_by_id 構造的等価） | `session_factory` + `PopulatedEmpireFactory` | 任意の valid Empire | (1) `save(empire)`、(2) 別 session で `find_by_id(empire.id)`、(3) 復元 Empire == 元 Empire | 構造的等価が成立。RoomRef / AgentRef の順序は domain 層で sort されるため一致（empire feature §確定 で凍結済み） |
+
+### delete-then-insert 5 段階順序（確定 B、受入基準 7）
+
+| テストID | 対象モジュール連携 | 使用 fixture | 前提条件 | 操作 | 期待結果 |
+|---------|------------------|--------------|---------|------|---------|
+| TC-IT-EMR-011 | `save()` 内 SQL 発行順序 | `session_factory` + `PopulatedEmpireFactory` + `sqlalchemy.event.listen(engine, "after_cursor_execute", ...)` で SQL ログ収集 | 1 度 save 済み Empire を更新 | 再 save 時の SQL 文を順序で観測 | 順序が確定 B 通り: (1) UPSERT empires、(2) DELETE empire_room_refs WHERE empire_id=?、(3) bulk INSERT empire_room_refs、(4) DELETE empire_agent_refs WHERE empire_id=?、(5) bulk INSERT empire_agent_refs |
+
+### Tx 境界の責務分離（確定 B）
+
+| テストID | 対象モジュール連携 | 使用 fixture | 前提条件 | 操作 | 期待結果 |
+|---------|------------------|--------------|---------|------|---------|
+| TC-IT-EMR-012 | service 層 `async with session.begin()` 配下の commit / rollback | `session_factory` | service スタブ（`async def save_empire(repo, empire)`） | (1) **正常系**: `async with session.begin(): await repo.save(empire)` → ブロック退出で commit、別 session で SELECT すると行が取得可能。(2) **異常系**: `async with session.begin(): await repo.save(empire); raise RuntimeError` → ブロック退出で rollback、別 session で SELECT すると行が取得不可 | commit 経路で Empire が永続化、rollback 経路で原子的に消える。Repository は `await session.commit()` / `session.rollback()` を呼ばない（責務境界、確定 B） |
+
+### FK CASCADE + UNIQUE 制約（データモデル契約、受入基準 9 補強）
+
+| テストID | 対象モジュール連携 | 使用 fixture | 前提条件 | 操作 | 期待結果 |
+|---------|------------------|--------------|---------|------|---------|
+| TC-IT-EMR-013 | `empires` DELETE → 子テーブル CASCADE | `session_factory` + `PopulatedEmpireFactory` | save 済み Empire | raw SQL で `DELETE FROM empires WHERE id=:id` を実行 | empire_room_refs / empire_agent_refs の対応行が CASCADE で削除される（FK ON DELETE CASCADE 制約の物理確認） |
+| TC-IT-EMR-014 | UNIQUE(empire_id, room_id) 違反 | `session_factory` | save 済み Empire | raw SQL で同じ `(empire_id, room_id)` ペアを 2 度 INSERT | `IntegrityError`（または UniqueViolation）が raise。同様に `(empire_id, agent_id)` も検証 |
+
+### Alembic 2nd revision（受入基準 9、確定 F）
+
+| テストID | 対象モジュール連携 | 使用 fixture | 前提条件 | 操作 | 期待結果 |
+|---------|------------------|--------------|---------|------|---------|
+| TC-IT-EMR-008 | Alembic 2nd revision 適用 | `tmp_path` 配下の bakufu.db | M1 + M2 永続化基盤の initial revision 適用済み | `alembic upgrade head` を実行 | (a) `0001_init` から `0002_empire_aggregate` への進行、(b) `SELECT name FROM sqlite_master WHERE type='table'` で `empires` / `empire_room_refs` / `empire_agent_refs` の 3 テーブルが追加、(c) UNIQUE INDEX `(empire_id, room_id)` / `(empire_id, agent_id)` が存在 |
+| TC-IT-EMR-015 | upgrade / downgrade 双方向 | `tmp_path` | initial revision 適用済み | (1) `alembic upgrade head`、(2) `alembic downgrade base`、(3) 再 `alembic upgrade head` | (1) で 3 テーブル追加、(2) で 3 テーブル削除（initial revision テーブルは残る）、(3) で再追加。idempotent な migration |
+| TC-IT-EMR-016 | revision chain 一直線 | Alembic config | versions/0001_init.py + versions/0002_empire_aggregate.py | `alembic heads` を実行 | head は単一（`0002_empire_aggregate`）、`0001_init` の down_revision is None、`0002_empire_aggregate.down_revision == "0001_init"` で chain が一直線。head 分岐がないことを物理確認（確定 F の後続 PR テンプレート要件） |
+
+### CI 三層防衛（受入基準 10, 11、確定 E）
+
+| テストID | 対象モジュール連携 | 使用 fixture | 前提条件 | 操作 | 期待結果 |
+|---------|------------------|--------------|---------|------|---------|
+| TC-CI-EMR-001 | Layer 1: `scripts/ci/check_masking_columns.sh` の Empire 拡張 | repo root | スクリプトが Empire 3 テーブルを明示登録 | `bash scripts/ci/check_masking_columns.sh` を実行 | exit 0。grep guard が Empire 3 テーブル定義ファイル（`tables/empires.py` 等）に `MaskedJSONEncoded` / `MaskedText` が登場しないことを確認、登場すると exit 非 0 |
+| TC-IT-EMR-009 | Layer 2: `tests/architecture/test_masking_columns.py` の Empire parametrize | `Base.metadata` | M2 永続化基盤の arch test が parametrize 形式 | parametrize に `empires` / `empire_room_refs` / `empire_agent_refs` を追加し、各カラムの `column.type.__class__` が `MaskedJSONEncoded` でも `MaskedText` でもないことを assert | 全 3 テーブルで pass。後続 PR が誤って `MaskedText` を Empire に追加した瞬間、この test が落下して PR ブロック |
+| TC-IT-EMR-017 | 「対象なし」明示登録の構造（後続 PR テンプレート） | parametrize リスト | Layer 1 / 2 の登録形式が「(table_name, expected_masked_columns: set)」のタプル | empires に `expected_masked_columns=set()` で登録、test 内で `actual_masked_columns == expected_masked_columns` を assert | 「空集合 = 対象なし」の明示登録経路が動作。後続 Repository PR が「対象あり」を `expected_masked_columns={'prompt_body'}` のように登録できる構造であることを物理確認 |
+
+### storage.md 逆引き表（確定 E Layer 3）
+
+| テストID | 対象モジュール連携 | 使用 fixture | 前提条件 | 操作 | 期待結果 |
+|---------|------------------|--------------|---------|------|---------|
+| TC-DOC-EMR-001 | storage.md §逆引き表に Empire 行存在 | repo root | `docs/architecture/domain-model/storage.md` 編集済み | `grep -E '^\| Empire' docs/architecture/domain-model/storage.md` を実行 | 「Empire 関連カラム: masking 対象なし」を示す行がヒット（後続 Repository PR が同様の行を追加するテンプレート） |
+
+### シングルトン強制責務分離（確定 D）
+
+| テストID | 対象モジュール連携 | 使用 fixture | 前提条件 | 操作 | 期待結果 |
+|---------|------------------|--------------|---------|------|---------|
+| TC-IT-EMR-018 | Repository は `count()` で事実報告のみ、シングルトン強制しない | `session_factory` | DB 空 | (1) 1 件目 `save(empire_a)`、(2) **同じ id でない別 Empire** `save(empire_b)` を続けて呼ぶ、(3) `count()` を確認 | (a) 2 件目 save が **例外を raise せず**正常に通る（Repository はシングルトン強制を持たない）、(b) `count()` が 2 を返す。Aggregate 集合知識（シングルトン制約）は `EmpireService.create()` 責務であり、本 PR スコープ外（確定 D） |
+
+## ユニットテストケース
+
+`tests/factories/empire.py` の factory 経由で domain 層 Empire を生成する。Repository クラス内 private method (`_to_row` / `_from_row`) は純粋ロジック（dict 変換）なので unit でテスト可能、DB アクセスは伴わない。
+
+### domain↔row 変換（確定 C、受入基準 8 補強）
+
+| テストID | 対象 | 種別 | 入力 | 期待結果 |
+|---------|-----|------|------|---------|
+| TC-UT-EMR-001 | `SqliteEmpireRepository._to_row(empire)` | 正常系 | `PopulatedEmpireFactory()` で生成した Empire（rooms 2 件 + agents 3 件） | (a) 戻り値が `tuple[dict, list[dict], list[dict]]`、(b) `empires_row == {'id': str, 'name': str}`、(c) `room_refs` が rooms 2 件分の dict、(d) `agent_refs` が agents 3 件分の dict、(e) Empire VO の各属性値が dict に正しく転写されている |
+| TC-UT-EMR-002 | `SqliteEmpireRepository._from_row(empire_row, room_refs, agent_refs)` | 正常系 | dict / list[dict] の 3 引数（factory で組み立て） | 戻り値が valid な Empire、`Empire.model_validator(mode='after')` を経由して構築。RoomRef / AgentRef も VO として復元 |
+| TC-UT-EMR-003 | `_from_row(_to_row(empire))` ラウンドトリップ | 正常系 | `PopulatedEmpireFactory()` | 復元 Empire == 元 Empire（構造的等価、frozen + `==` True）。empire feature #8 で凍結された RoomRef / AgentRef の sort 規約に従い順序も一致 |
+
+### Protocol 充足の型レベル検証（確定 A、受入基準 2 補強）
+
+| テストID | 対象 | 種別 | 入力 | 期待結果 |
+|---------|-----|------|------|---------|
+| （TC-IT-EMR-010 で実施） | `SqliteEmpireRepository: EmpireRepository = SqliteEmpireRepository(session)` の型代入 | 正常系 | — | pyright strict pass。`@runtime_checkable` なしのため isinstance 検査は使わない |
+
+## カバレッジ基準
+
+- REQ-EMR-001 〜 005 の各要件が**最低 1 件**のテストケースで検証されている（マトリクス参照）
+- **delete-then-insert 5 段階順序（確定 B）**: TC-IT-EMR-011 で実 SQL ログ観測、UPSERT → DELETE → INSERT × 2 の順序を物理確認
+- **Tx 境界の責務分離（確定 B）**: TC-IT-EMR-012 で commit / rollback 両経路、Repository が明示的 commit / rollback しないことを assert
+- **domain↔row 変換ラウンドトリップ（確定 C）**: TC-UT-EMR-003（unit 純粋）+ TC-IT-EMR-007（実 DB 経由）の 2 経路で構造的等価を物理確認
+- **シングルトン責務分離（確定 D）**: TC-IT-EMR-018 で「Repository 自身はシングルトン強制しない」物理確認
+- **CI 三層防衛（確定 E）**: Layer 1 grep（TC-CI-EMR-001）+ Layer 2 arch test（TC-IT-EMR-009）+ Layer 3 storage.md（TC-DOC-EMR-001）3 つすべて起票
+- **テンプレート責務（確定 F）**: 後続 6 件 Repository PR が確定 A〜E を直接参照することを test-design.md レビュー観点で凍結
+- **DB 制約**: FK CASCADE（TC-IT-EMR-013）+ UNIQUE 制約（TC-IT-EMR-014）+ Alembic chain（TC-IT-EMR-016）で migration の正しさを物理確認
+- **upgrade/downgrade idempotent**: TC-IT-EMR-015 で双方向 migration を物理確認
+- 受入基準 1 〜 11 の各々が**最低 1 件のユニット/結合ケース**で検証されている（E2E 不在のため戦略ガイドの「結合代替可」に従う）
+- 受入基準 12（依存方向）/ 13（pyright/ruff）/ 14（カバレッジ 90%）は CI ジョブで担保
+- 確定 A〜F すべてに証拠ケース
+- C0 目標: `application/ports/empire_repository.py` / `infrastructure/persistence/sqlite/repositories/empire_repository.py` で **90% 以上**（infrastructure 層基準、要件分析書 §非機能要求準拠）
+
+## 人間が動作確認できるタイミング
+
+本 feature は infrastructure 層単独だが、**M2 永続化基盤と同じく Backend プロセスを実起動して動作確認できる**。
+
+- CI 統合後: `gh pr checks` で 7 ジョブ緑（lint / typecheck / test-backend / audit / fmt / commit-msg / no-ai-footer）
+- ローカル: `bash scripts/setup.sh` → `cd backend && uv run pytest tests/infrastructure/persistence/sqlite/repositories/test_empire_repository.py tests/architecture/test_masking_columns.py -v` → 全テスト緑
+- Backend 実起動: `cd backend && uv run python -m bakufu`（環境変数 `BAKUFU_DATA_DIR=/tmp/bakufu-test` を設定）
+  - 起動時に Alembic auto-migrate で 0001_init + 0002_empire_aggregate が適用されることをログで目視
+  - `sqlite3 <DATA_DIR>/bakufu.db ".tables"` で `empires` / `empire_room_refs` / `empire_agent_refs` の 3 テーブルが見えることを目視
+  - `sqlite3 <DATA_DIR>/bakufu.db "SELECT * FROM sqlite_master WHERE type='index'"` で UNIQUE INDEX が見えることを目視
+- カバレッジ確認: `cd backend && uv run pytest --cov=bakufu.application.ports.empire_repository --cov=bakufu.infrastructure.persistence.sqlite.repositories.empire_repository --cov-report=term-missing` → 90% 以上
+- CI 三層防衛の実観測: `bash scripts/ci/check_masking_columns.sh` を手動実行 → exit 0 + Empire 3 テーブルが「対象なし」で pass する出力を目視
+- masking 対象漏れ test の挙動確認: 一時的に `tables/empires.py` の `name` カラムを `String(80)` から `MaskedText` に変えてみる → arch test が落ちることを目視（修正後元に戻す。後続 Repository PR の漏れ防止が物理層で機能していることの実観測）
+
+後段で `feature/empire-application`（`EmpireService.create() / get()` 等）/ `feature/admin-cli`（`bakufu admin empire show`）/ `feature/http-api`（Empire CRUD）が完成したら、本 feature の Repository を経由して `curl` 経由の手動シナリオで E2E 観測可能になる。
+
+## テストディレクトリ構造
+
+```
+backend/
+  tests/
+    factories/
+      __init__.py
+      empire.py                            # 既存（empire feature #8）+ PopulatedEmpireFactory 追加
+    architecture/
+      test_masking_columns.py              # 既存（M2 永続化基盤）+ Empire 3 テーブル parametrize 追加
+                                           # TC-IT-EMR-009 / 017
+    infrastructure/
+      persistence/
+        sqlite/
+          repositories/
+            __init__.py
+            test_empire_repository.py      # TC-IT-EMR-001〜007 / 010〜018, TC-UT-EMR-001〜003
+          test_alembic_empire.py           # TC-IT-EMR-008 / 015 / 016（Alembic 2nd revision 検証）
+    docs/
+      test_storage_md_back_index.py        # TC-DOC-EMR-001（storage.md 逆引き表検証、grep ベース）
+```
+
+**配置の根拠**:
+- 戦略ガイド §テストディレクトリ構造 の Python 標準慣習に従う
+- `repositories/` サブディレクトリを新設（後続 6 件 Repository PR が同様に追加）
+- `architecture/test_masking_columns.py` は M2 永続化基盤で既に新設済み、本 PR は parametrize に Empire 3 テーブル追加のみ
+- `test_alembic_empire.py` を独立ファイルにするのは Alembic 2nd revision の chain / upgrade / downgrade を 1 ファイルに集約し、後続 PR が `test_alembic_workflow.py` 等で同パターンを踏襲しやすくするため
+- `docs/test_storage_md_back_index.py` は storage.md §逆引き表が「11 行 + Empire 行追加」で構造的に検証可能であることを保証（後続 Repository PR が新行を追加した時の自動検証経路）
+
+## 未決課題・要起票 characterization task
+
+| # | タスク | 起票先 | 備考 |
+|---|-------|--------|------|
+| （N/A） | 該当なし — SQLite + Alembic + SQLAlchemy は標準ライブラリ仕様で固定 | — | 後続 6 件 Repository PR は本 PR を参照して同パターン実装。Aggregate 別の masking 対象カラムが存在する PR（agent / room / directive / task / external-review-gate）では `MaskedJSONEncoded` / `MaskedText` の Layer 2 arch test 検証が動作確認の対象になる |
+
+**Schneier 申し送り（前 PR レビューより継承）**:
+
+- **CI 三層防衛の Empire 拡張**: 本 PR で確定 E として正式凍結（M2 永続化基盤レビュー時の「後続 PR で各 Aggregate に拡張」申し送りに対応）。Layer 1 + Layer 2 + Layer 3 の 3 層が「対象なし」明示登録を含む構造で完備、後続 Repository PR の漏れを物理保証
+- **`storage.md` §逆引き表のテンプレート化**: 確定 E Layer 3 で「Empire は対象なし」を明示。後続 Repository PR は同形式で「対象あり」「対象なし」を区別して追加する責務（テンプレート参照源、確定 F）
+- **本 feature 固有の申し送り**:
+  - シングルトン強制（`EmpireAlreadyExistsError`）は `feature/empire-application` 責務、本 PR は `count()` メソッド提供のみ。後続 application PR で `EmpireService.create()` の Fail Fast 検査を漏れなく実装する申し送り
+  - `EmpireService.create()` の Tx 境界は **本 PR で凍結した「Repository は session 受け取り、commit/rollback は service 側」契約に従う**こと（確定 B）
+  - `feature/empire-application` がエラー文言（`EmpireAlreadyExistsError`）を実装する際、本 PR の Repository は文言定義を持たない（infrastructure は内部 API、ユーザー向けメッセージは application / API 層責務）
+
+## レビュー観点（テスト設計レビュー時）
+
+- [ ] REQ-EMR-001〜005 すべてに 1 件以上のテストケースがあり、特に integration が Repository 契約 + Alembic + CI 三層防衛を単独でカバーしている
+- [ ] **delete-then-insert 5 段階順序（確定 B）**が TC-IT-EMR-011 で実 SQL 発行順を物理観測している
+- [ ] **Tx 境界の責務分離（確定 B）**が TC-IT-EMR-012 で commit / rollback 両経路で確認、Repository が明示的 commit / rollback しないことを assert している
+- [ ] **domain↔row 変換ラウンドトリップ（確定 C）**が TC-UT-EMR-003（unit 純粋）+ TC-IT-EMR-007（実 DB 経由）の 2 経路で物理確認
+- [ ] **シングルトン責務分離（確定 D）**が TC-IT-EMR-018 で「Repository 自身は強制しない」物理確認
+- [ ] **CI 三層防衛（確定 E）**: Layer 1 grep（TC-CI-EMR-001）+ Layer 2 arch test（TC-IT-EMR-009）+ Layer 3 storage.md（TC-DOC-EMR-001）の 3 つすべてに証拠ケース
+- [ ] **「対象なし」明示登録のテンプレート構造（確定 E / F）**: TC-IT-EMR-017 で parametrize リスト形式が後続 Repository PR の「対象あり」登録にも対応できる構造であることを確認
+- [ ] **Alembic 2nd revision の chain 一直線**（確定 F）: TC-IT-EMR-016 で head 分岐なし、down_revision が `0001_init` を指していることを物理確認
+- [ ] **upgrade/downgrade idempotent**: TC-IT-EMR-015 で双方向 migration を物理確認
+- [ ] **DB 制約検証**: FK CASCADE（TC-IT-EMR-013）+ UNIQUE 制約（TC-IT-EMR-014）の Alembic 2nd revision DDL の正しさを物理確認
+- [ ] 確定 A〜F すべてに証拠ケースが含まれる
+- [ ] empire / persistence-foundation の WeakValueDictionary レジストリ + tmp_path 経由の実 DB 規約と整合した fixture 設計
+- [ ] Schneier 申し送り（CI 三層防衛拡張テンプレート / シングルトン強制の application 層責務 / Tx 境界の Repository / service 分離 / storage.md §逆引き表の Empire 行）が次レビュー時に確認可能な形で test-design および設計書に記録されている
+- [ ] **後続 6 件 Repository PR のテンプレート責務（確定 F）**: チェックリスト 11 項目（A〜E）を本 PR が満たすことが test-design.md レビュー観点で凍結されている


### PR DESCRIPTION
## Summary

Issue #25 工程2: Empire SQLite Repository のVモデル左側 4 設計書（要求分析 / 要件定義 / 基本設計 / 詳細設計）+ storage.md 逆引き表更新を新規作成。**M2 最初の Aggregate Repository PR**、後続 6 件（workflow / agent / room / directive / task / external-review-gate）のテンプレート責務を凍結。

## 設計ハイライト

### Repository 実装パターンの真実源（後続 6 件 PR が継承）

- **Repository ポート配置（イーロン承認）**: `application/ports/{aggregate}_repository.py` で **Aggregate 別ファイル分離**（単一ファイル集約は肥大化、domain 配置は依存方向違反）
- **`save()` 戦略（イーロン承認）**: **delete-then-insert**（同一 Tx 内で `DELETE FROM empire_room_refs WHERE empire_id=?` → 全件 bulk INSERT）。差分計算 / event sourcing は YAGNI、N≤100 で性能問題なし
- **domain ↔ row 変換**: Repository クラス内 `_to_row()` / `_from_row()` の private method
- **シングルトン強制責務分離**: `EmpireService.create()`（application 層、別 PR）が `count()` を呼ぶのみ、Repository は CRUD に閉じる
- **Tx 境界の責務分離**: service 層が `async with session.begin():` で UoW 管理、Repository 内では明示的な commit / rollback しない（複数 Repository を 1 Tx 内で呼ぶシナリオに対応）

### CI 三層防衛の Empire 拡張（masking 対象なし、明示登録）

Empire は masking 対象カラムを持たないが、後続 Repository PR の漏れ防止テンプレートとして**明示的な空リスト**で CI に登録:

- **Layer 1 (grep guard)**: `scripts/ci/check_masking_columns.sh` に Empire 3 テーブルを「対象なし」で明示登録
- **Layer 2 (arch test)**: `tests/architecture/test_masking_columns.py` の parametrize に 3 テーブル追加、各カラムが `MaskedJSONEncoded` / `MaskedText` でないことを assert
- **Layer 3 (逆引き表)**: `storage.md` §逆引き表に「Empire 関連カラム: masking 対象なし」行を追加（同一コミット）

これにより後続 Repository PR が「Empire の例があるから」と masking 対象漏れに気づかず誤って `MaskedText` を Empire に追加すると Layer 2 で検出 → CI 落下。

### Alembic revision 段階追加方針（テンプレート）

| revision | 内容 | 担当 PR |
|---|---|---|
| `0001_init_audit_pid_outbox` | M2 永続化基盤（マージ済み） | persistence-foundation #19 |
| `0002_empire_aggregate` | **Empire 3 テーブル** | **本 PR** |
| `0003〜0008` | workflow / agent / room / directive / task / external-review-gate | 後続 Repository PR |

各 revision は前 revision に対する down_revision を明示し、Alembic head が一直線になるよう順序管理（CI で head 分岐検査）。

### Empire テーブル群への FK 戦略

`empire_room_refs.room_id` / `empire_agent_refs.agent_id` は本 PR では FK を張らない（rooms / agents テーブルが別 Repository PR で追加されるため）。後続 `feature/room-repository` / `feature/agent-repository` PR の Alembic revision で `op.create_foreign_key(...)` により追加する責務分離。

## 後続 PR のチェックリスト（detailed-design.md §確定 F で凍結）

11 項目:

1. ✓ Protocol を `application/ports/{aggregate}_repository.py` で定義
2. ✓ 各メソッドを `async def` で宣言
3. ✓ `@runtime_checkable` を付与しない
4. ✓ SQLite 実装を `infrastructure/persistence/sqlite/repositories/{aggregate}_repository.py` で実装
5. ✓ `save()` で参照型カラムを delete-then-insert
6. ✓ Tx 境界は service 層責務、Repository 内で commit / rollback しない
7. ✓ domain ↔ row 変換は Repository クラス内 private method
8. ✓ Aggregate 集合知識検査は service 層責務
9. ✓ CI 三層防衛 Layer 1 + Layer 2 に新テーブルを parametrize 追加
10. ✓ storage.md §逆引き表に新テーブル行を追加（masking 対象 あり / なしを明示）
11. ✓ Alembic revision を 1 つ追加（initial revision に含めない）

## Test plan

- [ ] テスト担当（@ジェフ）が `docs/features/empire-repository/test-design.md` を作成（TC-IT-EMR-001〜009 + TC-CI-EMR-001 系を中心に）
- [ ] 内部レビュー担当（@スティーブ / @Norman / @Schneier）が設計書をレビュー
- [ ] 受入基準 14 項目（TC-IT-EMR-001〜009 + TC-CI-EMR-001 + 12〜14 は CI ジョブ）に紐づく結合テスト観点が test-design.md で具体化
- [ ] 結合テストで domain ↔ row のラウンドトリップが構造的等価で復元される（save → find_by_id → 元 Empire との `==` 比較）

Closes #25（上流マージ後の Repository 実装 PR で完全クローズ）
