### PR TITLE
fix(empire-repository): close BUG-EMR-001 with ORDER BY find_by_id

### DIFF
--- a/backend/src/bakufu/infrastructure/persistence/sqlite/repositories/empire_repository.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/repositories/empire_repository.py
@@ -64,10 +64,26 @@ class SqliteEmpireRepository:
         if empire_row is None:
             return None
 
-        room_stmt = select(EmpireRoomRefRow).where(EmpireRoomRefRow.empire_id == empire_id)
+        # BUG-EMR-001 fix: ORDER BY room_id / agent_id makes the
+        # hydrated list deterministic. Without it SQLite returns rows
+        # in internal-scan order, which broke ``Empire == Empire``
+        # round-trip equality (the Aggregate VO compares list-by-list).
+        # See docs/features/empire-repository/detailed-design.md
+        # §Known Issues for the design resolution; basic-design.md
+        # L127-128 froze ``ORDER BY room_id`` / ``ORDER BY agent_id``
+        # as the design contract.
+        room_stmt = (
+            select(EmpireRoomRefRow)
+            .where(EmpireRoomRefRow.empire_id == empire_id)
+            .order_by(EmpireRoomRefRow.room_id)
+        )
         room_rows = list((await self._session.execute(room_stmt)).scalars().all())
 
