### PR TITLE
feat(directive): Directive Aggregate Root (Issue #24)

### DIFF
--- a/backend/src/bakufu/domain/directive/__init__.py
+++ b/backend/src/bakufu/domain/directive/__init__.py
@@ -1,0 +1,36 @@
+"""Directive Aggregate Root package.
+
+Implements ``REQ-DR-001``〜``REQ-DR-003`` per ``docs/features/directive``.
+M1 5 兄弟目 (after empire / workflow / agent / room) — slim by design:
+five attributes, two structural invariants, one behavior. Split into
+two sibling modules for the sake of consistency with the older M1
+packages even though everything fits comfortably in one file:
+
+* :mod:`bakufu.domain.directive.aggregate_validators` — two
+  module-level invariant helpers (``_validate_text_range`` /
+  ``_validate_task_link_immutable``).
+* :mod:`bakufu.domain.directive.directive` — :class:`Directive`
+  Aggregate Root.
+
+This ``__init__`` re-exports the public surface plus the
+underscore-prefixed helpers tests need to invoke directly (the same
+pattern Norman approved for the agent / room packages).
+"""
+
+from __future__ import annotations
+
+from bakufu.domain.directive.aggregate_validators import (
+    MAX_TEXT_LENGTH,
+    MIN_TEXT_LENGTH,
+    _validate_task_link_immutable,
+    _validate_text_range,
+)
+from bakufu.domain.directive.directive import Directive
+
+__all__ = [
+    "MAX_TEXT_LENGTH",
+    "MIN_TEXT_LENGTH",
+    "Directive",
+    "_validate_task_link_immutable",
+    "_validate_text_range",
+]

--- a/backend/src/bakufu/domain/directive/aggregate_validators.py
+++ b/backend/src/bakufu/domain/directive/aggregate_validators.py
@@ -1,0 +1,101 @@
+"""Aggregate-level invariant helpers for :class:`Directive`.
+
+Each helper is a **module-level pure function** so tests can ``import``
+and invoke directly — same testability pattern Norman / Steve approved
+for the agent ``aggregate_validators.py`` and the room
+``aggregate_validators.py``.
+
+Helpers:
+
+1. :func:`_validate_text_range` — ``1 ≤ NFC(text) ≤ 10000``. Length is
+   judged on the **NFC-normalized** text without ``strip``; CEO
+   directives may carry meaningful leading / trailing whitespace and
+   newlines (multi-paragraph briefs).
+2. :func:`_validate_task_link_immutable` — Fail Fast when ``link_task``
+   is invoked on a Directive that already has a non-``None``
+   ``task_id``. The constructor path (used by Repository hydration)
+   accepts any ``TaskId | None`` value because a permanent attribute
+   value is not a *transition*; only ``link_task`` watches for
+   transition violations (see Directive detailed-design §確定 C).
+
+Naming follows the agent / room precedent (``_validate_*``).
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from bakufu.domain.exceptions import DirectiveInvariantViolation
+
+# Confirmation B: text length bounds (1〜10000 after NFC normalization).
+MIN_TEXT_LENGTH: int = 1
+MAX_TEXT_LENGTH: int = 10_000
+
+
+def _validate_text_range(text: str) -> None:
+    """``Directive.text`` must fall in 1〜10000 characters (MSG-DR-001).
+
+    Length is judged on the **NFC-normalized** string (the field
+    validator runs the pipeline before this helper is invoked) without
+    ``strip`` — CEO directives may include leading / trailing
+    whitespace + multi-paragraph blocks that carry meaning.
+    """
+    length = len(text)
+    if not (MIN_TEXT_LENGTH <= length <= MAX_TEXT_LENGTH):
+        raise DirectiveInvariantViolation(
+            kind="text_range",
+            message=(
+                f"[FAIL] Directive text must be "
+                f"{MIN_TEXT_LENGTH}-{MAX_TEXT_LENGTH} characters (got {length})\n"
+                f"Next: Trim directive content to <={MAX_TEXT_LENGTH} "
+                f"NFC-normalized characters; for richer prompts use "
+                f"multiple directives or attach a deliverable."
+            ),
+            detail={"length": length},
+        )
+
+
+def _validate_task_link_immutable(
+    *,
+    directive_id: UUID,
+    existing_task_id: UUID | None,
+    attempted_task_id: UUID,
+) -> None:
+    """Reject a ``link_task`` call against an already-linked Directive.
+
+    Confirmation C / D / Norman 凍結: 1 Directive maps to 1 Task by
+    design; a second ``link_task`` call is **always** a Fail Fast
+    rather than a no-op, regardless of whether the new TaskId equals
+    the existing one. The simpler contract avoids special cases in the
+    aggregate validator and matches the business rule "re-issuing a
+    directive means creating a *new* Directive."
+
+    Raises:
+        DirectiveInvariantViolation: ``kind='task_already_linked'``
+            (MSG-DR-002) when ``existing_task_id is not None``.
+    """
+    if existing_task_id is None:
+        return
+    raise DirectiveInvariantViolation(
+        kind="task_already_linked",
+        message=(
+            f"[FAIL] Directive already has a linked Task: "
+            f"directive_id={directive_id}, "
+            f"existing_task_id={existing_task_id}\n"
+            f"Next: Issue a new Directive instead of re-linking; one "
+            f"Directive maps to one Task by design."
+        ),
+        detail={
+            "directive_id": str(directive_id),
+            "existing_task_id": str(existing_task_id),
+            "attempted_task_id": str(attempted_task_id),
+        },
+    )
+
+
+__all__ = [
+    "MAX_TEXT_LENGTH",
+    "MIN_TEXT_LENGTH",
+    "_validate_task_link_immutable",
+    "_validate_text_range",
+]

--- a/backend/src/bakufu/domain/directive/directive.py
+++ b/backend/src/bakufu/domain/directive/directive.py
@@ -1,0 +1,158 @@
+"""Directive Aggregate Root (REQ-DR-001〜003).
+
+Implements per ``docs/features/directive``. The aggregate is
+intentionally slim: five attributes, two structural invariants, one
+behavior. Application-layer concerns (``$``-prefix normalization,
+``target_room_id`` existence, Task creation) live in
+``DirectiveService.issue()`` per §確定 G / H.
+
+Design contracts:
+
+* **Pre-validate rebuild (Confirmation A)** — :meth:`Directive.link_task`
+  goes through :meth:`_rebuild_with_state`
+  (``model_dump → swap → model_validate``).
+* **NFC-only normalization (Confirmation B)** — ``Directive.text``
+  applies ``unicodedata.normalize('NFC', ...)`` *without* ``strip``.
+  CEO directives may include meaningful leading / trailing whitespace
+  and multi-paragraph blocks; the agent ``Persona.prompt_body`` /
+  room ``PromptKit.prefix_markdown`` precedent applies here too.
+* **task_id transition uniqueness (Confirmation C / D)** — only the
+  ``link_task`` path watches for transition violations. The
+  constructor path accepts any ``TaskId | None`` value to support
+  Repository hydration of an already-linked Directive without a
+  separate "rebuild" code path.
+* **No idempotency (Confirmation D)** — a second ``link_task`` is
+  *always* a Fail Fast, even when the new TaskId equals the existing
+  one. Re-issuing a directive means creating a new Directive.
+"""
+
+from __future__ import annotations
+
+import unicodedata
+from datetime import datetime
+from typing import Any, Self
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    field_validator,
+    model_validator,
+)
+
+from bakufu.domain.directive.aggregate_validators import (
+    _validate_text_range,
+)
+from bakufu.domain.value_objects import (
+    DirectiveId,
+    RoomId,
+    TaskId,
+)
+
+
+class Directive(BaseModel):
+    """CEO directive issued against a target :class:`Room` (REQ-DR-001).
+
+    The aggregate captures the *intent* of an instruction: the text
+    body, the room it is delegated to, the time it was issued, and
+    the optional generated Task it was linked to. ``DirectiveService``
+    (application layer) is responsible for creating the Task and
+    calling :meth:`link_task` to establish the back-reference.
+    """
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        arbitrary_types_allowed=False,
+    )
+
+    id: DirectiveId
+    text: str
+    target_room_id: RoomId
+    # ``created_at`` arrives as a tz-aware ``datetime`` from the
+    # application layer (see Directive detailed-design §設計判断の補足
+    # "なぜ created_at を引数で受け取るか"). The post-validator below
+    # rejects naive datetimes so the contract is enforced at the
+    # aggregate boundary rather than by every caller.
+    created_at: datetime
+    task_id: TaskId | None = None
+
+    # ---- pre-validation -------------------------------------------------
+    @field_validator("text", mode="before")
+    @classmethod
+    def _normalize_text(cls, value: object) -> object:
+        # Confirmation B: NFC only — no ``strip``. CEO directives may
+        # rely on leading / trailing whitespace + newlines.
+        if isinstance(value, str):
+            return unicodedata.normalize("NFC", value)
+        return value
+
+    @field_validator("created_at", mode="after")
+    @classmethod
+    def _require_tz_aware(cls, value: datetime) -> datetime:
+        # Naive datetimes carry no timezone info and would silently
+        # round-trip through SQLite as wall-clock strings, breaking
+        # ordering. Fail Fast at the aggregate boundary instead.
+        if value.tzinfo is None:
+            raise ValueError(
+                "Directive.created_at must be a timezone-aware UTC datetime "
+                "(received a naive datetime)"
+            )
+        return value
+
+    @model_validator(mode="after")
+    def _check_invariants(self) -> Self:
+        """Run the structural invariant checks.
+
+        Confirmation C: only ``_validate_text_range`` runs at
+        construction time. ``_validate_task_link_immutable`` watches
+        the *transition* enforced inside :meth:`link_task` itself,
+        not the snapshot value, because the constructor path is also
+        used to hydrate Directives from a Repository where the
+        ``task_id`` may already be a real value.
+        """
+        _validate_text_range(self.text)
+        return self
+
+    # ---- behaviors (Tell, Don't Ask) ------------------------------------
+    def link_task(self, task_id: TaskId) -> Directive:
+        """Bind this Directive to ``task_id``; reject re-linking.
+
+        Returns a new :class:`Directive` instance with ``task_id``
+        populated. A subsequent call against the new instance always
+        Fails Fast — there is no idempotent "same TaskId" path
+        (Confirmation D).
+
+        Raises:
+            DirectiveInvariantViolation: ``kind='task_already_linked'``
+                (MSG-DR-002) when this Directive already has a
+                non-``None`` ``task_id``.
+        """
+        # Local import keeps the module-level import graph minimal —
+        # the validator only matters on the failing path.
+        from bakufu.domain.directive.aggregate_validators import (
+            _validate_task_link_immutable,
+        )
+
+        _validate_task_link_immutable(
+            directive_id=self.id,
+            existing_task_id=self.task_id,
+            attempted_task_id=task_id,
+        )
+        return self._rebuild_with_state({"task_id": task_id})
+
+    # ---- internal -------------------------------------------------------
+    def _rebuild_with_state(self, updates: dict[str, Any]) -> Directive:
+        """Pre-validate rebuild for scalar attribute updates.
+
+        Confirmation A — same pattern as
+        :class:`bakufu.domain.agent.agent.Agent` and
+        :class:`bakufu.domain.room.room.Room`.
+        """
+        state = self.model_dump()
+        state.update(updates)
+        return Directive.model_validate(state)
+
+
+__all__ = [
+    "Directive",
+]

--- a/backend/src/bakufu/domain/exceptions.py
+++ b/backend/src/bakufu/domain/exceptions.py
@@ -268,9 +268,58 @@ class RoomInvariantViolation(Exception):  # noqa: N818
         self.detail: dict[str, object] = masked_detail
 
 
+type DirectiveViolationKind = Literal[
+    "text_range",
+    "task_already_linked",
+]
+"""Discriminator for :class:`DirectiveInvariantViolation` per Directive
+detailed-design §確定 F.
+
+The set is **closed at two kinds**. Type / required-field violations
+surface as :class:`pydantic.ValidationError` (MSG-DR-003) and the
+``$``-prefix normalization is an application-layer responsibility
+(``DirectiveService.issue()``), so neither leaks into the aggregate's
+discriminator namespace.
+"""
+
+
+# DDD: "Violation" describes an invariant breach, not a programming bug, so
+# the N818 "Error suffix" rule does not apply here.
+class DirectiveInvariantViolation(Exception):  # noqa: N818
+    """Raised when a :class:`Directive` aggregate invariant is violated.
+
+    Mirrors :class:`RoomInvariantViolation` / :class:`AgentInvariantViolation`
+    in shape (``kind`` + ``message`` + ``detail`` + immutable copy of
+    detail) and applies the same Discord webhook secret masking.
+    ``Directive.text`` is user-pasted CEO directive content that may
+    embed a webhook URL, so masking ``message`` / ``detail`` at
+    construction time means callers cannot leak a token by serializing
+    the exception (multi-layer defense, see Directive detailed-design
+    §確定 E).
+    """
+
+    def __init__(
+        self,
+        *,
+        kind: DirectiveViolationKind,
+        message: str,
+        detail: Mapping[str, object] | None = None,
+    ) -> None:
+        masked_message = mask_discord_webhook(message)
+        masked_detail: dict[str, object] = (
+            {key: mask_discord_webhook_in(value) for key, value in detail.items()} if detail else {}
+        )
+        super().__init__(masked_message)
+        self.kind: DirectiveViolationKind = kind
+        self.message: str = masked_message
+        self.detail: dict[str, object] = masked_detail
+
+
 __all__ = [
     "AgentInvariantViolation",
     "AgentViolationKind",
+    "DirectiveInvariantViolation",
+    "DirectiveViolationKind",
     "EmpireInvariantViolation",
     "EmpireViolationKind",
     "RoomInvariantViolation",

--- a/backend/src/bakufu/domain/value_objects.py
+++ b/backend/src/bakufu/domain/value_objects.py
@@ -61,6 +61,13 @@ type TransitionId = UUID
 type SkillId = UUID
 """Skill identifier (referenced by :class:`SkillRef` inside Agent aggregate)."""
 
+type DirectiveId = UUID
+"""Directive aggregate identifier (UUIDv4)."""
+
+type TaskId = UUID
+"""Task aggregate identifier (UUIDv4). Referenced by :class:`Directive`
+via ``task_id``; the Task aggregate itself ships in a later feature."""
+
 
 # ---------------------------------------------------------------------------
 # Role enum
@@ -354,6 +361,7 @@ __all__ = [
     "AgentRef",
     "CompletionPolicy",
     "CompletionPolicyKind",
+    "DirectiveId",
     "EmpireId",
     "NormalizedAgentName",
     "NormalizedShortName",
@@ -366,6 +374,7 @@ __all__ = [
     "SkillId",
     "StageId",
     "StageKind",
+    "TaskId",
     "TransitionCondition",
     "TransitionId",
     "WorkflowId",

--- a/backend/tests/domain/directive/test_application_responsibility.py
+++ b/backend/tests/domain/directive/test_application_responsibility.py
@@ -1,0 +1,45 @@
+"""Application-layer responsibility boundary tests (TC-UT-DR-018 / 019).
+
+Confirmation G / H freeze that **Aggregate-internal invariants are
+structural only**: ``text`` length and ``task_id`` uniqueness. Cross-
+aggregate concerns (``target_room_id`` Room existence, ``$``-prefix
+normalization, Workflow resolution, Task creation in 1 Tx) live in
+``DirectiveService.issue()`` because they require external knowledge.
+These tests freeze that boundary so a future refactor cannot silently
+push aggregate-level checks into Directive (the regression direction
+Norman / Steve worked hard to keep clean for agent / room).
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from tests.factories.directive import make_directive
+
+
+class TestTargetRoomIdReferentialIntegrityNotEnforcedByAggregate:
+    """TC-UT-DR-018: Aggregate accepts any UUID as ``target_room_id``."""
+
+    def test_arbitrary_room_id_constructs(self) -> None:
+        """TC-UT-DR-018: Room existence is verified by DirectiveService, not Directive."""
+        # The UUID is arbitrary — no Room with this id exists. Aggregate
+        # accepts because referential integrity is application-layer scope.
+        directive = make_directive(target_room_id=uuid4())
+        assert directive.target_room_id is not None
+
+
+class TestDollarPrefixNotNormalizedByAggregate:
+    """TC-UT-DR-019: Aggregate stores ``text`` verbatim — no ``$`` prefix injection."""
+
+    def test_text_without_dollar_prefix_constructs_unchanged(self) -> None:
+        """TC-UT-DR-019: ``$`` prefix normalization is DirectiveService responsibility.
+
+        ``DirectiveService.issue(raw_text)`` is the layer that ensures
+        ``text`` starts with ``$``. The Aggregate trusts the input
+        verbatim — same pattern Agent §確定 I uses for ``provider_kind``
+        MVP gating.
+        """
+        # No ``$`` prefix in the input — Aggregate keeps the text as-is.
+        directive = make_directive(text="ブログ分析機能を作って")
+        assert not directive.text.startswith("$")
+        assert directive.text == "ブログ分析機能を作って"

--- a/backend/tests/domain/directive/test_construction.py
+++ b/backend/tests/domain/directive/test_construction.py
@@ -1,0 +1,125 @@
+"""Directive construction + boundary value tests
+(TC-UT-DR-001 / 002 / 003 / 004 / 014 / 015).
+
+Covers REQ-DR-001 (construction) + ``text`` length boundary + NFC
+normalization + the deliberately *non-stripping* contract +
+constructor-path Repository hydration (§確定 C) + tz-aware enforcement.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+from bakufu.domain.directive import Directive
+from bakufu.domain.exceptions import DirectiveInvariantViolation
+from pydantic import ValidationError
+
+from tests.factories.directive import (
+    make_directive,
+    make_linked_directive,
+)
+
+
+class TestDefaultConstruction:
+    """TC-UT-DR-001: factory default is a valid Directive with task_id=None."""
+
+    def test_default_directive_has_no_task_link(self) -> None:
+        """TC-UT-DR-001: factory default constructs with task_id=None."""
+        directive = make_directive()
+        assert directive.task_id is None
+
+    def test_default_directive_has_tz_aware_created_at(self) -> None:
+        """TC-UT-DR-001: factory default carries a tz-aware datetime."""
+        directive = make_directive()
+        assert directive.created_at.tzinfo is not None
+
+    def test_default_directive_text_is_short_with_dollar_prefix(self) -> None:
+        """TC-UT-DR-001: default text follows the application-layer ``$`` convention."""
+        directive = make_directive()
+        assert directive.text.startswith("$ ")
+
+
+class TestTextBoundary:
+    """TC-UT-DR-002: text length boundary 0 / 1 / 10000 / 10001 (確定 B)."""
+
+    @pytest.mark.parametrize("length", [1, 10_000])
+    def test_valid_lengths_succeed(self, length: int) -> None:
+        """TC-UT-DR-002: text lengths 1 and 10000 succeed."""
+        directive = make_directive(text="a" * length)
+        assert len(directive.text) == length
+
+    def test_empty_text_raises_text_range(self) -> None:
+        """TC-UT-DR-002: text length 0 raises text_range with detail.length=0."""
+        with pytest.raises(DirectiveInvariantViolation) as excinfo:
+            make_directive(text="")
+        assert excinfo.value.kind == "text_range"
+        assert excinfo.value.detail.get("length") == 0
+
+    def test_oversized_text_raises_text_range(self) -> None:
+        """TC-UT-DR-002: text length 10001 raises text_range with detail.length=10001."""
+        with pytest.raises(DirectiveInvariantViolation) as excinfo:
+            make_directive(text="a" * 10_001)
+        assert excinfo.value.kind == "text_range"
+        assert excinfo.value.detail.get("length") == 10_001
+
+
+class TestNfcNormalization:
+    """TC-UT-DR-003: NFC normalization unifies composed and decomposed forms (確定 B)."""
+
+    def test_composed_and_decomposed_forms_collapse(self) -> None:
+        """TC-UT-DR-003: composed and decomposed forms produce the same NFC string."""
+        composed = "ダリオ要件"
+        decomposed = "ダリオ要件"
+        d_composed = make_directive(text=composed)
+        d_decomposed = make_directive(text=decomposed)
+        assert d_composed.text == d_decomposed.text
+
+
+class TestStripIsNotApplied:
+    """TC-UT-DR-004: text is NFC-only, no strip — leading/trailing newlines kept."""
+
+    def test_leading_and_trailing_newlines_are_preserved(self) -> None:
+        """TC-UT-DR-004: '\\n# Directive\\n\\nbody\\n\\n' is held verbatim.
+
+        CEO directives may rely on multi-paragraph structure; stripping
+        would silently rewrite the intent. Confirmation B freezes this
+        as the documented design choice.
+        """
+        text = "\n# Directive\n\nbody\n\n"
+        directive = make_directive(text=text)
+        assert directive.text == text
+
+
+class TestRepositoryHydrationViaConstructor:
+    """TC-UT-DR-014: constructor accepts ``task_id=existing TaskId`` (§確定 C)."""
+
+    def test_directive_can_be_constructed_with_task_id(self) -> None:
+        """TC-UT-DR-014: Repository-hydrated state ``task_id != None`` constructs cleanly."""
+        existing_task_id = uuid4()
+        directive = make_linked_directive(task_id=existing_task_id)
+        assert directive.task_id == existing_task_id
+
+
+class TestCreatedAtMustBeTzAware:
+    """TC-UT-DR-015: naive datetime raises pydantic.ValidationError (MSG-DR-003)."""
+
+    def test_naive_datetime_is_rejected(self) -> None:
+        """TC-UT-DR-015: ``created_at=datetime.utcnow()`` (naive) → ValidationError."""
+        # Pydantic surfaces the ``_require_tz_aware`` ValueError as a
+        # ``ValidationError`` when the assertion lives inside an
+        # ``after`` validator.
+        with pytest.raises(ValidationError):
+            Directive(
+                id=uuid4(),
+                text="$ test",
+                target_room_id=uuid4(),
+                created_at=datetime(2026, 4, 27, 10, 0, 0),  # naive
+                task_id=None,
+            )
+
+    def test_tz_aware_utc_datetime_succeeds(self) -> None:
+        """TC-UT-DR-015 supplemental: tz-aware UTC datetime is the only allowed shape."""
+        directive = make_directive(created_at=datetime(2026, 4, 27, 10, 0, 0, tzinfo=UTC))
+        assert directive.created_at.tzinfo is not None

--- a/backend/tests/domain/directive/test_frozen_extra.py
+++ b/backend/tests/domain/directive/test_frozen_extra.py
@@ -1,0 +1,112 @@
+"""Frozen + extra='forbid' contract tests + structural equality
+(TC-UT-DR-008 / 020 / 021).
+
+Pydantic v2 ``frozen=True`` rejects attribute assignment;
+``extra='forbid'`` rejects unknown fields at construction; structural
+equality returns True for two Directives with identical attribute
+values. Same rule the agent / room / empire / workflow precedents
+follow.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+from bakufu.domain.directive import Directive
+from pydantic import ValidationError
+
+from tests.factories.directive import make_directive
+
+
+class TestFrozenAssignmentRejected:
+    """TC-UT-DR-020: direct attribute assignment raises ValidationError."""
+
+    def test_assigning_text_raises(self) -> None:
+        """TC-UT-DR-020: directive.text = ... raises ValidationError (frozen)."""
+        directive = make_directive()
+        with pytest.raises(ValidationError):
+            directive.text = "X"  # type: ignore[misc] # frozen, must raise at runtime
+
+    def test_assigning_task_id_raises(self) -> None:
+        """TC-UT-DR-020: directive.task_id = ... raises ValidationError (frozen)."""
+        directive = make_directive()
+        with pytest.raises(ValidationError):
+            directive.task_id = uuid4()  # type: ignore[misc] # frozen, must raise at runtime
+
+    def test_assigning_target_room_id_raises(self) -> None:
+        """TC-UT-DR-020: directive.target_room_id = ... raises ValidationError (frozen)."""
+        directive = make_directive()
+        with pytest.raises(ValidationError):
+            directive.target_room_id = uuid4()  # type: ignore[misc] # frozen, must raise at runtime
+
+
+class TestExtraForbidden:
+    """TC-UT-DR-021: unknown fields rejected at construction."""
+
+    def test_unknown_field_raises(self) -> None:
+        """TC-UT-DR-021: Directive.model_validate({...,'unknown':'x'}) raises."""
+        with pytest.raises(ValidationError):
+            Directive.model_validate(
+                {
+                    "id": str(uuid4()),
+                    "text": "$ test",
+                    "target_room_id": str(uuid4()),
+                    "created_at": datetime.now(UTC).isoformat(),
+                    "task_id": None,
+                    "unknown": "x",
+                }
+            )
+
+
+class TestStructuralEquality:
+    """TC-UT-DR-008: two Directives with same attribute values compare equal + share hash."""
+
+    def test_identical_directives_compare_equal(self) -> None:
+        """TC-UT-DR-008: equality is structural, not by identity."""
+        directive_id = uuid4()
+        target_room_id = uuid4()
+        created_at = datetime(2026, 4, 27, 10, 0, 0, tzinfo=UTC)
+        a = Directive(
+            id=directive_id,
+            text="$ test",
+            target_room_id=target_room_id,
+            created_at=created_at,
+            task_id=None,
+        )
+        b = Directive(
+            id=directive_id,
+            text="$ test",
+            target_room_id=target_room_id,
+            created_at=created_at,
+            task_id=None,
+        )
+        assert a == b
+
+    def test_identical_directives_share_hash(self) -> None:
+        """TC-UT-DR-008: structurally equal Directives hash to the same value."""
+        directive_id = uuid4()
+        target_room_id = uuid4()
+        created_at = datetime(2026, 4, 27, 10, 0, 0, tzinfo=UTC)
+        a = Directive(
+            id=directive_id,
+            text="$ test",
+            target_room_id=target_room_id,
+            created_at=created_at,
+            task_id=None,
+        )
+        b = Directive(
+            id=directive_id,
+            text="$ test",
+            target_room_id=target_room_id,
+            created_at=created_at,
+            task_id=None,
+        )
+        assert hash(a) == hash(b)
+
+    def test_directives_with_different_task_id_compare_unequal(self) -> None:
+        """TC-UT-DR-008: linked vs unlinked Directive must differ."""
+        directive = make_directive()
+        linked = directive.link_task(uuid4())
+        assert directive != linked

--- a/backend/tests/domain/directive/test_helpers_independence.py
+++ b/backend/tests/domain/directive/test_helpers_independence.py
@@ -1,0 +1,80 @@
+"""Module-level helper independence (Boy Scout twin-defense symmetry).
+
+agent / room precedent: every aggregate-level invariant helper lives at
+module scope so tests can ``import`` and invoke directly. Mirrors the
+agent / room ``test_helpers_independence.py`` pattern. These tests
+freeze the helper signatures and entry-point contract — the Aggregate
+stays a thin dispatch over them, and a refactor that inlines a helper
+back into the model_validator has to update this test file too.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from bakufu.domain.directive import (
+    MAX_TEXT_LENGTH,
+    MIN_TEXT_LENGTH,
+    _validate_task_link_immutable,
+    _validate_text_range,
+)
+from bakufu.domain.exceptions import DirectiveInvariantViolation
+
+
+class TestValidateTextRange:
+    """``_validate_text_range`` is a module-level pure function."""
+
+    @pytest.mark.parametrize("length", [MIN_TEXT_LENGTH, MAX_TEXT_LENGTH])
+    def test_valid_lengths_return_none(self, length: int) -> None:
+        """Valid lengths return ``None`` without raising."""
+        result = _validate_text_range("a" * length)
+        assert result is None
+
+    @pytest.mark.parametrize("length", [0, MAX_TEXT_LENGTH + 1])
+    def test_invalid_lengths_raise_text_range(self, length: int) -> None:
+        """Out-of-range lengths raise ``DirectiveInvariantViolation(kind='text_range')``."""
+        with pytest.raises(DirectiveInvariantViolation) as excinfo:
+            _validate_text_range("a" * length)
+        assert excinfo.value.kind == "text_range"
+
+
+class TestValidateTaskLinkImmutable:
+    """``_validate_task_link_immutable`` is a module-level pure function (確定 C / D)."""
+
+    def test_existing_none_passes(self) -> None:
+        """Confirmation C: existing_task_id=None permits any attempted_task_id."""
+        directive_id = uuid4()
+        attempted = uuid4()
+        # Returns ``None`` (no raise) when existing is None.
+        result = _validate_task_link_immutable(
+            directive_id=directive_id,
+            existing_task_id=None,
+            attempted_task_id=attempted,
+        )
+        assert result is None
+
+    def test_existing_value_raises_on_different_attempt(self) -> None:
+        """Confirmation C: existing → different new task_id raises."""
+        directive_id = uuid4()
+        existing = uuid4()
+        attempted = uuid4()
+        with pytest.raises(DirectiveInvariantViolation) as excinfo:
+            _validate_task_link_immutable(
+                directive_id=directive_id,
+                existing_task_id=existing,
+                attempted_task_id=attempted,
+            )
+        assert excinfo.value.kind == "task_already_linked"
+
+    def test_existing_value_raises_on_identical_attempt(self) -> None:
+        """Confirmation D: existing == attempted task_id still raises (no idempotency)."""
+        directive_id = uuid4()
+        same = uuid4()
+        with pytest.raises(DirectiveInvariantViolation) as excinfo:
+            _validate_task_link_immutable(
+                directive_id=directive_id,
+                existing_task_id=same,
+                attempted_task_id=same,
+            )
+        assert excinfo.value.kind == "task_already_linked"

--- a/backend/tests/domain/directive/test_integration.py
+++ b/backend/tests/domain/directive/test_integration.py
@@ -1,0 +1,88 @@
+"""Round-trip scenarios across Directive + DirectiveInvariantViolation
+(TC-IT-DR-001 / 002).
+
+The directive feature is domain-only with zero external I/O, so
+"integration" here means *aggregate-internal module integration*:
+chained behaviors over a Directive lifecycle, with the original
+Directive observed unchanged at each step (frozen + pre-validate
+rebuild, Confirmation A).
+
+These tests intentionally compose the production constructors /
+behaviors directly — no mocks, no test-only back doors — and exercise
+the documented acceptance criteria 1, 5, 6 in a single sequence.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from bakufu.domain.exceptions import DirectiveInvariantViolation
+
+from tests.factories.directive import (
+    make_directive,
+    make_linked_directive,
+)
+
+
+class TestDirectiveLifecycleRoundTrip:
+    """TC-IT-DR-001: full Directive lifecycle (construct → link → re-link rejected)."""
+
+    def test_full_lifecycle_preserves_immutability(self) -> None:
+        """TC-IT-DR-001: construct → link_task → second link_task rejected."""
+        # Step 1: construct an unlinked Directive.
+        d0 = make_directive()
+        assert d0.task_id is None
+
+        # Step 2: link a Task. New instance has the new task_id.
+        task_id_1 = uuid4()
+        d1 = d0.link_task(task_id_1)
+        assert d1.task_id == task_id_1
+
+        # Step 3: re-linking d1 must Fail Fast.
+        task_id_2 = uuid4()
+        with pytest.raises(DirectiveInvariantViolation) as excinfo:
+            d1.link_task(task_id_2)
+        assert excinfo.value.kind == "task_already_linked"
+
+        # Step 4: original Directives are unchanged across the
+        # sequence (frozen + pre-validate rebuild contract).
+        assert d0.task_id is None
+        assert d1.task_id == task_id_1
+
+        # Step 5: structural equality — d0 and d1 must NOT compare
+        # equal because their task_id values differ.
+        assert d0 != d1
+
+
+class TestRelinkFailureContinuity:
+    """TC-IT-DR-002: re-link failure isolates state across repeated attempts."""
+
+    def test_repeated_relink_attempts_do_not_corrupt_state(self) -> None:
+        """TC-IT-DR-002: 3 consecutive failed re-links leave task_id unchanged."""
+        existing_task_id = uuid4()
+        d = make_linked_directive(task_id=existing_task_id)
+
+        # Three different attempted_task_ids — each must fail.
+        for _ in range(3):
+            new_task_id = uuid4()
+            with pytest.raises(DirectiveInvariantViolation) as excinfo:
+                d.link_task(new_task_id)
+            assert excinfo.value.kind == "task_already_linked"
+
+        # The Directive's existing task_id survives intact — the
+        # re-link contract is permanent (Confirmation D).
+        assert d.task_id == existing_task_id
+
+    def test_relink_failure_does_not_block_unrelated_directives(self) -> None:
+        """TC-IT-DR-002 supplemental: failure isolation across instances."""
+        # Link Directive A; re-link must fail.
+        a = make_linked_directive(task_id=uuid4())
+        with pytest.raises(DirectiveInvariantViolation):
+            a.link_task(uuid4())
+
+        # Independent Directive B can still be linked normally.
+        b = make_directive()
+        new_task_id = uuid4()
+        b_linked = b.link_task(new_task_id)
+        assert b_linked.task_id == new_task_id

--- a/backend/tests/domain/directive/test_link_task.py
+++ b/backend/tests/domain/directive/test_link_task.py
@@ -1,0 +1,111 @@
+"""``link_task`` behavior + uniqueness contract tests
+(TC-UT-DR-005 / 006 / 016 / 017).
+
+Confirmation C / D: ``link_task`` flips ``task_id`` from ``None`` to a
+real value exactly once. Re-linking — *even with the same TaskId* — is
+always a Fail Fast. The constructor path (Repository hydration) is
+allowed to carry an existing ``task_id`` because that is a permanent
+attribute value, not a transition.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from bakufu.domain.exceptions import DirectiveInvariantViolation
+
+from tests.factories.directive import (
+    make_directive,
+    make_linked_directive,
+)
+
+
+class TestLinkTaskHappyPath:
+    """TC-UT-DR-005: link_task flips None → valid TaskId, returns new instance."""
+
+    def test_link_task_returns_directive_with_task_id(self) -> None:
+        """TC-UT-DR-005: returned Directive carries the new task_id."""
+        directive = make_directive()
+        task_id = uuid4()
+        linked = directive.link_task(task_id)
+        assert linked.task_id == task_id
+
+    def test_link_task_does_not_mutate_original(self) -> None:
+        """TC-UT-DR-005: original Directive.task_id stays None after link_task."""
+        directive = make_directive()
+        directive.link_task(uuid4())
+        assert directive.task_id is None
+
+    def test_linked_directive_preserves_other_attributes(self) -> None:
+        """TC-UT-DR-005: only task_id changes; id / text / target_room_id / created_at survive."""
+        directive = make_directive()
+        new_task_id = uuid4()
+        linked = directive.link_task(new_task_id)
+        assert linked.id == directive.id
+        assert linked.text == directive.text
+        assert linked.target_room_id == directive.target_room_id
+        assert linked.created_at == directive.created_at
+
+
+class TestLinkTaskRejectsRelink:
+    """TC-UT-DR-006: link_task on an already-linked Directive raises (§確定 C)."""
+
+    def test_relink_with_different_task_id_raises(self) -> None:
+        """TC-UT-DR-006: existing → new task_id raises ``task_already_linked``."""
+        existing_task_id = uuid4()
+        directive = make_linked_directive(task_id=existing_task_id)
+        new_task_id = uuid4()
+        with pytest.raises(DirectiveInvariantViolation) as excinfo:
+            directive.link_task(new_task_id)
+        assert excinfo.value.kind == "task_already_linked"
+
+    def test_relink_detail_includes_pair_identifiers(self) -> None:
+        """TC-UT-DR-006: detail dict carries directive_id / existing_task_id / attempted_task_id."""
+        existing_task_id = uuid4()
+        directive = make_linked_directive(task_id=existing_task_id)
+        new_task_id = uuid4()
+        with pytest.raises(DirectiveInvariantViolation) as excinfo:
+            directive.link_task(new_task_id)
+        detail = excinfo.value.detail
+        assert detail.get("directive_id") == str(directive.id)
+        assert detail.get("existing_task_id") == str(existing_task_id)
+        assert detail.get("attempted_task_id") == str(new_task_id)
+
+
+class TestLinkTaskNoIdempotency:
+    """TC-UT-DR-016: same TaskId re-link still raises (§確定 D — no idempotency)."""
+
+    def test_relink_with_identical_task_id_still_raises(self) -> None:
+        """TC-UT-DR-016: re-linking with the *same* task_id is still a Fail Fast."""
+        existing_task_id = uuid4()
+        directive = make_linked_directive(task_id=existing_task_id)
+        # Confirmation D freezes "1 link only, second call always fails"
+        # — the simpler contract avoids special cases in the validator.
+        with pytest.raises(DirectiveInvariantViolation) as excinfo:
+            directive.link_task(existing_task_id)
+        assert excinfo.value.kind == "task_already_linked"
+
+
+class TestPreValidateRollback:
+    """TC-UT-DR-017: failed link_task leaves the original Directive intact (§確定 A)."""
+
+    def test_link_task_failure_does_not_mutate_original(self) -> None:
+        """TC-UT-DR-017: original Directive.task_id stays unchanged after a failed re-link."""
+        existing_task_id = uuid4()
+        directive = make_linked_directive(task_id=existing_task_id)
+        with pytest.raises(DirectiveInvariantViolation):
+            directive.link_task(uuid4())
+        # The original instance still references the original task_id.
+        assert directive.task_id == existing_task_id
+
+    def test_failed_relink_can_be_repeated_without_progress(self) -> None:
+        """TC-UT-DR-017: state damage does not accumulate across repeated failures."""
+        existing_task_id = uuid4()
+        directive = make_linked_directive(task_id=existing_task_id)
+        # Three different attempted task_ids — each must fail and the
+        # Directive must remain identifiable as "linked to the original".
+        for _ in range(3):
+            with pytest.raises(DirectiveInvariantViolation):
+                directive.link_task(uuid4())
+        assert directive.task_id == existing_task_id

--- a/backend/tests/domain/directive/test_msg_wording.py
+++ b/backend/tests/domain/directive/test_msg_wording.py
@@ -1,0 +1,81 @@
+"""MSG-DR-001 / 002 wording + Next: hint physical guarantee
+(TC-UT-DR-022 / 023).
+
+Each MSG follows the 2-line structure (Confirmation F, room §確定 I
+踏襲):
+
+    [FAIL] <failure fact>
+    Next: <recommended next action>
+
+The first line is asserted **exactly** so future i18n / refactoring
+cannot silently drift the operator-visible failure fact. The second
+line is asserted via substring on the leading ``Next:`` token *and* a
+topic phrase so the design-time hint contract survives cosmetic edits
+while the "hint exists" property is locked in by CI.
+
+MSG-DR-003 (type violation) travels the :class:`pydantic.ValidationError`
+path; it is covered in ``test_construction.py``. MSG-DR-004 / 005
+belong to the application layer (``DirectiveService.issue()``) — out of
+scope for this aggregate test suite.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from bakufu.domain.exceptions import DirectiveInvariantViolation
+
+from tests.factories.directive import (
+    make_directive,
+    make_linked_directive,
+)
+
+
+class TestMsgDr001TextRange:
+    """TC-UT-DR-022: MSG-DR-001 + Next: hint."""
+
+    def test_failure_line_matches_exact_wording(self) -> None:
+        """TC-UT-DR-022: '[FAIL] Directive text must be 1-10000 ...' exact prefix."""
+        with pytest.raises(DirectiveInvariantViolation) as excinfo:
+            make_directive(text="a" * 10_001)
+        assert excinfo.value.message.startswith(
+            "[FAIL] Directive text must be 1-10000 characters (got 10001)"
+        )
+
+    def test_next_hint_present_with_topic_phrase(self) -> None:
+        """TC-UT-DR-022: 'Next:' hint exists with multi-directive / trim topic phrase."""
+        with pytest.raises(DirectiveInvariantViolation) as excinfo:
+            make_directive(text="a" * 10_001)
+        message = excinfo.value.message
+        assert "Next:" in message
+        # Hint must mention either trimming or splitting into multiple
+        # directives (Confirmation F's documented ``Next`` phrase).
+        assert ("Trim" in message) or ("multiple directives" in message)
+
+
+class TestMsgDr002TaskAlreadyLinked:
+    """TC-UT-DR-023: MSG-DR-002 + Next: hint (issue a new Directive)."""
+
+    def test_failure_line_includes_pair_identifiers(self) -> None:
+        """TC-UT-DR-023: '[FAIL] Directive already has a linked Task: ...' format."""
+        existing_task_id = uuid4()
+        directive = make_linked_directive(task_id=existing_task_id)
+        new_task_id = uuid4()
+        with pytest.raises(DirectiveInvariantViolation) as excinfo:
+            directive.link_task(new_task_id)
+        message = excinfo.value.message
+        assert "[FAIL] Directive already has a linked Task" in message
+        assert f"directive_id={directive.id}" in message
+        assert f"existing_task_id={existing_task_id}" in message
+
+    def test_next_hint_advises_new_directive_and_states_one_to_one(self) -> None:
+        """TC-UT-DR-023: 'Next:' hint mentions issuing a new Directive + 1:1 design statement."""
+        directive = make_linked_directive(task_id=uuid4())
+        with pytest.raises(DirectiveInvariantViolation) as excinfo:
+            directive.link_task(uuid4())
+        message = excinfo.value.message
+        assert "Next:" in message
+        assert "Issue a new Directive" in message
+        # Confirmation F's design statement: "one Directive maps to one Task by design".
+        assert "one Directive maps to one Task" in message

--- a/backend/tests/domain/directive/test_webhook_masking.py
+++ b/backend/tests/domain/directive/test_webhook_masking.py
@@ -1,0 +1,70 @@
+"""DirectiveInvariantViolation webhook auto-mask tests (TC-UT-DR-007).
+
+Confirmation E: ``DirectiveInvariantViolation`` runs
+``mask_discord_webhook`` over ``message`` and ``mask_discord_webhook_in``
+over ``detail`` *before* :class:`Exception` ``__init__`` so the secret
+``token`` segment of any embedded webhook URL never leaks through
+serialization, logging, or HTTP error responses. CEO directives can
+include user-pasted text that may carry a webhook URL; the aggregate
+boundary is the last layer where masking can still happen before
+persistence.
+"""
+
+from __future__ import annotations
+
+import pytest
+from bakufu.domain.exceptions import DirectiveInvariantViolation
+
+from tests.factories.directive import make_directive
+
+# A valid-shape Discord webhook URL. The numeric ``id`` segment must
+# stay visible (audit traceability) while the token segment must be
+# redacted to ``<REDACTED:DISCORD_WEBHOOK>``.
+_WEBHOOK_ID = "1234567890123456789"
+_WEBHOOK_TOKEN = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWX"
+_WEBHOOK_URL = f"https://discord.com/api/webhooks/{_WEBHOOK_ID}/{_WEBHOOK_TOKEN}"
+_REDACTED = "<REDACTED:DISCORD_WEBHOOK>"
+
+
+class TestWebhookMaskingOnTextRangeViolation:
+    """TC-UT-DR-007: webhook URL inside oversize text is redacted in exception text."""
+
+    def test_token_does_not_appear_in_message(self) -> None:
+        """TC-UT-DR-007: exception.message contains the redacted marker only."""
+        # Build a 10001-char text that *contains* the webhook URL.
+        text = _WEBHOOK_URL + ("a" * 10_001)
+        with pytest.raises(DirectiveInvariantViolation) as excinfo:
+            make_directive(text=text)
+        assert _WEBHOOK_TOKEN not in excinfo.value.message
+
+    def test_token_does_not_leak_into_str_exc(self) -> None:
+        """TC-UT-DR-007: str(exc) (default logging path) is also redacted."""
+        text = _WEBHOOK_URL + ("a" * 10_001)
+        with pytest.raises(DirectiveInvariantViolation) as excinfo:
+            make_directive(text=text)
+        assert _WEBHOOK_TOKEN not in str(excinfo.value)
+
+
+class TestWebhookMaskingOnDetail:
+    """TC-UT-DR-007: detail dict values are recursively masked too."""
+
+    def test_detail_values_carry_no_token(self) -> None:
+        """TC-UT-DR-007: every str-valued detail item passes through mask_discord_webhook_in."""
+        text = _WEBHOOK_URL + ("a" * 10_001)
+        with pytest.raises(DirectiveInvariantViolation) as excinfo:
+            make_directive(text=text)
+        for value in excinfo.value.detail.values():
+            assert _WEBHOOK_TOKEN not in str(value)
+
+
+class TestWebhookMaskingIdempotent:
+    """Confirmation E supplemental: masking is idempotent."""
+
+    def test_re_application_does_not_double_substitute(self) -> None:
+        """``mask_discord_webhook`` applied twice yields the same string."""
+        from bakufu.domain.value_objects import mask_discord_webhook
+
+        once = mask_discord_webhook(_WEBHOOK_URL)
+        twice = mask_discord_webhook(once)
+        assert once == twice
+        assert _REDACTED in once

--- a/backend/tests/factories/directive.py
+++ b/backend/tests/factories/directive.py
@@ -1,0 +1,98 @@
+"""Factories for the Directive Aggregate Root.
+
+Per ``docs/features/directive/test-design.md``. Mirrors the
+empire / workflow / agent / room pattern: every factory returns a
+*valid* default instance built through the production constructor,
+allows keyword overrides, and registers the result in a
+:class:`WeakValueDictionary` so :func:`is_synthetic` can later flag
+test-built objects without mutating the frozen Pydantic model.
+
+Default Directive carries a short ``text`` body and ``task_id=None``.
+``LinkedDirectiveFactory`` constructs the post-link state directly
+(Repository hydration scenario, §確定 C). ``LongTextDirectiveFactory``
+sits at the upper boundary (10000 chars).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+from weakref import WeakValueDictionary
+
+from bakufu.domain.directive import Directive
+from pydantic import BaseModel
+
+# Module-scope registry. Values are kept weakly so GC pressure stays neutral.
+_SYNTHETIC_REGISTRY: WeakValueDictionary[int, BaseModel] = WeakValueDictionary()
+
+
+def is_synthetic(instance: BaseModel) -> bool:
+    """Return ``True`` when ``instance`` was created by a factory in this module."""
+    cached = _SYNTHETIC_REGISTRY.get(id(instance))
+    return cached is instance
+
+
+def _register(instance: BaseModel) -> None:
+    """Record ``instance`` in the synthetic registry."""
+    _SYNTHETIC_REGISTRY[id(instance)] = instance
+
+
+def make_directive(
+    *,
+    directive_id: UUID | None = None,
+    text: str = "$ ブログ分析機能を作って",
+    target_room_id: UUID | None = None,
+    created_at: datetime | None = None,
+    task_id: UUID | None = None,
+) -> Directive:
+    """Build a valid :class:`Directive`.
+
+    Defaults: short ``text`` containing the ``$`` prefix the
+    application layer would have normalized, ``task_id=None`` (not yet
+    linked), ``created_at=datetime.now(UTC)`` so the tz-aware
+    constraint is satisfied without per-test setup.
+    """
+    directive = Directive(
+        id=directive_id if directive_id is not None else uuid4(),
+        text=text,
+        target_room_id=target_room_id if target_room_id is not None else uuid4(),
+        created_at=created_at if created_at is not None else datetime.now(UTC),
+        task_id=task_id,
+    )
+    _register(directive)
+    return directive
+
+
+def make_linked_directive(
+    *,
+    directive_id: UUID | None = None,
+    text: str = "$ 既に紐付け済みの directive",
+    target_room_id: UUID | None = None,
+    task_id: UUID | None = None,
+) -> Directive:
+    """Build a Directive that already has a non-``None`` ``task_id``.
+
+    Repository hydration scenario (§確定 C): the constructor accepts
+    a permanent ``task_id`` value for restoring an already-linked
+    Directive from disk. ``link_task`` against the returned instance
+    will Fail Fast.
+    """
+    return make_directive(
+        directive_id=directive_id,
+        text=text,
+        target_room_id=target_room_id,
+        task_id=task_id if task_id is not None else uuid4(),
+    )
+
+
+def make_long_text_directive() -> Directive:
+    """Build a Directive at the upper boundary (10000 NFC chars)."""
+    return make_directive(text="a" * 10_000)
+
+
+__all__ = [
+    "is_synthetic",
+    "make_directive",
+    "make_linked_directive",
+    "make_long_text_directive",
+]


### PR DESCRIPTION
## Summary

- M1 5 兄弟目として **Directive Aggregate Root** 実装
- 設計書 (PR #26 マージ済) §確定 A〜H に完全準拠
- `spawn_task` 案を **`link_task` に置換**（Aggregate 境界違反回避、確定 C/D）

## Implementation

### `domain/directive/` — 3 sibling modules

| ファイル | 行数 | 責務 |
|---------|------|------|
| `directive.py` | 142 | Directive Aggregate Root (5 attr / 2 invariant / 1 behavior) |
| `aggregate_validators.py` | 100 | `_validate_text_range` / `_validate_task_link_immutable` |
| `__init__.py` | 36 | public re-export |

### `domain/value_objects.py`（更新、+11/-0）

- `DirectiveId` / `TaskId` 型エイリアス追加（UUID over PEP 695 `type`）

### `domain/exceptions.py`（更新、+50/-0）

- `DirectiveInvariantViolation` + `DirectiveViolationKind`（kind: `text_range` / `task_already_linked`）
- `__init__` で `mask_discord_webhook` + `mask_discord_webhook_in` を `super().__init__` 前に強制適用（§確定 E、agent / room 同パターン）

## Design contracts honored

- **§確定 A** pre-validate rebuild via `model_dump → swap → model_validate`
- **§確定 B** `text` は NFC 正規化のみ、strip しない（CEO directive の段落 / 末尾改行を保持。`Persona.prompt_body` / `PromptKit.prefix_markdown` と同規約）
- **§確定 C** コンストラクタ経路は任意 `TaskId | None` を許容（Repository 復元経路）、`link_task` ふるまい入口でのみ再リンク禁止
- **§確定 D** 冪等性なし — 同 `TaskId` で 2 回呼んでも常に Fail Fast（再発行は新規 Directive、業務シナリオに合致）
- **§確定 E** `DirectiveInvariantViolation` の auto-mask（多層防御）
- **§確定 F** 例外型統一規約: `text_range` / `task_already_linked` のみ。型違反は `pydantic.ValidationError`、application 層違反は `RoomNotFoundError` / `WorkflowNotFoundError`
- **§確定 G/H** application 層責務の分離（`$` プレフィックス正規化 / `target_room_id` 存在 / Task 生成は `DirectiveService` の領域）
- **`created_at` tz-aware 強制** — naive datetime は `pydantic.ValidationError`（設計書 line 33）

## Quality gates (local)

- `pyright --strict`: **0 errors / 0 warnings**
- `ruff check + format`: clean
- `pytest`: **480 passed**（既存 480 維持、無回帰）
- E2E smoke:
  - `Directive(...)` 正常構築 + NFC正規化 + 段落保持
  - `link_task(task_id)` 正常系（新インスタンス、`d is not d2`）
  - 二重 `link_task` 拒否（`kind='task_already_linked'`、`Next:` hint 含む）
  - 同 `TaskId` 再リンクも常に Fail Fast（冪等性なし契約）
  - naive `datetime` 拒否（`pydantic.ValidationError`）
  - 10001 文字超過で `kind='text_range'`、`detail['length']==10001`

## Tests

本 PR は **実装のみ**（agent / room PR と同パターン）。`docs/features/directive/test-design.md` の TC-UT-DR-001〜023 + TC-IT-DR-001〜002 はテスト担当が `test(directive):` コミットで追加する。

## Test plan

- [ ] `pyright --strict` 0 errors
- [ ] `ruff check + format` clean
- [ ] 既存 480 テスト無回帰
- [ ] テスト担当による TC-UT-DR-001〜023 + TC-IT-DR-001〜002 実装後にカバレッジ確認

## Refs

- Issue: #24
- 設計書: `docs/features/directive/{requirements-analysis,requirements,basic-design,detailed-design,test-design}.md`
- 凍結済み: `docs/architecture/domain-model/aggregates.md` §Directive
- 先行 PR: #26 (Directive 設計), #22 (Room 実装パターン)