### PR TITLE
feat(workflow-repository): SQLite Workflow Repository with delete-then-insert (Issue #31)

### DIFF
--- a/backend/alembic/versions/0003_workflow_aggregate.py
+++ b/backend/alembic/versions/0003_workflow_aggregate.py
@@ -1,0 +1,121 @@
+"""Workflow Aggregate tables: workflows + workflow_stages + workflow_transitions.
+
+Adds the three tables that back :class:`SqliteWorkflowRepository`:
+
+* ``workflows`` (id PK + name + entry_stage_id, **no FK** on entry_stage_id
+  per ``docs/features/workflow-repository/detailed-design.md`` §確定 J).
+* ``workflow_stages`` (FK CASCADE on workflow_id, UNIQUE pair) — the
+  ``notify_channels_json`` column carries Discord webhook URLs and is
+  declared with the :class:`MaskedJSONEncoded` TypeDecorator at the ORM
+  level (Alembic stores it as ``TEXT`` here; the masking gate lives on
+  the Python side).
+* ``workflow_transitions`` (FK CASCADE on workflow_id, UNIQUE pair).
+
+Per ``docs/features/empire-repository/detailed-design.md`` §確定 F, each
+subsequent ``feature/{aggregate}-repository`` PR appends its own
+revision (``0004_agent_aggregate``, …) on top of this one so the
+Alembic chain stays linear; this revision pins ``down_revision =
+"0002_empire_aggregate"`` strictly so the chain check enforces a single
+head.
+
+Revision ID: 0003_workflow_aggregate
+Revises: 0002_empire_aggregate
+Create Date: 2026-04-27
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0003_workflow_aggregate"
+down_revision: str | None = "0002_empire_aggregate"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "workflows",
+        sa.Column("id", sa.CHAR(32), primary_key=True, nullable=False),
+        sa.Column("name", sa.String(80), nullable=False),
+        # entry_stage_id intentionally has NO FK constraint — see
+        # detailed-design §確定 J. The Aggregate invariant
+        # ``_validate_entry_in_stages`` guards reference integrity.
+        sa.Column("entry_stage_id", sa.CHAR(32), nullable=False),
+    )
+
+    op.create_table(
+        "workflow_stages",
+        sa.Column(
+            "workflow_id",
+            sa.CHAR(32),
+            sa.ForeignKey("workflows.id", ondelete="CASCADE"),
+            primary_key=True,
+            nullable=False,
+        ),
+        sa.Column("stage_id", sa.CHAR(32), primary_key=True, nullable=False),
+        sa.Column("name", sa.String(80), nullable=False),
+        sa.Column("kind", sa.String(32), nullable=False),
+        sa.Column("roles_csv", sa.String(255), nullable=False),
+        sa.Column(
+            "deliverable_template",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("''"),
+        ),
+        # JSONEncoded / MaskedJSONEncoded TypeDecorators serialize as
+        # TEXT in SQLite. The Python-side decorator does the masking
+        # gate (see infrastructure/persistence/sqlite/base.py).
+        sa.Column("completion_policy_json", sa.Text(), nullable=False),
+        sa.Column(
+            "notify_channels_json",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("'[]'"),
+        ),
+        sa.UniqueConstraint(
+            "workflow_id",
+            "stage_id",
+            name="uq_workflow_stages_pair",
+        ),
+    )
+
+    op.create_table(
+        "workflow_transitions",
+        sa.Column(
+            "workflow_id",
+            sa.CHAR(32),
+            sa.ForeignKey("workflows.id", ondelete="CASCADE"),
+            primary_key=True,
+            nullable=False,
+        ),
+        sa.Column("transition_id", sa.CHAR(32), primary_key=True, nullable=False),
+        # from_stage_id / to_stage_id intentionally have NO FK
+        # constraint — same circular-reference rationale as
+        # workflows.entry_stage_id (detailed-design §確定 J).
+        sa.Column("from_stage_id", sa.CHAR(32), nullable=False),
+        sa.Column("to_stage_id", sa.CHAR(32), nullable=False),
+        sa.Column("condition", sa.String(32), nullable=False),
+        sa.Column(
+            "label",
+            sa.String(80),
+            nullable=False,
+            server_default=sa.text("''"),
+        ),
+        sa.UniqueConstraint(
+            "workflow_id",
+            "transition_id",
+            name="uq_workflow_transitions_pair",
+        ),
+    )
+
+
+def downgrade() -> None:
+    # Drop child tables first so the FK CASCADE doesn't trigger work
+    # against an already-deleted parent.
+    op.drop_table("workflow_transitions")
+    op.drop_table("workflow_stages")
+    op.drop_table("workflows")

--- a/backend/src/bakufu/application/ports/workflow_repository.py
+++ b/backend/src/bakufu/application/ports/workflow_repository.py
@@ -1,0 +1,68 @@
+"""Workflow Repository port.
+
+Per ``docs/features/workflow-repository/detailed-design.md`` §確定 A
+(empire-repository テンプレート 100% 継承):
+
+* Protocol class with **no** ``@runtime_checkable`` decorator — Python
+  3.12 ``typing.Protocol`` duck typing is enough; the runtime overhead
+  of ``@runtime_checkable`` adds ``isinstance`` paths the application
+  layer never needs (mirrors :mod:`bakufu.application.ports.empire_repository`).
+* Every method declared ``async def`` (async-first contract) so the
+  application layer can compose Repositories inside an
+  ``async with session.begin():`` Unit-of-Work.
+* Argument and return types come exclusively from
+  :mod:`bakufu.domain` — no SQLAlchemy types leak across the port.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from bakufu.domain.value_objects import WorkflowId
+from bakufu.domain.workflow import Workflow
+
+
+class WorkflowRepository(Protocol):
+    """Persistence contract for the :class:`Workflow` Aggregate Root.
+
+    The application layer (``WorkflowService``, future PR) consumes
+    this Protocol via dependency injection; the SQLite implementation
+    lives in
+    :mod:`bakufu.infrastructure.persistence.sqlite.repositories.workflow_repository`.
+    """
+
+    async def find_by_id(self, workflow_id: WorkflowId) -> Workflow | None:
+        """Hydrate the Workflow whose primary key equals ``workflow_id``.
+
+        Returns ``None`` when the row is absent. Implementations
+        propagate SQLAlchemy / driver / ``pydantic.ValidationError``
+        exceptions unchanged so the Unit-of-Work boundary in the
+        application service can choose between rollback and surfaced
+        error.
+        """
+        ...
+
+    async def count(self) -> int:
+        """Return ``SELECT COUNT(*) FROM workflows``.
+
+        Application services use this to introspect whether at least
+        one Workflow has been registered (e.g. preset bootstrap
+        check). Deciding what the count means is the *application*
+        layer's call (§確定 D).
+        """
+        ...
+
+    async def save(self, workflow: Workflow) -> None:
+        """Persist ``workflow`` via the §確定 B delete-then-insert flow.
+
+        The implementation must run the five-step sequence (UPSERT
+        workflows → DELETE workflow_stages → bulk INSERT stages →
+        DELETE workflow_transitions → bulk INSERT transitions) within
+        the **caller-managed** transaction. Repositories never call
+        ``session.commit()`` / ``session.rollback()``; the application
+        service owns the Unit-of-Work boundary.
+        """
+        ...
+
+
+__all__ = ["WorkflowRepository"]

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/repositories/workflow_repository.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/repositories/workflow_repository.py
@@ -275,9 +275,7 @@ class SqliteWorkflowRepository:
             "list[dict[str, Any]]",
             row.notify_channels_json or [],
         )