-        agent_stmt = select(EmpireAgentRefRow).where(EmpireAgentRefRow.empire_id == empire_id)
+        agent_stmt = (
+            select(EmpireAgentRefRow)
+            .where(EmpireAgentRefRow.empire_id == empire_id)
+            .order_by(EmpireAgentRefRow.agent_id)
+        )
         agent_rows = list((await self._session.execute(agent_stmt)).scalars().all())
 
         return self._from_row(empire_row, room_rows, agent_rows)

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_empire_repository/test_save_semantics.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_empire_repository/test_save_semantics.py
@@ -65,26 +65,26 @@ class TestSaveDeleteThenInsert:
 class TestRoundTripStructuralEquality:
     """TC-IT-EMR-007 + TC-UT-EMR-003: save → find_by_id round-trip preserves equality.
 
-    Note (BUG-EMR-001): :meth:`SqliteEmpireRepository.find_by_id` does
-    not issue ``ORDER BY`` when SELECTing the side tables, so the
-    rooms / agents lists come back in whatever order SQLite happens
-    to scan. The Empire VO carries lists (ordered), but the design
-    docs do not freeze a list-order semantic for ``rooms`` /
-    ``agents`` and there is no insertion-order guarantee at the SQL
-    layer. The tests below therefore compare the **set** of rooms /
-    agents — which captures the design intent ("the same membership
-    survives the round-trip") without locking in an undocumented
-    list-order contract. The bug report recommends adding an
-    ``ORDER BY`` to ``find_by_id`` *only if* the design wants list
-    semantics; otherwise the Empire VO should be updated to compare
-    by set / frozenset of refs.
+    BUG-EMR-001 closure: :meth:`SqliteEmpireRepository.find_by_id` now
+    issues ``ORDER BY room_id`` / ``ORDER BY agent_id`` per
+    ``basic-design.md`` L127-128 and ``detailed-design.md`` §クラス設計.
+    The hydrated lists are deterministic, so the previous set-based
+    workaround is removed and replaced with the contracted list-order
+    comparison.
+
+    Test contract (ORDER BY 物理保証): the Repository's
+    ``ORDER BY room_id`` / ``ORDER BY agent_id`` design contract is
+    asserted by sorting the input Empire's collections by the same
+    key and demanding list equality. Failing this assertion means
+    the SQL contract regressed (either the ``ORDER BY`` was dropped
+    or the column changed).
     """
 
     async def test_populated_empire_round_trip(
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """TC-IT-EMR-007: round-trip preserves Empire identity + membership."""
+        """TC-IT-EMR-007: round-trip preserves Empire identity + membership in ORDER BY order."""
         empire = make_populated_empire(n_rooms=2, n_agents=3)
         async with session_factory() as session, session.begin():
             await SqliteEmpireRepository(session).save(empire)
@@ -94,11 +94,12 @@ class TestRoundTripStructuralEquality:
         assert restored is not None
         assert restored.id == empire.id
         assert restored.name == empire.name
-        # Set-based comparison (BUG-EMR-001 workaround): the Repository
-        # does not emit ORDER BY, so list order is undefined. Membership
-        # equality is the design intent we care about.
-        assert set(restored.rooms) == set(empire.rooms)
-        assert set(restored.agents) == set(empire.agents)
+        # ORDER BY room_id / agent_id 物理保証: restored side-table
+        # lists are deterministic, so list-order equality is the
+        # contract. The expected lists are sorted by the same key
+        # the Repository used in its ``ORDER BY``.
+        assert restored.rooms == sorted(empire.rooms, key=lambda r: r.room_id)
+        assert restored.agents == sorted(empire.agents, key=lambda a: a.agent_id)
 
     async def test_empty_empire_round_trip(
         self,
@@ -119,7 +120,7 @@ class TestRoundTripStructuralEquality:
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """TC-UT-EMR-003: ``_to_row`` → save + find_by_id (≡ ``_from_row``) preserves membership."""
+        """TC-UT-EMR-003: ``_to_row`` → save + find_by_id (≡ ``_from_row``) preserves equality."""
         empire = make_populated_empire(n_rooms=2, n_agents=3)
         async with session_factory() as session, session.begin():
             await SqliteEmpireRepository(session).save(empire)
@@ -127,12 +128,13 @@ class TestRoundTripStructuralEquality:
         async with session_factory() as session:
             restored = await SqliteEmpireRepository(session).find_by_id(empire.id)
         assert restored is not None
-        # Same set-based comparison as test_populated_empire_round_trip
-        # — see BUG-EMR-001 in the class docstring.
         assert restored.id == empire.id
         assert restored.name == empire.name
-        assert set(restored.rooms) == set(empire.rooms)
-        assert set(restored.agents) == set(empire.agents)
+        # Same ORDER BY-aware list comparison as
+        # test_populated_empire_round_trip — see class docstring for
+        # the BUG-EMR-001 closure rationale.
+        assert restored.rooms == sorted(empire.rooms, key=lambda r: r.room_id)
+        assert restored.agents == sorted(empire.agents, key=lambda a: a.agent_id)
 
 
 # ---------------------------------------------------------------------------

--- a/docs/features/empire-repository/detailed-design.md
+++ b/docs/features/empire-repository/detailed-design.md
@@ -241,7 +241,14 @@ Empire のシングルトン制約（bakufu インスタンスにつき 1 件）
 
 実装段階・テスト段階で発見されたが本 PR スコープ内では完全解消しない問題を凍結する。各項目は Issue 起票 / 別 PR で完了させる。
 
-### BUG-EMR-001 [LOW]: `find_by_id` の `ORDER BY` 欠落と `_from_row` 経路の list 順序非決定性
+### BUG-EMR-001 [LOW] [**RESOLVED in `feature/empire-repository-order-by`**]: `find_by_id` の `ORDER BY` 欠落と `_from_row` 経路の list 順序非決定性
+
+> **Status: Resolved.** `SqliteEmpireRepository.find_by_id` が
+> `ORDER BY room_id` / `ORDER BY agent_id` を発行するように修正された
+> (basic-design.md L127-128 の凍結に追従)。test 側は
+> `sorted(empire.rooms, key=lambda r: r.room_id)` で「ORDER BY 契約物理保証」
+> を assert する。本節の歴史的経緯は、設計契約の整合性回復ワークフローの
+> 監査証跡として保存する。
 
 ##### 観察された挙動（PR #29 ジェフレポート）
 
@@ -275,11 +282,11 @@ basic-design.md は既に正解を凍結していたが、detailed-design.md と
 
 本 PR ではドキュメント側の整合性回復（basic-design.md と detailed-design.md の再同期）のみ実施。コード側の修正は別 PR で行う:
 
-| タスク | 担当 PR | 内容 |
+| タスク | 担当 PR | 状態 |
 |---|---|---|
-| Repository 修正 | `feature/empire-repository-order-by`（別 PR） | `find_by_id` の SELECT 文に `ORDER BY room_id` / `ORDER BY agent_id` を追加 |
-| テスト修正 | 同上 | `test_empire_repository/test_save_semantics.py` の set 比較 workaround を **list 順序比較**に戻す（保存順 == 復元順を物理保証） |
-| 申し送りクローズ | 同上 | 本 §Known Issues §BUG-EMR-001 を「Resolved in PR #XX」に更新 |
+| Repository 修正 | `feature/empire-repository-order-by` | ✓ 完了 — `find_by_id` の SELECT 文に `ORDER BY room_id` / `ORDER BY agent_id` を追加（commit 上記） |
+| テスト修正 | 同上 | ✓ 完了 — `test_empire_repository/test_save_semantics.py` の set 比較 workaround を **`sorted(..., key=lambda r: r.room_id)` でソートした list 比較**に戻し、ORDER BY 契約を物理保証 |
+| 申し送りクローズ | 同上 | ✓ 完了 — 本 §Known Issues §BUG-EMR-001 を「RESOLVED」に更新 |
 
 ##### 緊急度: LOW
 


### PR DESCRIPTION
## Summary

PR #29 のレビューで凍結された **BUG-EMR-001 [LOW]** をクローズ。`SqliteEmpireRepository.find_by_id` の SELECT に `ORDER BY room_id` / `ORDER BY agent_id` を追加し、`save → find_by_id` の round-trip を順序保証付きの list 比較に戻す。

## Background

PR #29 でジェフが発見:
- `find_by_id` が SQLite 内部スキャン順依存で rooms/agents を返す
- `Empire` VO は ordered `list[RoomRef]` / `list[AgentRef]` を持つので `Empire == Empire` 比較が壊れる
- `basic-design.md L127-128` は **既に** `ORDER BY room_id` / `ORDER BY agent_id` を「設計上の正解」として凍結済み
- detailed-design.md と実装が basic-design に追従していなかった（片肺状態）

PR #29 では設計書側の整合性回復のみ実施し、実装は本 PR で完了させる方針が決議された（detailed-design.md §Known Issues §BUG-EMR-001）。

## Changes (3 files, +56/-31)

### `backend/src/bakufu/infrastructure/persistence/sqlite/repositories/empire_repository.py`

`find_by_id` の SELECT 文に `ORDER BY` を追加:

```python
room_stmt = (
    select(EmpireRoomRefRow)
    .where(EmpireRoomRefRow.empire_id == empire_id)
    .order_by(EmpireRoomRefRow.room_id)
)
agent_stmt = (
    select(EmpireAgentRefRow)
    .where(EmpireAgentRefRow.empire_id == empire_id)
    .order_by(EmpireAgentRefRow.agent_id)
)
```

inline コメントで basic-design.md L127-128 + §Known Issues を参照。

### `backend/tests/.../test_save_semantics.py`

`TestRoundTripStructuralEquality` の set 比較 workaround を **ORDER BY 契約物理保証**型の list 比較に戻す:

```python
assert restored.rooms == sorted(empire.rooms, key=lambda r: r.room_id)
assert restored.agents == sorted(empire.agents, key=lambda a: a.agent_id)
```

これで SQL の `ORDER BY` 句が将来 dropped されると test が落ちる退行検出装置として機能。

### `docs/features/empire-repository/detailed-design.md`

§Known Issues §BUG-EMR-001 を **RESOLVED** に更新:
- セクションタイトルに `[**RESOLVED in feature/empire-repository-order-by**]` 追加
- セクション冒頭に Status banner で closure summary
- 修正タスク 3 件すべて ✓ 完了 マーク
- 歴史的経緯は監査証跡として保存（PR #23 §確定 R1-D で確立した「設計契約反転凍結」ワークフローの第 2 適用例）

## Quality gates (local)

- `pyright --strict`: 0 errors / 0 warnings
- `ruff check + format`: clean
- `pytest`: **554 passed**（PR #29 と同数、無回帰 — set workaround を list 比較に in-place 置換）

## Refs

- 本 PR でクローズ: BUG-EMR-001 (PR #29 のジェフ test report で発見、Steve / Norman レビューで設計書凍結)
- 設計書真実源: `docs/features/empire-repository/basic-design.md` L127-128 / `detailed-design.md` §Known Issues
- 関連 PR: #29 (empire-repository merged), #23 (R1-D 反転凍結ワークフローの先例)