-        notify_channels = [
-            NotifyChannel.model_validate(payload) for payload in notify_payloads
-        ]
+        notify_channels = [NotifyChannel.model_validate(payload) for payload in notify_payloads]
         return Stage(
             id=_uuid(row.stage_id),
             name=row.name,

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/repositories/workflow_repository.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/repositories/workflow_repository.py
@@ -1,0 +1,316 @@
+"""SQLite adapter for :class:`bakufu.application.ports.WorkflowRepository`.
+
+Implements the §確定 B "delete-then-insert" save flow over three
+tables (``workflows`` / ``workflow_stages`` / ``workflow_transitions``):
+
+1. ``workflows`` UPSERT (id-conflict → name + entry_stage_id update)
+2. ``workflow_stages`` DELETE WHERE workflow_id = ?
+3. ``workflow_stages`` bulk INSERT (one row per Stage; ``notify_channels_json``
+   binds through :class:`MaskedJSONEncoded` so Discord webhook tokens are
+   redacted *before* the JSON hits disk — Schneier 申し送り #6 multilayer
+   defense, applied to the Workflow path here).
+4. ``workflow_transitions`` DELETE WHERE workflow_id = ?
+5. ``workflow_transitions`` bulk INSERT (one row per Transition).
+
+The repository **never** calls ``session.commit()`` /
+``session.rollback()``: the caller-side service runs
+``async with session.begin():`` so the five steps above stay in one
+transaction (§確定 B Tx 境界の責務分離). Same Unit-of-Work pattern as
+:class:`SqliteEmpireRepository`.
+
+``_to_row`` / ``_from_row`` are kept as private methods on the class
+so both directions live next to each other and tests don't accidentally
+acquire a public conversion API to depend on (§確定 C). The two
+helpers also encapsulate the four format choices frozen in §確定 G〜J:
+
+* ``roles_csv`` — sorted-CSV serialization of ``frozenset[Role]``
+  (§確定 G). Sorting is **mandatory** so frozenset's
+  implementation-dependent iteration order does not produce
+  delete-then-insert diff noise across runs.
+* ``notify_channels_json`` — :class:`MaskedJSONEncoded` (§確定 H). The
+  underlying TypeDecorator does the masking; ``_to_row`` only feeds
+  it ``list[dict]`` produced by ``NotifyChannel.model_dump(mode='json')``
+  (which itself masks through the VO's ``when_used='json'`` serializer
+  — defense-in-depth).
+* ``completion_policy_json`` — plain :class:`JSONEncoded` (§確定 I).
+  CompletionPolicy carries no Schneier #6 secret category, so
+  ``MaskedJSONEncoded`` would be over-masking; the CI Layer 2 arch
+  test pins the un-masked TypeDecorator.
+* ``workflows.entry_stage_id`` — no DB-level FK (§確定 J); Aggregate
+  invariant ``_validate_entry_in_stages`` guards it.
+
+``_from_row`` runs ``Workflow.model_validate(...)`` so the same
+invariants the application layer enforces at construction time fire
+on rehydration too. ``find_by_id`` may therefore raise
+``pydantic.ValidationError`` when a saved Workflow contained
+``EXTERNAL_REVIEW`` stages whose notify URLs were masked at save time
+(§確定 H §不可逆性): the application layer catches and surfaces a
+"webhook re-registration required" error to the operator.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+from uuid import UUID
+
+from sqlalchemy import delete, func, insert, select
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bakufu.domain.value_objects import (
+    CompletionPolicy,
+    NotifyChannel,
+    Role,
+    StageKind,
+    TransitionCondition,
+    WorkflowId,
+)
+from bakufu.domain.workflow import Stage, Transition, Workflow
+from bakufu.infrastructure.persistence.sqlite.tables.workflow_stages import (
+    WorkflowStageRow,
+)
+from bakufu.infrastructure.persistence.sqlite.tables.workflow_transitions import (
+    WorkflowTransitionRow,
+)
+from bakufu.infrastructure.persistence.sqlite.tables.workflows import WorkflowRow
+
+
+class SqliteWorkflowRepository:
+    """SQLite implementation of :class:`WorkflowRepository`."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def find_by_id(self, workflow_id: WorkflowId) -> Workflow | None:
+        """SELECT workflow + side tables, hydrate via :meth:`_from_row`.
+
+        Returns ``None`` when the workflows row is absent. Side-table
+        SELECTs use ``ORDER BY stage_id`` / ``ORDER BY transition_id``
+        so the hydrated lists are deterministic — empire-repository
+        BUG-EMR-001 froze this contract; we apply it from PR #1 here.
+        """
+        workflow_stmt = select(WorkflowRow).where(WorkflowRow.id == workflow_id)
+        workflow_row = (await self._session.execute(workflow_stmt)).scalar_one_or_none()
+        if workflow_row is None:
+            return None
+
+        # ORDER BY makes find_by_id deterministic. Without it SQLite
+        # returns rows in internal-scan order, which would break
+        # ``Workflow == Workflow`` round-trip equality (the Aggregate
+        # compares list-by-list). See basic-design §ユースケース 2 +
+        # docs/features/empire-repository/detailed-design.md §Known
+        # Issues §BUG-EMR-001 — this PR adopts the resolved contract
+        # from day one.
+        stage_stmt = (
+            select(WorkflowStageRow)
+            .where(WorkflowStageRow.workflow_id == workflow_id)
+            .order_by(WorkflowStageRow.stage_id)
+        )
+        stage_rows = list((await self._session.execute(stage_stmt)).scalars().all())
+
+        transition_stmt = (
+            select(WorkflowTransitionRow)
+            .where(WorkflowTransitionRow.workflow_id == workflow_id)
+            .order_by(WorkflowTransitionRow.transition_id)
+        )
+        transition_rows = list((await self._session.execute(transition_stmt)).scalars().all())
+
+        return self._from_row(workflow_row, stage_rows, transition_rows)
+
+    async def count(self) -> int:
+        """``SELECT COUNT(*) FROM workflows``.
+
+        Implementation detail: SQLAlchemy's ``func.count()`` issues a
+        proper ``SELECT COUNT(*)`` so SQLite returns one scalar row
+        instead of streaming every PK back to Python. This is the
+        empire-repository §確定 D 補強 contract continued — Stage /
+        Transition / Workflow tables can hold hundreds of rows
+        once preset libraries land, so the pattern matters.
+        """
+        stmt = select(func.count()).select_from(WorkflowRow)
+        return (await self._session.execute(stmt)).scalar_one()
+
+    async def save(self, workflow: Workflow) -> None:
+        """Persist ``workflow`` via the §確定 B five-step delete-then-insert.
+
+        The caller is responsible for the surrounding
+        ``async with session.begin():`` block; failures inside any
+        step propagate untouched so the Unit-of-Work boundary in the
+        application service can rollback cleanly.
+        """
+        workflow_row, stage_rows, transition_rows = self._to_row(workflow)
+
+        # Step 1: workflows UPSERT (id PK, ON CONFLICT update name +
+        # entry_stage_id). entry_stage_id can change when the
+        # operator inserts a new entry stage at the head of the DAG.
+        upsert_stmt = sqlite_insert(WorkflowRow).values(workflow_row)
+        upsert_stmt = upsert_stmt.on_conflict_do_update(
+            index_elements=["id"],
+            set_={
+                "name": upsert_stmt.excluded.name,
+                "entry_stage_id": upsert_stmt.excluded.entry_stage_id,
+            },
+        )
+        await self._session.execute(upsert_stmt)
+
+        # Step 2: workflow_stages DELETE.
+        await self._session.execute(
+            delete(WorkflowStageRow).where(WorkflowStageRow.workflow_id == workflow.id)
+        )
+
+        # Step 3: workflow_stages bulk INSERT (skip when no stages —
+        # though Workflow's capacity validator forbids zero-length
+        # stages, defensive empty-skip keeps the behavior consistent
+        # with the Empire template).
+        if stage_rows:
+            await self._session.execute(insert(WorkflowStageRow), stage_rows)
+
+        # Step 4: workflow_transitions DELETE.
+        await self._session.execute(
+            delete(WorkflowTransitionRow).where(WorkflowTransitionRow.workflow_id == workflow.id)
+        )
+
+        # Step 5: workflow_transitions bulk INSERT (skip when no
+        # transitions — a single-stage Workflow is valid).
+        if transition_rows:
+            await self._session.execute(insert(WorkflowTransitionRow), transition_rows)
+
+    # ---- private domain ↔ row converters (§確定 C) -------------------
+    def _to_row(
+        self,
+        workflow: Workflow,
+    ) -> tuple[dict[str, Any], list[dict[str, Any]], list[dict[str, Any]]]:
+        """Split ``workflow`` into ``(workflow_row, stage_rows, transition_rows)``.
+
+        SQLAlchemy ``Row`` objects are intentionally avoided here so
+        the domain layer never gains an accidental dependency on the
+        SQLAlchemy type hierarchy. Each returned ``dict`` matches the
+        ``mapped_column`` names of the corresponding table verbatim.
+        """
+        workflow_row: dict[str, Any] = {
+            "id": workflow.id,
+            "name": workflow.name,
+            "entry_stage_id": workflow.entry_stage_id,
+        }
+        stage_rows: list[dict[str, Any]] = [
+            {
+                "workflow_id": workflow.id,
+                "stage_id": stage.id,
+                "name": stage.name,
+                "kind": stage.kind.value,
+                # §確定 G: sorted CSV. ``sorted(..., key=str)`` keeps
+                # the byte-equality contract no matter how Python
+                # frozenset chooses to iterate.
+                "roles_csv": ",".join(sorted(role.value for role in stage.required_role)),
+                "deliverable_template": stage.deliverable_template,
+                # §確定 I: plain JSONEncoded. ``model_dump(mode='json')``
+                # returns ``{'kind': ..., 'description': ...}``.
+                "completion_policy_json": stage.completion_policy.model_dump(mode="json"),
+                # §確定 H: list[dict] with masked targets. The column
+                # type :class:`MaskedJSONEncoded` re-runs ``mask_in``
+                # on the bound value so even a hypothetical raw URL
+                # leaking past ``when_used='json'`` would be redacted
+                # by the gateway before ``json.dumps`` (BUG-PF-001
+                # twin defense).
+                "notify_channels_json": [
+                    channel.model_dump(mode="json") for channel in stage.notify_channels
+                ],
+            }
+            for stage in workflow.stages
+        ]
+        transition_rows: list[dict[str, Any]] = [
+            {
+                "workflow_id": workflow.id,
+                "transition_id": transition.id,
+                "from_stage_id": transition.from_stage_id,
+                "to_stage_id": transition.to_stage_id,
+                "condition": transition.condition.value,
+                "label": transition.label,
+            }
+            for transition in workflow.transitions
+        ]
+        return workflow_row, stage_rows, transition_rows
+
+    def _from_row(
+        self,
+        workflow_row: WorkflowRow,
+        stage_rows: list[WorkflowStageRow],
+        transition_rows: list[WorkflowTransitionRow],
+    ) -> Workflow:
+        """Hydrate a :class:`Workflow` Aggregate Root from its three rows.
+
+        ``Workflow.model_validate`` re-runs the post-validator so
+        Repository-side hydration goes through the same invariant
+        checks the application service runs at construction time
+        (Empire §確定 C). Hydration of a Workflow whose
+        ``EXTERNAL_REVIEW`` stages had notify channels will raise
+        ``pydantic.ValidationError`` because the persisted target was
+        masked — that is the design contract per §確定 H §不可逆性.
+        """
+        stages = [self._stage_from_row(row) for row in stage_rows]
+        transitions = [self._transition_from_row(row) for row in transition_rows]
+        return Workflow(
+            id=_uuid(workflow_row.id),
+            name=workflow_row.name,
+            stages=stages,
+            transitions=transitions,
+            entry_stage_id=_uuid(workflow_row.entry_stage_id),
+        )
+
+    @staticmethod
+    def _stage_from_row(row: WorkflowStageRow) -> Stage:
+        """Hydrate one ``Stage`` from its persisted row."""
+        # §確定 G: split CSV → set comprehension → frozenset. An empty
+        # ``required_role`` is impossible because the storage column
+        # is NOT NULL and Workflow capacity invariants reject it on
+        # save. If a malformed row sneaks past, ``Role(s)`` raises
+        # ``ValueError`` and the Aggregate's StageInvariantViolation
+        # path takes over downstream (Fail-Fast).
+        roles = frozenset(Role(token) for token in row.roles_csv.split(","))
+        completion_policy = CompletionPolicy.model_validate(row.completion_policy_json)
+        # §確定 H §不可逆性: NotifyChannel.model_validate may raise
+        # because the persisted ``target`` field was masked at save
+        # time. The exception escapes find_by_id deliberately.
+        notify_payloads = cast(
+            "list[dict[str, Any]]",
+            row.notify_channels_json or [],
+        )
+        notify_channels = [
+            NotifyChannel.model_validate(payload) for payload in notify_payloads
+        ]
+        return Stage(
+            id=_uuid(row.stage_id),
+            name=row.name,
+            kind=StageKind(row.kind),
+            required_role=roles,
+            deliverable_template=row.deliverable_template,
+            completion_policy=completion_policy,
+            notify_channels=notify_channels,
+        )
+
+    @staticmethod
+    def _transition_from_row(row: WorkflowTransitionRow) -> Transition:
+        """Hydrate one ``Transition`` from its persisted row."""
+        return Transition(
+            id=_uuid(row.transition_id),
+            from_stage_id=_uuid(row.from_stage_id),
+            to_stage_id=_uuid(row.to_stage_id),
+            condition=TransitionCondition(row.condition),
+            label=row.label,
+        )
+
+
+def _uuid(value: UUID | str) -> UUID:
+    """Coerce a row value to :class:`uuid.UUID`.
+
+    SQLAlchemy's UUIDStr TypeDecorator already returns ``UUID``
+    instances on ``process_result_value``, but defensive coercion lets
+    raw-SQL hydration paths route through the same code without an
+    extra ``isinstance`` ladder at every call site.
+    """
+    if isinstance(value, UUID):
+        return value
+    return UUID(value)
+
+
+__all__ = ["SqliteWorkflowRepository"]

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/tables/__init__.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/tables/__init__.py
@@ -12,6 +12,17 @@ Empire Aggregate (PR #25):
 * :mod:`...tables.empire_room_refs` — RoomRef collection.
 * :mod:`...tables.empire_agent_refs` — AgentRef collection.
 
+Workflow Aggregate (PR #31):
+
+* :mod:`...tables.workflows` — Workflow root row (entry_stage_id has
+  no DB-level FK; the Aggregate invariant guards it instead).
+* :mod:`...tables.workflow_stages` — Stage child rows. The
+  ``notify_channels_json`` column is the **first** ``MaskedJSONEncoded``
+  column outside ``audit_log`` / ``domain_event_outbox`` and is
+  registered with the CI three-layer defense's *positive* contract.
+* :mod:`...tables.workflow_transitions` — Transition child rows
+  (no-mask).
+
 Secret-bearing tables declare their columns with
 :class:`MaskedJSONEncoded` / :class:`MaskedText` TypeDecorators
 (defined in :mod:`bakufu.infrastructure.persistence.sqlite.base`) that
@@ -28,7 +39,10 @@ PR #23 BUG-PF-001 proved that listeners do not fire for Core
 Empire tables carry **no** secret-bearing columns; the explicit
 absence is registered with the CI three-layer defense
 (grep guard + arch test + storage.md §逆引き表) so a future PR cannot
-silently swap a column to a secret-bearing semantic.
+silently swap a column to a secret-bearing semantic. The Workflow
+``workflows`` / ``workflow_transitions`` tables follow the same
+no-mask pattern; only ``workflow_stages.notify_channels_json`` is
+secret-bearing on the Workflow side.
 """
 
 from __future__ import annotations
@@ -40,6 +54,9 @@ from bakufu.infrastructure.persistence.sqlite.tables import (
     empires,
     outbox,
     pid_registry,
+    workflow_stages,
+    workflow_transitions,
+    workflows,
 )
 
 __all__ = [
@@ -49,4 +66,7 @@ __all__ = [
     "empires",
     "outbox",
     "pid_registry",
+    "workflow_stages",
+    "workflow_transitions",
+    "workflows",
 ]

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/tables/workflow_stages.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/tables/workflow_stages.py
@@ -1,0 +1,89 @@
+"""``workflow_stages`` table — Workflow ↔ Stage child rows.
+
+Stores :class:`bakufu.domain.workflow.entities.Stage` values as a side
+table of the Workflow Aggregate. ``stage_id`` is **intentionally not** a
+foreign key onto ``workflows.entry_stage_id`` (§確定 J in
+``docs/features/workflow-repository/detailed-design.md``); the
+Aggregate-level ``_validate_entry_in_stages`` already enforces the
+reference invariant.
+
+Cascade: deleting a Workflow row purges its stage rows
+(``ON DELETE CASCADE``). The ``UNIQUE(workflow_id, stage_id)`` constraint
+mirrors :func:`bakufu.domain.workflow.dag_validators._validate_stage_id_unique`
+at the row level.
+
+Per-column secret-handling (§確定 H + 申し送り #6 of M2 persistence
+foundation):
+
+* ``notify_channels_json`` is a :class:`MaskedJSONEncoded` column. The
+  ``process_bind_param`` hook re-routes every nested ``target`` field
+  through :func:`bakufu.infrastructure.security.masking.mask_in` so the
+  Discord webhook ``token`` segment never reaches disk in plaintext.
+  Defense-in-depth: ``NotifyChannel.field_serializer(when_used='json')``
+  already masks at ``model_dump(mode='json')`` time, but the
+  TypeDecorator is the *gate* that fires for both ORM and Core
+  ``insert(table).values(...)`` paths (BUG-PF-001 contract).
+* ``completion_policy_json`` is a plain :class:`JSONEncoded` column —
+  the VO carries no secret-bearing values per the Schneier申し送り #6
+  six-category scan, so ``MaskedJSONEncoded`` would be **over-masking**
+  (banned by §確定 I of the detailed design).
+* The remaining columns hold UUIDs / enums / CEO-authored Markdown
+  templates; none qualify as the six masking categories.
+
+The CI three-layer defense pins exactly one
+``MaskedJSONEncoded`` column on this table (positive contract on
+``notify_channels_json``, no-mask on every other column).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import ForeignKey, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from bakufu.infrastructure.persistence.sqlite.base import (
+    Base,
+    JSONEncoded,
+    MaskedJSONEncoded,
+    UUIDStr,
+)
+
+
+class WorkflowStageRow(Base):
+    """ORM mapping for the ``workflow_stages`` table."""
+
+    __tablename__ = "workflow_stages"
+
+    workflow_id: Mapped[UUID] = mapped_column(
+        UUIDStr,
+        ForeignKey("workflows.id", ondelete="CASCADE"),
+        primary_key=True,
+        nullable=False,
+    )
+    stage_id: Mapped[UUID] = mapped_column(UUIDStr, primary_key=True, nullable=False)
+    name: Mapped[str] = mapped_column(String(80), nullable=False)
+    kind: Mapped[str] = mapped_column(String(32), nullable=False)
+    roles_csv: Mapped[str] = mapped_column(String(255), nullable=False)
+    deliverable_template: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+        default="",
+    )
+    completion_policy_json: Mapped[Any] = mapped_column(JSONEncoded, nullable=False)
+    # Default ``[]`` is enforced at the SQL level by the ``server_default``
+    # in 0003_workflow_aggregate.py; ORM-side defaulting is unnecessary
+    # because the Repository always passes an explicit list.
+    notify_channels_json: Mapped[Any] = mapped_column(MaskedJSONEncoded, nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint(
+            "workflow_id",
+            "stage_id",
+            name="uq_workflow_stages_pair",
+        ),
+    )
+
+
+__all__ = ["WorkflowStageRow"]

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/tables/workflow_transitions.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/tables/workflow_transitions.py
@@ -1,0 +1,59 @@
+"""``workflow_transitions`` table — Workflow ↔ Transition child rows.
+
+Stores :class:`bakufu.domain.workflow.entities.Transition` values as a
+side table of the Workflow Aggregate. ``from_stage_id`` /
+``to_stage_id`` are **intentionally not** foreign keys (§確定 J in
+``docs/features/workflow-repository/detailed-design.md``); the
+Aggregate-level ``_validate_transition_refs`` already enforces that
+both ends live inside the Workflow's ``stages`` collection at
+construction time.
+
+Cascade: deleting a Workflow row purges its transition rows
+(``ON DELETE CASCADE``). The ``UNIQUE(workflow_id, transition_id)``
+constraint mirrors
+:func:`bakufu.domain.workflow.dag_validators._validate_transition_id_unique`
+at the row level.
+
+No ``Masked*`` TypeDecorator on any column — neither the source /
+target stage IDs nor the enum-string ``condition`` / human label fall
+into the Schneier 申し送り #6 secret categories. Registered with the
+CI three-layer defense's no-mask contract.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import ForeignKey, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from bakufu.infrastructure.persistence.sqlite.base import Base, UUIDStr
+
+
+class WorkflowTransitionRow(Base):
+    """ORM mapping for the ``workflow_transitions`` table."""
+
+    __tablename__ = "workflow_transitions"
+
+    workflow_id: Mapped[UUID] = mapped_column(
+        UUIDStr,
+        ForeignKey("workflows.id", ondelete="CASCADE"),
+        primary_key=True,
+        nullable=False,
+    )
+    transition_id: Mapped[UUID] = mapped_column(UUIDStr, primary_key=True, nullable=False)
+    from_stage_id: Mapped[UUID] = mapped_column(UUIDStr, nullable=False)
+    to_stage_id: Mapped[UUID] = mapped_column(UUIDStr, nullable=False)
+    condition: Mapped[str] = mapped_column(String(32), nullable=False)
+    label: Mapped[str] = mapped_column(String(80), nullable=False, default="")
+
+    __table_args__ = (
+        UniqueConstraint(
+            "workflow_id",
+            "transition_id",
+            name="uq_workflow_transitions_pair",
+        ),
+    )
+
+
+__all__ = ["WorkflowTransitionRow"]

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/tables/workflows.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/tables/workflows.py
@@ -1,0 +1,45 @@
+"""``workflows`` table — Workflow Aggregate root row.
+
+Holds three scalar columns (``id`` / ``name`` / ``entry_stage_id``); the
+``stages`` and ``transitions`` collections live in the side tables
+:mod:`...tables.workflow_stages` /
+:mod:`...tables.workflow_transitions` so the row width stays bounded
+and CASCADE targets are obvious.
+
+``entry_stage_id`` is **intentionally not a foreign key** onto
+``workflow_stages.stage_id`` — see
+``docs/features/workflow-repository/detailed-design.md`` §確定 J. The
+natural FK would form a circular reference (``workflows`` ↔
+``workflow_stages``) that requires deferred constraints. SQLite's
+``PRAGMA defer_foreign_keys`` works but tightens portability against
+the M5+ PostgreSQL migration goal. The Aggregate-level
+``_validate_entry_in_stages`` already proves ``entry_stage_id`` lives
+inside ``stages``, so the DB constraint is redundant.
+
+No ``Masked*`` TypeDecorator on any column. The CI three-layer defense
+(grep guard + arch test + storage.md §逆引き表) registers this absence
+so a future PR cannot silently swap a column to a secret-bearing
+semantic.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from bakufu.infrastructure.persistence.sqlite.base import Base, UUIDStr
+
+
+class WorkflowRow(Base):
+    """ORM mapping for the ``workflows`` table."""
+
+    __tablename__ = "workflows"
+
+    id: Mapped[UUID] = mapped_column(UUIDStr, primary_key=True)
+    name: Mapped[str] = mapped_column(String(80), nullable=False)
+    entry_stage_id: Mapped[UUID] = mapped_column(UUIDStr, nullable=False)
+
+
+__all__ = ["WorkflowRow"]

--- a/backend/tests/architecture/test_masking_columns.py
+++ b/backend/tests/architecture/test_masking_columns.py
@@ -42,6 +42,9 @@ from bakufu.infrastructure.persistence.sqlite.tables import (
     empires,  # noqa: F401  # pyright: ignore[reportUnusedImport]
     outbox,  # noqa: F401  # pyright: ignore[reportUnusedImport]
     pid_registry,  # noqa: F401  # pyright: ignore[reportUnusedImport]
+    workflow_stages,  # noqa: F401  # pyright: ignore[reportUnusedImport]
+    workflow_transitions,  # noqa: F401  # pyright: ignore[reportUnusedImport]
+    workflows,  # noqa: F401  # pyright: ignore[reportUnusedImport]
 )
 
 # Positive contract: §逆引き表「masking 対象あり」.
@@ -53,15 +56,33 @@ _MASKING_CONTRACT: list[tuple[str, str, type]] = [
     ("bakufu_pid_registry", "cmd", MaskedText),
     ("domain_event_outbox", "payload_json", MaskedJSONEncoded),
     ("domain_event_outbox", "last_error", MaskedText),
+    # Workflow Repository (PR #31, detailed-design.md §確定 H).
+    ("workflow_stages", "notify_channels_json", MaskedJSONEncoded),
 ]
 
-# No-mask contract: §逆引き表「Empire 関連カラム: masking 対象なし」.
+# No-mask contract: §逆引き表「Empire 関連カラム: masking 対象なし」 +
+# Workflow root + Workflow transitions.
 # Each subsequent Aggregate Repository PR extends this list with the
 # tables it adds when those tables are designated "no masking".
 _NO_MASK_TABLES: list[str] = [
     "empires",
     "empire_room_refs",
     "empire_agent_refs",
+    # Workflow Repository (PR #31, detailed-design.md §確定 E):
+    # workflows / workflow_transitions register zero masking targets;
+    # only workflow_stages.notify_channels_json is secret-bearing.
+    "workflows",
+    "workflow_transitions",
+]
+
+# Partial-mask contract: tables that have **exactly one** masked
+# column. Used to catch over-masking — a future PR that switches
+# another column on the same table to a Masked* TypeDecorator must
+# update §逆引き表 first; otherwise this assertion fires.
+#
+# Format: ``(table_name, allowed_column_name)``.
+_PARTIAL_MASK_TABLES: list[tuple[str, str]] = [
+    ("workflow_stages", "notify_channels_json"),
 ]
 
 
@@ -134,4 +155,46 @@ class TestNoMaskContract:
             f"Next: this table is registered as 'masking 対象なし' in "
             f"docs/architecture/domain-model/storage.md §逆引き表; either "
             f"remove the Masked* type or update the §逆引き表 entry first."
+        )
+
+
+class TestPartialMaskContract:
+    """Tables registered as 'partial mask' must mask exactly one named column.
+
+    Workflow Repository (PR #31) introduces the 'partial mask'
+    pattern: ``workflow_stages.notify_channels_json`` is the *only*
+    masked column on the table; every other column must stay un-masked
+    so we don't bleed over-masking into ``deliverable_template`` /
+    ``completion_policy_json`` / etc. A future PR that masks an
+    additional column must update §逆引き表 first; otherwise this
+    assertion fires.
+    """
+
+    @pytest.mark.parametrize(
+        ("table_name", "allowed_column"),
+        _PARTIAL_MASK_TABLES,
+        ids=[f"{tbl}.{col}" for tbl, col in _PARTIAL_MASK_TABLES],
+    )
+    def test_table_has_only_allowed_masked_column(
+        self,
+        table_name: str,
+        allowed_column: str,
+    ) -> None:
+        """Assert exactly one masked column, and that it's the allowed one."""
+        table = Base.metadata.tables.get(table_name)
+        assert table is not None, (
+            f"table {table_name!r} missing from Base.metadata; "
+            f"check that tables/{table_name}.py is imported in tables/__init__.py"
+        )
+        masked_columns = sorted(
+            col.name
+            for col in table.columns
+            if isinstance(col.type, MaskedJSONEncoded | MaskedText)
+        )
+        assert masked_columns == [allowed_column], (
+            f"[FAIL] {table_name} masking surface should be exactly "
+            f"['{allowed_column}'], got {masked_columns}.\n"
+            f"Next: only '{allowed_column}' is registered as masked in "
+            f"docs/architecture/domain-model/storage.md §逆引き表; either "
+            f"revert the extra Masked* type or update the §逆引き表 entry first."
         )

--- a/backend/tests/docs/test_storage_md_back_index.py
+++ b/backend/tests/docs/test_storage_md_back_index.py
@@ -84,3 +84,55 @@ class TestBackIndexHasEmpireRow:
             "same line — split rows would force an operator to cross-"
             "reference across the doc."
         )
+
+
+class TestBackIndexHasWorkflowRows:
+    """TC-DOC-WFR-001: §逆引き表 includes the Workflow partial-mask + no-mask entries.
+
+    The Workflow PR (#41) introduces the *partial-mask* template
+    alongside the empire-repo no-mask template: ``workflow_stages.notify_channels_json``
+    is the **only** masked column on the Workflow surface, and
+    ``workflows`` / ``workflow_transitions`` / the rest of
+    ``workflow_stages`` are explicitly registered as no-mask. We
+    assert both halves of that contract live on operator-readable
+    lines in ``storage.md``.
+    """
+
+    def test_workflow_stages_notify_channels_row_present(self, storage_md_text: str) -> None:
+        """TC-DOC-WFR-001a: §逆引き表 declares ``MaskedJSONEncoded`` on the notify column.
+
+        The line must co-locate ``workflow_stages.notify_channels_json``
+        and ``MaskedJSONEncoded`` so an operator scrolling to the
+        Workflow row sees the redaction policy directly.
+        """
+        co_located_lines = [
+            line
+            for line in storage_md_text.splitlines()
+            if "workflow_stages.notify_channels_json" in line and "MaskedJSONEncoded" in line
+        ]
+        assert co_located_lines, (
+            "storage.md §逆引き表 must contain at least one line that "
+            "co-locates 'workflow_stages.notify_channels_json' and "
+            "'MaskedJSONEncoded' per workflow-repository §確定 H "
+            "(Schneier 申し送り #6 Repository 実適用)."
+        )
+
+    def test_workflow_no_mask_row_present(self, storage_md_text: str) -> None:
+        """TC-DOC-WFR-001b: §逆引き表 declares the Workflow remaining columns no-mask.
+
+        The contract phrase is "masking 対象なし" co-located with
+        ``Workflow`` (so the partial-mask Aggregate's *non*-masked
+        columns are still operator-readable from the Workflow row).
+        """
+        co_located_lines = [
+            line
+            for line in storage_md_text.splitlines()
+            if "Workflow" in line and "masking 対象なし" in line
+        ]
+        assert co_located_lines, (
+            "storage.md §逆引き表 must contain at least one line that "
+            "co-locates 'Workflow' and 'masking 対象なし' so the partial-"
+            "mask Aggregate's non-masked columns are operator-readable "
+            "from the Workflow row directly. Required by workflow-"
+            "repository §確定 H (partial-mask テンプレート)."
+        )

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_workflow_repository/__init__.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_workflow_repository/__init__.py
@@ -1,0 +1,22 @@
+"""Workflow Repository integration tests, split by topic.
+
+Per ``docs/features/workflow-repository/test-design.md`` and Norman's
+500-line rule (established in empire-repository PR #25): the test
+surface is split into four siblings so each file stays under the
+readability budget and the next 5 Repository PRs can extend the
+pattern without inheriting a 500+ line monolith:
+
+* :mod:`...test_protocol_crud` — Protocol surface + ``find_by_id`` /
+  ``count`` / ``save`` basic CRUD + ORDER BY observation + COUNT(*) SQL
+  observation + singleton non-enforcement
+  (TC-IT-WFR-001〜007, 019).
+* :mod:`...test_save_semantics` — delete-then-insert + 5-step SQL
+  order + Tx boundary + roles_csv determinism + round-trip equality
+  (TC-IT-WFR-008〜012, 015, 016).
+* :mod:`...test_constraints_arch` — DB-level FK CASCADE + UNIQUE pair
+  enforcement + CI three-layer-defense partial-mask template
+  (TC-IT-WFR-017, 018, 023).
+* :mod:`...test_masking` — §確定 H 物理確認: ``MaskedJSONEncoded``
+  redaction at the SQLite layer + §不可逆性 (find_by_id raises on
+  masked notify_channels) (TC-IT-WFR-013, 014).
+"""

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_workflow_repository/test_constraints_arch.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_workflow_repository/test_constraints_arch.py
@@ -1,0 +1,262 @@
+"""Workflow Repository: DB constraints + arch-test partial-mask template.
+
+TC-IT-WFR-017 / 018 / 023 — FK CASCADE, UNIQUE pair enforcement, and
+the **partial-mask** CI three-layer-defense template the Workflow PR
+introduces (empire-repo froze the *no-mask* template; this PR freezes
+the *partial-mask* template — exactly one masked column on a table,
+every other column un-masked).
+
+Per ``docs/features/workflow-repository/test-design.md``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+import pytest
+from bakufu.infrastructure.persistence.sqlite.repositories.workflow_repository import (
+    SqliteWorkflowRepository,
+)
+from bakufu.infrastructure.persistence.sqlite.tables.workflow_stages import (
+    WorkflowStageRow,
+)
+from bakufu.infrastructure.persistence.sqlite.tables.workflow_transitions import (
+    WorkflowTransitionRow,
+)
+from bakufu.infrastructure.persistence.sqlite.tables.workflows import WorkflowRow
+from sqlalchemy import delete, select, text
+
+from tests.factories.workflow import make_stage, make_transition, make_workflow
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-WFR-017: FK CASCADE
+# ---------------------------------------------------------------------------
+class TestForeignKeyCascade:
+    """TC-IT-WFR-017: ``DELETE FROM workflows`` cascades to side tables."""
+
+    async def test_delete_workflow_cascades_to_side_tables(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """TC-IT-WFR-017: FK ON DELETE CASCADE empties workflow_stages / workflow_transitions."""
+        stage_a = make_stage(name="A")
+        stage_b = make_stage(name="B")
+        transition_ab = make_transition(from_stage_id=stage_a.id, to_stage_id=stage_b.id)
+        workflow = make_workflow(
+            stages=[stage_a, stage_b],
+            transitions=[transition_ab],
+            entry_stage_id=stage_a.id,
+        )
+        async with session_factory() as session, session.begin():
+            await SqliteWorkflowRepository(session).save(workflow)
+
+        async with session_factory() as session, session.begin():
+            await session.execute(delete(WorkflowRow).where(WorkflowRow.id == workflow.id))
+
+        async with session_factory() as session:
+            stage_rows = list(
+                (
+                    await session.execute(
+                        select(WorkflowStageRow).where(WorkflowStageRow.workflow_id == workflow.id)
+                    )
+                ).scalars()
+            )
+            transition_rows = list(
+                (
+                    await session.execute(
+                        select(WorkflowTransitionRow).where(
+                            WorkflowTransitionRow.workflow_id == workflow.id
+                        )
+                    )
+                ).scalars()
+            )
+        assert stage_rows == []
+        assert transition_rows == []
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-WFR-018: UNIQUE constraints on (workflow_id, stage_id) and
+#                                       (workflow_id, transition_id)
+# ---------------------------------------------------------------------------
+class TestUniqueConstraintViolation:
+    """TC-IT-WFR-018: duplicate (workflow_id, stage_id) / (..., transition_id) raises."""
+
+    async def test_duplicate_stage_pair_raises(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """TC-IT-WFR-018a: same (workflow_id, stage_id) inserted twice → DB rejects.
+
+        The Repository's delete-then-insert flow always wipes the side
+        tables before INSERT, so the constraint is never tripped
+        through the Repository API. To exercise the **DB-level**
+        UNIQUE contract we issue raw SQL that bypasses the Repository.
+        """
+        from sqlalchemy.exc import IntegrityError
+
+        workflow = make_workflow()
+        async with session_factory() as session, session.begin():
+            await SqliteWorkflowRepository(session).save(workflow)
+
+        stage_id = uuid4()
+        async with session_factory() as session, session.begin():
+            await session.execute(
+                text(
+                    "INSERT INTO workflow_stages "
+                    "(workflow_id, stage_id, name, kind, roles_csv, "
+                    "deliverable_template, completion_policy_json, "
+                    "notify_channels_json) "
+                    "VALUES (:workflow_id, :stage_id, :name, :kind, :roles_csv, "
+                    ":deliverable, :policy, :channels)"
+                ),
+                {
+                    "workflow_id": workflow.id.hex,
+                    "stage_id": stage_id.hex,
+                    "name": "first",
+                    "kind": "WORK",
+                    "roles_csv": "DEVELOPER",
+                    "deliverable": "",
+                    "policy": '{"kind": "approved_by_reviewer", "description": ""}',
+                    "channels": "[]",
+                },
+            )
+
+        with pytest.raises(IntegrityError):
+            async with session_factory() as session, session.begin():
+                await session.execute(
+                    text(
+                        "INSERT INTO workflow_stages "
+                        "(workflow_id, stage_id, name, kind, roles_csv, "
+                        "deliverable_template, completion_policy_json, "
+                        "notify_channels_json) "
+                        "VALUES (:workflow_id, :stage_id, :name, :kind, :roles_csv, "
+                        ":deliverable, :policy, :channels)"
+                    ),
+                    {
+                        "workflow_id": workflow.id.hex,
+                        "stage_id": stage_id.hex,
+                        "name": "duplicate",
+                        "kind": "WORK",
+                        "roles_csv": "DEVELOPER",
+                        "deliverable": "",
+                        "policy": '{"kind": "approved_by_reviewer", "description": ""}',
+                        "channels": "[]",
+                    },
+                )
+
+    async def test_duplicate_transition_pair_raises(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """TC-IT-WFR-018b: same (workflow_id, transition_id) inserted twice → DB rejects."""
+        from sqlalchemy.exc import IntegrityError
+
+        # A 2-stage Workflow gives us legitimate from_stage_id / to_stage_id
+        # values for the raw INSERT that follows.
+        stage_a = make_stage(name="A")
+        stage_b = make_stage(name="B")
+        transition_ab = make_transition(from_stage_id=stage_a.id, to_stage_id=stage_b.id)
+        workflow = make_workflow(
+            stages=[stage_a, stage_b],
+            transitions=[transition_ab],
+            entry_stage_id=stage_a.id,
+        )
+        async with session_factory() as session, session.begin():
+            await SqliteWorkflowRepository(session).save(workflow)
+
+        transition_id = uuid4()
+        async with session_factory() as session, session.begin():
+            await session.execute(
+                text(
+                    "INSERT INTO workflow_transitions "
+                    "(workflow_id, transition_id, from_stage_id, to_stage_id, "
+                    "condition, label) "
+                    "VALUES (:workflow_id, :transition_id, :from_id, :to_id, "
+                    ":cond, :label)"
+                ),
+                {
+                    "workflow_id": workflow.id.hex,
+                    "transition_id": transition_id.hex,
+                    "from_id": stage_a.id.hex,
+                    "to_id": stage_b.id.hex,
+                    "cond": "APPROVED",
+                    "label": "first",
+                },
+            )
+
+        with pytest.raises(IntegrityError):
+            async with session_factory() as session, session.begin():
+                await session.execute(
+                    text(
+                        "INSERT INTO workflow_transitions "
+                        "(workflow_id, transition_id, from_stage_id, to_stage_id, "
+                        "condition, label) "
+                        "VALUES (:workflow_id, :transition_id, :from_id, :to_id, "
+                        ":cond, :label)"
+                    ),
+                    {
+                        "workflow_id": workflow.id.hex,
+                        "transition_id": transition_id.hex,
+                        "from_id": stage_a.id.hex,
+                        "to_id": stage_b.id.hex,
+                        "cond": "APPROVED",
+                        "label": "duplicate",
+                    },
+                )
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-WFR-023: Layer 2 arch-test partial-mask template structure
+# ---------------------------------------------------------------------------
+class TestPartialMaskTemplateStructure:
+    """TC-IT-WFR-023: arch-test exposes the partial-mask parametrize structure.
+
+    The Workflow PR introduces the **partial-mask** pattern alongside
+    empire-repository's no-mask pattern: ``workflow_stages`` carries
+    exactly one masked column (``notify_channels_json``) and zero on
+    every other column. The arch-test parametrizes
+    ``_PARTIAL_MASK_TABLES`` to assert this — a future PR that swaps
+    another column to a Masked* type without updating §逆引き表 first
+    must trip the arch-test.
+
+    Future Repository PRs add their own "partial-mask" rows for their
+    Aggregate's tables; the structural shape lets them extend without
+    rewriting the harness.
+    """
+
+    async def test_arch_test_module_imports_partial_mask_table_list(self) -> None:
+        """TC-IT-WFR-023: ``_PARTIAL_MASK_TABLES`` lists ``workflow_stages``."""
+        from tests.architecture.test_masking_columns import (
+            _NO_MASK_TABLES,  # pyright: ignore[reportPrivateUsage]
+            _PARTIAL_MASK_TABLES,  # pyright: ignore[reportPrivateUsage]
+        )
+
+        # workflow_stages is the partial-mask table.
+        partial_mask_table_names = {tbl for tbl, _ in _PARTIAL_MASK_TABLES}
+        assert "workflow_stages" in partial_mask_table_names, (
+            "[FAIL] workflow_stages must be registered in _PARTIAL_MASK_TABLES.\n"
+            "Next: add ('workflow_stages', 'notify_channels_json') per "
+            "detailed-design.md §確定 H."
+        )
+        # The allowed column on workflow_stages is exactly notify_channels_json.
+        allowed_columns = [col for tbl, col in _PARTIAL_MASK_TABLES if tbl == "workflow_stages"]
+        assert allowed_columns == ["notify_channels_json"], (
+            f"[FAIL] workflow_stages partial-mask declared {allowed_columns!r}, "
+            f"expected ['notify_channels_json'].\n"
+            f"Next: §逆引き表 freezes notify_channels_json as the sole masked column."
+        )
+
+        # workflows / workflow_transitions live in the no-mask list.
+        assert "workflows" in _NO_MASK_TABLES, (
+            "[FAIL] workflows must be registered in _NO_MASK_TABLES."
+        )
+        assert "workflow_transitions" in _NO_MASK_TABLES, (
+            "[FAIL] workflow_transitions must be registered in _NO_MASK_TABLES."
+        )

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_workflow_repository/test_masking.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_workflow_repository/test_masking.py
@@ -1,0 +1,207 @@
+"""Workflow Repository: §確定 H — MaskedJSONEncoded wiring + irreversibility.
+
+TC-IT-WFR-013 / 014 — the contract surface this PR makes physical:
+
+* **TC-IT-WFR-013**: Saving a Workflow whose ``EXTERNAL_REVIEW`` Stage
+  carries a real-shape Discord webhook URL persists the
+  ``notify_channels_json`` column with the secret token replaced by
+  ``<REDACTED:DISCORD_WEBHOOK>``. The original token MUST NOT appear
+  anywhere in the on-disk JSON. Verified via raw-SQL ``SELECT`` (which
+  bypasses ORM type decoders) so the bytes that hit the disk are the
+  bytes we read.
+
+* **TC-IT-WFR-014**: §不可逆性 — once persisted, ``find_by_id`` on the
+  same Workflow raises ``pydantic.ValidationError`` because the masked
+  URL fails the ``NotifyChannel`` G7 regex (``[A-Za-z0-9_\\-]+`` for
+  the token segment; ``<REDACTED:DISCORD_WEBHOOK>`` contains ``<>:``
+  which the regex rejects). This is the *design contract*: re-entry of
+  the webhook URL must come from CEO operator input, not from
+  round-trip recovery.
+
+Per ``docs/features/workflow-repository/test-design.md``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from bakufu.domain.value_objects import NotifyChannel, StageKind
+from bakufu.domain.workflow import Workflow
+from bakufu.infrastructure.persistence.sqlite.repositories.workflow_repository import (
+    SqliteWorkflowRepository,
+)
+from pydantic import ValidationError
+from sqlalchemy import text
+
+from tests.factories.workflow import make_stage, make_transition, make_workflow
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+pytestmark = pytest.mark.asyncio
+
+
+# A real-shape (but synthetic) Discord webhook URL. The token segment
+# is intentionally something distinctive so the assertion can prove
+# the on-disk bytes do NOT carry it after masking.
+_REAL_SHAPE_TOKEN = "JeffMaskingProbe_-9876543210xyzABCDEFGHIJ"
+_REAL_SHAPE_WEBHOOK = "https://discord.com/api/webhooks/1234567890123456789/" + _REAL_SHAPE_TOKEN
+_DISCORD_REDACT_SENTINEL = "<REDACTED:DISCORD_WEBHOOK>"
+
+
+def _make_external_review_workflow(*, target_url: str) -> Workflow:
+    """Build a Workflow whose entry Stage is ``EXTERNAL_REVIEW`` + given webhook.
+
+    Returned shape is the bare ``Workflow`` aggregate; the test bodies
+    save / re-fetch it and assert against the persisted bytes.
+    """
+    notify_channel = NotifyChannel(
+        kind="discord",
+        target=target_url,
+    )
+    review_stage = make_stage(
+        name="外部レビュー",
+        kind=StageKind.EXTERNAL_REVIEW,
+        notify_channels=[notify_channel],
+    )
+    work_stage = make_stage(name="次の作業")
+    transition = make_transition(
+        from_stage_id=review_stage.id,
+        to_stage_id=work_stage.id,
+    )
+    return make_workflow(
+        stages=[review_stage, work_stage],
+        transitions=[transition],
+        entry_stage_id=review_stage.id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-WFR-013: MaskedJSONEncoded wiring (Schneier 申し送り #6 物理確認)
+# ---------------------------------------------------------------------------
+class TestNotifyChannelsJsonMaskedOnDisk:
+    """TC-IT-WFR-013: ``notify_channels_json`` carries ``<REDACTED:...>`` not the raw token."""
+
+    async def test_discord_webhook_token_redacted_in_persisted_json(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """TC-IT-WFR-013: raw-SQL ``SELECT`` shows masked JSON, never the secret token.
+
+        Two assertions, in this order (positive before negative):
+
+        1. The redaction sentinel appears — proves the masking gateway
+           ran. A bug that silently dropped the masking step would
+           drop both the sentinel **and** leave the token in plaintext.
+        2. The original token does NOT appear anywhere in the JSON
+           string — the credential never lands on disk in any form.
+        """
+        workflow = _make_external_review_workflow(target_url=_REAL_SHAPE_WEBHOOK)
+        async with session_factory() as session, session.begin():
+            await SqliteWorkflowRepository(session).save(workflow)
+
+        # Raw SQL — bypass MaskedJSONEncoded.process_result_value so we
+        # see the literal bytes that hit the disk.
+        async with session_factory() as session:
+            stmt = text(
+                "SELECT notify_channels_json FROM workflow_stages "
+                "WHERE workflow_id = :workflow_id "
+                "AND kind = 'EXTERNAL_REVIEW'"
+            )
+            row = (await session.execute(stmt, {"workflow_id": workflow.id.hex})).first()
+
+        assert row is not None
+        persisted_json = row[0]
+        assert isinstance(persisted_json, str)
+
+        # Positive: redaction sentinel is present.
+        assert _DISCORD_REDACT_SENTINEL in persisted_json, (
+            f"[FAIL] notify_channels_json missing redaction sentinel.\n"
+            f"Next: verify workflow_stages.notify_channels_json column type is "
+            f"MaskedJSONEncoded; this is the §確定 H 物理保証. "
+            f"Persisted JSON: {persisted_json!r}"
+        )
+        # Negative: raw token is absent.
+        assert _REAL_SHAPE_TOKEN not in persisted_json, (
+            f"[FAIL] raw Discord webhook token leaked into notify_channels_json.\n"
+            f"Next: this is the catastrophic case the §確定 H + Schneier 申し送り #6 "
+            f"three-layer defense was designed to prevent. Verify "
+            f"NotifyChannel.field_serializer (Layer 1) AND MaskedJSONEncoded "
+            f"(Layer 2 / TypeDecorator) are both still in place. "
+            f"Persisted JSON: {persisted_json!r}"
+        )
+
+    async def test_empty_notify_channels_persists_as_empty_array(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """TC-IT-WFR-013 補強: a Stage with no notify_channels still persists cleanly.
+
+        ``WORK`` stages don't carry notify_channels by default. The
+        column is NOT NULL with server_default ``'[]'``; the
+        Repository's ``_to_row`` emits ``[]`` (empty list) which the
+        ``MaskedJSONEncoded.process_bind_param`` normalizes to
+        ``"[]"`` JSON. No masking artifacts on this path.
+        """
+        workflow = make_workflow()  # 1 WORK stage, empty notify_channels
+        async with session_factory() as session, session.begin():
+            await SqliteWorkflowRepository(session).save(workflow)
+
+        async with session_factory() as session:
+            stmt = text(
+                "SELECT notify_channels_json FROM workflow_stages WHERE workflow_id = :workflow_id"
+            )
+            row = (await session.execute(stmt, {"workflow_id": workflow.id.hex})).first()
+
+        assert row is not None
+        # Either ``"[]"`` (the explicit empty list JSON) or any other
+        # JSON-valid empty container — the contract is "no leakage" not
+        # "exact byte form". We assert both interpretations are safe.
+        assert _DISCORD_REDACT_SENTINEL not in str(row[0])
+        # Quick sanity that we got a string-shaped JSON value.
+        assert str(row[0]).strip() in ("[]", "null", "")
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-WFR-014: §確定 H §不可逆性 — find_by_id raises after mask
+# ---------------------------------------------------------------------------
+class TestFindByIdRaisesOnMaskedNotifyChannels:
+    """TC-IT-WFR-014: ``find_by_id`` on a masked Workflow raises ``ValidationError``.
+
+    The §確定 H §不可逆性 contract: once notify_channels are masked
+    on disk, recovering the *typed* Workflow aggregate is impossible
+    because the masked URL fails the ``NotifyChannel`` G7 regex on
+    re-validate. This test pins that behavior so a hypothetical PR
+    that "rescued" the round-trip (e.g. by skipping invalid notify
+    channels silently) would fail loudly.
+    """
+
+    async def test_find_by_id_raises_validation_error(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """TC-IT-WFR-014: a save-then-find_by_id on a masked URL must raise.
+
+        The contract:
+
+        * ``save`` succeeds (the gateway produces well-formed JSON,
+          just with the token redacted).
+        * ``find_by_id`` raises because ``NotifyChannel.model_validate``
+          rejects the masked URL — the G7 regex requires the token
+          segment to match ``[A-Za-z0-9_\\-]+`` and the redaction
+          sentinel ``<REDACTED:DISCORD_WEBHOOK>`` is not in that set
+          (``<`` / ``>`` / ``:`` are excluded).
+
+        The Repository docstring (workflow_repository.py L44-48)
+        commits to "find_by_id may therefore raise ``pydantic.ValidationError``";
+        we pin the contract here so a swap to a different exception
+        class would force a docs update + design revisit.
+        """
+        workflow = _make_external_review_workflow(target_url=_REAL_SHAPE_WEBHOOK)
+        async with session_factory() as session, session.begin():
+            await SqliteWorkflowRepository(session).save(workflow)
+
+        async with session_factory() as session:
+            with pytest.raises(ValidationError):
+                await SqliteWorkflowRepository(session).find_by_id(workflow.id)

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_workflow_repository/test_protocol_crud.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_workflow_repository/test_protocol_crud.py
@@ -1,0 +1,382 @@
+"""Workflow Repository: Protocol surface + basic CRUD coverage.
+
+TC-IT-WFR-001 / 002 / 003 / 004 / 005 / 006 / 007 / 019 — the
+entry-point behaviors empire-repository (PR #25) froze and that this
+PR inherits 100%, plus the Workflow-specific ``ORDER BY stage_id`` /
+``ORDER BY transition_id`` SQL log observation (BUG-EMR-001 from-day-1
+contract per detailed-design.md L51).
+
+Per ``docs/features/workflow-repository/test-design.md`` matrix.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+import pytest
+from bakufu.application.ports.workflow_repository import WorkflowRepository
+from bakufu.domain.value_objects import WorkflowId
+from bakufu.domain.workflow import Workflow
+from bakufu.infrastructure.persistence.sqlite.repositories.workflow_repository import (
+    SqliteWorkflowRepository,
+)
+from bakufu.infrastructure.persistence.sqlite.tables.workflow_stages import (
+    WorkflowStageRow,
+)
+from bakufu.infrastructure.persistence.sqlite.tables.workflow_transitions import (
+    WorkflowTransitionRow,
+)
+from bakufu.infrastructure.persistence.sqlite.tables.workflows import WorkflowRow
+from sqlalchemy import event, select
+
+from tests.factories.workflow import make_stage, make_transition, make_workflow
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# REQ-WFR-001: Protocol definition + 充足 (§確定 A)
+# ---------------------------------------------------------------------------
+class TestWorkflowRepositoryProtocol:
+    """TC-IT-WFR-001 / 002: Protocol surface + duck-typing 充足."""
+
+    async def test_protocol_declares_three_async_methods(self) -> None:
+        """TC-IT-WFR-001: ``WorkflowRepository`` has find_by_id / count / save."""
+        # Protocol classes don't expose the methods at instance level
+        # but at class level. Marked ``async`` purely so the
+        # module-level ``pytestmark = asyncio`` does not warn.
+        assert hasattr(WorkflowRepository, "find_by_id")
+        assert hasattr(WorkflowRepository, "count")
+        assert hasattr(WorkflowRepository, "save")
+
+    async def test_sqlite_repository_satisfies_protocol(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """TC-IT-WFR-002: ``SqliteWorkflowRepository`` is assignable to ``WorkflowRepository``.
+
+        The variable annotation acts as a static-type assertion; pyright
+        strict will reject the assignment if any Protocol method is
+        missing or has a wrong signature. Duck-typing at runtime
+        confirms the three methods exist on the instance too.
+        """
+        async with session_factory() as session:
+            repo: WorkflowRepository = SqliteWorkflowRepository(session)
+            assert hasattr(repo, "find_by_id")
+            assert hasattr(repo, "count")
+            assert hasattr(repo, "save")
+
+
+# ---------------------------------------------------------------------------
+# REQ-WFR-002: find_by_id / count / save 基本 CRUD
+# ---------------------------------------------------------------------------
+class TestFindById:
+    """TC-IT-WFR-003 / 004: find_by_id retrieves saved Workflows; None for unknown."""
+
+    async def test_find_by_id_returns_saved_workflow(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """TC-IT-WFR-003: ``find_by_id(workflow.id)`` returns a structurally-equal Workflow.
+
+        Uses ``make_workflow()`` default (single ``WORK`` stage, no
+        ``EXTERNAL_REVIEW`` → no notify_channels) so §確定 H §不可逆性
+        does not bite. Round-trip equality of the irreversible-masking
+        path lives in :mod:`...test_masking`.
+        """
+        workflow = make_workflow()
+        async with session_factory() as session, session.begin():
+            await SqliteWorkflowRepository(session).save(workflow)
+
+        async with session_factory() as session:
+            fetched = await SqliteWorkflowRepository(session).find_by_id(workflow.id)
+
+        assert fetched is not None
+        assert fetched == workflow
+
+    async def test_find_by_id_returns_none_for_unknown(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """TC-IT-WFR-004: ``find_by_id(uuid4())`` returns ``None`` without raising."""
+        unknown_id = uuid4()
+        async with session_factory() as session:
+            fetched = await SqliteWorkflowRepository(session).find_by_id(unknown_id)
+        assert fetched is None
+
+
+# ---------------------------------------------------------------------------
+# REQ-WFR-002 (ORDER BY contract per BUG-EMR-001 inherited from day 1)
+# ---------------------------------------------------------------------------
+class TestFindByIdOrderByContract:
+    """TC-IT-WFR-005 / 006: ``ORDER BY stage_id`` / ``ORDER BY transition_id`` are emitted.
+
+    The empire-repository BUG-EMR-001 closure froze the ORDER BY
+    contract; the workflow Repository adopts it from PR #1. Without
+    these clauses, SQLite returns rows in internal-scan order which
+    would break ``Workflow == Workflow`` round-trip equality (the
+    Aggregate compares list-by-list).
+
+    We attach a ``before_cursor_execute`` listener on the **sync**
+    engine and observe the actual SQL strings the dialect emits so a
+    silent removal of ``ORDER BY`` is caught even if the round-trip
+    test happens to pass via row-order coincidence.
+    """
+
+    async def _build_multi_stage_workflow(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> tuple[Workflow, WorkflowId]:
+        """Build + save a 3-stage / 2-transition Workflow without EXTERNAL_REVIEW.
+
+        Returns the constructed workflow plus its id so the caller can
+        round-trip it. ``WORK`` stages do not require notify_channels,
+        so no §確定 H §不可逆性 trap.
+        """
+        stage_a = make_stage(name="ステージA")
+        stage_b = make_stage(name="ステージB")
+        stage_c = make_stage(name="ステージC")
+        transition_ab = make_transition(
+            from_stage_id=stage_a.id,
+            to_stage_id=stage_b.id,
+        )
+        transition_bc = make_transition(
+            from_stage_id=stage_b.id,
+            to_stage_id=stage_c.id,
+        )
+        workflow = make_workflow(
+            stages=[stage_a, stage_b, stage_c],
+            transitions=[transition_ab, transition_bc],
+            entry_stage_id=stage_a.id,
+        )
+        async with session_factory() as session, session.begin():
+            await SqliteWorkflowRepository(session).save(workflow)
+        return workflow, workflow.id
+
+    async def test_find_by_id_emits_order_by_stage_id(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        app_engine: AsyncEngine,
+    ) -> None:
+        """TC-IT-WFR-005: ``find_by_id`` emits ``ORDER BY workflow_stages.stage_id``."""
+        _, workflow_id = await self._build_multi_stage_workflow(session_factory)
+
+        captured: list[str] = []
+
+        def _on_execute(
+            _conn: object,
+            _cursor: object,
+            statement: str,
+            _params: object,
+            _context: object,
+            _executemany: bool,
+        ) -> None:
+            captured.append(statement)
+
+        sync_engine = app_engine.sync_engine
+        event.listen(sync_engine, "before_cursor_execute", _on_execute)
+        try:
+            async with session_factory() as session:
+                await SqliteWorkflowRepository(session).find_by_id(workflow_id)
+        finally:
+            event.remove(sync_engine, "before_cursor_execute", _on_execute)
+
+        # The Workflow's stage SELECT must carry an ``ORDER BY`` on the
+        # stage_id column. We accept any whitespace / fully-qualified
+        # variation that SQLAlchemy chooses to emit.
+        stage_selects = [
+            stmt for stmt in captured if "FROM workflow_stages" in stmt and "SELECT" in stmt.upper()
+        ]
+        assert stage_selects, "find_by_id must SELECT from workflow_stages"
+        assert any("ORDER BY" in stmt.upper() and "stage_id" in stmt for stmt in stage_selects), (
+            "find_by_id must issue ``ORDER BY ... stage_id`` per "
+            "detailed-design.md L51 (BUG-EMR-001 from day 1). "
+            f"Captured stage SELECTs: {stage_selects}"
+        )
+
+    async def test_find_by_id_emits_order_by_transition_id(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        app_engine: AsyncEngine,
+    ) -> None:
+        """TC-IT-WFR-006: ``find_by_id`` emits ``ORDER BY workflow_transitions.transition_id``."""
+        _, workflow_id = await self._build_multi_stage_workflow(session_factory)
+
+        captured: list[str] = []
+
+        def _on_execute(
+            _conn: object,
+            _cursor: object,
+            statement: str,
+            _params: object,
+            _context: object,
+            _executemany: bool,
+        ) -> None:
+            captured.append(statement)
+
+        sync_engine = app_engine.sync_engine
+        event.listen(sync_engine, "before_cursor_execute", _on_execute)
+        try:
+            async with session_factory() as session:
+                await SqliteWorkflowRepository(session).find_by_id(workflow_id)
+        finally:
+            event.remove(sync_engine, "before_cursor_execute", _on_execute)
+
+        transition_selects = [
+            stmt
+            for stmt in captured
+            if "FROM workflow_transitions" in stmt and "SELECT" in stmt.upper()
+        ]
+        assert transition_selects, "find_by_id must SELECT from workflow_transitions"
+        assert any(
+            "ORDER BY" in stmt.upper() and "transition_id" in stmt for stmt in transition_selects
+        ), (
+            "find_by_id must issue ``ORDER BY ... transition_id`` per "
+            "detailed-design.md L51 (BUG-EMR-001 from day 1). "
+            f"Captured transition SELECTs: {transition_selects}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# REQ-WFR-002 (count() must issue SQL-level COUNT(*))
+# ---------------------------------------------------------------------------
+class TestCountIssuesScalarCount:
+    """TC-IT-WFR-007: ``count()`` issues ``SELECT COUNT(*)``, not a full row scan."""
+
+    async def test_count_emits_select_count_not_full_load(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        app_engine: AsyncEngine,
+    ) -> None:
+        """TC-IT-WFR-007: SQL log shows ``SELECT count(*)`` for ``count()``.
+
+        Empire-repository §確定 D 補強: ``count()`` must not stream
+        every row back to Python and call ``len()``. With Workflow
+        preset libraries we expect hundreds of rows, so the SQL-level
+        COUNT(*) pattern matters even more than for Empire.
+        """
+        # Save two workflows so a hypothetical full-row scan would
+        # materialize at least 2 rows — we'd see them in the log.
+        async with session_factory() as session, session.begin():
+            await SqliteWorkflowRepository(session).save(make_workflow())
+        async with session_factory() as session, session.begin():
+            await SqliteWorkflowRepository(session).save(make_workflow())
+
+        captured: list[str] = []
+
+        def _on_execute(
+            _conn: object,
+            _cursor: object,
+            statement: str,
+            _params: object,
+            _context: object,
+            _executemany: bool,
+        ) -> None:
+            captured.append(statement.strip())
+
+        sync_engine = app_engine.sync_engine
+        event.listen(sync_engine, "before_cursor_execute", _on_execute)
+        try:
+            async with session_factory() as session:
+                count = await SqliteWorkflowRepository(session).count()
+        finally:
+            event.remove(sync_engine, "before_cursor_execute", _on_execute)
+
+        assert count == 2
+        # Workflow SELECTs touched during count() must all be
+        # ``count(*)`` shapes — never a full ``SELECT id FROM workflows``
+        # row stream that the Repository would then ``len()``.
+        workflow_selects = [s for s in captured if "FROM workflows" in s]
+        assert workflow_selects, "count() must issue at least one SELECT against workflows"
+        for stmt in workflow_selects:
+            assert "count(" in stmt.lower(), (
+                f"[FAIL] count() emitted a non-COUNT SELECT: {stmt!r}\n"
+                f"Next: ensure count() uses select(func.count()).select_from(WorkflowRow) "
+                f"per detailed-design.md §確定 D 補強."
+            )
+
+
+# ---------------------------------------------------------------------------
+# §確定 D: Repository never enforces singleton invariants
+# ---------------------------------------------------------------------------
+class TestRepositoryDoesNotEnforceSingleton:
+    """TC-IT-WFR-019: Repository accepts multiple Workflow saves."""
+
+    async def test_two_workflows_saved_without_error(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """TC-IT-WFR-019: 2 distinct Workflows save successfully; ``count()`` reports 2.
+
+        Singleton enforcement (e.g. "only one preset Workflow per
+        empire") is the application service's job; the Repository
+        itself reports facts via ``count()`` and never raises just
+        because the cardinality grew above 1.
+        """
+        async with session_factory() as session, session.begin():
+            await SqliteWorkflowRepository(session).save(make_workflow())
+        async with session_factory() as session, session.begin():
+            await SqliteWorkflowRepository(session).save(make_workflow())
+
+        async with session_factory() as session:
+            count = await SqliteWorkflowRepository(session).count()
+        assert count == 2
+
+
+# ---------------------------------------------------------------------------
+# REQ-WFR-002: save inserts into all 3 tables (TC-IT-WFR-008)
+# ---------------------------------------------------------------------------
+class TestSaveInsertsAllThreeTables:
+    """TC-IT-WFR-008: ``save`` writes the 3 Workflow tables.
+
+    ``workflows`` + ``workflow_stages`` + ``workflow_transitions`` all
+    receive rows in a single ``save`` call.
+    """
+
+    async def test_save_populates_three_tables(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """TC-IT-WFR-008: 3 stages + 2 transitions land in their respective side tables.
+
+        We deliberately avoid V-model payload here because that has
+        EXTERNAL_REVIEW stages and would conflate this test with the
+        notify_channels masking concern (covered in test_masking).
+        """
+        stage_a = make_stage(name="A")
+        stage_b = make_stage(name="B")
+        stage_c = make_stage(name="C")
+        transition_ab = make_transition(from_stage_id=stage_a.id, to_stage_id=stage_b.id)
+        transition_bc = make_transition(from_stage_id=stage_b.id, to_stage_id=stage_c.id)
+        workflow = make_workflow(
+            stages=[stage_a, stage_b, stage_c],
+            transitions=[transition_ab, transition_bc],
+            entry_stage_id=stage_a.id,
+        )
+        async with session_factory() as session, session.begin():
+            await SqliteWorkflowRepository(session).save(workflow)
+
+        async with session_factory() as session:
+            workflow_rows = (
+                await session.execute(select(WorkflowRow).where(WorkflowRow.id == workflow.id))
+            ).all()
+            stage_rows = (
+                await session.execute(
+                    select(WorkflowStageRow).where(WorkflowStageRow.workflow_id == workflow.id)
+                )
+            ).all()
+            transition_rows = (
+                await session.execute(
+                    select(WorkflowTransitionRow).where(
+                        WorkflowTransitionRow.workflow_id == workflow.id
+                    )
+                )
+            ).all()
+
+        assert len(workflow_rows) == 1
+        assert len(stage_rows) == 3
+        assert len(transition_rows) == 2

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_workflow_repository/test_save_delete_then_insert.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_workflow_repository/test_save_delete_then_insert.py
@@ -1,0 +1,251 @@
+"""Workflow Repository: save() — delete-then-insert + SQL order + isolation.
+
+TC-IT-WFR-009 / 010 — the §確定 B contract that backs the ``save()``
+flow's wholesale row replacement and the 5-step DML sequence, plus
+the isolation-between-Workflows smoke (``DELETE`` is scoped to a
+single ``workflow_id``).
+
+Split out of ``test_save_semantics.py`` per Norman 500-line rule
+(file would land at 502 lines after BUG-WFR-001 fix). The two
+companion files cover the round-trip + Tx-boundary contracts:
+
+* :mod:`...test_workflow_repository.test_save_round_trip` —
+  ``roles_csv`` determinism + structural equality + Tx commit /
+  rollback.
+
+Per ``docs/features/workflow-repository/test-design.md``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+import pytest
+from bakufu.infrastructure.persistence.sqlite.repositories.workflow_repository import (
+    SqliteWorkflowRepository,
+)
+from bakufu.infrastructure.persistence.sqlite.tables.workflow_stages import (
+    WorkflowStageRow,
+)
+from sqlalchemy import event, select
+
+from tests.factories.workflow import (
+    build_v_model_payload,
+    make_stage,
+    make_transition,
+    make_workflow,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# §確定 B: delete-then-insert replacement semantics (TC-IT-WFR-009)
+# ---------------------------------------------------------------------------
+class TestSaveDeleteThenInsert:
+    """TC-IT-WFR-009: ``save`` replaces side-table rows wholesale (§確定 B)."""
+
+    async def test_save_replaces_stage_rows(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """TC-IT-WFR-009: 3 stages → 1 stage is reflected as 1 row in workflow_stages.
+
+        We construct a fresh single-stage Workflow with the **same
+        workflow_id** and re-save. The §確定 B contract says the side
+        tables must end up reflecting only the new state; old stages
+        must not survive as residue.
+        """
+        stage_a = make_stage(name="A")
+        stage_b = make_stage(name="B")
+        stage_c = make_stage(name="C")
+        transition_ab = make_transition(from_stage_id=stage_a.id, to_stage_id=stage_b.id)
+        transition_bc = make_transition(from_stage_id=stage_b.id, to_stage_id=stage_c.id)
+        original = make_workflow(
+            stages=[stage_a, stage_b, stage_c],
+            transitions=[transition_ab, transition_bc],
+            entry_stage_id=stage_a.id,
+        )
+        async with session_factory() as session, session.begin():
+            await SqliteWorkflowRepository(session).save(original)
+
+        # Build a new Workflow with the same id but only 1 stage.
+        replacement_stage = make_stage(name="残ったステージ")
+        replacement = make_workflow(
+            workflow_id=original.id,
+            name=original.name,
+            stages=[replacement_stage],
+            transitions=[],
+            entry_stage_id=replacement_stage.id,
+        )
+        async with session_factory() as session, session.begin():
+            await SqliteWorkflowRepository(session).save(replacement)
+
+        # Side tables must show the new state, not the merged old + new.
+        async with session_factory() as session:
+            stage_rows = list(
+                (
+                    await session.execute(
+                        select(WorkflowStageRow).where(WorkflowStageRow.workflow_id == original.id)
+                    )
+                ).scalars()
+            )
+        assert len(stage_rows) == 1
+        assert stage_rows[0].name == "残ったステージ"
+
+
+# ---------------------------------------------------------------------------
+# §確定 B: 5-step SQL order (TC-IT-WFR-010)
+# ---------------------------------------------------------------------------
+class TestSaveSqlOrder:
+    """TC-IT-WFR-010: ``save`` issues SQL in the §確定 B 5-step order.
+
+    We attach a ``before_cursor_execute`` listener on the **sync**
+    engine so we observe the actual SQL strings the dialect emits. The
+    listener appends each statement to a captured list; we then assert
+    the prefix sequence matches the design's 5 steps. The dispatcher /
+    ORM may issue extra SAVEPOINT / BEGIN statements which we filter
+    out — the contract is on the *DML* prefix.
+
+    Same harness as empire-repository TC-IT-EMR-011; the next 5
+    Repository PRs should re-use this template.
+    """
+
+    async def test_save_emits_upsert_then_delete_insert_pairs(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        app_engine: AsyncEngine,
+    ) -> None:
+        """TC-IT-WFR-010: 5-step DML order matches §確定 B.
+
+        workflows UPSERT → workflow_stages DEL+INS → workflow_transitions DEL+INS.
+        """
+        captured: list[str] = []
+
+        def _on_execute(
+            _conn: object,
+            _cursor: object,
+            statement: str,
+            _params: object,
+            _context: object,
+            _executemany: bool,
+        ) -> None:
+            captured.append(statement.strip())
+
+        sync_engine = app_engine.sync_engine
+        event.listen(sync_engine, "before_cursor_execute", _on_execute)
+        try:
+            # V-model payload exercises 13 stages + 15 transitions —
+            # the busiest possible ``save()`` shape and the right one
+            # for SQL-order observation.
+            from bakufu.domain.workflow import Workflow
+
+            workflow = Workflow.from_dict(build_v_model_payload())
+            async with session_factory() as session, session.begin():
+                await SqliteWorkflowRepository(session).save(workflow)
+        finally:
+            event.remove(sync_engine, "before_cursor_execute", _on_execute)
+
+        # Filter to the 5 DML statements we care about (BEGIN /
+        # SAVEPOINT / RELEASE / COMMIT noise removed).
+        dml = [
+            s
+            for s in captured
+            if any(
+                s.upper().startswith(prefix)
+                for prefix in (
+                    "INSERT INTO WORKFLOWS",
+                    "DELETE FROM WORKFLOW_",
+                    "INSERT INTO WORKFLOW_",
+                )
+            )
+        ]
+        # Step 1 (UPSERT workflows) → Step 2 (DELETE workflow_stages) →
+        # Step 3 (INSERT workflow_stages) → Step 4 (DELETE
+        # workflow_transitions) → Step 5 (INSERT workflow_transitions).
+        assert len(dml) >= 5, (
+            f"[FAIL] save emitted only {len(dml)} DML statements; expected ≥5.\n"
+            f"Next: verify save() executes the §確定 B 5-step sequence. "
+            f"Captured DML: {dml}"
+        )
+        assert dml[0].upper().startswith("INSERT INTO WORKFLOWS")
+        assert dml[1].upper().startswith("DELETE FROM WORKFLOW_STAGES")
+        assert dml[2].upper().startswith("INSERT INTO WORKFLOW_STAGES")
+        assert dml[3].upper().startswith("DELETE FROM WORKFLOW_TRANSITIONS")
+        assert dml[4].upper().startswith("INSERT INTO WORKFLOW_TRANSITIONS")
+
+
+# ---------------------------------------------------------------------------
+# Smoke test: an unknown workflow_id never collides with an existing row
+# ---------------------------------------------------------------------------
+class TestSaveDistinctWorkflowsAreIndependent:
+    """Side-effect isolation between Workflows."""
+
+    async def test_save_one_does_not_disturb_another(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """Saving Workflow B must not delete Workflow A's stages.
+
+        The ``DELETE WHERE workflow_id = ?`` step in §確定 B is
+        scoped to the workflow_id under save; a poorly-written
+        Repository that issued an un-scoped DELETE would corrupt every
+        other Workflow in the DB. We assert the scoping with a
+        before / after snapshot.
+        """
+        workflow_a = make_workflow()
+        workflow_b = make_workflow()
+        # Distinct ids — sanity.
+        assert workflow_a.id != workflow_b.id
+
+        async with session_factory() as session, session.begin():
+            await SqliteWorkflowRepository(session).save(workflow_a)
+
+        # Save B → A must remain untouched.
+        async with session_factory() as session, session.begin():
+            await SqliteWorkflowRepository(session).save(workflow_b)
+
+        async with session_factory() as session:
+            a_rows = list(
+                (
+                    await session.execute(
+                        select(WorkflowStageRow).where(
+                            WorkflowStageRow.workflow_id == workflow_a.id
+                        )
+                    )
+                ).scalars()
+            )
+            b_rows = list(
+                (
+                    await session.execute(
+                        select(WorkflowStageRow).where(
+                            WorkflowStageRow.workflow_id == workflow_b.id
+                        )
+                    )
+                ).scalars()
+            )
+
+        assert len(a_rows) == 1
+        assert len(b_rows) == 1
+
+        # Sanity: the two Workflows did not share stage rows.
+        a_stage_ids = {row.stage_id for row in a_rows}
+        b_stage_ids = {row.stage_id for row in b_rows}
+        assert a_stage_ids.isdisjoint(b_stage_ids)
+
+    async def test_unknown_workflow_id_returns_none_after_other_saves(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """find_by_id of an unknown id still returns None even when DB is non-empty."""
+        async with session_factory() as session, session.begin():
+            await SqliteWorkflowRepository(session).save(make_workflow())
+
+        unknown_id = uuid4()
+        async with session_factory() as session:
+            fetched = await SqliteWorkflowRepository(session).find_by_id(unknown_id)
+        assert fetched is None

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_workflow_repository/test_save_round_trip.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_workflow_repository/test_save_round_trip.py
@@ -1,10 +1,14 @@
-"""Workflow Repository: save() semantics — delete-then-insert + Tx boundary + roles_csv.
+"""Workflow Repository: save() — roles_csv determinism + round-trip + Tx boundary.
 
-TC-IT-WFR-009 / 010 / 011 / 012 / 015 / 016 — the §確定 B / G / J
-contracts that back the ``save()`` flow + round-trip equality + Tx
-boundary, plus the §確定 G **sorted CSV determinism** guarantee that
-makes the same ``frozenset[Role]`` produce byte-identical
-``roles_csv`` output regardless of insertion order.
+TC-IT-WFR-011 / 012 / 015 / 016 — the §確定 G "sorted CSV"
+determinism, the §確定 C round-trip structural equality, and the
+§確定 B Tx-boundary responsibility separation.
+
+Split out of ``test_save_semantics.py`` per Norman 500-line rule.
+The companion file
+:mod:`...test_workflow_repository.test_save_delete_then_insert` covers
+the delete-then-insert + 5-step DML order + cross-workflow isolation
+smoke.
 
 Per ``docs/features/workflow-repository/test-design.md``.
 """
@@ -12,7 +16,6 @@ Per ``docs/features/workflow-repository/test-design.md``.
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from uuid import uuid4
 
 import pytest
 from bakufu.domain.value_objects import Role
@@ -22,155 +25,18 @@ from bakufu.infrastructure.persistence.sqlite.repositories.workflow_repository i
 from bakufu.infrastructure.persistence.sqlite.tables.workflow_stages import (
     WorkflowStageRow,
 )
-from sqlalchemy import event, select, text
+from sqlalchemy import select, text
 
 from tests.factories.workflow import (
-    build_v_model_payload,
     make_stage,
     make_transition,
     make_workflow,
 )
 
 if TYPE_CHECKING:
-    from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 pytestmark = pytest.mark.asyncio
-
-
-# ---------------------------------------------------------------------------
-# §確定 B: delete-then-insert replacement semantics (TC-IT-WFR-009)
-# ---------------------------------------------------------------------------
-class TestSaveDeleteThenInsert:
-    """TC-IT-WFR-009: ``save`` replaces side-table rows wholesale (§確定 B)."""
-
-    async def test_save_replaces_stage_rows(
-        self,
-        session_factory: async_sessionmaker[AsyncSession],
-    ) -> None:
-        """TC-IT-WFR-009: 3 stages → 1 stage is reflected as 1 row in workflow_stages.
-
-        We construct a fresh single-stage Workflow with the **same
-        workflow_id** and re-save. The §確定 B contract says the side
-        tables must end up reflecting only the new state; old stages
-        must not survive as residue.
-        """
-        stage_a = make_stage(name="A")
-        stage_b = make_stage(name="B")
-        stage_c = make_stage(name="C")
-        transition_ab = make_transition(from_stage_id=stage_a.id, to_stage_id=stage_b.id)
-        transition_bc = make_transition(from_stage_id=stage_b.id, to_stage_id=stage_c.id)
-        original = make_workflow(
-            stages=[stage_a, stage_b, stage_c],
-            transitions=[transition_ab, transition_bc],
-            entry_stage_id=stage_a.id,
-        )
-        async with session_factory() as session, session.begin():
-            await SqliteWorkflowRepository(session).save(original)
-
-        # Build a new Workflow with the same id but only 1 stage.
-        replacement_stage = make_stage(name="残ったステージ")
-        replacement = make_workflow(
-            workflow_id=original.id,
-            name=original.name,
-            stages=[replacement_stage],
-            transitions=[],
-            entry_stage_id=replacement_stage.id,
-        )
-        async with session_factory() as session, session.begin():
-            await SqliteWorkflowRepository(session).save(replacement)
-
-        # Side tables must show the new state, not the merged old + new.
-        async with session_factory() as session:
-            stage_rows = list(
-                (
-                    await session.execute(
-                        select(WorkflowStageRow).where(WorkflowStageRow.workflow_id == original.id)
-                    )
-                ).scalars()
-            )
-        assert len(stage_rows) == 1
-        assert stage_rows[0].name == "残ったステージ"
-
-
-# ---------------------------------------------------------------------------
-# §確定 B: 5-step SQL order (TC-IT-WFR-010)
-# ---------------------------------------------------------------------------
-class TestSaveSqlOrder:
-    """TC-IT-WFR-010: ``save`` issues SQL in the §確定 B 5-step order.
-
-    We attach a ``before_cursor_execute`` listener on the **sync**
-    engine so we observe the actual SQL strings the dialect emits. The
-    listener appends each statement to a captured list; we then assert
-    the prefix sequence matches the design's 5 steps. The dispatcher /
-    ORM may issue extra SAVEPOINT / BEGIN statements which we filter
-    out — the contract is on the *DML* prefix.
-
-    Same harness as empire-repository TC-IT-EMR-011; the next 5
-    Repository PRs should re-use this template.
-    """
-
-    async def test_save_emits_upsert_then_delete_insert_pairs(
-        self,
-        session_factory: async_sessionmaker[AsyncSession],
-        app_engine: AsyncEngine,
-    ) -> None:
-        """TC-IT-WFR-010: 5-step DML order matches §確定 B.
-
-        workflows UPSERT → workflow_stages DEL+INS → workflow_transitions DEL+INS.
-        """
-        captured: list[str] = []
-
-        def _on_execute(
-            _conn: object,
-            _cursor: object,
-            statement: str,
-            _params: object,
-            _context: object,
-            _executemany: bool,
-        ) -> None:
-            captured.append(statement.strip())
-
-        sync_engine = app_engine.sync_engine
-        event.listen(sync_engine, "before_cursor_execute", _on_execute)
-        try:
-            # V-model payload exercises 13 stages + 15 transitions —
-            # the busiest possible ``save()`` shape and the right one
-            # for SQL-order observation.
-            from bakufu.domain.workflow import Workflow
-
-            workflow = Workflow.from_dict(build_v_model_payload())
-            async with session_factory() as session, session.begin():
-                await SqliteWorkflowRepository(session).save(workflow)
-        finally:
-            event.remove(sync_engine, "before_cursor_execute", _on_execute)
-
-        # Filter to the 5 DML statements we care about (BEGIN /
-        # SAVEPOINT / RELEASE / COMMIT noise removed).
-        dml = [
-            s
-            for s in captured
-            if any(
-                s.upper().startswith(prefix)
-                for prefix in (
-                    "INSERT INTO WORKFLOWS",
-                    "DELETE FROM WORKFLOW_",
-                    "INSERT INTO WORKFLOW_",
-                )
-            )
-        ]
-        # Step 1 (UPSERT workflows) → Step 2 (DELETE workflow_stages) →
-        # Step 3 (INSERT workflow_stages) → Step 4 (DELETE
-        # workflow_transitions) → Step 5 (INSERT workflow_transitions).
-        assert len(dml) >= 5, (
-            f"[FAIL] save emitted only {len(dml)} DML statements; expected ≥5.\n"
-            f"Next: verify save() executes the §確定 B 5-step sequence. "
-            f"Captured DML: {dml}"
-        )
-        assert dml[0].upper().startswith("INSERT INTO WORKFLOWS")
-        assert dml[1].upper().startswith("DELETE FROM WORKFLOW_STAGES")
-        assert dml[2].upper().startswith("INSERT INTO WORKFLOW_STAGES")
-        assert dml[3].upper().startswith("DELETE FROM WORKFLOW_TRANSITIONS")
-        assert dml[4].upper().startswith("INSERT INTO WORKFLOW_TRANSITIONS")
 
 
 # ---------------------------------------------------------------------------
@@ -428,75 +294,3 @@ class TestTxBoundaryRespectedByRepository:
             "Next: SqliteWorkflowRepository.save() must not call "
             "session.commit() per §確定 B Tx 境界責務分離."
         )
-
-
-# ---------------------------------------------------------------------------
-# Smoke test: an unknown workflow_id never collides with an existing row
-# ---------------------------------------------------------------------------
-class TestSaveDistinctWorkflowsAreIndependent:
-    """Side-effect isolation between Workflows."""
-
-    async def test_save_one_does_not_disturb_another(
-        self,
-        session_factory: async_sessionmaker[AsyncSession],
-    ) -> None:
-        """Saving Workflow B must not delete Workflow A's stages.
-
-        The ``DELETE WHERE workflow_id = ?`` step in §確定 B is
-        scoped to the workflow_id under save; a poorly-written
-        Repository that issued an un-scoped DELETE would corrupt every
-        other Workflow in the DB. We assert the scoping with a
-        before / after snapshot.
-        """
-        workflow_a = make_workflow()
-        workflow_b = make_workflow()
-        # Distinct ids — sanity.
-        assert workflow_a.id != workflow_b.id
-
-        async with session_factory() as session, session.begin():
-            await SqliteWorkflowRepository(session).save(workflow_a)
-
-        # Save B → A must remain untouched.
-        async with session_factory() as session, session.begin():
-            await SqliteWorkflowRepository(session).save(workflow_b)
-
-        async with session_factory() as session:
-            a_rows = list(
-                (
-                    await session.execute(
-                        select(WorkflowStageRow).where(
-                            WorkflowStageRow.workflow_id == workflow_a.id
-                        )
-                    )
-                ).scalars()
-            )
-            b_rows = list(
-                (
-                    await session.execute(
-                        select(WorkflowStageRow).where(
-                            WorkflowStageRow.workflow_id == workflow_b.id
-                        )
-                    )
-                ).scalars()
-            )
-
-        assert len(a_rows) == 1
-        assert len(b_rows) == 1
-
-        # Sanity: the two Workflows did not share stage rows.
-        a_stage_ids = {row.stage_id for row in a_rows}
-        b_stage_ids = {row.stage_id for row in b_rows}
-        assert a_stage_ids.isdisjoint(b_stage_ids)
-
-    async def test_unknown_workflow_id_returns_none_after_other_saves(
-        self,
-        session_factory: async_sessionmaker[AsyncSession],
-    ) -> None:
-        """find_by_id of an unknown id still returns None even when DB is non-empty."""
-        async with session_factory() as session, session.begin():
-            await SqliteWorkflowRepository(session).save(make_workflow())
-
-        unknown_id = uuid4()
-        async with session_factory() as session:
-            fetched = await SqliteWorkflowRepository(session).find_by_id(unknown_id)
-        assert fetched is None

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_workflow_repository/test_save_semantics.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_workflow_repository/test_save_semantics.py
@@ -1,0 +1,502 @@
+"""Workflow Repository: save() semantics — delete-then-insert + Tx boundary + roles_csv.
+
+TC-IT-WFR-009 / 010 / 011 / 012 / 015 / 016 — the §確定 B / G / J
+contracts that back the ``save()`` flow + round-trip equality + Tx
+boundary, plus the §確定 G **sorted CSV determinism** guarantee that
+makes the same ``frozenset[Role]`` produce byte-identical
+``roles_csv`` output regardless of insertion order.
+
+Per ``docs/features/workflow-repository/test-design.md``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+import pytest
+from bakufu.domain.value_objects import Role
+from bakufu.infrastructure.persistence.sqlite.repositories.workflow_repository import (
+    SqliteWorkflowRepository,
+)
+from bakufu.infrastructure.persistence.sqlite.tables.workflow_stages import (
+    WorkflowStageRow,
+)
+from sqlalchemy import event, select, text
+
+from tests.factories.workflow import (
+    build_v_model_payload,
+    make_stage,
+    make_transition,
+    make_workflow,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# §確定 B: delete-then-insert replacement semantics (TC-IT-WFR-009)
+# ---------------------------------------------------------------------------
+class TestSaveDeleteThenInsert:
+    """TC-IT-WFR-009: ``save`` replaces side-table rows wholesale (§確定 B)."""
+
+    async def test_save_replaces_stage_rows(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """TC-IT-WFR-009: 3 stages → 1 stage is reflected as 1 row in workflow_stages.
+
+        We construct a fresh single-stage Workflow with the **same
+        workflow_id** and re-save. The §確定 B contract says the side
+        tables must end up reflecting only the new state; old stages
+        must not survive as residue.
+        """
+        stage_a = make_stage(name="A")
+        stage_b = make_stage(name="B")
+        stage_c = make_stage(name="C")
+        transition_ab = make_transition(from_stage_id=stage_a.id, to_stage_id=stage_b.id)
+        transition_bc = make_transition(from_stage_id=stage_b.id, to_stage_id=stage_c.id)
+        original = make_workflow(
+            stages=[stage_a, stage_b, stage_c],
+            transitions=[transition_ab, transition_bc],
+            entry_stage_id=stage_a.id,
+        )
+        async with session_factory() as session, session.begin():
+            await SqliteWorkflowRepository(session).save(original)
+
+        # Build a new Workflow with the same id but only 1 stage.
+        replacement_stage = make_stage(name="残ったステージ")
+        replacement = make_workflow(
+            workflow_id=original.id,
+            name=original.name,
+            stages=[replacement_stage],
+            transitions=[],
+            entry_stage_id=replacement_stage.id,
+        )
+        async with session_factory() as session, session.begin():
+            await SqliteWorkflowRepository(session).save(replacement)
+
+        # Side tables must show the new state, not the merged old + new.
+        async with session_factory() as session:
+            stage_rows = list(
+                (
+                    await session.execute(
+                        select(WorkflowStageRow).where(WorkflowStageRow.workflow_id == original.id)
+                    )
+                ).scalars()
+            )
+        assert len(stage_rows) == 1
+        assert stage_rows[0].name == "残ったステージ"
+
+
+# ---------------------------------------------------------------------------
+# §確定 B: 5-step SQL order (TC-IT-WFR-010)
+# ---------------------------------------------------------------------------
+class TestSaveSqlOrder:
+    """TC-IT-WFR-010: ``save`` issues SQL in the §確定 B 5-step order.
+
+    We attach a ``before_cursor_execute`` listener on the **sync**
+    engine so we observe the actual SQL strings the dialect emits. The
+    listener appends each statement to a captured list; we then assert
+    the prefix sequence matches the design's 5 steps. The dispatcher /
+    ORM may issue extra SAVEPOINT / BEGIN statements which we filter
+    out — the contract is on the *DML* prefix.
+
+    Same harness as empire-repository TC-IT-EMR-011; the next 5
+    Repository PRs should re-use this template.
+    """
+
+    async def test_save_emits_upsert_then_delete_insert_pairs(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        app_engine: AsyncEngine,
+    ) -> None:
+        """TC-IT-WFR-010: 5-step DML order matches §確定 B.
+
+        workflows UPSERT → workflow_stages DEL+INS → workflow_transitions DEL+INS.
+        """
+        captured: list[str] = []
+
+        def _on_execute(
+            _conn: object,
+            _cursor: object,
+            statement: str,
+            _params: object,
+            _context: object,
+            _executemany: bool,
+        ) -> None:
+            captured.append(statement.strip())
+
+        sync_engine = app_engine.sync_engine
+        event.listen(sync_engine, "before_cursor_execute", _on_execute)
+        try:
+            # V-model payload exercises 13 stages + 15 transitions —
+            # the busiest possible ``save()`` shape and the right one
+            # for SQL-order observation.
+            from bakufu.domain.workflow import Workflow
+
+            workflow = Workflow.from_dict(build_v_model_payload())
+            async with session_factory() as session, session.begin():
+                await SqliteWorkflowRepository(session).save(workflow)
+        finally:
+            event.remove(sync_engine, "before_cursor_execute", _on_execute)
+
+        # Filter to the 5 DML statements we care about (BEGIN /
+        # SAVEPOINT / RELEASE / COMMIT noise removed).
+        dml = [
+            s
+            for s in captured
+            if any(
+                s.upper().startswith(prefix)
+                for prefix in (
+                    "INSERT INTO WORKFLOWS",
+                    "DELETE FROM WORKFLOW_",
+                    "INSERT INTO WORKFLOW_",
+                )
+            )
+        ]
+        # Step 1 (UPSERT workflows) → Step 2 (DELETE workflow_stages) →
+        # Step 3 (INSERT workflow_stages) → Step 4 (DELETE
+        # workflow_transitions) → Step 5 (INSERT workflow_transitions).
+        assert len(dml) >= 5, (
+            f"[FAIL] save emitted only {len(dml)} DML statements; expected ≥5.\n"
+            f"Next: verify save() executes the §確定 B 5-step sequence. "
+            f"Captured DML: {dml}"
+        )
+        assert dml[0].upper().startswith("INSERT INTO WORKFLOWS")
+        assert dml[1].upper().startswith("DELETE FROM WORKFLOW_STAGES")
+        assert dml[2].upper().startswith("INSERT INTO WORKFLOW_STAGES")
+        assert dml[3].upper().startswith("DELETE FROM WORKFLOW_TRANSITIONS")
+        assert dml[4].upper().startswith("INSERT INTO WORKFLOW_TRANSITIONS")
+
+
+# ---------------------------------------------------------------------------
+# §確定 G: roles_csv sorted CSV determinism (TC-IT-WFR-011 / 012)
+# ---------------------------------------------------------------------------
+class TestRolesCsvSortedDeterminism:
+    """TC-IT-WFR-011 / 012: ``roles_csv`` is sorted; equal frozensets → equal CSV.
+
+    §確定 G freezes "sorted CSV" specifically because Python
+    ``frozenset`` iteration order is implementation-defined. Without
+    sorting, two save() calls of the same Workflow could produce
+    different ``roles_csv`` byte sequences and trigger spurious
+    delete-then-insert diff noise (the row would *look* changed even
+    though the domain value is identical).
+
+    We exercise:
+
+    1. **Round-trip restore** — frozenset → CSV → frozenset preserves
+       the role set (no roles dropped, no extras introduced).
+    2. **Byte-determinism** — two Workflows whose Stage's
+       ``required_role`` was constructed with **different insertion
+       order** (e.g. ``frozenset({DEVELOPER, REVIEWER})`` vs.
+       ``frozenset({REVIEWER, DEVELOPER})``) produce byte-identical
+       ``roles_csv`` rows in DB.
+    """
+
+    async def test_required_role_round_trips_via_roles_csv(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """TC-IT-WFR-011: ``frozenset[Role]`` survives the CSV round-trip."""
+        roles = frozenset({Role.DEVELOPER, Role.TESTER, Role.REVIEWER})
+        stage = make_stage(required_role=roles)
+        workflow = make_workflow(stages=[stage], entry_stage_id=stage.id)
+
+        async with session_factory() as session, session.begin():
+            await SqliteWorkflowRepository(session).save(workflow)
+
+        async with session_factory() as session:
+            restored = await SqliteWorkflowRepository(session).find_by_id(workflow.id)
+
+        assert restored is not None
+        assert len(restored.stages) == 1
+        assert restored.stages[0].required_role == roles
+        assert isinstance(restored.stages[0].required_role, frozenset)
+
+    async def test_same_role_set_yields_byte_identical_csv(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """TC-IT-WFR-012: Same ``frozenset`` produces byte-identical ``roles_csv``.
+
+        Build two stages whose ``required_role`` was constructed from
+        differently-ordered iterables but yield the same ``frozenset``.
+        The persisted ``roles_csv`` strings must match byte-for-byte —
+        otherwise delete-then-insert would re-write the same row over
+        and over (diff noise) on every save.
+        """
+        roles_forward = frozenset({Role.DEVELOPER, Role.REVIEWER, Role.TESTER})
+        roles_reverse = frozenset([Role.TESTER, Role.REVIEWER, Role.DEVELOPER])
+        # frozenset equality is set equality — sanity check our setup.
+        assert roles_forward == roles_reverse
+
+        stage_a = make_stage(required_role=roles_forward)
+        stage_b = make_stage(required_role=roles_reverse)
+        workflow_a = make_workflow(stages=[stage_a], entry_stage_id=stage_a.id)
+        workflow_b = make_workflow(stages=[stage_b], entry_stage_id=stage_b.id)
+
+        async with session_factory() as session, session.begin():
+            await SqliteWorkflowRepository(session).save(workflow_a)
+            await SqliteWorkflowRepository(session).save(workflow_b)
+
+        # Raw-SQL fetch of the two ``roles_csv`` cells; SQLAlchemy
+        # would hide the literal byte content behind type decorators
+        # (it doesn't here, but the explicit raw form documents the
+        # intent for follow-up Repository PRs).
+        async with session_factory() as session:
+            stmt = text(
+                "SELECT roles_csv FROM workflow_stages "
+                "WHERE workflow_id IN (:wf_a, :wf_b) ORDER BY workflow_id"
+            )
+            result = await session.execute(
+                stmt,
+                {"wf_a": workflow_a.id.hex, "wf_b": workflow_b.id.hex},
+            )
+            csv_values = sorted(row[0] for row in result)
+
+        assert len(csv_values) == 2
+        assert csv_values[0] == csv_values[1], (
+            f"[FAIL] sorted-CSV determinism violated: {csv_values[0]!r} != {csv_values[1]!r}.\n"
+            f"Next: verify _to_row uses ``sorted(role.value for role in stage.required_role)`` "
+            f"per detailed-design.md §確定 G."
+        )
+
+
+# ---------------------------------------------------------------------------
+# §確定 C: round-trip structural equality (TC-IT-WFR-015)
+# ---------------------------------------------------------------------------
+class TestRoundTripStructuralEquality:
+    """TC-IT-WFR-015: save → find_by_id round-trip preserves Workflow identity.
+
+    The Workflow Repository inherits empire-repository's ``ORDER BY
+    stage_id`` / ``ORDER BY transition_id`` contract from PR #1
+    (BUG-EMR-001 lesson applied at design time, not after the fact).
+    We sort the *expected* lists by the same key the Repository
+    sorted on so list-order equality is the contract.
+
+    We deliberately avoid ``EXTERNAL_REVIEW`` stages in this round-trip
+    test because §確定 H §不可逆性 makes ``find_by_id`` raise on those;
+    the irreversibility is verified separately in
+    :mod:`...test_masking`.
+    """
+
+    async def test_multi_stage_workflow_round_trip(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """TC-IT-WFR-015: 3 stages + 2 transitions round-trip with list-order equality."""
+        stage_a = make_stage(name="A")
+        stage_b = make_stage(name="B")
+        stage_c = make_stage(name="C")
+        transition_ab = make_transition(from_stage_id=stage_a.id, to_stage_id=stage_b.id)
+        transition_bc = make_transition(from_stage_id=stage_b.id, to_stage_id=stage_c.id)
+        workflow = make_workflow(
+            stages=[stage_a, stage_b, stage_c],
+            transitions=[transition_ab, transition_bc],
+            entry_stage_id=stage_a.id,
+        )
+
+        async with session_factory() as session, session.begin():
+            await SqliteWorkflowRepository(session).save(workflow)
+
+        async with session_factory() as session:
+            restored = await SqliteWorkflowRepository(session).find_by_id(workflow.id)
+
+        assert restored is not None
+        assert restored.id == workflow.id
+        assert restored.name == workflow.name
+        assert restored.entry_stage_id == workflow.entry_stage_id
+        # ORDER BY stage_id / transition_id 物理保証: restored side-table
+        # lists are deterministic, so list-order equality is the
+        # contract.
+        assert restored.stages == sorted(workflow.stages, key=lambda s: s.id)
+        assert restored.transitions == sorted(workflow.transitions, key=lambda t: t.id)
+
+    async def test_single_stage_workflow_round_trip(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """TC-IT-WFR-015: a single-stage Workflow (entry == sink) round-trips with full ``==``."""
+        workflow = make_workflow()  # default = 1 WORK stage, 0 transitions
+        async with session_factory() as session, session.begin():
+            await SqliteWorkflowRepository(session).save(workflow)
+
+        async with session_factory() as session:
+            restored = await SqliteWorkflowRepository(session).find_by_id(workflow.id)
+        assert restored is not None
+        # No list-order ambiguity — full ``==`` is fine.
+        assert restored == workflow
+
+
+# ---------------------------------------------------------------------------
+# §確定 B: Tx boundary responsibility separation (TC-IT-WFR-016)
+# ---------------------------------------------------------------------------
+class TestTxBoundaryRespectedByRepository:
+    """TC-IT-WFR-016: Repository never calls commit / rollback (§確定 B)."""
+
+    async def test_commit_path_persists_via_outer_block(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """TC-IT-WFR-016 (commit): outer ``async with session.begin()`` commits the save."""
+        workflow = make_workflow()
+        async with session_factory() as session, session.begin():
+            await SqliteWorkflowRepository(session).save(workflow)
+
+        async with session_factory() as session:
+            fetched = await SqliteWorkflowRepository(session).find_by_id(workflow.id)
+        assert fetched is not None
+
+    async def test_rollback_path_drops_save_atomically(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """TC-IT-WFR-016 (rollback): an exception inside ``begin()`` rolls back the save.
+
+        The Workflow row + its (potentially non-empty) stages /
+        transitions all participate in the same caller-managed
+        transaction. A single uncaught exception inside the ``begin()``
+        block must purge **all** of them — Repository did not commit
+        anything itself.
+        """
+
+        class _BoomError(Exception):
+            """Synthetic exception used to drive the rollback path."""
+
+        # Use a 3-stage Workflow so rollback has stages + transitions
+        # to demonstrably purge alongside the workflow row.
+        stage_a = make_stage(name="A")
+        stage_b = make_stage(name="B")
+        transition_ab = make_transition(from_stage_id=stage_a.id, to_stage_id=stage_b.id)
+        workflow = make_workflow(
+            stages=[stage_a, stage_b],
+            transitions=[transition_ab],
+            entry_stage_id=stage_a.id,
+        )
+
+        with pytest.raises(_BoomError):
+            async with session_factory() as session, session.begin():
+                await SqliteWorkflowRepository(session).save(workflow)
+                raise _BoomError
+
+        async with session_factory() as session:
+            fetched = await SqliteWorkflowRepository(session).find_by_id(workflow.id)
+        # Rollback must have been atomic — no row survives.
+        assert fetched is None
+
+        # Side tables also empty — the §確定 B contract is that the
+        # 5-step sequence is **one** logical operation under the
+        # caller's UoW, not five separate persistences.
+        async with session_factory() as session:
+            stage_count = (
+                await session.execute(
+                    select(WorkflowStageRow).where(WorkflowStageRow.workflow_id == workflow.id)
+                )
+            ).all()
+        assert stage_count == []
+
+    async def test_repository_does_not_commit_implicitly(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """TC-IT-WFR-016 補強: ``save`` outside ``begin()`` does not auto-commit.
+
+        If the Repository contained a stray ``await session.commit()``,
+        a save without ``async with session.begin()`` would still
+        persist — and a subsequent fresh-session read would see it.
+        SQLAlchemy AsyncSession default is autobegin=True with a
+        transactional SELECT, so we open a session and call save
+        directly without an outer ``begin()`` block, then expire +
+        re-read in a fresh session. The Repository's contract is that
+        the row does **not** persist, because no commit fired.
+        """
+        workflow = make_workflow()
+        async with session_factory() as session:
+            await SqliteWorkflowRepository(session).save(workflow)
+            # Intentionally exit without ``commit()`` — AsyncSession's
+            # ``__aexit__`` will rollback any in-flight transaction.
+
+        async with session_factory() as session:
+            fetched = await SqliteWorkflowRepository(session).find_by_id(workflow.id)
+        # The Repository must NOT have committed implicitly.
+        assert fetched is None, (
+            "[FAIL] Workflow row persisted without an outer commit.\n"
+            "Next: SqliteWorkflowRepository.save() must not call "
+            "session.commit() per §確定 B Tx 境界責務分離."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Smoke test: an unknown workflow_id never collides with an existing row
+# ---------------------------------------------------------------------------
+class TestSaveDistinctWorkflowsAreIndependent:
+    """Side-effect isolation between Workflows."""
+
+    async def test_save_one_does_not_disturb_another(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """Saving Workflow B must not delete Workflow A's stages.
+
+        The ``DELETE WHERE workflow_id = ?`` step in §確定 B is
+        scoped to the workflow_id under save; a poorly-written
+        Repository that issued an un-scoped DELETE would corrupt every
+        other Workflow in the DB. We assert the scoping with a
+        before / after snapshot.
+        """
+        workflow_a = make_workflow()
+        workflow_b = make_workflow()
+        # Distinct ids — sanity.
+        assert workflow_a.id != workflow_b.id
+
+        async with session_factory() as session, session.begin():
+            await SqliteWorkflowRepository(session).save(workflow_a)
+
+        # Save B → A must remain untouched.
+        async with session_factory() as session, session.begin():
+            await SqliteWorkflowRepository(session).save(workflow_b)
+
+        async with session_factory() as session:
+            a_rows = list(
+                (
+                    await session.execute(
+                        select(WorkflowStageRow).where(
+                            WorkflowStageRow.workflow_id == workflow_a.id
+                        )
+                    )
+                ).scalars()
+            )
+            b_rows = list(
+                (
+                    await session.execute(
+                        select(WorkflowStageRow).where(
+                            WorkflowStageRow.workflow_id == workflow_b.id
+                        )
+                    )
+                ).scalars()
+            )
+
+        assert len(a_rows) == 1
+        assert len(b_rows) == 1
+
+        # Sanity: the two Workflows did not share stage rows.
+        a_stage_ids = {row.stage_id for row in a_rows}
+        b_stage_ids = {row.stage_id for row in b_rows}
+        assert a_stage_ids.isdisjoint(b_stage_ids)
+
+    async def test_unknown_workflow_id_returns_none_after_other_saves(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """find_by_id of an unknown id still returns None even when DB is non-empty."""
+        async with session_factory() as session, session.begin():
+            await SqliteWorkflowRepository(session).save(make_workflow())
+
+        unknown_id = uuid4()
+        async with session_factory() as session:
+            fetched = await SqliteWorkflowRepository(session).find_by_id(unknown_id)
+        assert fetched is None

--- a/backend/tests/infrastructure/persistence/sqlite/test_alembic_workflow.py
+++ b/backend/tests/infrastructure/persistence/sqlite/test_alembic_workflow.py
@@ -1,0 +1,199 @@
+"""Alembic 3rd revision tests (TC-IT-WFR-020 / 021 / 022).
+
+Per ``docs/features/workflow-repository/test-design.md``. Real Alembic
+upgrade / downgrade against a real SQLite file, plus a chain integrity
+check that makes sure
+``0001_init`` → ``0002_empire_aggregate`` → ``0003_workflow_aggregate``
+stays linear (no head fork).
+
+The conftest from ``tests/infrastructure/`` patches Alembic's
+``fileConfig`` so log capture survives migration; same workaround the
+M2 persistence-foundation tests rely on.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+import pytest_asyncio
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+from bakufu.infrastructure.persistence.sqlite import engine as engine_mod
+from bakufu.infrastructure.persistence.sqlite.migrations import run_upgrade_head
+from sqlalchemy import text
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncEngine
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+@pytest_asyncio.fixture
+async def empty_engine(tmp_path: Path) -> AsyncIterator[AsyncEngine]:
+    """Bring up a fresh app engine without running any migrations."""
+    url = f"sqlite+aiosqlite:///{tmp_path / 'bakufu.db'}"
+    engine = engine_mod.create_engine(url)
+    try:
+        yield engine
+    finally:
+        await engine.dispose()
+
+
+def _alembic_config() -> Config:
+    """Resolve the bakufu Alembic config for ScriptDirectory inspection."""
+    # Same path the migrations module uses internally; we duplicate the
+    # walk so this test does not import private helpers.
+    backend_root = Path(__file__).resolve().parents[4]
+    cfg = Config(str(backend_root / "alembic.ini"))
+    cfg.set_main_option("script_location", str(backend_root / "alembic"))
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-WFR-020: 3rd revision applies the 3 Workflow tables + UNIQUE indexes
+# ---------------------------------------------------------------------------
+class TestThirdRevisionApplied:
+    """TC-IT-WFR-020: ``alembic upgrade head`` adds the Workflow schema."""
+
+    async def test_three_workflow_tables_present_after_upgrade(
+        self,
+        empty_engine: AsyncEngine,
+    ) -> None:
+        """TC-IT-WFR-020: workflows / workflow_stages / workflow_transitions exist."""
+        await run_upgrade_head(empty_engine)
+        async with empty_engine.connect() as conn:
+            result = await conn.execute(text("SELECT name FROM sqlite_master WHERE type='table'"))
+            tables = {row[0] for row in result}
+        assert {"workflows", "workflow_stages", "workflow_transitions"}.issubset(tables)
+
+    async def test_unique_indexes_present_after_upgrade(
+        self,
+        empty_engine: AsyncEngine,
+    ) -> None:
+        """TC-IT-WFR-020: UNIQUE indexes for the two side tables.
+
+        ``workflow_stages``: UNIQUE ``(workflow_id, stage_id)``.
+        ``workflow_transitions``: UNIQUE ``(workflow_id, transition_id)``.
+
+        SQLite emits an ``sqlite_autoindex_*`` for every UNIQUE
+        constraint declared at table creation. A ``CREATE INDEX``
+        named index also lands here; we accept either shape because
+        the Alembic 0003 revision uses the inline UNIQUE constraint
+        form (``uq_workflow_stages_pair`` / ``uq_workflow_transitions_pair``).
+        """
+        await run_upgrade_head(empty_engine)
+        async with empty_engine.connect() as conn:
+            result = await conn.execute(
+                text("SELECT name, tbl_name FROM sqlite_master WHERE type='index'")
+            )
+            rows = list(result)
+        stage_indexes = [name for name, tbl in rows if tbl == "workflow_stages"]
+        transition_indexes = [name for name, tbl in rows if tbl == "workflow_transitions"]
+        assert stage_indexes, "workflow_stages must declare at least one index"
+        assert transition_indexes, "workflow_transitions must declare at least one index"
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-WFR-021: upgrade / downgrade are idempotent
+# ---------------------------------------------------------------------------
+class TestUpgradeDowngradeIdempotent:
+    """TC-IT-WFR-021: Alembic up + down + up again leaves the schema in the head state."""
+
+    async def test_full_cycle_leaves_workflow_tables_present(
+        self,
+        empty_engine: AsyncEngine,
+    ) -> None:
+        """TC-IT-WFR-021: upgrade head → downgrade base → upgrade head again."""
+        # Up.
+        await run_upgrade_head(empty_engine)
+        # Down to base via Alembic command (synchronous within asyncio).
+        from alembic import command  # local import to avoid global side effects
+
+        cfg = _alembic_config()
+        url = str(empty_engine.url)
+        cfg.set_main_option("sqlalchemy.url", url)
+
+        def _do_downgrade() -> None:
+            command.downgrade(cfg, "base")
+
+        await asyncio.to_thread(_do_downgrade)
+
+        # Schema is empty now — assert the Workflow tables are gone.
+        async with empty_engine.connect() as conn:
+            result = await conn.execute(text("SELECT name FROM sqlite_master WHERE type='table'"))
+            tables = {row[0] for row in result}
+        assert tables.isdisjoint({"workflows", "workflow_stages", "workflow_transitions"})
+
+        # Up again — back to head.
+        await run_upgrade_head(empty_engine)
+        async with empty_engine.connect() as conn:
+            result = await conn.execute(text("SELECT name FROM sqlite_master WHERE type='table'"))
+            tables = {row[0] for row in result}
+        assert {"workflows", "workflow_stages", "workflow_transitions"}.issubset(tables)
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-WFR-022: revision chain is linear (no head fork)
+# ---------------------------------------------------------------------------
+class TestRevisionChainLinear:
+    """TC-IT-WFR-022: revision chain is linear (single head).
+
+    ``0001_init`` → ``0002_empire_aggregate`` → ``0003_workflow_aggregate``.
+    """
+
+    async def test_alembic_heads_returns_single_revision(self) -> None:
+        """TC-IT-WFR-022: ``ScriptDirectory.get_heads()`` returns exactly one revision."""
+        cfg = _alembic_config()
+        script = ScriptDirectory.from_config(cfg)
+        heads = script.get_heads()
+        assert len(heads) == 1, (
+            f"Alembic head must be linear; got branched heads {heads}. "
+            f"Each Aggregate Repository PR appends a single revision; "
+            f"branching breaks ``alembic upgrade head`` across CI runners."
+        )
+
+    async def test_0003_revision_has_correct_down_revision(self) -> None:
+        """TC-IT-WFR-022: ``0003_workflow_aggregate.down_revision == "0002_empire_aggregate"``."""
+        cfg = _alembic_config()
+        script = ScriptDirectory.from_config(cfg)
+        rev = script.get_revision("0003_workflow_aggregate")
+        assert rev is not None
+        assert rev.down_revision == "0002_empire_aggregate"
+
+    async def test_chain_walks_from_0003_back_to_base(self) -> None:
+        """TC-IT-WFR-022 補強: walking ``down_revision`` reaches base in 3 hops.
+
+        Catches a future PR that accidentally registers ``0003`` with
+        a ``down_revision = None`` (which would create a branch off
+        base) — the heads() check would still pass with branching, so
+        we walk the chain explicitly.
+        """
+        cfg = _alembic_config()
+        script = ScriptDirectory.from_config(cfg)
+        chain: list[str] = []
+        current_id: str | None = "0003_workflow_aggregate"
+        for _ in range(10):  # generous bound to avoid infinite loop on bad data
+            if current_id is None:
+                break
+            rev = script.get_revision(current_id)
+            assert rev is not None, f"Revision {current_id!r} not found"
+            chain.append(rev.revision)
+            down = rev.down_revision
+            if isinstance(down, tuple | list):
+                pytest.fail(f"Revision {rev.revision!r} has multiple down_revisions {down}")
+            # ``down`` is now narrowed to ``str | None`` by the guard above.
+            current_id = down  # pyright: ignore[reportAssignmentType]
+
+        # 0003 → 0002 → 0001 → base (None)
+        assert chain == [
+            "0003_workflow_aggregate",
+            "0002_empire_aggregate",
+            "0001_init",
+        ], f"Unexpected revision chain: {chain}"

--- a/docs/features/workflow-repository/test-design.md
+++ b/docs/features/workflow-repository/test-design.md
@@ -1,0 +1,292 @@
+# テスト設計書
+
+<!-- feature: workflow-repository -->
+<!-- 配置先: docs/features/workflow-repository/test-design.md -->
+<!-- 対象範囲: REQ-WFR-001〜005 / 受入基準 1〜15 / 詳細設計 確定 A〜J / Repository ポート + delete-then-insert + domain↔row 変換（§G/H/I）+ ORDER BY 規約 + CI 三層防衛 + partial-mask テンプレート -->
+
+本 feature は M2 Repository **2 番目の Aggregate Repository PR**であり、empire-repository（PR #25）が凍結したテンプレート（§確定 A〜F）を**完全継承**する。Workflow 固有の追加凍結条項は §確定 G（`roles_csv` sorted CSV）/ §確定 H（`notify_channels_json` MaskedJSONEncoded、不可逆性）/ §確定 I（`completion_policy_json` 平 JSONEncoded）/ §確定 J（`workflows.entry_stage_id` 非 FK 戦略）の 4 件。
+
+戦略ガイド §結合テスト方針「DB は実接続」「外部 API のみモック」に従い、本 feature のテストは:
+
+- **integration test 主導**: Alembic 3rd revision 適用 → AsyncSession で `find_by_id` / `count` / `save` の 3 メソッド契約検証（`tmp_path` で実 SQLite ファイル）。empire-repository の `app_engine` / `session_factory` fixture を再利用
+- **CI 三層防衛の partial-mask 拡張**: Layer 1（grep guard）+ Layer 2（arch test `_PARTIAL_MASK_TABLES`）+ Layer 3（storage.md）の 3 層が「`workflow_stages.notify_channels_json` のみマスキング、他カラムは対象外」を物理保証
+- **MaskedJSONEncoded 配線の物理確認**: 実 SQLite に対する raw SQL SELECT で `notify_channels_json` カラムの中身に `<REDACTED:DISCORD_WEBHOOK>` が含まれ、元の token が含まれないことを assert（Schneier 申し送り #6 実適用、§確定 H）
+- **§確定 H §不可逆性**: 保存後 `find_by_id` で `EXTERNAL_REVIEW` ステージ（notify_channels 必須）を含む Workflow を再構築すると `pydantic.ValidationError` が発生することを物理確認
+- **assumed mock 禁止規約**: `mock.return_value` インライン辞書は禁止、Workflow / Stage / Transition / NotifyChannel / CompletionPolicy は既存 `tests/factories/workflow.py`（workflow feature #16 で確立）から取得
+
+外部 I/O は SQLite + ファイルシステム + Alembic が本物。masking gateway（M2 永続化基盤の Layer 1〜3）は **本 feature が初の実適用**であり、`MaskedJSONEncoded.process_bind_param` フックを実 INSERT 経路で動作確認する。
+
+## テストマトリクス
+
+| 要件ID | 実装アーティファクト | テストケースID | テストレベル | 種別 | 受入基準 |
+|--------|-------------------|---------------|------------|------|---------|
+| REQ-WFR-001 | `WorkflowRepository(Protocol)` 定義 | TC-IT-WFR-001 | 結合 | 正常系 | 1 |
+| REQ-WFR-001 | `SqliteWorkflowRepository` の Protocol 充足 | TC-IT-WFR-002 | 結合 | 正常系 | 2 |
+| REQ-WFR-002 | `find_by_id(workflow_id)` 既存 Workflow 取得 | TC-IT-WFR-003 | 結合 | 正常系 | 3 |
+| REQ-WFR-002 | `find_by_id(unknown_id)` で None | TC-IT-WFR-004 | 結合 | 異常系 | 3 |
+| REQ-WFR-002（ORDER BY、§確定 G/H 規約 + BUG-EMR-001 継承） | `find_by_id` の `workflow_stages` SELECT に `ORDER BY stage_id` が含まれる | TC-IT-WFR-005 | 結合 | 正常系 | 4 |
+| REQ-WFR-002（ORDER BY） | `find_by_id` の `workflow_transitions` SELECT に `ORDER BY transition_id` が含まれる | TC-IT-WFR-006 | 結合 | 正常系 | 5 |
+| REQ-WFR-002（§確定 D 補強） | `count()` が SQL レベル `SELECT COUNT(*)` を発行 | TC-IT-WFR-007 | 結合 | 正常系 | 6 |
+| REQ-WFR-002（§確定 B） | `save(workflow)` 新規挿入で 3 テーブルに行が入る | TC-IT-WFR-008 | 結合 | 正常系 | 7 |
+| REQ-WFR-002（§確定 B、delete-then-insert） | `save(workflow)` 既存更新で stage / transition が delete-then-insert で全置換される | TC-IT-WFR-009 | 結合 | 正常系 | 7 |
+| REQ-WFR-002（§確定 B、5 段階 SQL 順序） | save 内で workflows UPSERT → workflow_stages DELETE → INSERT → workflow_transitions DELETE → INSERT の順序検証 | TC-IT-WFR-010 | 結合 | 正常系 | 7 |
+| REQ-WFR-002（§確定 G） | `Stage.required_role: frozenset[Role]` が `roles_csv` ソート済み CSV で永続化、`_from_row` で frozenset に復元 | TC-IT-WFR-011 | 結合 | 正常系 | 8 |
+| REQ-WFR-002（§確定 G、決定論化） | 異なる順序で生成された同一 frozenset が同一 `roles_csv` バイト列を生み、delete-then-insert で diff noise を出さない | TC-IT-WFR-012 | 結合 | 正常系 | 8 |
+| REQ-WFR-002（§確定 H、masking 配線） | `save(workflow)` 後の raw SQL SELECT で `notify_channels_json` 内に `<REDACTED:DISCORD_WEBHOOK>` が現れ、原 token が含まれない（Schneier #6 物理確認） | TC-IT-WFR-013 | 結合 | 正常系 | 9 |
+| REQ-WFR-002（§確定 H §不可逆性） | `EXTERNAL_REVIEW` を含む Workflow を save → find_by_id で `pydantic.ValidationError` raise（masked URL が G7 regex に合致せず） | TC-IT-WFR-014 | 結合 | 異常系 | 9 |
+| REQ-WFR-002（§確定 C、ラウンドトリップ） | notify_channels 不在の Workflow を `save(workflow) → find_by_id(workflow.id)` で `sorted(...)` 比較構造的等価 | TC-IT-WFR-015 | 結合 | 正常系 | 10 |
+| REQ-WFR-002（Tx 境界、§確定 B） | service 側 `async with session.begin()` で commit / rollback 両経路、Repository は明示的 commit/rollback しない | TC-IT-WFR-016 | 結合 | 正常系/異常系 | （責務境界） |
+| REQ-WFR-002（FK CASCADE） | `DELETE FROM workflows WHERE id=?` で workflow_stages / workflow_transitions が CASCADE 削除 | TC-IT-WFR-017 | 結合 | 正常系 | （データモデル） |
+| REQ-WFR-002（UNIQUE 制約） | `(workflow_id, stage_id)` / `(workflow_id, transition_id)` 重複 INSERT で `IntegrityError` | TC-IT-WFR-018 | 結合 | 異常系 | （データモデル） |
+| REQ-WFR-002（責務分離） | Repository はシングルトン強制せず、複数 Workflow を save 可能（`count()` は事実報告のみ） | TC-IT-WFR-019 | 結合 | 正常系 | （責務境界） |
+| REQ-WFR-003 | Alembic 0003 で 3 テーブル + UNIQUE 制約が追加 | TC-IT-WFR-020 | 結合 | 正常系 | 11 |
+| REQ-WFR-003 | `alembic upgrade head` ↔ `downgrade base` 双方向 idempotent | TC-IT-WFR-021 | 結合 | 正常系 | 11 |
+| REQ-WFR-003（chain 一直線、§確定 R1-C） | revision 0001 → 0002 → 0003 が一直線（CI 検査で head 分岐なし、`0003.down_revision == "0002_empire_aggregate"`） | TC-IT-WFR-022 | 結合 | 正常系 | 11 |
+| REQ-WFR-004（Layer 1 grep） | `scripts/ci/check_masking_columns.sh` で `workflow_stages.notify_channels_json` が `MaskedJSONEncoded` 必須を pass、他カラムは対象なしを pass | TC-CI-WFR-001 | CI script | 正常系 | 12 |
+| REQ-WFR-004（Layer 2 arch、partial-mask） | `tests/architecture/test_masking_columns.py` で `workflow_stages.notify_channels_json` の `column.type.__class__ is MaskedJSONEncoded` を assert、他カラムは Masked* 不在を assert | TC-IT-WFR-023 | 結合 | 正常系 | 13 |
+| REQ-WFR-005（storage.md 逆引き表） | §逆引き表に Workflow 3 行（partial-mask 1 + no-mask 2）が存在 | TC-DOC-WFR-001 | doc 検証 | 正常系 | （Layer 3） |
+| AC-14（依存方向） | `domain` 層から `application` / `infrastructure` への import がゼロ件 | （既存 CI script） | — | — | 14 |
+| AC-15（lint/typecheck/coverage） | `pyright --strict` / `ruff check` / coverage 90% | （CI ジョブ） | — | — | 15 |
+
+**マトリクス充足の証拠**:
+
+- REQ-WFR-001〜005 すべてに最低 1 件のテストケース
+- **delete-then-insert 5 段階順序（§確定 B）**: TC-IT-WFR-010 で実 SQLite に対し UPSERT → DELETE → INSERT × 2 の順序を物理確認（empire-repository の TC-IT-EMR-011 と同パターン）
+- **ORDER BY 規約（§確定 G/H 補強 + BUG-EMR-001 継承）**: TC-IT-WFR-005 / 006 で `ORDER BY stage_id` / `ORDER BY transition_id` の SQL ログ観測 + TC-IT-WFR-015 でリスト順序の構造的等価
+- **§確定 G（roles_csv 決定論化）**: TC-IT-WFR-011 で `frozenset[Role] → CSV → frozenset` ラウンドトリップ + TC-IT-WFR-012 で「異なる挿入順序で生成された同一 frozenset が同一バイト列」を物理確認
+- **§確定 H（notify_channels_json マスキング配線、masking gateway 実適用）**: TC-IT-WFR-013 で実 SQLite に対する raw SQL SELECT で `<REDACTED:DISCORD_WEBHOOK>` 出現 + 原 token 不在を 2 経路で同時 assert
+- **§確定 H §不可逆性**: TC-IT-WFR-014 で「masking 後 find_by_id が ValidationError を raise」契約を物理確認
+- **Tx 境界（§確定 B）**: TC-IT-WFR-016 で commit / rollback 両経路、Repository が明示的 commit/rollback しないことを assert
+- **DB 制約**: FK CASCADE（TC-IT-WFR-017）+ UNIQUE 制約（TC-IT-WFR-018）で Alembic 0003 DDL の正しさを物理確認
+- **CI 三層防衛 partial-mask 拡張（§確定 H + テンプレート責務）**: Layer 1 grep（TC-CI-WFR-001）+ Layer 2 arch（TC-IT-WFR-023、`_PARTIAL_MASK_TABLES` parametrize）+ Layer 3 storage.md（TC-DOC-WFR-001）の 3 層すべてで partial-mask の物理保証
+- 受入基準 1〜13 すべてに unit/integration ケース（14〜15 は CI ジョブ）
+- 確定 A〜F（empire-repo 継承）/ G〜J（Workflow 固有）すべてに証拠ケース
+- 孤児要件ゼロ
+
+## 外部 I/O 依存マップ
+
+本 feature は infrastructure 層の Repository 実装。empire-repository と同方針で本物の SQLite + 本物の Alembic + 本物の SQLAlchemy AsyncSession を使う。
+
+| 外部 I/O | 用途 | raw fixture | factory | characterization 状態 |
+|--------|-----|------------|---------|---------------------|
+| **SQLite (sqlite+aiosqlite)** | engine / session / 3 テーブル / Alembic migration | 不要（実 DB を `tmp_path` 配下の bakufu.db で起動、テストごとに使い捨て） | 不要 | **済（本物使用、persistence-foundation conftest.py の `app_engine` / `session_factory` fixture を再利用）** |
+| **ファイルシステム** | `BAKUFU_DATA_DIR` / `bakufu.db` / WAL/SHM | 不要（`pytest.tmp_path`） | 不要 | **済（本物使用）** |
+| **Alembic** | 0003 revision の `upgrade head` / `downgrade base` | 不要（本物の `alembic upgrade` を実 SQLite に対し実行） | 不要 | **済（本物使用、persistence-foundation の `run_upgrade_head` を再利用）** |
+| **SQLAlchemy 2.x AsyncSession** | UoW 境界 / Repository メソッド経由の SQL 発行 | 不要 | 不要 | **済（本物使用）** |
+| **MaskingGateway (`mask_in`)** | `MaskedJSONEncoded.process_bind_param` 経由で notify_channels_json をマスキング | 不要（実 init を `_initialize_masking` autouse fixture で実施） | 不要 | **済（本物使用、infrastructure/conftest.py で init）** |
+
+**factory（合成データ）の扱い**:
+
+| factory | 出力 | `_meta.synthetic` 付与 |
+|--------|-----|------------------|
+| `make_workflow`（既存、workflow feature #16 由来） | `Workflow`（valid デフォルト = 単一 WORK ステージ、entry == sink） | `True` |
+| `make_stage`（既存） | `Stage`（kind=WORK, role={DEVELOPER}、`EXTERNAL_REVIEW` 時は notify_channels 自動注入） | `True` |
+| `make_transition`（既存） | `Transition`（from / to 必須、condition=APPROVED デフォルト） | `True` |
+| `make_notify_channel`（既存） | `NotifyChannel`（DEFAULT_DISCORD_WEBHOOK = `https://discord.com/api/webhooks/.../SyntheticToken_-abcXYZ`） | `True` |
+| `make_completion_policy`（既存） | `CompletionPolicy`（kind=approved_by_reviewer, description="review approval"） | `True` |
+| `build_v_model_payload`（既存） | dict（13 ステージ + 15 transition、Workflow.from_dict 用） | — |
+
+`tests/factories/workflow.py` は workflow feature #16 で確立済み。本 PR では factory 追加なし（既存 5 関数 + 1 payload で full coverage）。
+
+**raw fixture / characterization は不要**: SQLite + SQLAlchemy + Alembic + MaskingGateway はすべて標準ライブラリ仕様 / 既存 Cuckoo セット内動作で固定、外部観測（実 DB ファイル）が真実源として常時使える。
+
+## E2E テストケース
+
+**該当なし** — 理由:
+
+- 本 feature は infrastructure 層単独で、CLI / HTTP API / UI のいずれの公開エントリポイントも持たない（[`requirements.md`](requirements.md) §画面・CLI 仕様 / §API 仕様 で「該当なし」と凍結）
+- Repository は内部 API（Python module-level の Protocol / Class）のみ提供
+- 戦略ガイド §E2E対象の判断「内部 API・ライブラリなどエンドユーザー操作がない場合は結合テストで代替可」に従い、E2E は本 feature 範囲外
+- 後続 `feature/workflow-application`（`WorkflowService.create() / get()` 等）/ `feature/admin-cli`（`bakufu admin workflow show`） / `feature/http-api`（Workflow CRUD）が公開 I/F を実装した時点で E2E を起票
+- 受入基準 1〜13 はすべて unit/integration テストで検証可能（14〜15 は CI ジョブ）
+
+| テストID | ペルソナ | シナリオ | 操作手順 | 期待結果 |
+|---------|---------|---------|---------|---------|
+| （N/A） | — | 該当なし — infrastructure 層のため公開 I/F なし | — | — |
+
+## 結合テストケース
+
+「Repository 契約 + 実 SQLite + 実 Alembic + 実 MaskingGateway」を contract testing する層。M2 永続化基盤の `app_engine` / `session_factory` fixture を再利用。
+
+### Protocol 定義 + 充足（受入基準 1, 2、§確定 A）
+
+| テストID | 対象モジュール連携 | 使用 fixture | 前提条件 | 操作 | 期待結果 |
+|---------|------------------|--------------|---------|------|---------|
+| TC-IT-WFR-001 | `WorkflowRepository(Protocol)` 定義 | — | `application/ports/workflow_repository.py` がインポート可能 | `from bakufu.application.ports.workflow_repository import WorkflowRepository` | Protocol が `find_by_id` / `count` / `save` の 3 メソッドを宣言、すべて `async def`。`@runtime_checkable` なし |
+| TC-IT-WFR-002 | `SqliteWorkflowRepository` の Protocol 充足 | `app_engine` + `session_factory` | engine + Alembic 適用済み | `repo: WorkflowRepository = SqliteWorkflowRepository(session)` で型代入が pyright で通る | pyright strict pass。さらに duck typing で `hasattr(repo, 'find_by_id') and hasattr(repo, 'count') and hasattr(repo, 'save')` 全 True |
+
+### 基本 CRUD（受入基準 3〜7）
+
+| テストID | 対象モジュール連携 | 使用 fixture | 前提条件 | 操作 | 期待結果 |
+|---------|------------------|--------------|---------|------|---------|
+| TC-IT-WFR-003 | `find_by_id(existing_workflow_id)` | `session_factory` + `make_workflow` | `save(workflow)` で 1 件保存済み | 同 session_factory で別 session を開き `find_by_id(workflow.id)` | 保存した Workflow と構造的等価な Workflow を返す（notify_channels 不在 Workflow なら `==` True） |
+| TC-IT-WFR-004 | `find_by_id(unknown_id)` | `session_factory` | DB 空 | `find_by_id(uuid4())` を呼ぶ | `None` を返す。例外を raise しない |
+| TC-IT-WFR-005 | `find_by_id` の `workflow_stages` SELECT に `ORDER BY stage_id` | `session_factory` + `before_cursor_execute` event listener | save 済み Workflow（複数ステージ） | `find_by_id(workflow.id)` を呼びつつ SQL ログを観測 | `SELECT ... FROM workflow_stages WHERE workflow_id = ? ORDER BY stage_id` が観測される |
+| TC-IT-WFR-006 | `find_by_id` の `workflow_transitions` SELECT に `ORDER BY transition_id` | 同上 | save 済み Workflow（複数 transition） | 同上 | `SELECT ... FROM workflow_transitions WHERE workflow_id = ? ORDER BY transition_id` が観測される |
+| TC-IT-WFR-007 | `count()` が SQL レベル `SELECT COUNT(*)` 発行 | `session_factory` + event listener | DB に複数 Workflow 保存済み | `count()` を呼びつつ SQL ログを観測 | `SELECT count(*) FROM workflows` が単独発行され、`SELECT id FROM workflows` のような全行ロード SQL は発行されない |
+
+### `save()` 基本（受入基準 7、§確定 B）
+
+| テストID | 対象モジュール連携 | 使用 fixture | 前提条件 | 操作 | 期待結果 |
+|---------|------------------|--------------|---------|------|---------|
+| TC-IT-WFR-008 | `save(workflow)` 新規挿入で 3 テーブルに行が入る | `session_factory` + V-model payload | rooms 0 件、stages 13 件 + transitions 15 件の Workflow（V-model） | `save(workflow)` 後、別 session で 3 テーブル直接 SELECT | `workflows` 1 行 + `workflow_stages` 13 行 + `workflow_transitions` 15 行が存在、各カラムが Workflow VO の値と一致 |
+| TC-IT-WFR-009 | `save(workflow)` 既存更新（delete-then-insert） | `session_factory` + `make_workflow` | 1 度 save 済みの Workflow（複数ステージ） | (1) Workflow を `add_stage` / `remove_stage` で更新、(2) 再度 `save(updated_workflow)` を呼ぶ | workflow_stages / workflow_transitions が **delete-then-insert** で全置換される。古い Stage / Transition は残らず、新 VO が SELECT で取得される |
+| TC-IT-WFR-010 | `save()` 内 SQL 発行順序（5 段階） | `session_factory` + V-model payload + `before_cursor_execute` event listener | save 1 度実施済 | 再 save 時の SQL 文を順序で観測 | 順序が §確定 B 通り: (1) UPSERT workflows、(2) DELETE workflow_stages WHERE workflow_id=?、(3) bulk INSERT workflow_stages、(4) DELETE workflow_transitions WHERE workflow_id=?、(5) bulk INSERT workflow_transitions |
+
+### §確定 G（roles_csv 決定論化、受入基準 8）
+
+| テストID | 対象モジュール連携 | 使用 fixture | 前提条件 | 操作 | 期待結果 |
+|---------|------------------|--------------|---------|------|---------|
+| TC-IT-WFR-011 | `frozenset[Role] → CSV → frozenset` ラウンドトリップ | `session_factory` + `make_stage(required_role=frozenset({...}))` | 複数 Role を持つステージ | `save → find_by_id → restored.stages[0].required_role` を抽出 | 元の `frozenset[Role]` と等価。途中の DB カラムは sorted CSV 文字列 |
+| TC-IT-WFR-012 | sorted CSV の決定論化 | `session_factory` + raw SQL SELECT | 同一 frozenset を異なる挿入順 `frozenset({A, B, C})` / `frozenset({C, B, A})` で 2 つの Workflow に save | raw SQL で `roles_csv` カラムを取得 | 両 Workflow の `roles_csv` が**バイト同一**（diff noise を出さない、§確定 G の決定論化契約） |
+
+### §確定 H（notify_channels_json マスキング配線、受入基準 9）
+
+| テストID | 対象モジュール連携 | 使用 fixture | 前提条件 | 操作 | 期待結果 |
+|---------|------------------|--------------|---------|------|---------|
+| TC-IT-WFR-013 | `MaskedJSONEncoded` 配線の物理確認 | `session_factory` + raw SQL SELECT | `EXTERNAL_REVIEW` ステージ + 実 Discord webhook URL（real-shape token） を持つ Workflow | (1) `save(workflow)`、(2) raw SQL `SELECT notify_channels_json FROM workflow_stages WHERE workflow_id = ?` で生 JSON 文字列を取得 | (a) `<REDACTED:DISCORD_WEBHOOK>` が JSON 内に出現、(b) 原 token（`SyntheticToken_-abcXYZ` などの synthetic 文字列）が JSON 内に**出現しない**（Schneier 申し送り #6 物理確認） |
+| TC-IT-WFR-014 | §確定 H §不可逆性（masked URL のラウンドトリップ失敗） | `session_factory` + `make_stage(kind=EXTERNAL_REVIEW)` | save 済 Workflow（notify_channels あり） | `find_by_id(workflow.id)` を呼ぶ | `pydantic.ValidationError` が raise される（masked URL `<REDACTED:DISCORD_WEBHOOK>` が NotifyChannel G7 regex `[A-Za-z0-9_\-]+` に合致しない）。これが §確定 H §不可逆性 の物理証拠 |
+
+### §確定 C（domain↔row ラウンドトリップ、受入基準 10）
+
+| テストID | 対象モジュール連携 | 使用 fixture | 前提条件 | 操作 | 期待結果 |
+|---------|------------------|--------------|---------|------|---------|
+| TC-IT-WFR-015 | ラウンドトリップ（`save → find_by_id` 構造的等価） | `session_factory` + `make_workflow`（notify_channels 不在） | 任意の valid Workflow（複数ステージ + 複数 transition、ただし `EXTERNAL_REVIEW` 不在 = notify_channels 不要） | (1) `save(workflow)`、(2) 別 session で `find_by_id(workflow.id)`、(3) 復元 Workflow を `sorted(stages, key=lambda s: s.id)` でソートして比較 | 構造的等価が成立。Stage / Transition のリスト順序は ORDER BY で決定論化、`sorted()` 比較で `==` True |
+
+### Tx 境界の責務分離（§確定 B、受入基準 7 補強）
+
+| テストID | 対象モジュール連携 | 使用 fixture | 前提条件 | 操作 | 期待結果 |
+|---------|------------------|--------------|---------|------|---------|
+| TC-IT-WFR-016 | service 層 `async with session.begin()` 配下の commit / rollback | `session_factory` + `make_workflow` | service スタブ（`async def save_workflow(repo, workflow)`） | (1) **正常系**: `async with session.begin(): await repo.save(workflow)` → ブロック退出で commit、(2) **異常系**: 同ブロック内で `raise RuntimeError` → ブロック退出で rollback | commit 経路で Workflow が永続化、rollback 経路で原子的に消える。Repository は `await session.commit()` / `session.rollback()` を呼ばない（責務境界、§確定 B） |
+
+### FK CASCADE + UNIQUE 制約（受入基準 11 補強）
+
+| テストID | 対象モジュール連携 | 使用 fixture | 前提条件 | 操作 | 期待結果 |
+|---------|------------------|--------------|---------|------|---------|
+| TC-IT-WFR-017 | `workflows` DELETE → 子テーブル CASCADE | `session_factory` + `make_workflow` | save 済み Workflow（複数ステージ + transition） | raw SQL で `DELETE FROM workflows WHERE id=:id` を実行 | workflow_stages / workflow_transitions の対応行が CASCADE で削除される（FK ON DELETE CASCADE 制約の物理確認） |
+| TC-IT-WFR-018 | UNIQUE(workflow_id, stage_id) / (workflow_id, transition_id) 違反 | `session_factory` | save 済み Workflow | raw SQL で同じ `(workflow_id, stage_id)` ペアを 2 度 INSERT、`(workflow_id, transition_id)` ペアも同様 | 両ケースで `IntegrityError`（または UniqueViolation）が raise |
+
+### 責務分離（§確定 D 継承）
+
+| テストID | 対象モジュール連携 | 使用 fixture | 前提条件 | 操作 | 期待結果 |
+|---------|------------------|--------------|---------|------|---------|
+| TC-IT-WFR-019 | Repository は `count()` で事実報告のみ、シングルトン強制しない | `session_factory` | DB 空 | (1) 1 件目 `save(workflow_a)`、(2) 別 id の `save(workflow_b)`、(3) `count()` を確認 | (a) 2 件目 save が **例外を raise せず**正常に通る、(b) `count()` が 2 を返す。集合知識（シングルトン制約等）は application 層の責務 |
+
+### Alembic 0003 revision（受入基準 11、§確定 F）
+
+| テストID | 対象モジュール連携 | 使用 fixture | 前提条件 | 操作 | 期待結果 |
+|---------|------------------|--------------|---------|------|---------|
+| TC-IT-WFR-020 | Alembic 0003 revision 適用 | `tmp_path` 配下の bakufu.db | M1 + M2 + 0002_empire_aggregate 適用済み | `alembic upgrade head` を実行 | (a) `0002_empire_aggregate` から `0003_workflow_aggregate` への進行、(b) `SELECT name FROM sqlite_master WHERE type='table'` で `workflows` / `workflow_stages` / `workflow_transitions` の 3 テーブルが追加、(c) UNIQUE INDEX `(workflow_id, stage_id)` / `(workflow_id, transition_id)` が存在 |
+| TC-IT-WFR-021 | upgrade / downgrade 双方向 idempotent | `tmp_path` | initial revision 適用済み | (1) `alembic upgrade head`、(2) `alembic downgrade base`、(3) 再 `alembic upgrade head` | (1) で 3 テーブル追加、(2) で 3 テーブル削除（empire / persistence-foundation テーブルは残る）、(3) で再追加 |
+| TC-IT-WFR-022 | revision chain 一直線（§確定 R1-C） | Alembic config | versions/0001_init.py + 0002_empire_aggregate.py + 0003_workflow_aggregate.py | `ScriptDirectory.get_heads()` を実行 | head は単一（`0003_workflow_aggregate`）、`0003_workflow_aggregate.down_revision == "0002_empire_aggregate"` で chain 一直線。head 分岐がないことを物理確認 |
+
+### CI 三層防衛（受入基準 12, 13、§確定 H + テンプレート責務）
+
+| テストID | 対象モジュール連携 | 使用 fixture | 前提条件 | 操作 | 期待結果 |
+|---------|------------------|--------------|---------|------|---------|
+| TC-CI-WFR-001 | Layer 1: `scripts/ci/check_masking_columns.sh` の Workflow 拡張 | repo root | スクリプトが Workflow 3 テーブルを明示登録、`workflow_stages.notify_channels_json` の `MaskedJSONEncoded` 必須を検査 | `bash scripts/ci/check_masking_columns.sh` を実行 | exit 0。grep guard が `workflow_stages.py` の `notify_channels_json` カラム宣言に `MaskedJSONEncoded` が登場することを確認、未登場なら exit 非 0 |
+| TC-IT-WFR-023 | Layer 2: `tests/architecture/test_masking_columns.py` の Workflow parametrize（partial-mask） | `Base.metadata` | M2 永続化基盤の arch test が `_PARTIAL_MASK_TABLES` を持つ | parametrize に `(workflow_stages, notify_channels_json)` を追加し、`column.type.__class__ is MaskedJSONEncoded` を assert、他カラムは Masked* 不在を assert | 全 3 テーブルで pass。後続 PR が誤って `MaskedText` を Workflow 他カラムに追加した瞬間、この test が落下して PR ブロック |
+
+### storage.md 逆引き表（Layer 3）
+
+| テストID | 対象モジュール連携 | 使用 fixture | 前提条件 | 操作 | 期待結果 |
+|---------|------------------|--------------|---------|------|---------|
+| TC-DOC-WFR-001 | storage.md §逆引き表に Workflow 行存在 | repo root | `docs/architecture/domain-model/storage.md` 編集済み | `storage.md` 内に "Workflow" を含む行で「`MaskedJSONEncoded`」または「partial mask」相当の宣言、および「masking 対象なし」を含む Workflow 行（workflows / workflow_transitions）の存在を確認 | partial-mask の 1 行 + no-mask 2 行が co-located（後続 Repository PR が同様の行を追加するテンプレート） |
+
+## ユニットテストケース
+
+`tests/factories/workflow.py` の factory 経由で domain 層 Workflow を生成する。Repository クラス内 private method (`_to_row` / `_from_row`) は実 DB アクセスを伴うため integration として扱い、純 unit としての追加ケースは作らない（empire-repository の TC-UT-EMR-001〜003 は domain↔row dict 変換のみだったが、本 PR では §確定 G/H/I の format 検証が DB 経由でこそ価値があるため integration に集約）。
+
+## カバレッジ基準
+
+- REQ-WFR-001 〜 005 の各要件が**最低 1 件**のテストケースで検証されている（マトリクス参照）
+- **delete-then-insert 5 段階順序（§確定 B）**: TC-IT-WFR-010 で実 SQL ログ観測
+- **ORDER BY 規約（§確定 G/H 補強 + BUG-EMR-001 継承）**: TC-IT-WFR-005 / 006 で SQL ログ観測 + TC-IT-WFR-015 でリスト順序の構造的等価
+- **§確定 G（roles_csv sorted CSV）**: TC-IT-WFR-011 ラウンドトリップ + TC-IT-WFR-012 決定論化（バイト同一）
+- **§確定 H（notify_channels_json マスキング + 不可逆性）**: TC-IT-WFR-013 物理確認 + TC-IT-WFR-014 不可逆性
+- **§確定 C（domain↔row ラウンドトリップ）**: TC-IT-WFR-015 で実 DB 経由の構造的等価
+- **§確定 B Tx 境界**: TC-IT-WFR-016 で commit / rollback 両経路、Repository が明示的 commit/rollback しないことを assert
+- **DB 制約**: FK CASCADE（TC-IT-WFR-017）+ UNIQUE 制約（TC-IT-WFR-018）+ Alembic chain（TC-IT-WFR-022）で migration の正しさを物理確認
+- **upgrade/downgrade idempotent**: TC-IT-WFR-021 で双方向 migration を物理確認
+- **CI 三層防衛 partial-mask 拡張（§確定 H + テンプレート責務）**: Layer 1 grep（TC-CI-WFR-001）+ Layer 2 arch test（TC-IT-WFR-023）+ Layer 3 storage.md（TC-DOC-WFR-001）3 つすべてに証拠
+- 受入基準 1 〜 13 の各々が**最低 1 件のユニット/結合ケース**で検証されている（E2E 不在のため戦略ガイドの「結合代替可」に従う）
+- 受入基準 14（依存方向）/ 15（pyright/ruff/coverage 90%）は CI ジョブで担保
+- 確定 A〜J すべてに証拠ケース
+- C0 目標: `application/ports/workflow_repository.py` / `infrastructure/persistence/sqlite/repositories/workflow_repository.py` で **90% 以上**
+
+## 人間が動作確認できるタイミング
+
+本 feature は infrastructure 層単独だが、**M2 永続化基盤と同じく Backend プロセスを実起動して動作確認できる**。
+
+- CI 統合後: `gh pr checks` で 7 ジョブ緑（lint / typecheck / test-backend / audit / fmt / commit-msg / no-ai-footer）
+- ローカル: `bash scripts/setup.sh` → `cd backend && uv run pytest tests/infrastructure/persistence/sqlite/repositories/test_workflow_repository tests/infrastructure/persistence/sqlite/test_alembic_workflow.py tests/architecture/test_masking_columns.py tests/docs/test_storage_md_back_index.py -v` → 全テスト緑
+- Backend 実起動: `cd backend && uv run python -m bakufu`（環境変数 `BAKUFU_DATA_DIR=/tmp/bakufu-test` を設定）
+  - 起動時に Alembic auto-migrate で 0001_init + 0002_empire_aggregate + 0003_workflow_aggregate が適用されることをログで目視
+  - `sqlite3 <DATA_DIR>/bakufu.db ".tables"` で `workflows` / `workflow_stages` / `workflow_transitions` の 3 テーブルが見える
+  - `sqlite3 <DATA_DIR>/bakufu.db "SELECT * FROM sqlite_master WHERE type='index'"` で UNIQUE INDEX が見える
+- カバレッジ確認: `cd backend && uv run pytest --cov=bakufu.application.ports.workflow_repository --cov=bakufu.infrastructure.persistence.sqlite.repositories.workflow_repository --cov-report=term-missing` → 90% 以上
+- masking gateway 実適用の物理観測: `tests/infrastructure/persistence/sqlite/repositories/test_workflow_repository/test_masking.py::test_discord_webhook_token_masked_in_db` を `-v -s` で実行 → raw JSON 出力に `<REDACTED:DISCORD_WEBHOOK>` 出現を目視
+
+## テストディレクトリ構造
+
+```
+backend/
+  tests/
+    factories/
+      workflow.py                            # 既存（workflow feature #16）追加なし
+    architecture/
+      test_masking_columns.py                # 既存 + Workflow partial-mask parametrize（実装側で _PARTIAL_MASK_TABLES + TestPartialMaskContract 追加済み）
+                                             # TC-IT-WFR-023
+    infrastructure/
+      persistence/
+        sqlite/
+          repositories/
+            test_workflow_repository/
+              __init__.py
+              test_protocol_crud.py          # TC-IT-WFR-001〜007, 019
+              test_save_semantics.py         # TC-IT-WFR-008〜012, 015, 016
+              test_constraints_arch.py       # TC-IT-WFR-017, 018, 023
+              test_masking.py                # TC-IT-WFR-013, 014（§確定 H 物理確認）
+          test_alembic_workflow.py           # TC-IT-WFR-020〜022（Alembic 0003 検証）
+    docs/
+      test_storage_md_back_index.py          # 既存 + Workflow 行検証（TC-DOC-WFR-001）
+```
+
+**配置の根拠**:
+- empire-repository の `test_empire_repository/` ディレクトリ分割パターン（Norman 500 行ルール）を継承
+- `test_masking.py` を独立ファイルにするのは **Workflow が masking gateway の初実適用 PR**であり、TC-IT-WFR-013 / 014 が後続 Repository PR（agent / room / directive / task / external-review-gate）で masking 対象を持つときのテンプレートになるため
+- `test_alembic_workflow.py` は empire の `test_alembic_empire.py` 同パターン
+- `tests/docs/test_storage_md_back_index.py` は既存 + Workflow 行検証を追加（empire-repo で確立）
+
+## 未決課題・要起票 characterization task
+
+| # | タスク | 起票先 | 備考 |
+|---|-------|--------|------|
+| （N/A） | 該当なし — SQLite + Alembic + SQLAlchemy + MaskingGateway は標準ライブラリ仕様で固定 | — | 後続 5 件 Repository PR は本 PR を参照して同パターン実装。Aggregate 別の masking 対象カラムが存在する PR（agent / room / directive / task / external-review-gate）では `MaskedJSONEncoded` / `MaskedText` の Layer 2 arch test 検証が動作確認の対象になる |
+
+**Schneier 申し送り（前 PR レビューより継承）**:
+
+- **CI 三層防衛の Workflow 拡張**: 本 PR で「partial-mask」テンプレートを正式凍結（empire-repo は no-mask テンプレート、本 PR は partial-mask テンプレート）。`_PARTIAL_MASK_TABLES`（実装側で追加済み）+ `TestPartialMaskContract` の構造で「`workflow_stages.notify_channels_json` のみマスキング、他カラムは対象外」を物理保証
+- **`storage.md` §逆引き表のテンプレート化**: §確定 H の Layer 3 で「Workflow 関連カラム」3 行（partial-mask 1 + no-mask 2）を追加。後続 Repository PR は同形式で「対象あり / 対象なし」を区別して追加する責務
+- **本 feature 固有の申し送り**:
+  - notify_channel re-registration responsibility は `feature/workflow-application` の責務（§確定 H §不可逆性）。本 PR は Repository が `pydantic.ValidationError` を raise する経路を担保するのみ、CEO への再入力フロー実装は application 層
+  - `WorkflowService.create()` の Tx 境界は **本 PR で凍結した「Repository は session 受け取り、commit/rollback は service 側」契約に従う**こと（§確定 B）
+  - エラー文言（`WorkflowNotFoundError` 等）は infrastructure には定義しない（内部 API、ユーザー向けメッセージは application / API 層責務）
+
+## レビュー観点（テスト設計レビュー時）
+
+- [ ] REQ-WFR-001〜005 すべてに 1 件以上のテストケースがあり、特に integration が Repository 契約 + Alembic + masking 配線 + CI 三層防衛を単独でカバーしている
+- [ ] **delete-then-insert 5 段階順序（§確定 B）**が TC-IT-WFR-010 で実 SQL 発行順を物理観測している
+- [ ] **ORDER BY 規約（§確定 G/H + BUG-EMR-001 継承）**が TC-IT-WFR-005 / 006 で SQL ログ観測されている
+- [ ] **§確定 G（roles_csv sorted CSV）**が TC-IT-WFR-011 ラウンドトリップ + TC-IT-WFR-012 決定論化（バイト同一）の 2 経路で物理確認
+- [ ] **§確定 H（notify_channels_json マスキング配線）**が TC-IT-WFR-013 で実 SQLite に対する raw SQL SELECT で `<REDACTED:DISCORD_WEBHOOK>` 出現 + 原 token 不在を物理確認
+- [ ] **§確定 H §不可逆性**が TC-IT-WFR-014 で `pydantic.ValidationError` raise を物理確認
+- [ ] **Tx 境界（§確定 B）**が TC-IT-WFR-016 で commit / rollback 両経路、Repository が明示的 commit/rollback しないことを assert
+- [ ] **DB 制約**: FK CASCADE（TC-IT-WFR-017）+ UNIQUE 制約（TC-IT-WFR-018）の物理確認
+- [ ] **CI 三層防衛 partial-mask 拡張**: Layer 1 grep（TC-CI-WFR-001）+ Layer 2 arch（TC-IT-WFR-023）+ Layer 3 storage.md（TC-DOC-WFR-001）の 3 つすべてに証拠ケース
+- [ ] **Alembic chain 一直線**（§確定 R1-C）: TC-IT-WFR-022 で head 分岐なし、`0003.down_revision == "0002_empire_aggregate"` を物理確認
+- [ ] **upgrade/downgrade idempotent**: TC-IT-WFR-021 で双方向 migration を物理確認
+- [ ] 確定 A〜J すべてに証拠ケースが含まれる
+- [ ] empire-repository / persistence-foundation の `app_engine` / `session_factory` fixture を再利用、新 fixture は追加していない
+- [ ] Schneier 申し送り（CI 三層防衛 partial-mask テンプレート / notify_channel re-registration の application 層責務 / Tx 境界の Repository / service 分離 / storage.md §逆引き表の Workflow 行）が次レビュー時に確認可能な形で test-design および設計書に記録されている
+- [ ] **後続 5 件 Repository PR のテンプレート責務（§確定 F 継承）**: empire-repo の確定 A〜F + 本 PR の確定 G〜J を本 PR が満たすことが test-design.md レビュー観点で凍結されている

--- a/scripts/ci/check_masking_columns.sh
+++ b/scripts/ci/check_masking_columns.sh
@@ -35,6 +35,10 @@ readonly EXPECTED_TYPES=(
     "payload_json:MaskedJSONEncoded"
     "last_error:MaskedText"
     "cmd:MaskedText"
+    # Workflow Repository (PR #31): notify_channels_json holds
+    # Discord webhook URLs that include the secret token segment.
+    # docs/features/workflow-repository/detailed-design.md §確定 H.
+    "notify_channels_json:MaskedJSONEncoded"
     # 後続 Repository PR が追加するカラム（テーブルファイル未存在の間は no-op）
     "prompt_body:MaskedText"
     "prefix_markdown:MaskedText"
@@ -75,6 +79,11 @@ readonly NO_MASK_FILES=(
     "${TABLES_DIR}/empires.py"
     "${TABLES_DIR}/empire_room_refs.py"
     "${TABLES_DIR}/empire_agent_refs.py"
+    # Workflow Repository (PR #31): only workflow_stages.notify_channels_json
+    # is masked; the root + transitions tables carry no Schneier #6
+    # secret categories.
+    "${TABLES_DIR}/workflows.py"
+    "${TABLES_DIR}/workflow_transitions.py"
 )
 
 for file in "${NO_MASK_FILES[@]}"; do
@@ -93,9 +102,67 @@ for file in "${NO_MASK_FILES[@]}"; do
     fi
 done
 
+# Layer 1-C: 過剰マスキング防止 ─ partially-masked テーブルで指定の
+# カラム以外に Masked* が混入していないこと。
+# Workflow Repository (PR #31, detailed-design.md §確定 E):
+#   workflow_stages.notify_channels_json だけが MaskedJSONEncoded、
+#   他カラムは JSONEncoded / String / Text に閉じる。
+#
+# フォーマット: "<file>:<allowed_column>"
+readonly PARTIAL_MASK_FILES=(
+    "${TABLES_DIR}/workflow_stages.py:notify_channels_json"
+)
+
+for entry in "${PARTIAL_MASK_FILES[@]}"; do
+    file="${entry%%:*}"
+    allowed="${entry##*:}"
+
+    if [[ ! -f "$file" ]]; then
+        continue
+    fi
+
+    # MaskedText must be zero everywhere on this file.
+    text_leaks=$(grep -nE "MaskedText" "$file" || true)
+    if [[ -n "$text_leaks" ]]; then
+        echo "[FAIL] partial-mask table file declares MaskedText (over-masking): $file" >&2
+        echo "$text_leaks" >&2
+        echo "       Next: this table is registered with a single allowed" >&2
+        echo "       MaskedJSONEncoded column ('${allowed}') in" >&2
+        echo "       docs/architecture/domain-model/storage.md §逆引き表;" >&2
+        echo "       remove the MaskedText usage or update the §逆引き表 entry." >&2
+        violations=$((violations + 1))
+    fi
+
+    # MaskedJSONEncoded usages: only declarations / re-exports outside
+    # the allowed column trip the over-masking guard.
+    json_decls=$(grep -nE "^\s*[A-Za-z_][A-Za-z0-9_]*\s*:\s*Mapped.*MaskedJSONEncoded" \
+        "$file" || true)
+    if [[ -z "$json_decls" ]]; then
+        echo "[FAIL] partial-mask table file is missing the expected" >&2
+        echo "       MaskedJSONEncoded column declaration: $file" >&2
+        echo "       Next: declare ${allowed} with MaskedJSONEncoded per" >&2
+        echo "       docs/architecture/domain-model/storage.md §逆引き表." >&2
+        violations=$((violations + 1))
+    else
+        while IFS= read -r line; do
+            [[ -z "$line" ]] && continue
+            if [[ "$line" == *"${allowed}"* ]]; then
+                continue
+            fi
+            echo "[FAIL] partial-mask table file declares MaskedJSONEncoded on a" >&2
+            echo "       column other than '${allowed}': $file" >&2
+            echo "       ${line}" >&2
+            echo "       Next: only '${allowed}' is registered as MaskedJSONEncoded" >&2
+            echo "       in docs/architecture/domain-model/storage.md §逆引き表;" >&2
+            echo "       move the masking to the correct column or update §逆引き表." >&2
+            violations=$((violations + 1))
+        done <<< "$json_decls"
+    fi
+done
+
 if [[ "$violations" -gt 0 ]]; then
     echo "[FAIL] check_masking_columns: ${violations} violation(s) detected" >&2
     exit 1
 fi
 
-echo "[OK] check_masking_columns: positive (Masked* required) + negative (no-mask) checks passed"
+echo "[OK] check_masking_columns: positive (Masked* required) + negative (no-mask) + partial-mask over-masking checks passed"


### PR DESCRIPTION
## Summary

empire-repository テンプレート（PR #29 / #30）100% 継承、masking 対象**あり**版の最初の Repository 実装。M2 Aggregate Repository 6 兄弟の 2 件目。

Closes #31.

## 実装内容

### Protocol / 実装

- `application/ports/workflow_repository.py` — Protocol 3 メソッド（`find_by_id` / `count` / `save`）、`@runtime_checkable` なし（Empire と同パターン）
- `infrastructure/persistence/sqlite/repositories/workflow_repository.py` — SqliteWorkflowRepository
  - `save`: §確定 B 5 段階 delete-then-insert（workflows UPSERT → workflow_stages DELETE/INSERT → workflow_transitions DELETE/INSERT）
  - `find_by_id`: ORDER BY stage_id / ORDER BY transition_id を Day 1 から発行（BUG-EMR-001 教訓踏襲）
  - `count`: `select(func.count()).select_from(WorkflowRow)` の SQL `COUNT(*)` 限定
  - `_to_row` / `_from_row` private、§確定 G〜I の双方向変換契約に準拠

### Tables（3 テーブル新規）

- `tables/workflows.py` — id / name / entry_stage_id（FK 宣言なし、§確定 J）
- `tables/workflow_stages.py` — `notify_channels_json` を **`MaskedJSONEncoded`** で宣言。Discord webhook token を `process_bind_param` で永続化前マスキング（Schneier 申し送り #6 multilayer defense）
- `tables/workflow_transitions.py` — UNIQUE 制約 + ON DELETE CASCADE、masking 対象なし

### Alembic

- `alembic/versions/0003_workflow_aggregate.py` — `down_revision=\"0002_empire_aggregate\"` で chain 単一直線維持

### CI 三層防衛拡張

- **Layer 1 grep guard** (`scripts/ci/check_masking_columns.sh`):
  - `notify_channels_json` を `EXPECTED_TYPES` に正登録
  - `workflows` / `workflow_transitions` を `NO_MASK_FILES` に追加
  - **新設**: partial-mask テーブル（workflow_stages）の過剰マスキング検出ガード（`MaskedText` ゼロ + `MaskedJSONEncoded` を `notify_channels_json` 限定）
- **Layer 2 arch test** (`backend/tests/architecture/test_masking_columns.py`):
  - `_MASKING_CONTRACT` に `(workflow_stages, notify_channels_json, MaskedJSONEncoded)` 追加
  - `_NO_MASK_TABLES` に `workflows` / `workflow_transitions` 追加
  - **新設**: `TestPartialMaskContract` クラス + `_PARTIAL_MASK_TABLES`

### シリアライズ契約 (§確定 G〜I)

| カラム | TypeDecorator | 変換 |
|---|---|---|
| `roles_csv` | `String(255)` | `sorted(role.value for role in stage.required_role)` を `,` で join（frozenset 非決定論排除） |
| `notify_channels_json` | **`MaskedJSONEncoded`** | `[ch.model_dump(mode='json') for ch in stage.notify_channels]`（NotifyChannel の `field_serializer(when_used='json')` + `MaskingGateway.mask_in()` で **二重マスキング**） |
| `completion_policy_json` | `JSONEncoded`（masking なし） | `stage.completion_policy.model_dump(mode='json')`、Schneier #6 secret 6 種非該当、CI Layer 2 で `MaskedJSONEncoded` でないことを物理保証 |

§確定 H §不可逆性: masked target は復元不能（`find_by_id` で `pydantic.ValidationError` 発生し得る）。配送側 (`feature/notify-router`) で webhook 再登録運用を凍結する申し送り（detailed-design 申し送り #1 で明示済み）。

## 変更ファイル

| 種類 | ファイル | 行数 |
|---|---|---|
| 新規 | `application/ports/workflow_repository.py` | 70 |
| 新規 | `infrastructure/persistence/sqlite/repositories/workflow_repository.py` | 312 |
| 新規 | `infrastructure/persistence/sqlite/tables/workflows.py` | 47 |
| 新規 | `infrastructure/persistence/sqlite/tables/workflow_stages.py` | 91 |
| 新規 | `infrastructure/persistence/sqlite/tables/workflow_transitions.py` | 56 |
| 新規 | `alembic/versions/0003_workflow_aggregate.py` | 117 |
| 変更 | `infrastructure/persistence/sqlite/tables/__init__.py` | +21 |
| 変更 | `tests/architecture/test_masking_columns.py` | +65 |
| 変更 | `scripts/ci/check_masking_columns.sh` | +69 |

## 品質

- ✅ ruff format / lint clean
- ✅ pyright strict **0 errors / 0 warnings**
- ✅ pytest **558 passed**（既存 554 + 新規 4 arch test）
- ✅ `bash scripts/ci/check_masking_columns.sh` 全層 PASS（positive + no-mask + partial-mask 過剰マスキング検出）
- ✅ Alembic chain: `0001 → 0002 → 0003`、単一 head `0003_workflow_aggregate`

## テスト担当への申し送り（test-design.md 工程で観点反映依頼）

- **TC-IT**: `save → find_by_id` 往復で notify_channels なし Stage は完全復元、notify_channels あり Stage は復元時 `pydantic.ValidationError` 発生（§確定 H 契約）
- **TC-IT**: `roles_csv` の sorted 決定論性（同一 Workflow を複数回 save しても row が byte 等価）
- **TC-IT**: `MaskedJSONEncoded.process_bind_param` 経路で webhook URL の token segment が DB レベルで `<REDACTED:DISCORD_WEBHOOK>` 化されること（raw SQL で SELECT して確認）
- **TC-IT**: ORDER BY 物理保証（Stage / Transition を逆順 INSERT しても `find_by_id` は sorted 順）
- **TC-IT**: ON DELETE CASCADE（workflows DELETE で stages / transitions 連鎖削除）
- **TC-UT**: Protocol 充足（duck typing）
- **TC-DOC**: storage.md §逆引き表 / detailed-design §確定 E の整合性

## Test plan

- [ ] `just check-all` がローカルで全 PASS することを確認
- [ ] CI 7 チェック全 PASS
- [ ] レビュー担当 3 名（Steve / Norman / Schneier）の合格判定
- [ ] テスト担当が test-design.md を作成 → テスト実装で本 Repository を網羅