### PR TITLE
docs(agent-repository): freeze design books for Issue #32 (Schneier #3 実適用)

### DIFF
--- a/docs/architecture/domain-model/storage.md
+++ b/docs/architecture/domain-model/storage.md
@@ -184,13 +184,14 @@ LLM subprocess の stdout / stderr、Outbox の `payload_json` / `last_error`、
 | `audit_log.args_json` | `audit_log` | `tables/audit_log.py` | `MaskedJSONEncoded` | **本 PR** |
 | `audit_log.error_text` | `audit_log` | `tables/audit_log.py` | `MaskedText` | **本 PR** |
 | `Task.last_error` | `tasks` | `tables/tasks.py` | `MaskedText` | `feature/task-repository`（後続） |
-| `Persona.prompt_body` | `agents` | `tables/agents.py` | `MaskedText` | `feature/agent-repository`（後続、Schneier 申し送り #3） |
+| `Persona.prompt_body` | `agents` | `tables/agents.py` | `MaskedText` | `feature/agent-repository`（Issue #32、**Schneier 申し送り #3 実適用済み**、persistence-foundation #23 で hook 構造提供 → 本 PR で配線完了） |
 | `PromptKit.prefix_markdown` | `rooms` | `tables/rooms.py` | `MaskedText` | `feature/room-repository`（後続） |
 | `bakufu_pid_registry.cmd` | `bakufu_pid_registry` | `tables/pid_registry.py` | `MaskedText` | **本 PR** |
 | 構造化ログ | （ファイル） | `infrastructure/logging/structured.py` | log filter（TypeDecorator 対象外、ログ層で `MaskingGateway.mask()` 呼び出し） | `feature/logging` |
 | **Empire 関連カラム（`empires` / `empire_room_refs` / `empire_agent_refs`）** | 同左 3 テーブル | `infrastructure/persistence/sqlite/repositories/empire_repository.py` + `tables/empires.py` 等 | **masking 対象なし**（`String` / `UUIDStr` / `Boolean` のみ。後続 Repository PR が誤って `MaskedText` を追加しないテンプレート、CI 三層防衛 Layer 1+2 で物理保証） | `feature/empire-repository`（PR #25） |
 | `workflow_stages.notify_channels_json` | `workflow_stages` | `infrastructure/persistence/sqlite/tables/workflow_stages.py` | **`MaskedJSONEncoded`** | `feature/workflow-repository`（Issue #31、Schneier 申し送り #6 + workflow §Confirmation G の Repository 経路実適用、Discord webhook token マスキング） |
 | **Workflow 残カラム（`workflows` 全カラム / `workflow_transitions` 全カラム / `workflow_stages` の `notify_channels_json` 以外）** | 同左 | `tables/workflows.py` / `tables/workflow_transitions.py` / `tables/workflow_stages.py` | **masking 対象なし**（`UUIDStr` / `String` / `Text` / `JSONEncoded` のみ。`completion_policy_json` は VO の自由記述だが secret 6 種非該当のため `JSONEncoded`、CI Layer 2 で `MaskedJSONEncoded` でないことを arch test で保証） | `feature/workflow-repository`（Issue #31） |
+| **Agent 残カラム（`agents` の `prompt_body` 以外 / `agent_providers` 全カラム / `agent_skills` 全カラム）** | 同左 | `tables/agents.py` / `tables/agent_providers.py` / `tables/agent_skills.py` | **masking 対象なし**（`UUIDStr` / `String` / `Boolean` のみ。`agents.prompt_body` 以外のカラムが secret 6 種に該当しないことを CI Layer 2 で arch test で保証、過剰マスキング防止） | `feature/agent-repository`（Issue #32） |
 
 ##### 逆引き表の運用ルール
 

--- a/docs/features/agent-repository/basic-design.md
+++ b/docs/features/agent-repository/basic-design.md
@@ -1,0 +1,305 @@
+# 基本設計書
+
+> feature: `agent-repository`
+> 関連: [requirements.md](requirements.md) / [`docs/features/empire-repository/`](../empire-repository/) **テンプレート真実源** / [`docs/features/workflow-repository/`](../workflow-repository/) **2 件目テンプレート** / [`docs/features/agent/`](../agent/)
+
+## 記述ルール（必ず守ること）
+
+基本設計に**疑似コード・サンプル実装（python/ts/sh/yaml 等の言語コードブロック）を書かない**。
+ソースコードと二重管理になりメンテナンスコストしか生まない。
+必要なのは構造契約（クラス・モジュール・データの関係）であり、実装の細部は [detailed-design.md](detailed-design.md) で凍結する。
+
+## モジュール構成
+
+| 機能 ID | モジュール | ディレクトリ | 責務 |
+|--------|----------|------------|------|
+| REQ-AGR-001 | `AgentRepository` Protocol | `backend/src/bakufu/application/ports/agent_repository.py` | Repository ポート定義（4 method、empire-repo の 3 method + 第 4 method `find_by_name`、§確定 R1-C） |
+| REQ-AGR-002 | `SqliteAgentRepository` | `backend/src/bakufu/infrastructure/persistence/sqlite/repositories/agent_repository.py` | SQLite 実装、§確定 R1-A〜D |
+| REQ-AGR-003 | Alembic 0004 revision | `backend/alembic/versions/0004_agent_aggregate.py` | 3 テーブル + UNIQUE + partial unique index 追加、`down_revision="0003_workflow_aggregate"` |
+| REQ-AGR-004 | CI 三層防衛拡張 Layer 1 | `scripts/ci/check_masking_columns.sh`（既存ファイル更新）| Agent 3 テーブル明示登録、`agents.prompt_body` の `MaskedText` 必須を assert（正のチェック）|
+| REQ-AGR-004 | CI 三層防衛拡張 Layer 2 | `backend/tests/architecture/test_masking_columns.py`（既存ファイル更新）| parametrize に Agent 3 テーブル追加 |
+| REQ-AGR-005 | storage.md 逆引き表更新 | `docs/architecture/domain-model/storage.md`（既存ファイル更新）| Agent 関連 2 行追加（既存 `Persona.prompt_body` 行を本 PR で実適用済みに更新） |
+| 共通 | tables/agents.py / agent_providers.py / agent_skills.py | `backend/src/bakufu/infrastructure/persistence/sqlite/tables/` | 新規 3 ファイル |
+
+```
+ディレクトリ構造（本 feature で追加・変更されるファイル）:
+
+.
+├── backend/
+│   ├── alembic/
+│   │   └── versions/
+│   │       └── 0004_agent_aggregate.py             # 新規: 3 テーブル + UNIQUE + partial unique index
+│   ├── src/
+│   │   └── bakufu/
+│   │       ├── application/
+│   │       │   └── ports/
+│   │       │       └── agent_repository.py         # 新規: Protocol（4 method）
+│   │       └── infrastructure/
+│   │           └── persistence/
+│   │               └── sqlite/
+│   │                   ├── repositories/
+│   │                   │   └── agent_repository.py # 新規: SqliteAgentRepository
+│   │                   └── tables/
+│   │                       ├── agents.py           # 新規（prompt_body は MaskedText、Schneier #3 実適用）
+│   │                       ├── agent_providers.py  # 新規（partial unique index WHERE is_default=1）
+│   │                       └── agent_skills.py     # 新規
+│   └── tests/
+│       ├── infrastructure/
+│       │   └── persistence/
+│       │       └── sqlite/
+│       │           └── repositories/
+│       │               └── test_agent_repository/   # 新規ディレクトリ（500 行ルール、最初から分割）
+│       │                   ├── __init__.py
+│       │                   ├── test_protocol_crud.py
+│       │                   ├── test_save_semantics.py
+│       │                   ├── test_constraints_arch.py
+│       │                   └── test_masking_persona.py  # Schneier #3 実適用専用テスト
+│       └── architecture/
+│           └── test_masking_columns.py             # 既存更新: Agent 3 テーブル parametrize 追加
+├── scripts/
+│   └── ci/
+│       └── check_masking_columns.sh                # 既存更新: Agent 3 テーブル明示登録
+└── docs/
+    ├── architecture/
+    │   └── domain-model/
+    │       └── storage.md                          # 既存更新: 逆引き表に Agent 行追加
+    └── features/
+        └── agent-repository/                       # 本 feature 設計書 5 本
+```
+
+## クラス設計（概要）
+
+```mermaid
+classDiagram
+    class AgentRepository {
+        <<Protocol>>
+        +async find_by_id(agent_id) Agent | None
+        +async count() int
+        +async save(agent) None
+        +async find_by_name(empire_id, name) Agent | None
+    }
+    class SqliteAgentRepository {
+        +session: AsyncSession
+        +async find_by_id(agent_id) Agent | None
+        +async count() int
+        +async save(agent) None
+        +async find_by_name(empire_id, name) Agent | None
+        -_to_row(agent) tuple
+        -_from_row(agent_row, provider_rows, skill_rows) Agent
+    }
+    class Agent {
+        <<Aggregate Root>>
+        +id: AgentId
+        +empire_id: EmpireId
+        +name: str
+        +role: Role
+        +persona: Persona
+        +providers: list~ProviderConfig~
+        +skills: list~SkillRef~
+        +archived: bool
+    }
+
+    SqliteAgentRepository ..|> AgentRepository : implements
+    SqliteAgentRepository --> Agent : returns
+    AgentRepository ..> Agent : returns
+```
+
+**凝集のポイント**:
+
+- `AgentRepository` Protocol は application 層、domain は知らない（empire-repo §確定 A）
+- `SqliteAgentRepository` は infrastructure 層、Protocol を型レベルで満たす
+- domain ↔ row 変換は `_to_row()` / `_from_row()` の private method（empire-repo §確定 C）
+- `save()` は同一 Tx 内で 3 テーブル delete-then-insert（empire-repo §確定 B、Agent では 5 段階手順）
+- 呼び出し側 service が `async with session.begin():` で UoW 境界を管理
+- **`find_by_name(empire_id, name)` は第 4 method**、Empire スコープ検索（§確定 R1-C）
+
+## 処理フロー
+
+### ユースケース 1: Agent の新規 hire（save 経路、`AgentService.hire()` 起点）
+
+1. application 層 `AgentService.hire(empire_id, name, persona, providers, skills)` を呼ぶ（本 PR スコープ外、別 PR）
+2. application 層が `AgentRepository.find_by_name(empire_id, name)` で重複検査 → None なら新規作成、既存なら `AgentNameAlreadyExistsError` で 409
+3. `Agent(id=uuid4(), empire_id=..., name=name, persona=..., providers=..., skills=..., archived=False)` を構築（pre-validate）
+4. service が `async with session.begin():` で UoW 境界を開く
+5. service が `AgentRepository.save(agent)` を呼ぶ
+6. `SqliteAgentRepository.save(agent)` が以下を順次実行（同一 Tx 内、5 段階）:
+   - `_to_row(agent)` で `agents_row` / `provider_rows` / `skill_rows` に分離
+   - agents UPSERT（`prompt_body` は `MaskedText` 経由で `MaskingGateway.mask()` 適用、Schneier #3 実適用）
+   - agent_providers DELETE → bulk INSERT（partial unique index `WHERE is_default=1` が DB レベル一意性を保証）
+   - agent_skills DELETE → bulk INSERT
+7. `session.begin()` ブロック退出で commit
+
+### ユースケース 2: Agent の取得（find_by_id 経路）
+
+1. application 層が `AgentRepository.find_by_id(agent_id)` を呼ぶ
+2. `SqliteAgentRepository.find_by_id(agent_id)` が以下を実行:
+   - `SELECT * FROM agents WHERE id = :agent_id`（不在なら None）
+   - `SELECT * FROM agent_providers WHERE agent_id = :agent_id ORDER BY provider_kind`（§BUG-EMR-001 規約）
+   - `SELECT * FROM agent_skills WHERE agent_id = :agent_id ORDER BY skill_id`（同上）
+   - `_from_row(agent_row, provider_rows, skill_rows)` で Agent 復元（**`prompt_body` は masked 文字列のまま** で `Persona` 構築、不可逆性、申し送り）
+3. valid な Agent を返却（pre-validate 通過）
+
+### ユースケース 3: Agent の Empire 内一意検索（find_by_name 経路、§確定 R1-C）
+
+1. application 層 `AgentService.hire()` 内で `AgentRepository.find_by_name(empire_id, name)` を呼ぶ
+2. `SqliteAgentRepository.find_by_name(empire_id, name)`:
+   - `SELECT id FROM agents WHERE empire_id = :empire_id AND name = :name LIMIT 1`
+   - 不在なら None
+   - 存在すれば `find_by_id(found_id)` を呼んで子テーブル含めて Agent を復元
+3. application 層が結果で重複判定（None → 新規作成可、Agent → 409）
+
+### ユースケース 4: Agent の更新（save 経路、persona 変更等）
+
+1. application 層が `find_by_id(agent_id)` で既存 Agent を取得
+2. service が Agent のドメイン操作（例: `agent.set_default_provider(...)` / persona 変更で再構築）で新 Agent を構築（pre-validate 方式、agent #17 で凍結）
+3. service が `AgentRepository.save(updated_agent)` を呼ぶ
+4. ユースケース 1 と同じ手順で同一 Tx 内に delete-then-insert
+
+### ユースケース 5: Agent 件数取得（count 経路）
+
+1. application 層が `AgentRepository.count()` を呼ぶ
+2. `SqliteAgentRepository.count()` が `select(func.count()).select_from(AgentRow)` で SQL `COUNT(*)` 発行（empire-repo §確定 D 踏襲）
+3. `scalar_one()` で `int` 取得
+
+## シーケンス図
+
+```mermaid
+sequenceDiagram
+    participant Svc as AgentService（別 PR）
+    participant Repo as SqliteAgentRepository
+    participant Sess as AsyncSession
+    participant Mask as MaskedText
+    participant DB as SQLite
+
+    Svc->>Repo: find_by_name(empire_id, name)
+    Repo->>Sess: SELECT id FROM agents WHERE empire_id=? AND name=? LIMIT 1
+    Sess->>DB: SQL
+    DB-->>Sess: row or empty
+    Sess-->>Repo: AgentId or None
+    Repo-->>Svc: Agent or None（None なら新規作成可）
+
+    Svc->>Sess: async with session.begin():
+    Svc->>Repo: save(agent)
+    Repo->>Repo: _to_row(agent)
+    Repo->>Sess: INSERT INTO agents ON CONFLICT UPDATE (prompt_body bind)
+    Sess->>Mask: process_bind_param(prompt_body)
+    Mask-->>Sess: masked str（API key → <REDACTED:ANTHROPIC_KEY>）
+    Sess->>DB: SQL
+    Repo->>Sess: DELETE FROM agent_providers WHERE agent_id=?
+    Sess->>DB: SQL
+    Repo->>Sess: INSERT INTO agent_providers bulk (partial unique index 検査)
+    Sess->>DB: SQL（is_default=True が複数あれば IntegrityError）
+    Repo->>Sess: DELETE FROM agent_skills WHERE agent_id=?
+    Sess->>DB: SQL
+    Repo->>Sess: INSERT INTO agent_skills bulk
+    Sess->>DB: SQL
+    Repo-->>Svc: ok
+    Svc->>Sess: session.begin() 退出 → commit
+    Sess->>DB: COMMIT
+```
+
+## アーキテクチャへの影響
+
+- `docs/architecture/domain-model.md` への変更: なし
+- `docs/architecture/domain-model/storage.md` への変更: **§逆引き表に Agent 関連 2 行追加 + 既存 `Persona.prompt_body` 行を本 PR で実適用済みに更新**（§確定 R1-E、本 PR で同一コミット）
+- `docs/architecture/migration-plan.md` への変更: なし（Agent は Postgres 移行論点なし、本 Aggregate の FK 構造に循環なし）
+- `docs/architecture/tech-stack.md` への変更: なし
+- 既存 feature への波及:
+  - `feature/persistence-foundation`（PR #23）の `MaskedText` TypeDecorator + Schneier #3 hook 構造の上に乗る、本 PR で実適用配線
+  - `feature/empire-repository`（PR #29 / #30）+ `feature/workflow-repository`（PR #41）テンプレート踏襲
+  - `feature/agent`（PR #17）の domain 層 Agent / Persona / ProviderConfig / SkillRef を import するのみ、agent 設計書は変更しない
+
+## 外部連携
+
+該当なし — 理由: infrastructure 層に閉じる。
+
+| 連携先 | 目的 | プロトコル | 認証 | タイムアウト / リトライ |
+|-------|------|----------|-----|--------------------|
+| 該当なし | — | — | — | — |
+
+## UX 設計
+
+該当なし — 理由: UI を持たない infrastructure 層。
+
+| シナリオ | 期待される挙動 |
+|---------|------------|
+| 該当なし | — |
+
+**アクセシビリティ方針**: 該当なし。
+
+## セキュリティ設計
+
+### 脅威モデル
+
+詳細な信頼境界は [`docs/architecture/threat-model.md`](../../architecture/threat-model.md)。本 feature 範囲では以下の 3 件。
+
+| 想定攻撃者 | 攻撃経路 | 保護資産 | 対策 |
+|-----------|---------|---------|------|
+| **T1: `agents.prompt_body` 経由の API key / GitHub PAT 漏洩**（Schneier #3 中核）| CEO が persona 設計時に prompt_body に「`環境変数 ANTHROPIC_API_KEY=sk-ant-...` を使え」と書く → Repository 経由で永続化 → DB 直読み / バックアップ / 監査ログ経路で token 流出 | API key / GitHub PAT / OAuth token | `agents.prompt_body` を **`MaskedText`** で宣言、`process_bind_param` で `MaskingGateway.mask()` 経由マスキング（`<REDACTED:ANTHROPIC_KEY>` / `<REDACTED:GITHUB_PAT>` 化）。**Schneier 申し送り #3 の実適用**。CI 三層防衛 Layer 1 + Layer 2 で `MaskedText` 必須を物理保証 |
+| **T2: `is_default` 複数違反でデータ破損**（partial unique index による二重防衛）| Aggregate 内 `_validate_provider_is_default_unique` を迂回する経路（直 SQL 流入 / マイグレーション失敗 等）で `is_default=True` が複数行 INSERT される → Aggregate 復元時に valid 判定が壊れて非決定的挙動 | Agent の整合性 | DB レベル **partial unique index** (`UNIQUE WHERE is_default = 1`) で INSERT/UPDATE を物理拒否 → IntegrityError、application 層が catch して 500 にマッピング（§確定 R1-D 二重防衛） |
+| **T3: 永続化 Tx の半端終了による参照整合性破損** | `save()` 中に SQLite クラッシュ → `agent_providers` 行のみ INSERT されて `agent_skills` が DELETE のみで終了 | Agent の整合性 | 同一 Tx 内の delete-then-insert（empire-repo §確定 B）+ M2 永続化基盤の WAL crash safety + foreign_keys ON。Tx 全体が ATOMIC、半端終了で rollback |
+
+### OWASP Top 10 対応
+
+| # | カテゴリ | 対応状況 |
+|---|---------|---------|
+| A01 | Broken Access Control | 該当なし（infrastructure 層、認可は別 feature） |
+| A02 | Cryptographic Failures | **適用**: `agents.prompt_body` の API key / GitHub PAT を `MaskedText` で永続化前マスキング（**Schneier #3 実適用**） |
+| A03 | Injection | **適用**: SQLAlchemy ORM 経由で SQL injection 防御。raw SQL は使わない |
+| A04 | Insecure Design | **適用**: Repository ポート分離 + delete-then-insert + partial unique index による二重防衛 |
+| A05 | Security Misconfiguration | M2 永続化基盤の PRAGMA 強制の上に乗る |
+| A06 | Vulnerable Components | SQLAlchemy 2.x / Alembic / aiosqlite |
+| A07 | Auth Failures | 該当なし |
+| A08 | Data Integrity Failures | **適用**: foreign_keys ON + ON DELETE CASCADE で参照整合性、Tx 原子性、partial unique index で `is_default` 二重防衛 |
+| A09 | Logging Failures | **適用**: `agents.prompt_body` のマスキングにより SQL ログ / 監査ログ経路で token 漏洩なし（Schneier #3 実適用の二次効果）|
+| A10 | SSRF | 該当なし（外部 URL fetch なし）|
+
+## ER 図
+
+```mermaid
+erDiagram
+    AGENTS {
+        UUIDStr id PK
+        UUIDStr empire_id FK
+        String name "1〜40 文字、Empire 内一意 (application 層責務)"
+        String role "Role enum"
+        String display_name "Persona.display_name"
+        String archetype "Persona.archetype"
+        MaskedText prompt_body "Schneier #3 実適用、API key / GitHub PAT マスキング"
+        Boolean archived "DEFAULT FALSE"
+    }
+    AGENT_PROVIDERS {
+        UUIDStr agent_id FK
+        String provider_kind "ProviderKind enum (CLAUDE_CODE / CODEX / ...)"
+        String model
+        Boolean is_default "DEFAULT FALSE"
+    }
+    AGENT_SKILLS {
+        UUIDStr agent_id FK
+        UUIDStr skill_id "SkillId"
+        String name "SkillRef.name"
+        String path "SkillRef.path (H1〜H10 検証は VO 構築時)"
+    }
+    EMPIRES ||--o{ AGENTS : "has 0..N agents (CASCADE)"
+    AGENTS ||--o{ AGENT_PROVIDERS : "has 1..N providers (CASCADE)"
+    AGENTS ||--o{ AGENT_SKILLS : "has 0..N skills (CASCADE)"
+```
+
+UNIQUE 制約:
+
+- `agent_providers(agent_id, provider_kind)`: 同 Agent 内で provider_kind 重複禁止
+- `agent_providers (agent_id) WHERE is_default = 1`: **partial unique index、§確定 R1-D**
+- `agent_skills(agent_id, skill_id)`: 同 Agent 内で skill_id 重複禁止
+
+masking 対象カラム: `agents.prompt_body` のみ（`MaskedText`、§確定 R1-B）。CI 三層防衛で物理保証。
+
+## エラーハンドリング方針
+
+| 例外種別 | 処理方針 | ユーザーへの通知 |
+|---------|---------|----------------|
+| `sqlalchemy.IntegrityError`（FK / UNIQUE / partial unique index 違反）| application 層に伝播、HTTP API 層で 409 Conflict | application 層 / HTTP API の MSG（別 feature） |
+| `sqlalchemy.OperationalError`（接続切断、ロック timeout）| application 層に伝播、HTTP API 層で 503 | 同上 |
+| `pydantic.ValidationError`（domain Agent 構築時、`_from_row` 内で発生し得る）| Repository 内で catch せず application 層に伝播、データ破損として扱う | application 層 / HTTP API の MSG |
+| その他 | 握り潰さない、application 層へ伝播 | 汎用エラーメッセージ |
+
+**Repository 内で明示的な commit / rollback はしない**: 呼び出し側 service が `async with session.begin():` で UoW 境界を管理（empire-repo §確定 B 踏襲）。

--- a/docs/features/agent-repository/detailed-design.md
+++ b/docs/features/agent-repository/detailed-design.md
@@ -1,0 +1,343 @@
+# 詳細設計書
+
+> feature: `agent-repository`
+> 関連: [basic-design.md](basic-design.md) / [`docs/features/empire-repository/detailed-design.md`](../empire-repository/detailed-design.md) **テンプレート真実源** / [`docs/features/workflow-repository/detailed-design.md`](../workflow-repository/detailed-design.md) **2 件目テンプレート** / [`docs/features/agent/detailed-design.md`](../agent/detailed-design.md)
+
+## 記述ルール（必ず守ること）
+
+詳細設計に**疑似コード・サンプル実装（python/ts/sh/yaml 等の言語コードブロック）を書かない**。
+ソースコードと二重管理になりメンテナンスコストしか生まない。
+必要なのは「構造契約（属性名・型・制約）」と「確定文言（メッセージ文字列）」と「実装の意図」。
+
+## クラス設計（詳細）
+
+```mermaid
+classDiagram
+    class AgentRepository {
+        <<Protocol>>
+        +async find_by_id(agent_id: AgentId) Agent | None
+        +async count() int
+        +async save(agent: Agent) None
+        +async find_by_name(empire_id: EmpireId, name: str) Agent | None
+    }
+    class SqliteAgentRepository {
+        +session: AsyncSession
+        +async find_by_id(agent_id: AgentId) Agent | None
+        +async count() int
+        +async save(agent: Agent) None
+        +async find_by_name(empire_id: EmpireId, name: str) Agent | None
+        -_to_row(agent: Agent) tuple
+        -_from_row(agent_row, provider_rows, skill_rows) Agent
+    }
+```
+
+### Protocol: AgentRepository（`application/ports/agent_repository.py`）
+
+| メソッド | 引数 | 戻り値 | 制約 |
+|----|----|----|----|
+| `find_by_id(agent_id: AgentId)` | AgentId | `Agent \| None` | 不在時 None。SQLAlchemy 例外は上位伝播 |
+| `count()` | なし | `int` | 全 Agent 数（empire-repo §確定 D 同 SQL `COUNT(*)` 契約） |
+| `save(agent: Agent)` | Agent | None | 同一 Tx 内で agents + agent_providers + agent_skills を delete-then-insert（empire-repo §確定 B 踏襲）|
+| `find_by_name(empire_id: EmpireId, name: str)` | EmpireId + name 文字列 | `Agent \| None` | **第 4 method**、Empire スコープでの一意検査（§確定 R1-C）。不在時 None |
+
+`@runtime_checkable` は付与しない（empire-repo §確定 A）。
+
+### Class: SqliteAgentRepository（`infrastructure/persistence/sqlite/repositories/agent_repository.py`）
+
+| 属性 | 型 | 制約 |
+|----|----|----|
+| `session` | `AsyncSession` | コンストラクタで注入、Tx 境界は外側 service が管理 |
+
+| 関数 | 引数 | 戻り値 | 制約 |
+|----|----|----|----|
+| `__init__(session: AsyncSession)` | session | None | session を保持するだけ、Tx は開かない |
+| `find_by_id(agent_id)` | AgentId | `Agent \| None` | agents SELECT → 不在なら None。存在すれば agent_providers を `ORDER BY provider_kind` / agent_skills を `ORDER BY skill_id` で SELECT（§BUG-EMR-001 規約）→ `_from_row` で構築 |
+| `count()` | なし | int | `select(func.count()).select_from(AgentRow)` で SQL `COUNT(*)`、`scalar_one()` で int 取得。**全行ロード+ Python `len()` パターン禁止** |
+| `save(agent)` | Agent | None | §確定 B の delete-then-insert（5 段階手順、後述） |
+| `find_by_name(empire_id, name)` | EmpireId + str | `Agent \| None` | `SELECT id FROM agents WHERE empire_id = :empire_id AND name = :name LIMIT 1` で AgentId 取得 → 存在すれば `find_by_id(found_id)` で子テーブル含めて Agent 復元（§確定 G）|
+| `_to_row(agent)` | Agent | `tuple[dict, list[dict], list[dict]]` | (agents_row, provider_rows, skill_rows) に分離（empire-repo §確定 C） |
+| `_from_row(agent_row, provider_rows, skill_rows)` | dict, list[dict], list[dict] | Agent | VO 構造で復元（§確定 H で `prompt_body` の masked 復元を凍結） |
+
+### Tables（既存 M2 永続化基盤の table モジュール群に追加）
+
+| テーブル | モジュール | カラム |
+|----|----|----|
+| `agents` | `infrastructure/persistence/sqlite/tables/agents.py`（新規）| `id: UUIDStr PK` / `empire_id: UUIDStr FK CASCADE` / `name: String(40) NOT NULL`（DB UNIQUE なし）/ `role: String(32) NOT NULL` / `display_name: String(80) NOT NULL` / `archetype: String(80) NOT NULL DEFAULT ''` / **`prompt_body: MaskedText NOT NULL DEFAULT ''`** / `archived: Boolean NOT NULL DEFAULT FALSE` |
+| `agent_providers` | `infrastructure/persistence/sqlite/tables/agent_providers.py`（新規）| `agent_id: UUIDStr FK CASCADE` / `provider_kind: String(32)` / `model: String(80)` / `is_default: Boolean DEFAULT FALSE` / UNIQUE(agent_id, provider_kind) / **partial unique index `WHERE is_default = 1`** |
+| `agent_skills` | `infrastructure/persistence/sqlite/tables/agent_skills.py`（新規）| `agent_id: UUIDStr FK CASCADE` / `skill_id: UUIDStr` / `name: String(80)` / `path: String(500)` / UNIQUE(agent_id, skill_id) |
+
+すべて `bakufu.infrastructure.persistence.sqlite.base.Base` を継承。
+
+## 確定事項（先送り撤廃）
+
+### 確定 A: empire-repo / workflow-repo テンプレート 100% 継承（再凍結）
+
+empire-repository PR #29/#30 の §確定 A〜F + §Known Issues §BUG-EMR-001 規約 + workflow-repository PR #41 の §確定 E（CI 三層防衛 正のチェック）を**そのまま継承**。本 PR で再議論しない項目:
+
+| empire/workflow 確定 | 本 PR への適用 |
+|---|---|
+| empire §確定 A | `application/ports/agent_repository.py` 新規、Protocol、`@runtime_checkable` なし |
+| empire §確定 B | `save()` で agents UPSERT + agent_providers DELETE/INSERT + agent_skills DELETE/INSERT、Repository 内 commit/rollback なし |
+| empire §確定 C | `_to_row` / `_from_row` を private method に閉じる |
+| empire §確定 D | `count()` は SQL `COUNT(*)` 限定 |
+| empire §確定 E | CI 三層防衛 Layer 1 + Layer 2 + Layer 3 全部に Agent 3 テーブル明示登録 |
+| empire §BUG-EMR-001 規約 | `find_by_id` 子テーブル SELECT は `ORDER BY provider_kind` / `ORDER BY skill_id` 必須 |
+| workflow §確定 E（正のチェック）| `agents.prompt_body` の `MaskedText` 必須を grep + arch test で物理保証 |
+
+### 確定 B: `save()` 5 段階手順（empire-repo §確定 B の Agent 適用）
+
+| 順 | 操作 | SQL（概要） |
+|---|---|---|
+| 1 | agents UPSERT | `INSERT INTO agents (id, empire_id, name, role, display_name, archetype, prompt_body, archived) VALUES (...) ON CONFLICT (id) DO UPDATE SET name=..., prompt_body=...`（**`prompt_body` は `MaskedText.process_bind_param` 経由でマスキング**）|
+| 2 | agent_providers DELETE | `DELETE FROM agent_providers WHERE agent_id = :agent_id` |
+| 3 | agent_providers bulk INSERT | `INSERT INTO agent_providers (agent_id, provider_kind, model, is_default) VALUES ...`（agent.providers 件数分）|
+| 4 | agent_skills DELETE | `DELETE FROM agent_skills WHERE agent_id = :agent_id` |
+| 5 | agent_skills bulk INSERT | `INSERT INTO agent_skills (agent_id, skill_id, name, path) VALUES ...`（agent.skills 件数分）|
+
+##### Tx 境界の責務分離（再凍結）
+
+`SqliteAgentRepository.save()` は **明示的な commit / rollback をしない**。呼び出し側 service が `async with session.begin():` で UoW 境界を管理（empire-repo §確定 B 踏襲）。
+
+### 確定 C: domain ↔ row 変換契約（empire-repo §確定 C の Agent 適用）
+
+##### `_to_row(agent: Agent)` 契約
+
+| 入力 | 出力 |
+|---|---|
+| `Agent`（Aggregate Root インスタンス） | `tuple[dict, list[dict], list[dict]]` |
+
+戻り値:
+1. `agents_row: dict[str, Any]` — `{'id': ..., 'empire_id': ..., 'name': ..., 'role': ..., 'display_name': agent.persona.display_name, 'archetype': agent.persona.archetype, 'prompt_body': agent.persona.prompt_body, 'archived': ...}`
+2. `provider_rows: list[dict[str, Any]]` — 各 ProviderConfig を `{'agent_id': ..., 'provider_kind': ..., 'model': ..., 'is_default': ...}` に変換
+3. `skill_rows: list[dict[str, Any]]` — 各 SkillRef を `{'agent_id': ..., 'skill_id': ..., 'name': ..., 'path': ...}` に変換
+
+##### `_from_row(agent_row, provider_rows, skill_rows)` 契約
+
+| 入力 | 出力 |
+|---|---|
+| `agent_row: dict` / `provider_rows: list[dict]` / `skill_rows: list[dict]` | `Agent` |
+
+戻り値: `Agent(id=..., empire_id=..., name=..., role=..., persona=Persona(display_name=..., archetype=..., prompt_body=masked_str), providers=[...], skills=[...], archived=...)`。Aggregate Root の不変条件は構築時の `model_validator(mode='after')` で再走（agent #17 で凍結済み）。
+
+##### masked `prompt_body` 復元の不可逆性凍結（§確定 H）
+
+`prompt_body` は DB 上で masked された文字列で保存されているため、`_from_row` で読み出した値は raw 復元不能。`Persona(prompt_body=masked_str)` で構築するが、当該 Agent を LLM Adapter に配送すると `<REDACTED:*>` が prompt に流れる。MVP では「CEO が再 hire」運用、後続 `feature/llm-adapter` で警告経路を凍結（§Known Issues §申し送り）。
+
+### 確定 D: `count()` SQL 契約（empire-repo §確定 D 踏襲）
+
+| 採用 | 不採用 | 理由 |
+|---|---|---|
+| `select(func.count()).select_from(AgentRow)` で SQL `COUNT(*)` 発行、`scalar_one()` で int 取得 | `select(AgentRow.id)` で全行を取得して Python `len(list(result.scalars().all()))` | 後続 PR が `count()` を実装する際、本 PR の実装パターンを真似する。Agent provider / skill は 100+ 件まで膨れ得るため、**全行ロード+ Python `len()` パターン伝播禁止** |
+
+### 確定 E: CI 三層防衛 Agent 拡張（**正/負のチェック併用**、workflow-repo §確定 E パターン）
+
+##### Layer 1: grep guard（`scripts/ci/check_masking_columns.sh`）
+
+| 登録内容 | 期待結果 |
+|---|---|
+| `tables/agents.py` の `prompt_body` カラム宣言行に `MaskedText` が含まれる | grep ヒット必須 → pass（**正のチェック**、Schneier #3 実適用 grep 物理保証）|
+| `tables/agents.py` の `prompt_body` 以外のカラムに `MaskedText` / `MaskedJSONEncoded` が登場しない | grep 1 ヒット限定 → pass（過剰マスキング防止）|
+| `tables/agent_providers.py` 全体に `MaskedText` / `MaskedJSONEncoded` が登場しない | grep ゼロヒット → pass |
+| `tables/agent_skills.py` 全体に同上 | 同上 |
+
+##### Layer 2: arch test（`backend/tests/architecture/test_masking_columns.py`）
+
+| 入力 | 期待 assertion |
+|---|---|
+| `Base.metadata.tables['agents']` の `prompt_body` カラム | `column.type.__class__ is MaskedText`（**正のチェック**）|
+| `Base.metadata.tables['agents']` の `prompt_body` 以外のカラム | `column.type.__class__` が `MaskedText` でも `MaskedJSONEncoded` でもない |
+| `Base.metadata.tables['agent_providers']` | 全カラム masking なし |
+| `Base.metadata.tables['agent_skills']` | 全カラム masking なし |
+
+##### Layer 3: storage.md 逆引き表更新（REQ-AGR-005）
+
+`docs/architecture/domain-model/storage.md` §逆引き表に Agent 関連 2 行追加（既存 `Persona.prompt_body` 行は本 PR で実適用済みに更新）。
+
+### 確定 F: `find_by_name(empire_id, name)` 第 4 method 契約（§確定 R1-C 詳細）
+
+##### 採用方針: Empire スコープで `(empire_id, name)` 複合検索
+
+| 候補 | 採否 | 理由 |
+|---|---|---|
+| **(a) `find_by_name(empire_id, name)` で `WHERE empire_id=? AND name=?`** | ✓ 採用 | name 一意性が Empire 内なので empire_id を必須引数にとる |
+| (b) `find_by_name(name)` で全 Empire を検索 | ✗ 不採用 | 異 Empire で同 name を持つ Agent が存在し得るため、複数行返って判定が壊れる |
+| (c) `find_by_id` を全件 SELECT して filter | ✗ 不採用 | N+1、後続 PR が真似すると数千 Agent でメモリ枯渇 |
+
+##### 実装契約
+
+| 段階 | 動作 |
+|---|---|
+| 1 | `SELECT id FROM agents WHERE empire_id = :empire_id AND name = :name LIMIT 1` で AgentId 取得 |
+| 2 | 不在なら `None` を返す |
+| 3 | 存在すれば `await self.find_by_id(found_id)` を呼んで子テーブル含めて Agent 復元 |
+| 4 | Agent or `None` を返す（None は概念上「ヒットしたが復元失敗」が起こり得ないので返らない、Step 1 で None 確定）|
+
+##### `find_by_id` 経由で復元する根拠
+
+`find_by_name` が独立して agents + agent_providers + agent_skills の 3 SELECT を実装すると、`find_by_id` のロジックと重複する。`_from_row` 系の責務散在を防ぐため、**`find_by_name` は AgentId だけ取得 → `find_by_id` に委譲**する。
+
+### 確定 G: `is_default` partial unique index 二重防衛（§確定 R1-D 詳細）
+
+##### Alembic での生成
+
+```
+op.create_index(
+    'uq_agent_providers_default',
+    'agent_providers',
+    ['agent_id'],
+    unique=True,
+    sqlite_where=sa.text('is_default = 1'),
+)
+```
+
+##### 違反時の挙動
+
+| 経路 | 違反検出層 | 例外 |
+|---|---|---|
+| Aggregate 内（既存）| `_validate_provider_is_default_unique` で list を走査（agent #17 凍結） | `AgentInvariantViolation(kind='default_provider_uniqueness')` |
+| **DB partial unique index（本 PR 新規）** | INSERT/UPDATE で `WHERE is_default=1` の集合に違反する行が来たら raise | `sqlalchemy.IntegrityError` |
+
+二重防衛の意図: Aggregate 検査が壊れた場合（VO バグ / 直 SQL 流入）の最終防衛線として DB レベルで物理拒否、Defense in Depth。
+
+### 確定 H: `prompt_body` masking の不可逆性凍結（Schneier #3 実適用の副作用）
+
+##### 採用方針: masking は永続化前のみ実施、復元時は復元できないことを許容
+
+`agents.prompt_body` は **`MaskedText.process_bind_param` で永続化前マスキング**。`MaskingGateway.mask()` は不可逆操作（API key 形式正規表現マッチ → `<REDACTED:ANTHROPIC_KEY>` 等）で、DB から読み出した文字列から元の token は復元できない。
+
+| シナリオ | 想定挙動 |
+|---|---|
+| `save(agent)` で raw `prompt_body='ANTHROPIC_API_KEY=sk-ant-XXX...'` を渡す | DB には `<REDACTED:ENV:ANTHROPIC_API_KEY>` or `<REDACTED:ANTHROPIC_KEY>` が永続化（適用順序は storage.md §マスキング規則の通り）|
+| `find_by_id(agent.id)` で復元 | `Persona.prompt_body` には masked 文字列が入る、Pydantic 構築は通過（PROMPT_BODY_MAX 内、文字種制約なし）|
+| LLM Adapter が `Persona.prompt_body` を prompt に展開 | `<REDACTED:*>` がそのまま LLM に流れる、品質劣化 |
+
+##### 申し送り（Agent 後続申し送り #1）: LLM Adapter での masked 検出 + 警告
+
+後続 `feature/llm-adapter` で「`Persona.prompt_body` に `<REDACTED:*>` を含む Agent はログ警告 + 配送停止」契約を凍結する責務。本 PR では Repository 層の masking 不可逆性のみ凍結し、配送側は範囲外。
+
+| 候補 | 採否 |
+|---|---|
+| (a) Repository が復元時に masked 検出して警告を上げる | ✗ 不採用（Repository は単機能 CRUD、警告は LLM Adapter / application 層責務） |
+| (b) `Persona` VO 側で masked 検出 | ✗ 不採用（VO は raw / masked を区別せず保持、構造的制約のみ）|
+| **(c) `feature/llm-adapter` で配送前検出 + 警告 + 配送停止** | ✓ **採用**（責務分離、本 PR は masking 適用のみで完結） |
+
+### 確定 I: テスト責務の 4 ファイル分割（empire-repo PR #29 / workflow-repo PR #41 教訓を最初から反映）
+
+empire-repo PR #29 で 506 行 → 500 行ルール違反でディレクトリ分割した教訓、workflow-repo PR #41 で 502 行 → 同じく分割した教訓を踏襲。本 PR は**最初から 4 ファイル分割**:
+
+| ファイル | 責務 |
+|---|---|
+| `test_agent_repository/test_protocol_crud.py` | save → find_by_id 経路の正常系、count() の SQL 契約、find_by_name の Empire スコープ検索 |
+| `test_agent_repository/test_save_semantics.py` | delete-then-insert の物理保証、ORDER BY 規約（§BUG-EMR-001 継承）|
+| `test_agent_repository/test_constraints_arch.py` | UNIQUE 制約 / **partial unique index `WHERE is_default=1`** / FK CASCADE / pyright Protocol 充足 |
+| `test_agent_repository/test_masking_persona.py` | **Schneier #3 実適用専用**: raw `prompt_body` を渡して DB に `<REDACTED:*>` が永続化されることを raw SQL で物理確認、masking 不可逆性の物理確認 |
+
+各ファイルは 200 行を目安、500 行ルール厳守。
+
+## 設計判断の補足
+
+### なぜ `find_by_name` を Protocol に追加するか（empire-repo の 3 method を超える初の Repository）
+
+empire-repo §確定 A では Protocol を 3 method（find_by_id / count / save）で凍結したが、Agent には「name の Empire 内一意」という Aggregate 不変条件のうち**集合知識**（DB SELECT を要する）が必要。application 層が `find_by_id` を全件呼び出して filter する実装は N+1 / メモリ枯渇のテンプレを後続 PR に伝染させる経路（empire-repo §確定 D の `count()` 教訓と同方針）。
+
+`find_by_name(empire_id, name)` を Repository に追加することで、**Aggregate 不変条件の集合知識を Repository が SQL レベルで吸収**する責務分離テンプレートを確立。後続 PR（room / directive / task）が同パターンを真似できる。
+
+### なぜ `agents.name` に DB UNIQUE を張らないか
+
+`agents(empire_id, name)` の複合 UNIQUE を張ると、application 層が MSG-AG-NNN を出す前に `IntegrityError` が raise され、ユーザー向けメッセージの統一が崩れる（agent feature §確定 R1-B 凍結済みの責務分離方針）。`find_by_name` 経由で application 層検査の経路を残し、DB UNIQUE は張らない。
+
+`is_default` の partial unique index は別問題（§確定 G）: こちらは Aggregate 内検査の最終防衛線として **DB レベルで物理拒否**することに意味がある（壊れたデータが Aggregate 復元時に valid 判定をすり抜ける経路を物理的に塞ぐ）。
+
+### なぜ `prompt_body` を `MaskedText` にするか（Schneier #3 実適用の根拠）
+
+CEO が persona 設計時に prompt_body に「`環境変数 ANTHROPIC_API_KEY=sk-ant-...` を使え」と書く経路は現実にあり得る。masking しないと:
+
+1. DB 直読み / バックアップで token 流出
+2. SQL ログで token 流出
+3. 監査ログで token 流出
+4. 後続 PR の `find_all()` 系で token 流出
+
+application 層でマスキングする方針は実装漏れリスクが高く、**永続化前の単一ゲートウェイ**（persistence-foundation §確定 R1-D）を信じて `MaskedText` で TypeDecorator 経由のマスキング強制が正解。
+
+## ユーザー向けメッセージの確定文言
+
+該当なし — 理由: Repository は内部 API、ユーザー向けメッセージは application 層 / HTTP API 層が定義する。Repository は SQLAlchemy 例外 + `pydantic.ValidationError` を上位伝播するのみ。
+
+## データ構造（永続化キー）
+
+### `agents` テーブル
+
+| カラム | 型 | 制約 | 意図 |
+|----|----|----|----|
+| `id` | `UUIDStr` | PK, NOT NULL | AgentId |
+| `empire_id` | `UUIDStr` | FK → `empires.id` ON DELETE CASCADE, NOT NULL | 所属 Empire |
+| `name` | `String(40)` | NOT NULL（DB UNIQUE なし、application 層責務）| 表示名 |
+| `role` | `String(32)` | NOT NULL（Role enum）| 役割テンプレ |
+| `display_name` | `String(80)` | NOT NULL | Persona.display_name |
+| `archetype` | `String(80)` | NOT NULL DEFAULT '' | Persona.archetype |
+| `prompt_body` | **`MaskedText`** | NOT NULL DEFAULT '' | Persona.prompt_body（**Schneier #3 実適用、§確定 H 不可逆性凍結**）|
+| `archived` | `Boolean` | NOT NULL DEFAULT FALSE | アーカイブ状態 |
+
+### `agent_providers` テーブル
+
+| カラム | 型 | 制約 | 意図 |
+|----|----|----|----|
+| `agent_id` | `UUIDStr` | FK → `agents.id` ON DELETE CASCADE, NOT NULL | 所属 Agent |
+| `provider_kind` | `String(32)` | NOT NULL（ProviderKind enum）| LLM プロバイダ |
+| `model` | `String(80)` | NOT NULL | model 名 |
+| `is_default` | `Boolean` | NOT NULL DEFAULT FALSE | 既定 provider |
+| UNIQUE | `(agent_id, provider_kind)` | — | 同 Agent 内で provider_kind 重複禁止 |
+| **partial unique** | `(agent_id) WHERE is_default = 1` | — | **§確定 G 二重防衛、Aggregate `_validate_provider_is_default_unique` の最終防衛線** |
+
+### `agent_skills` テーブル
+
+| カラム | 型 | 制約 | 意図 |
+|----|----|----|----|
+| `agent_id` | `UUIDStr` | FK → `agents.id` ON DELETE CASCADE, NOT NULL | 所属 Agent |
+| `skill_id` | `UUIDStr` | NOT NULL | SkillId |
+| `name` | `String(80)` | NOT NULL | SkillRef.name |
+| `path` | `String(500)` | NOT NULL | SkillRef.path（H1〜H10 検証は VO 構築時に完了済み）|
+| UNIQUE | `(agent_id, skill_id)` | — | 同 Agent 内で skill_id 重複禁止 |
+
+### Alembic 4th revision キー構造（`0004_agent_aggregate.py`）
+
+| 項目 | 値 |
+|----|----|
+| revision id | `0004_agent_aggregate`（固定） |
+| down_revision | `0003_workflow_aggregate`（workflow-repo PR #41 で凍結済み）|
+
+| 操作 | 対象 |
+|----|----|
+| `op.create_table('agents', ...)` | 8 カラム |
+| `op.create_table('agent_providers', ...)` | 4 カラム + UNIQUE(agent_id, provider_kind) |
+| `op.create_index('uq_agent_providers_default', 'agent_providers', ['agent_id'], unique=True, sqlite_where=sa.text('is_default = 1'))` | partial unique index |
+| `op.create_table('agent_skills', ...)` | 4 カラム + UNIQUE(agent_id, skill_id) |
+
+`downgrade()` は `op.drop_table` で逆順実行（agent_skills → agent_providers → agents、CASCADE で子から先に削除）。
+
+##### Alembic chain 一直線の物理保証
+
+CI で head が分岐していないことを検査する既存スクリプト（M2 永続化基盤で凍結）が `0001 → 0002 → 0003 → 0004` の単一 chain を assert。
+
+## API エンドポイント詳細
+
+該当なし — 理由: 本 feature は infrastructure 層のみ。HTTP API は `feature/http-api` で凍結する。
+
+## Known Issues
+
+### 申し送り #1: masked `prompt_body` の LLM Adapter 配送経路（§確定 H）
+
+`find_by_id` で復元される Agent の `Persona.prompt_body` には masked 文字列が入る。LLM Adapter が prompt に展開すると `<REDACTED:*>` がそのまま流れて品質劣化。後続 `feature/llm-adapter` で「masked 検出 + ログ警告 + 配送停止」契約を凍結する責務（本 PR スコープ外）。
+
+## 出典・参考
+
+- [SQLAlchemy 2.0 — async / AsyncEngine / AsyncSession](https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html)
+- [SQLAlchemy 2.0 — TypeDecorator](https://docs.sqlalchemy.org/en/20/core/custom_types.html#augmenting-existing-types) — `MaskedText` の `process_bind_param` 経路
+- [SQLite — Partial Indexes](https://www.sqlite.org/partialindex.html) — §確定 G の `WHERE is_default = 1` 根拠
+- [Alembic Tutorial](https://alembic.sqlalchemy.org/en/latest/tutorial.html)
+- [`docs/features/persistence-foundation/`](../persistence-foundation/) — M2 永続化基盤（PR #23、`MaskedText` + Schneier #3 hook 構造）
+- [`docs/features/empire-repository/`](../empire-repository/) — **テンプレート真実源**（§確定 A〜F + §BUG-EMR-001 規約）
+- [`docs/features/workflow-repository/`](../workflow-repository/) — **2 件目テンプレート**（masking 対象あり版、CI 三層防衛 正のチェック）
+- [`docs/features/agent/`](../agent/) — Agent domain 設計（PR #17 マージ済み、§確定 K で `is_default` 一意性、§確定 H で SkillRef path 検証 H1〜H10 凍結）
+- [`docs/architecture/domain-model/storage.md`](../../architecture/domain-model/storage.md) — 逆引き表（本 PR で Agent 行追加 + 既存 `Persona.prompt_body` 行を実適用済みに更新）
+- [`docs/architecture/threat-model.md`](../../architecture/threat-model.md) — A02 / A04 / A08 / A09 対応根拠

--- a/docs/features/agent-repository/requirements-analysis.md
+++ b/docs/features/agent-repository/requirements-analysis.md
@@ -1,0 +1,226 @@
+# 要求分析書
+
+> feature: `agent-repository`
+> Issue: [#32 feat(agent-repository): Agent SQLite Repository (M2, 0004, Schneier #3 実適用)](https://github.com/bakufu-dev/bakufu/issues/32)
+> 関連: [`docs/features/empire-repository/`](../empire-repository/) **テンプレート真実源**（§確定 A〜F + §Known Issues §BUG-EMR-001 規約） / [`docs/features/workflow-repository/`](../workflow-repository/) **2 件目テンプレート**（masking 対象あり版で正のチェック CI 三層防衛 + `migration-plan.md` 流入元の先例） / [`docs/features/agent/`](../agent/) （domain 設計済み、PR #17 マージ済み）
+
+## 人間の要求
+
+> Issue #32:
+>
+> bakufu MVP（v0.1.0）M2「SQLite 永続化」の後続 Repository PR（empire-repository #25 のテンプレート責務継承）。**Agent Aggregate** の SQLite 永続化を実装する。Alembic revision **0004_agent_aggregate** で `agents` / `agent_providers` / `agent_skills` の 3 テーブルを追加。**Schneier 申し送り #3（`Persona.prompt_body` Repository マスキング）の実適用が本 PR の核心**。
+
+## 背景・目的
+
+### 現状の痛点
+
+1. M2 永続化基盤（PR #23）+ empire-repository（PR #29 / #30）+ workflow-repository（PR #41 マージ済み）が 3 件 chain で揃ったが、Agent は domain 層（PR #17）が完了していても **`Persona.prompt_body` の永続化経路がない**。MVP 核心ユースケース「CEO directive → Task → Agent が成果物 commit」のうち Agent 側の Repository が塞がれている
+2. **Schneier 申し送り #3**: persistence-foundation PR #23 で `MaskedText` の TypeDecorator 構造は提供されたが、`Persona.prompt_body` への**実適用**は agent-repository PR で行うとして hook 構造のみ凍結。本 PR で実適用に移行しないと「Persona に API key / GitHub PAT が混入したらマスキングされない」状態が継続する
+3. agent feature §確定 R1-B で「`name` の Empire 内一意は application 層責務（`AgentService.hire()` で検査）」と凍結したが、Repository に `find_by_name(empire_id, name)` を追加しないと application 層の検査経路が成立しない。**empire-repo の 3 method（find_by_id / count / save）を超える初の Repository PR**
+4. agent feature §確定 K で `providers` の `is_default == True` は 1 件のみという Aggregate 不変条件を凍結したが、**DB レベル制約（partial unique index）**を張らないと「Repository が壊れた行を返したときに Aggregate 構築で初めて気づく」二重防衛の物理保証が抜ける
+
+### 解決されれば変わること
+
+- `feature/dispatcher` / `feature/llm-adapter`（後続）が Agent を `AgentRepository.find_by_id` で復元 → Persona / ProviderConfig / SkillRef を valid な状態で受け取れる
+- application 層 `AgentService.hire(empire_id, name, ...)` が `find_by_name(empire_id, name)` で重複検査 → Empire 内一意性を保証
+- Persona.prompt_body に CEO が誤って API key / GitHub PAT を貼り付けても DB には `<REDACTED:ANTHROPIC_KEY>` / `<REDACTED:GITHUB_PAT>` で永続化、ログ・監査経路への流出を防ぐ（**Schneier 申し送り #3 完了**）
+- empire-repo / workflow-repo に続く **3 件目のテンプレート** として、後続 4 件 Repository PR（room / directive / task / external-review-gate-repository）が `find_by_name` 系の追加 method パターンを真似できる経路が確立
+
+### ビジネス価値
+
+- bakufu の核心思想「AI 協業」の主体である Agent を**安全に永続化**する。Persona に CEO が貼り付けたシステムプロンプトに secret が混入する経路を物理的に塞ぐ（Defense in Depth、persistence-foundation §シークレットマスキング規則の Repository 経路実適用）
+- `find_by_name` 第 4 method の追加で「Aggregate 不変条件のうち DB SELECT を要する集合知識（Empire 内一意）」を application 層で安全に検査できる Repository 契約のテンプレートを確立
+
+## 議論結果
+
+### 設計担当による採用前提
+
+- empire-repository PR #29 / #30 §確定 A〜F + §Known Issues §BUG-EMR-001 規約を **100% 継承**
+- workflow-repository PR #41 §確定 G〜J + §確定 E（CI 三層防衛で **正のチェック導入**）を継承（masking 対象あり版テンプレート）
+- Aggregate Root: Agent、3 テーブル: `agents` / `agent_providers` / `agent_skills`
+- Alembic revision: `0004_agent_aggregate`、`down_revision="0003_workflow_aggregate"`（chain 一直線）
+- masking 対象カラム: **`agents.prompt_body` のみ**（`MaskedText`、Schneier #3 実適用）
+- find_by_id 子テーブル SELECT は `ORDER BY provider_kind` / `ORDER BY skill_id`（§Known Issues §BUG-EMR-001 規約）
+- save() は delete-then-insert で 3 テーブル（empire-repo §確定 B 踏襲、5 段階手順 → Agent では 5 段階に拡張: agents UPSERT + agent_providers DELETE/INSERT + agent_skills DELETE/INSERT）
+- count() は SQL `COUNT(*)`（empire-repo §確定 D 踏襲）
+
+### 却下候補と根拠
+
+| 候補 | 却下理由 |
+|---|---|
+| `agents.prompt_body` を `JSONEncoded` で保存（masking なし）+ application 層でマスキング | application 層実装漏れで raw 永続化リスク、Schneier 申し送り #3 違反。`MaskedText` 強制 |
+| `agents.name` に DB レベル UNIQUE 制約 (`UNIQUE(empire_id, name)`) を張る | empire feature §確定 R1-B で「name は application 層責務」と凍結済み。DB UNIQUE を張ると application 層の MSG-AG-NNN を出す前に IntegrityError が raise され、ユーザー向けメッセージが汚れる。`find_by_name` で application 層検査の経路を残す |
+| `is_default` partial unique index は使わず application 層検査のみ | Aggregate 内不変条件 + application 層検査のみだと、Repository が壊れた行を返した場合の最終防衛線が抜ける。SQLite `CREATE UNIQUE INDEX ... WHERE is_default = 1` で**二重防衛** |
+| `agent_skills` テーブルで `path` カラムに正規表現 CHECK 制約 | SkillRef.path の H1〜H10 検証は domain VO 構築時に既に走っている（agent feature §確定 H 凍結済み）。Repository は valid な SkillRef のみ受け取る契約、DB レベル CHECK は冗長で portability も下がる |
+| `find_by_name(empire_id, name) -> Agent \| None` を Protocol に追加せず application 層が `find_by_id` を全件 SELECT して filter | N+1 / 全件ロードで MVP の数十 Agent は耐えられるが、後続 PR が「ある Empire の全 Agent を一覧」で同パターンを真似すると数千 Agent でメモリ枯渇。empire-repo §確定 D の `count()` 教訓と同じ理由で **SQL レベル WHERE で済ませる** |
+
+### 重要な選定確定（レビュー指摘 R1 応答）
+
+#### 確定 R1-A: empire / workflow テンプレート 100% 継承（再凍結）
+
+| 継承項目 | 本 PR への適用 |
+|---|---|
+| empire §確定 A | `application/ports/agent_repository.py` 新規、Protocol、`@runtime_checkable` なし |
+| empire §確定 B | save() で agents UPSERT + agent_providers DELETE/INSERT + agent_skills DELETE/INSERT、Repository 内 commit/rollback なし |
+| empire §確定 C | `_to_row` / `_from_row` を private method に閉じる |
+| empire §確定 D | `count()` は SQL `COUNT(*)` 限定 |
+| empire §確定 E | CI 三層防衛 Layer 1 + Layer 2 + Layer 3 全部に Agent 3 テーブル明示登録 |
+| empire §Known Issues §BUG-EMR-001 規約 | `find_by_id` 子テーブル SELECT は `ORDER BY provider_kind` / `ORDER BY skill_id` 必須 |
+| workflow §確定 E | **正のチェック CI 三層防衛**（`agents.prompt_body` の `MaskedText` 必須を grep + arch test で物理保証） |
+| workflow §確定 J | DB FK 不採用論点は本 Aggregate にはなし（agent_providers / agent_skills は agent_id への FK CASCADE で循環なし）、ただし migration-plan.md 流入元の先例は踏襲（必要に応じて TODO-MIG-NNN を追記） |
+
+#### 確定 R1-B: Schneier 申し送り #3 の実適用（本 PR の核心）
+
+`agents.prompt_body` カラムを **`MaskedText`** で宣言、`process_bind_param` で `MaskingGateway.mask()` 経由マスキング:
+
+| 経路 | 動作 |
+|---|---|
+| `_to_row(agent)` | `agents_row['prompt_body'] = agent.persona.prompt_body`（raw 文字列） |
+| `MaskedText.process_bind_param` | INSERT/UPDATE 直前に `MaskingGateway.mask(prompt_body)` を呼ぶ → `<REDACTED:*>` 化された文字列を DB に保存 |
+| `_from_row(agent_row, ...)` | DB から masked 文字列を取得、`Persona(prompt_body=masked_string)` で復元（masking 不可逆性は workflow-repo §確定 H と同方針、復元時の元 token 復元は不可） |
+
+**復元不可逆性の申し送り**: `find_by_id` で復元される Agent の `Persona.prompt_body` には masked 文字列が入る。Agent が LLM Adapter にこれを送ると `<REDACTED:*>` がそのまま prompt に流れ、LLM 出力品質が下がる経路が生じる。MVP では「CEO が再 hire する運用」で吸収、後続 `feature/llm-adapter` で「prompt_body に `<REDACTED:*>` を含む Agent はログ警告 + 配送停止」契約を凍結する申し送り（workflow-repo §確定 H 申し送り #1 と同パターン）。
+
+#### 確定 R1-C: `find_by_name(empire_id, name) -> Agent | None` 第 4 method 追加
+
+empire-repo の Protocol は 3 method（find_by_id / count / save）だが、本 PR で **第 4 method として `find_by_name` を追加**する:
+
+| メソッド | 引数 | 戻り値 | 用途 |
+|---|---|---|---|
+| `find_by_name(empire_id: EmpireId, name: str) -> Agent \| None` | EmpireId + name 文字列 | 該当 Agent or None | application 層 `AgentService.hire()` の Empire 内一意検査 |
+
+##### Empire スコープでの検索を必須とする理由
+
+`name` 一意性は Empire 内（`(empire_id, name)` の複合一意）のため、`find_by_name(name)` だけでは不十分。`empire_id` も引数に取って `WHERE empire_id = :empire_id AND name = :name` で SELECT する。
+
+##### 後続 Repository PR への申し送り（テンプレート責務）
+
+本 §確定 R1-C は「Aggregate 不変条件のうち DB SELECT を要する集合知識（Empire 内一意 / Room 内一意 等）を Repository 第 4+ method として追加するテンプレート」を確立する。後続 PR が同パターンを採用する場合:
+
+| 後続 PR 候補 | 想定される追加 method |
+|---|---|
+| `feature/room-repository` | `find_by_name(empire_id, name)` 同パターン |
+| `feature/directive-repository` | `find_by_target_room_id(room_id, after: datetime)` 等の Room 別検索（業務要件次第） |
+| `feature/task-repository`（Issue #35） | `find_blocked() -> list[Task]`（admin CLI `list-blocked` の経路）|
+
+#### 確定 R1-D: `is_default` partial unique index による二重防衛
+
+agent feature §確定 K で「`providers` のうち `is_default == True` は 1 件のみ」を Aggregate 内不変条件として凍結済み。本 PR で **DB レベル partial unique index** を追加して二重防衛:
+
+```sql
+CREATE UNIQUE INDEX uq_agent_providers_default
+  ON agent_providers (agent_id)
+  WHERE is_default = 1;
+```
+
+| 防衛層 | 検査内容 | 違反時 |
+|---|---|---|
+| Aggregate 内（既存）| `_validate_provider_is_default_unique` で list を走査 | `AgentInvariantViolation(kind='default_provider_uniqueness')` |
+| **DB partial unique index（本 PR 新規）** | INSERT/UPDATE で `WHERE is_default=1` の集合に違反する行が来たら IntegrityError | `sqlalchemy.IntegrityError`、application 層が catch して 500 にマッピング（データ破損として扱う） |
+
+##### partial unique index を選ぶ根拠
+
+| 採用 | 不採用 | 理由 |
+|---|---|---|
+| **partial unique index** (`UNIQUE WHERE is_default = 1`) | フル UNIQUE 制約 (`UNIQUE(agent_id, is_default)`) | フル UNIQUE は `is_default=False` の行が複数あったとき重複を許せない（`(agent_a, False)` を 2 件持てなくなる）。partial で「True の行に限る」が正解 |
+| | アプリ層検査のみ | Aggregate 内検査が壊れた場合の最終防衛線が消える、Defense in Depth 違反 |
+
+SQLite は partial index をサポート（[公式ドキュメント](https://www.sqlite.org/partialindex.html)）。Alembic は `op.create_index('...', '...', ['agent_id'], unique=True, sqlite_where=sa.text('is_default = 1'))` で生成可能。
+
+#### 確定 R1-E: storage.md 逆引き表更新（Schneier #3 実適用の物理保証）
+
+`docs/architecture/domain-model/storage.md` §逆引き表に Agent 関連 2 行追加:
+
+| 行 | 内容 |
+|---|---|
+| `agents.prompt_body` | `MaskedText`、Schneier 申し送り #3 **実適用**、persistence-foundation #23 で hook 構造提供済みを本 PR で配線 |
+| `agents` 残カラム + `agent_providers` 全カラム + `agent_skills` 全カラム | masking 対象なし（`UUIDStr` / `String` / `Boolean` / `Integer` のみ。CI Layer 2 で `MaskedText` でないことを arch test で保証）|
+
+storage.md §逆引き表の既存 `Persona.prompt_body` 行（persistence-foundation #23 時点で「`feature/agent-repository`（後続）」と表記）を **本 PR で配線済みに更新**する責務。
+
+## ペルソナ
+
+| ペルソナ名 | 役割 | 技術レベル | 利用文脈 | 達成したいゴール |
+|-----------|------|-----------|---------|----------------|
+| 個人開発者 CEO（堀川さん想定） | Agent を Web UI / CLI で hire | GitHub / Docker / CLI 日常使用 | UI で「Senior Backend Engineer」persona の Agent を hire → DB 永続化 → Dispatcher が復元して LLM Adapter 経由で起動 | Persona / Provider / Skills を一度設定すれば永続化される |
+| 後続 Issue 担当（バックエンド開発者） | `feature/dispatcher` / `feature/llm-adapter` 実装者 | DDD 経験あり、SQLAlchemy 2.x async / Pydantic v2 経験あり | 本 PR の設計書を真実源として読み、Agent 復元経路を実装 | empire-repo / workflow-repo / 本 PR テンプレートを直接参照して同パターンで Repository を増やせる |
+| セキュリティレビュワー（Schneier 想定） | persistence-foundation #23 の Schneier 申し送り #3 を本 PR で完了確認 | secret マスキング Defense in Depth | `agents.prompt_body` カラムが `MaskedText` で宣言、SQL 直読みで raw token が出ないことを物理確認 | 永続化前マスキングの単一ゲートウェイが Agent 経路でも機能、ログ・監査経路に raw 流出しない |
+
+##### ペルソナ別ジャーニー（個人開発者 CEO）
+
+1. **Agent 設定**: UI で persona / providers / skills を入力 → `AgentService.hire(empire_id, name, persona, providers, skills)` を呼ぶ
+2. **Empire 内一意検査**: application 層 `AgentService.hire()` が `AgentRepository.find_by_name(empire_id, name)` を呼び、None なら新規作成、既存なら `AgentNameAlreadyExistsError` で 409 Conflict
+3. **永続化**: `AgentRepository.save(agent)` → SQLite に書き込み（`agents.prompt_body` は `MaskedText` 経由で masking 適用、CEO が persona に API key を含めても `<REDACTED:*>` 化）
+4. **Dispatcher 起動時**: `AgentRepository.find_by_id(agent_id)` で復元 → `Persona.prompt_body` には masked 文字列、LLM Adapter 配送時に警告経路（後続 feature 責務、申し送り）
+
+##### ジャーニーから逆算した受入要件
+
+- ジャーニー 2: `find_by_name(empire_id, name) -> Agent | None` が Empire スコープで動作（§確定 R1-C）
+- ジャーニー 3: `agents.prompt_body` に raw API key を渡しても DB には `<REDACTED:ANTHROPIC_KEY>` で永続化（§確定 R1-B、Schneier #3 実適用）
+- ジャーニー 4: `find_by_id` で復元される Agent は valid（Pydantic 構築通過）、ただし `Persona.prompt_body` は masked 文字列（不可逆性、後続 LLM Adapter 警告経路の申し送り）
+
+## 前提条件・制約
+
+| 区分 | 内容 |
+|-----|------|
+| 既存技術スタック | Python 3.12+ / SQLAlchemy 2.x async / Alembic / aiosqlite / Pydantic v2 / pyright strict / pytest |
+| 既存 CI | lint / typecheck / test-backend / audit |
+| 既存ブランチ戦略 | GitFlow（CONTRIBUTING.md §ブランチ戦略） |
+| コミット規約 | Conventional Commits |
+| ライセンス | MIT |
+| ネットワーク | 該当なし — infrastructure 層、外部通信なし |
+| 対象 OS | Windows 10 21H2+ / macOS 12+ / Linux glibc 2.35+ |
+
+## 機能一覧
+
+| 機能ID | 機能名 | 概要 | 優先度 |
+|--------|-------|------|--------|
+| REQ-AGR-001 | AgentRepository Protocol 定義 | `application/ports/agent_repository.py` で 4 method（find_by_id / count / save / find_by_name）を `async def` で宣言 | 必須 |
+| REQ-AGR-002 | SqliteAgentRepository 実装 | `infrastructure/persistence/sqlite/repositories/agent_repository.py` で SQLite 実装、§確定 R1-A〜D を満たす | 必須 |
+| REQ-AGR-003 | Alembic 0004 revision | `0004_agent_aggregate.py` で 3 テーブル + UNIQUE 制約 + partial unique index 追加、`down_revision="0003_workflow_aggregate"` | 必須 |
+| REQ-AGR-004 | CI 三層防衛の Agent 拡張 | Layer 1 grep guard（agents.prompt_body 行に `MaskedText` 必須、正のチェック）+ Layer 2 arch test + Layer 3 storage.md 更新 | 必須 |
+| REQ-AGR-005 | storage.md 逆引き表更新 | Agent 関連 2 行追加（§確定 R1-E） | 必須 |
+
+## Sub-issue 分割計画
+
+本 Issue は単一 Aggregate Repository に閉じる粒度のため Sub-issue 分割は不要。1 PR で 5 設計書 + 実装 + ユニットテストを完結させる（empire-repo / workflow-repo と同方針）。
+
+| Sub-issue 名 | 紐付く REQ | スコープ | 依存関係 |
+|------------|-----------|---------|---------|
+| 単一 PR | REQ-AGR-001〜005 | Agent SQLite Repository + ユニットテスト + storage.md 更新 | M1 agent（PR #17）+ M2 永続化基盤（PR #23）+ empire-repo（PR #29/#30）+ workflow-repo（PR #41）マージ済み |
+
+## 非機能要求
+
+| 区分 | 要求 |
+|-----|------|
+| パフォーマンス | `count()` は O(1) SQL `COUNT(*)`。`find_by_id` は子テーブル含めて O(1) Tx で 3 SELECT。`find_by_name` は `(empire_id, name)` で SELECT、index 必要なら別 PR |
+| 可用性 | 該当なし — infrastructure 層 |
+| 保守性 | pyright strict pass / ruff 警告ゼロ / カバレッジ 95% 以上（empire-repo / workflow-repo 実績水準） |
+| 可搬性 | SQLite 単一前提、Postgres 移行時は migration-plan.md §TODO-MIG-NNN として追記 |
+| セキュリティ | `agents.prompt_body` の API key / GitHub PAT を `MaskedText` で永続化前マスキング（Schneier 申し送り #3 実適用）。CI 三層防衛で物理保証。詳細は [`threat-model.md`](../../architecture/threat-model.md) §A02 / §A09 |
+
+## 受入基準
+
+| # | 基準 | 検証方法 |
+|---|------|---------|
+| 1 | `AgentRepository` Protocol が 4 method（find_by_id / count / save / find_by_name）を `async def` で定義、`@runtime_checkable` なし | TC-UT-AGR-001 |
+| 2 | `SqliteAgentRepository` が Protocol を型レベルで満たす（pyright strict） | CI typecheck |
+| 3 | `save(agent)` が agents UPSERT + agent_providers DELETE/INSERT + agent_skills DELETE/INSERT を同一 Tx 内で実行 | TC-UT-AGR-002 |
+| 4 | `find_by_id` の子テーブル SELECT が `ORDER BY provider_kind` / `ORDER BY skill_id` を発行（§BUG-EMR-001 規約） | TC-UT-AGR-003 |
+| 5 | `count()` が SQL `COUNT(*)` を発行（全行ロード+ Python `len()` 禁止） | TC-UT-AGR-004 |
+| 6 | `find_by_name(empire_id, name)` が `WHERE empire_id=:empire_id AND name=:name` で SELECT、不在なら None | TC-UT-AGR-005 |
+| 7 | `agents.prompt_body` が `MaskedText` で宣言、raw API key を保存しても DB には `<REDACTED:ANTHROPIC_KEY>` で永続化（Schneier #3 実適用） | TC-IT-AGR-006-masking |
+| 8 | `agent_providers` の partial unique index `WHERE is_default=1` が DB レベルで一意性を保証（同 agent_id で is_default=True が 2 件あったら IntegrityError） | TC-IT-AGR-007 |
+| 9 | Alembic 0004 revision で 3 テーブル + UNIQUE 制約 + partial unique index が SQLite に作成される | TC-IT-AGR-008 |
+| 10 | CI 三層防衛 Layer 1（grep guard で agents.prompt_body の `MaskedText` 必須）+ Layer 2（arch test）+ Layer 3（storage.md 更新）が pass | CI ジョブ |
+| 11 | `pyright --strict` および `ruff check` がエラーゼロ | CI lint / typecheck |
+| 12 | カバレッジが Agent Repository 配下で 95% 以上 | pytest --cov |
+
+## 扱うデータと機密レベル
+
+| 区分 | 内容 | 機密レベル |
+|-----|------|----------|
+| `agents.prompt_body` | Persona の自然言語、システムプロンプトに展開される | **高**（API key / GitHub PAT が混入し得る、Schneier #3 実適用、`MaskedText` 配線必須） |
+| `agents.id` / `empire_id` / `name` / `archetype` / `display_name` / `role` / `archived` | 識別子・表示名・enum・bool | 低 |
+| `agent_providers.*`（provider_kind / model / is_default） | LLM 設定 | 低（model 名は ASCII 識別子、secret なし） |
+| `agent_skills.*`（skill_id / name / path） | Skill ファイル参照 | 低（path は `BAKUFU_DATA_DIR/skills/` 内、H1〜H10 検証で path traversal 防御済み） |

--- a/docs/features/agent-repository/requirements.md
+++ b/docs/features/agent-repository/requirements.md
@@ -1,0 +1,125 @@
+# 要件定義書
+
+> feature: `agent-repository`
+> 関連: [requirements-analysis.md](requirements-analysis.md) / [`docs/features/empire-repository/`](../empire-repository/) **テンプレート真実源** / [`docs/features/workflow-repository/`](../workflow-repository/) **2 件目テンプレート** / [`docs/features/agent/`](../agent/)
+
+## 機能要件
+
+### REQ-AGR-001: AgentRepository Protocol 定義
+
+| 項目 | 内容 |
+|------|------|
+| 入力 | 該当なし（Protocol 定義） |
+| 処理 | `application/ports/agent_repository.py` で `AgentRepository(Protocol)` を定義。**4 method**（empire-repo の 3 method + 第 4 method `find_by_name`、§確定 R1-C）: `find_by_id(agent_id: AgentId) -> Agent \| None` / `count() -> int` / `save(agent: Agent) -> None` / `find_by_name(empire_id: EmpireId, name: str) -> Agent \| None`。すべて `async def`、`@runtime_checkable` なし |
+| 出力 | Protocol 定義。pyright strict で SqliteAgentRepository が満たすことを型レベル検証 |
+| エラー時 | 該当なし |
+
+### REQ-AGR-002: SqliteAgentRepository 実装
+
+| 項目 | 内容 |
+|------|------|
+| 入力 | `AsyncSession`（コンストラクタ引数）、各 method の引数 |
+| 処理 | `find_by_id`: `agents` SELECT → 不在なら None。存在すれば `agent_providers` を `ORDER BY provider_kind` / `agent_skills` を `ORDER BY skill_id` で SELECT（§BUG-EMR-001 規約） → `_from_row()` で Agent 復元。`count`: `select(func.count()).select_from(AgentRow)` で SQL `COUNT(*)`。`save`: §確定 R1-A の delete-then-insert（5 段階手順、empire-repo と同パターンで子テーブル数のみ拡張）。`find_by_name`: `SELECT ... WHERE empire_id=:empire_id AND name=:name LIMIT 1`、子テーブル含めて Agent 復元 or None |
+| 出力 | `find_by_id` / `find_by_name`: `Agent \| None`、`count`: `int`、`save`: `None` |
+| エラー時 | SQLAlchemy `IntegrityError`（partial unique index 違反等）/ `OperationalError` を上位伝播。Repository 内で明示的 `commit` / `rollback` はしない |
+
+### REQ-AGR-003: Alembic 0004 revision
+
+| 項目 | 内容 |
+|------|------|
+| 入力 | workflow-repo の 0003 revision（`down_revision="0003_workflow_aggregate"` で chain 一直線）|
+| 処理 | `0004_agent_aggregate.py` で 3 テーブル追加: (a) `agents`（id PK / empire_id FK → empires.id CASCADE / name String(40) / role String(32) / display_name String(80) / archetype String(80) / **prompt_body Text MaskedText** / archived Boolean、UNIQUE 制約は張らない — name 一意は application 層責務）、(b) `agent_providers`（agent_id FK CASCADE / provider_kind String(32) / model String(80) / is_default Boolean、UNIQUE(agent_id, provider_kind)、**partial unique index `WHERE is_default = 1`**）、(c) `agent_skills`（agent_id FK CASCADE / skill_id UUIDStr / name String(80) / path String(500)、UNIQUE(agent_id, skill_id)） |
+| 出力 | 3 テーブル + UNIQUE 制約 + partial unique index が SQLite に存在 |
+| エラー時 | migration 失敗 → `BakufuMigrationError`、Bootstrap stage 3 で Fail Fast |
+
+### REQ-AGR-004: CI 三層防衛の Agent 拡張（**正/負のチェック併用**、workflow-repo §確定 E パターン）
+
+| 項目 | 内容 |
+|------|------|
+| 入力 | `scripts/ci/check_masking_columns.sh`（Layer 1）と `backend/tests/architecture/test_masking_columns.py`（Layer 2）|
+| 処理 | (a) Layer 1 grep guard: `tables/agents.py` の `prompt_body` カラム宣言行に **`MaskedText` 必須**（正のチェック、Schneier #3 実適用 grep 物理保証）。`tables/agents.py` の `prompt_body` 以外のカラムに `MaskedText` / `MaskedJSONEncoded` が登場しない（過剰マスキング防止）。`tables/agent_providers.py` / `tables/agent_skills.py` 全体に登場しない（負のチェック）。(b) Layer 2 arch test: parametrize に Agent 3 テーブル追加、`agents.prompt_body` の `column.type.__class__ is MaskedText` を assert |
+| 出力 | CI が Agent 3 テーブルで「`agents.prompt_body` は `MaskedText` 必須、その他は masking なし」を物理保証 |
+| エラー時 | 後続 PR が誤って `prompt_body` を `Text`（masking なし）に変更 → Layer 2 arch test で落下、PR ブロック |
+
+### REQ-AGR-005: storage.md 逆引き表更新
+
+| 項目 | 内容 |
+|------|------|
+| 入力 | `docs/architecture/domain-model/storage.md` §逆引き表（既存 `Persona.prompt_body` 行は persistence-foundation #23 で「`feature/agent-repository`（後続）」と表記） |
+| 処理 | §逆引き表に Agent 関連 2 行追加: (a) `agents.prompt_body: MaskedText`（Schneier #3 **実適用**、persistence-foundation #23 で hook 構造提供済みを本 PR で配線）、(b) `agents` 残カラム + `agent_providers` 全カラム + `agent_skills` 全カラムは masking 対象なし。既存の `Persona.prompt_body` 行は本 PR で**実適用済み**を明示するよう更新 |
+| 出力 | storage.md §逆引き表が「Agent 関連の masking 対象は `agents.prompt_body` のみ、Schneier #3 実適用済み」状態 |
+| エラー時 | 該当なし |
+
+## 画面・CLI 仕様
+
+### CLI レシピ / コマンド
+
+該当なし — 理由: 本 feature は infrastructure 層（Repository 実装）。
+
+| コマンド | 概要 |
+|---------|------|
+| 該当なし | — |
+
+### Web UI 画面
+
+該当なし — 理由: UI を持たない。
+
+| 画面ID | 画面名 | 主要操作 |
+|-------|-------|---------|
+| 該当なし | — | — |
+
+## API 仕様
+
+該当なし — 理由: HTTP API は `feature/http-api` で扱う。
+
+| メソッド | パス | 用途 | リクエスト | レスポンス |
+|---------|-----|------|----------|----------|
+| 該当なし | — | — | — | — |
+
+## データモデル
+
+本 Issue で導入する 3 テーブル + UNIQUE 制約 + partial unique index。
+
+| エンティティ | 属性 | 型 | 制約 | 関連 |
+|-------------|------|---|------|------|
+| `agents` | `id` | `UUIDStr` | PK, NOT NULL | AgentId |
+| `agents` | `empire_id` | `UUIDStr` | FK → `empires.id` ON DELETE CASCADE, NOT NULL | 所属 Empire |
+| `agents` | `name` | `String(40)` | NOT NULL（**DB UNIQUE は張らない、application 層責務**） | 表示名（Empire 内一意） |
+| `agents` | `role` | `String(32)` | NOT NULL（Role enum） | 役割テンプレ |
+| `agents` | `display_name` | `String(80)` | NOT NULL | Persona.display_name |
+| `agents` | `archetype` | `String(80)` | NOT NULL DEFAULT '' | Persona.archetype |
+| `agents` | `prompt_body` | **`MaskedText`** | NOT NULL DEFAULT '' | Persona.prompt_body（Schneier #3 実適用） |
+| `agents` | `archived` | `Boolean` | NOT NULL DEFAULT FALSE | アーカイブ状態 |
+| `agent_providers` | `agent_id` | `UUIDStr` | FK → `agents.id` ON DELETE CASCADE, NOT NULL | 所属 Agent |
+| `agent_providers` | `provider_kind` | `String(32)` | NOT NULL（ProviderKind enum）| LLM プロバイダ |
+| `agent_providers` | `model` | `String(80)` | NOT NULL | model 名 |
+| `agent_providers` | `is_default` | `Boolean` | NOT NULL DEFAULT FALSE | 既定 provider |
+| `agent_providers` UNIQUE | `(agent_id, provider_kind)` | — | — | 同 Agent 内で provider_kind 重複禁止 |
+| `agent_providers` partial unique | `(agent_id) WHERE is_default = 1` | — | — | **§確定 R1-D 二重防衛** |
+| `agent_skills` | `agent_id` | `UUIDStr` | FK → `agents.id` ON DELETE CASCADE, NOT NULL | 所属 Agent |
+| `agent_skills` | `skill_id` | `UUIDStr` | NOT NULL | SkillId |
+| `agent_skills` | `name` | `String(80)` | NOT NULL | SkillRef.name |
+| `agent_skills` | `path` | `String(500)` | NOT NULL | SkillRef.path（H1〜H10 検証は VO 構築時に完了済み）|
+| `agent_skills` UNIQUE | `(agent_id, skill_id)` | — | — | 同 Agent 内で skill_id 重複禁止 |
+
+**masking 対象カラム**: `agents.prompt_body` のみ（`MaskedText`、§確定 R1-B）。その他 13 カラムは masking 対象なし、CI 三層防衛で「対象なし」を明示登録。
+
+## ユーザー向けメッセージ一覧
+
+該当なし — 理由: Repository は内部 API、ユーザー向けメッセージは application 層 / HTTP API 層が定義する（agent feature §確定 / `AgentService` の MSG-AG-NNN 系で扱う）。
+
+| ID | 種別 | メッセージ（要旨） | 表示条件 |
+|----|------|----------------|---------|
+| 該当なし | — | — | — |
+
+## 依存関係
+
+| 区分 | 依存 | バージョン方針 | 導入経路 | 備考 |
+|-----|------|-------------|---------|------|
+| ランタイム | Python 3.12+ | pyproject.toml | uv | 既存 |
+| Python 依存 | SQLAlchemy 2.x / Alembic / aiosqlite | pyproject.toml | uv | 既存（M2 永続化基盤）|
+| Python 依存 | typing.Protocol | 標準ライブラリ | — | Python 3.12 標準 |
+| ドメイン | `Agent` / `AgentId` / `EmpireId` / `Persona` / `ProviderConfig` / `ProviderKind` / `SkillRef` / `SkillId` / `Role` | `domain/agent/` / `domain/value_objects.py` | 内部 import | 既存（agent #17）|
+| インフラ | `Base` / `UUIDStr` / `MaskedText` / `MaskingGateway` | `infrastructure/persistence/sqlite/base.py` / `infrastructure/security/masking.py` | 内部 import | 既存（M2 永続化基盤、persistence-foundation #23 で `MaskedText` の TypeDecorator + Schneier #3 hook 構造提供済み）|
+| インフラ | `AsyncSession` / `async_sessionmaker` | `infrastructure/persistence/sqlite/session.py` | 内部 import | 既存 |
+| 外部サービス | 該当なし | — | — | infrastructure 層、外部通信なし |

--- a/docs/features/agent-repository/test-design.md
+++ b/docs/features/agent-repository/test-design.md
@@ -1,0 +1,159 @@
+# テスト設計書
+
+<!-- feature: agent-repository -->
+<!-- 配置先: docs/features/agent-repository/test-design.md -->
+<!-- 対象範囲: REQ-AGR-001〜005 / 受入基準 1〜12 / 詳細設計 §確定 A〜I / Schneier #3 実適用物理確認 -->
+
+本 feature は M2 永続化基盤の上で動く Agent Aggregate Repository。empire-repo (PR #29/#30) / workflow-repo (PR #41) と同じ規約で、**最初から 4 ファイル分割** で test を構成（Norman R-N1 教訓継承）。**`test_masking_persona.py` が Schneier #3 実適用の物理確認を担う本 PR 固有のテストファイル**。
+
+## テストマトリクス
+
+| 要件ID | 実装アーティファクト | テストケースID | テストレベル | 種別 | 受入基準 |
+|--------|-------------------|---------------|------------|------|---------|
+| REQ-AGR-001 | `AgentRepository` Protocol 4 method 定義 | TC-UT-AGR-001 | ユニット | 正常系 | 1, 2 |
+| REQ-AGR-002（save） | `SqliteAgentRepository.save` の delete-then-insert | TC-UT-AGR-002 | ユニット | 正常系 | 3 |
+| REQ-AGR-002（find_by_id ORDER BY） | 子テーブル SELECT の `ORDER BY provider_kind` / `ORDER BY skill_id` | TC-UT-AGR-003 | ユニット | 正常系 | 4 |
+| REQ-AGR-002（count SQL）| `count()` が SQL `COUNT(*)` を発行 | TC-UT-AGR-004 | ユニット | 正常系 | 5 |
+| REQ-AGR-002（find_by_name）| Empire スコープ検索 | TC-UT-AGR-005 | ユニット | 正常系 / 異常系 | 6 |
+| **REQ-AGR-002（masking、§確定 R1-B / H）** | raw `prompt_body` → DB に `<REDACTED:*>` 永続化（**Schneier #3 実適用**）| TC-IT-AGR-006-masking-anthropic / TC-IT-AGR-006-masking-github / TC-IT-AGR-006-masking-roundtrip | 結合 | 正常系 | 7 |
+| REQ-AGR-003（partial unique index）| `is_default=True` 重複で IntegrityError | TC-IT-AGR-007 | 結合 | 異常系 | 8 |
+| REQ-AGR-003（Alembic）| 0004 revision で 3 テーブル + 制約作成 | TC-IT-AGR-008 | 結合 | 正常系 | 9 |
+| REQ-AGR-004（CI Layer 1）| grep guard で `agents.prompt_body` の `MaskedText` 必須 | （CI ジョブ） | — | — | 10 |
+| REQ-AGR-004（CI Layer 2）| arch test parametrize | TC-UT-AGR-009-arch | ユニット | 正常系 | 10 |
+| REQ-AGR-005（storage.md） | §逆引き表更新 | （手動レビュー）| — | — | 10 |
+| AC-11（lint/typecheck）| pyright strict / ruff | （CI ジョブ）| — | — | 11 |
+| AC-12（カバレッジ） | `pytest --cov=bakufu.infrastructure.persistence.sqlite.repositories.agent_repository` | （CI ジョブ）| — | — | 12 |
+| 確定 A（テンプレ継承） | empire/workflow §確定 A〜F + §BUG-EMR-001 | TC-UT-AGR-001〜005 全件 | ユニット | — | — |
+| 確定 B（5 段階 save） | DML 順序の物理確認 | TC-UT-AGR-002, TC-UT-AGR-010-sql-order | ユニット | 正常系 | 3 |
+| 確定 C（_to_row / _from_row）| 双方向変換 | TC-UT-AGR-011-roundtrip | ユニット | 正常系 | — |
+| 確定 D（count SQL） | `select(func.count())` の物理確認 | TC-UT-AGR-004 | ユニット | 正常系 | 5 |
+| 確定 E（CI 三層防衛）| 正のチェック + 負のチェック併用 | TC-UT-AGR-009-arch | ユニット | 正常系 | 10 |
+| 確定 F（find_by_name 契約） | Empire スコープで AgentId → find_by_id 委譲 | TC-UT-AGR-005 | ユニット | 正常系 / 異常系 | 6 |
+| 確定 G（partial unique index 二重防衛）| Aggregate 検査 + DB 検査 | TC-IT-AGR-007 | 結合 | 異常系 | 8 |
+| **確定 H（masking 不可逆性）** | masked `prompt_body` 復元時に raw 戻らない | TC-IT-AGR-006-masking-roundtrip | 結合 | 正常系 | 7 |
+| 確定 I（4 ファイル分割） | test_*.py 全ファイル 500 行未満 | （静的確認） | — | — | — |
+
+## 外部 I/O 依存マップ
+
+| 外部 I/O | 用途 | raw fixture | factory | characterization 状態 |
+|--------|-----|------------|---------|---------------------|
+| SQLite (aiosqlite, in-memory) | Repository 永続化テスト | — | `tests/factories/agent.py`（`AgentFactory` 既存）+ AsyncSession fixture | 不要（M2 永続化基盤 conftest が提供）|
+| `MaskingGateway.mask()` | `MaskedText.process_bind_param` 経路 | — | — | 不要（persistence-foundation #23 で characterization 完了）|
+
+`tests/factories/agent.py`（agent #17 で導入）の `AgentFactory` を再利用。`prompt_body` に raw API key 形式文字列を含む `AgentWithSecretsFactory` を本 PR で追加（`test_masking_persona.py` 専用、`_meta.synthetic = True` 付与）。
+
+## E2E テストケース
+
+該当なし — 理由: infrastructure 層、HTTP API / CLI / UI なし。
+
+| テストID | ペルソナ | シナリオ | 操作手順 | 期待結果 |
+|---------|---------|---------|---------|---------|
+| 該当なし | — | — | — | — |
+
+## 結合テストケース
+
+実 SQLite + Alembic マイグレーション + Repository の往復シナリオ。empire-repo / workflow-repo のテンプレートを継承。
+
+| テストID | 対象 | 使用 fixture | 前提条件 | 操作 | 期待結果 |
+|---------|------|--------------|---------|------|---------|
+| TC-IT-AGR-006-masking-anthropic | T1: `prompt_body` の Anthropic API key マスキング（**Schneier #3 中核**）| AgentFactory + raw `prompt_body='Use ANTHROPIC_API_KEY=sk-ant-api03-XXX...'` | empty DB | save(agent) → raw SQL `SELECT prompt_body FROM agents WHERE id=?` で永続化値確認 | DB 上の `prompt_body` が `<REDACTED:ANTHROPIC_KEY>` or `<REDACTED:ENV:ANTHROPIC_API_KEY>` を含む（適用順序は storage.md §マスキング規則）、**raw `sk-ant-api03-XXX...` が DB に一切残らない**ことを assert |
+| TC-IT-AGR-006-masking-github | T1: GitHub PAT マスキング | AgentFactory + raw `prompt_body='Use ghp_XXX... for git push'` | empty DB | save(agent) → raw SQL SELECT | DB 上に `<REDACTED:GITHUB_PAT>` を含む、raw `ghp_XXX...` が残らない |
+| TC-IT-AGR-006-masking-roundtrip | §確定 H: masking 不可逆性 | Agent factory（raw secret 含み）| save 済み Agent | `find_by_id(agent.id)` で復元 → `Persona.prompt_body` を取得 | 復元値は `<REDACTED:*>` を含む文字列、raw secret を復元できないことを assert（不可逆性の物理確認）|
+| TC-IT-AGR-007 | §確定 G: partial unique index 二重防衛 | 直接 INSERT 経路（Aggregate 経由しない）| empty DB | 同 agent_id で `is_default=True` を 2 行 INSERT | 2 行目で `sqlalchemy.exc.IntegrityError`（partial unique index 違反）。Aggregate 検査を迂回した経路で DB が物理拒否することを確認 |
+| TC-IT-AGR-008 | Alembic 0004 マイグレーション | clean DB | `alembic upgrade head` 実行 | 3 テーブル + UNIQUE 制約 + partial unique index が SQLite に作成、`alembic downgrade -1` で逆順削除 |
+| TC-IT-AGR-LIFECYCLE | Lifecycle: save → find_by_name → find_by_id → save（更新）| AgentFactory | empty DB | (1) `save(agent_a)` → (2) `find_by_name(empire_id, 'agent_a')` → Agent 取得 → (3) `find_by_id(agent.id)` で再取得 → (4) persona 変更で再構築 → `save(updated_agent)` | 各段階で valid Agent を返す、persona 変更が永続化される、`prompt_body` masking が再 save でも適用 |
+
+## ユニットテストケース
+
+`tests/factories/agent.py` の factory 経由で入力を生成。
+
+### Protocol / CRUD 正常系（test_protocol_crud.py、受入基準 1, 2, 5, 6）
+
+| テストID | 対象 | 種別 | 入力 | 期待結果 |
+|---------|-----|------|------|---------|
+| TC-UT-AGR-001 | `AgentRepository` Protocol 型レベル充足 | 正常系 | `SqliteAgentRepository` インスタンス | `isinstance(repo, AgentRepository)` 不採用（`@runtime_checkable` なし）、pyright strict で `repo: AgentRepository = SqliteAgentRepository(session)` が pass |
+| TC-UT-AGR-004 | `count()` SQL 契約 | 正常系 | DB に 5 件 Agent | `count()` の戻り値が 5、SQL ログに `SELECT count(*)` が含まれる、全行ロード経路（`SELECT id FROM agents`）が**ない**ことを SQL ログで assert |
+| TC-UT-AGR-005 | `find_by_name(empire_id, name)` 契約（§確定 F）| 正常系 / 異常系 | (1) DB に `(empire_a, 'agent_a')` の Agent / (2) 不在 / (3) 異 Empire で同 name | (1) Agent を返す / (2) None を返す / (3) None を返す（Empire スコープ）|
+
+### save delete-then-insert（test_save_semantics.py、受入基準 3, 4）
+
+| テストID | 対象 | 種別 | 入力 | 期待結果 |
+|---------|-----|------|------|---------|
+| TC-UT-AGR-002 | save の 5 段階 DML 順序 | 正常系 | 既存 Agent + providers 2 件 + skills 3 件 を providers 1 件 + skills 2 件に更新 | save 後 DB の providers が 1 件、skills が 2 件、削除された行が消えている。SQL ログで agents UPSERT → agent_providers DELETE → INSERT → agent_skills DELETE → INSERT の 5 段階順序を確認 |
+| TC-UT-AGR-003 | `find_by_id` の `ORDER BY` 規約（§BUG-EMR-001）| 正常系 | 同 agent_id で provider_kind 順序逆 / skill_id 順序逆で INSERT | `find_by_id` の戻り値で providers が `provider_kind` 昇順、skills が `skill_id` 昇順、SQL ログに `ORDER BY provider_kind` / `ORDER BY skill_id` が出る |
+| TC-UT-AGR-010-sql-order | save の Tx 境界 | 正常系 | service 側で `async with session.begin()` で囲む | Repository 内では commit/rollback なし、Tx 全体が ATOMIC、半端終了で rollback |
+| TC-UT-AGR-011-roundtrip | `_to_row` / `_from_row` 双方向変換 | 正常系 | AgentFactory（providers / skills 含む）| `_from_row(_to_row(agent))` が元 Agent と構造的等価（Pydantic frozen `==` 判定）|
+
+### 制約 / アーキテクチャ（test_constraints_arch.py、受入基準 8, 10）
+
+| テストID | 対象 | 種別 | 入力 | 期待結果 |
+|---------|-----|------|------|---------|
+| TC-UT-AGR-009-arch | CI Layer 2 arch test 自身 | 正常系 | `Base.metadata.tables['agents']` の `prompt_body` カラム | `column.type.__class__ is MaskedText` を assert（**正のチェック**）。他カラムは masking なし |
+
+### Schneier #3 実適用専用（test_masking_persona.py、受入基準 7）
+
+**本 PR の核心テストファイル**。Schneier 申し送り #3 実適用の物理保証。
+
+| テストID | 対象 | 種別 | 入力 | 期待結果 |
+|---------|-----|------|------|---------|
+| TC-IT-AGR-006-masking-anthropic | Anthropic API key マスキング | 正常系 | raw `prompt_body='ANTHROPIC_API_KEY=sk-ant-api03-XXX...'` | DB raw SELECT で `<REDACTED:*>` を含む、raw `sk-ant-api03-XXX...` が一切残らない（grep で 0 hit）|
+| TC-IT-AGR-006-masking-github | GitHub PAT マスキング | 正常系 | raw `prompt_body='Use ghp_XXX... for git push'` | DB raw SELECT で `<REDACTED:GITHUB_PAT>`、raw `ghp_XXX...` が残らない |
+| TC-IT-AGR-006-masking-openai | OpenAI key マスキング | 正常系 | raw `prompt_body='OPENAI_API_KEY=sk-XXX...'` | DB raw SELECT で `<REDACTED:OPENAI_KEY>` |
+| TC-IT-AGR-006-masking-bearer | Bearer token マスキング | 正常系 | raw `prompt_body='Authorization: Bearer XXX'` | DB raw SELECT で `<REDACTED:BEARER>` |
+| TC-IT-AGR-006-masking-no-secret | secret なしの passthrough | 正常系 | raw `prompt_body='You are a helpful agent.'` | DB raw SELECT で文字列が改変されない（masking 適用範囲外）|
+| TC-IT-AGR-006-masking-roundtrip | §確定 H: masking 不可逆性 | 正常系 | save → find_by_id 経路 | 復元 `Persona.prompt_body` が `<REDACTED:*>` を含む、元 token が復元不能 |
+| TC-IT-AGR-006-masking-multiple | 複数 secret 同時マスキング | 正常系 | raw `prompt_body` に 3 種 secret 混在 | すべて `<REDACTED:*>` 化、raw token 全消滅 |
+
+## カバレッジ基準
+
+- REQ-AGR-001〜005 すべてに最低 1 件のテストケース
+- **Schneier #3 実適用 7 経路**（anthropic / github / openai / bearer / no-secret / roundtrip / multiple）すべてに正常系ケース、TC-IT-AGR-006-masking-* で物理確認
+- **partial unique index 二重防衛**（§確定 G）: 直接 INSERT 経路で IntegrityError が出ることを TC-IT-AGR-007 で確認
+- empire-repo §確定 A〜F + §BUG-EMR-001 規約の継承を TC-UT-AGR-002〜005 全件で確認
+- C0 目標: `infrastructure/persistence/sqlite/repositories/agent_repository.py` で **95% 以上**
+
+## 人間が動作確認できるタイミング
+
+- CI 統合後: `gh pr checks` で全ジョブ緑
+- ローカル: `cd backend && uv run pytest tests/infrastructure/persistence/sqlite/repositories/test_agent_repository/ -v` → 全テスト緑
+- masking 物理確認: `uv run pytest tests/.../test_masking_persona.py -v` → 7 ケース緑、raw token が DB に残らないことを目視
+- Alembic: `uv run alembic upgrade head` → 0004_agent_aggregate 適用、`sqlite3 bakufu.db ".schema agents"` で `prompt_body` 列の型確認
+
+## テストディレクトリ構造
+
+```
+backend/
+  tests/
+    factories/
+      agent.py                                  # 既存 + AgentWithSecretsFactory 追加（_meta.synthetic）
+    infrastructure/
+      persistence/
+        sqlite/
+          repositories/
+            test_agent_repository/              # 新規ディレクトリ（4 ファイル分割、最初から）
+              __init__.py
+              test_protocol_crud.py             # TC-UT-AGR-001/004/005
+              test_save_semantics.py            # TC-UT-AGR-002/003/010/011
+              test_constraints_arch.py          # TC-UT-AGR-009 + TC-IT-AGR-007/008
+              test_masking_persona.py           # TC-IT-AGR-006-masking-* (7 ケース、Schneier #3 中核)
+```
+
+## 未決課題・要起票 characterization task
+
+| # | タスク | 起票先 | 備考 |
+|---|-------|--------|------|
+| Agent 後続申し送り #1 | masked `prompt_body` の LLM Adapter 配送経路（§確定 H）| `feature/llm-adapter`（後続） | 「`<REDACTED:*>` を含む Persona は配送停止 + ログ警告」契約を凍結する責務 |
+
+**Schneier 申し送り（前 PR から継承）**:
+
+- **Schneier #3 (`Persona.prompt_body` Repository マスキング)**: persistence-foundation #23 で hook 構造提供、本 PR で実適用配線完了 → **Schneier 申し送り #3 クローズ**
+
+## レビュー観点（テスト設計レビュー時）
+
+- [ ] REQ-AGR-001〜005 すべてに 1 件以上のテストケース
+- [ ] **Schneier #3 実適用 7 経路**すべてに TC-IT-AGR-006-masking-* で物理確認、raw token が DB に残らないことを assert
+- [ ] **partial unique index 二重防衛**を TC-IT-AGR-007 で物理確認（直 INSERT 経路で IntegrityError）
+- [ ] `find_by_name` Empire スコープ検索を TC-UT-AGR-005 で 3 経路（ヒット / 不在 / 異 Empire 同 name）すべて確認
+- [ ] empire-repo / workflow-repo テンプレート継承（§確定 A〜F + §BUG-EMR-001）が崩れていない
+- [ ] **テストファイル分割（4 ファイル）が basic-design.md §モジュール構成と整合**（empire-repo PR #29 / workflow-repo PR #41 教訓を最初から反映）
+- [ ] Schneier 申し送り #3 クローズが PR 本文に明示されている


### PR DESCRIPTION
## Summary

- Issue #32 agent-repository の **設計書 5 本（V-model 完全形）** を `feature/32-agent-repository` ブランチで凍結
- empire-repository (#29/#30) / workflow-repository (#41) のテンプレート真実源を継承
- **Schneier 申し送り #3（`agents.prompt_body` MaskedText 実適用）が本 PR の核心**
- empire-repo の 3 method を超える **初の Repository PR**（`find_by_name` 第 4 method 追加）

## 設計書 5 本

| ファイル | 行数 | 主な内容 |
|---|---|---|
| requirements-analysis.md | 226 | §確定 R1-A〜E、5 functional + 12 acceptance criteria |
| requirements.md | 125 | REQ-AGR-001〜005、データモデル 14 カラム |
| basic-design.md | 305 | 5 ユースケース、シーケンス図、T1〜T3 脅威モデル |
| detailed-design.md | 343 | 5 段階 save 手順、CI 三層防衛、§確定 A〜I |
| test-design.md | 159 | TC-UT-AGR-001〜011 + TC-IT-AGR-006-masking-* (**7 経路**) |

500 行ルール遵守（最大 343）。

## Agent 固有の凍結事項

| 確定 | 内容 | 根拠 |
|---|---|---|
| §確定 R1-B | **Schneier #3 実適用** — `agents.prompt_body` を `MaskedText` で宣言、`process_bind_param` で `MaskingGateway.mask()` 経由 | persistence-foundation #23 の hook 構造を本 PR で配線、API key / GitHub PAT が DB に raw 保存される経路を物理消滅 |
| §確定 R1-C | **`find_by_name(empire_id, name)` 第 4 method 追加** | empire-repo の 3 method を超える、Aggregate 不変条件の集合知識（Empire 内一意）を Repository が SQL レベルで吸収するテンプレート確立 |
| §確定 R1-D | **`is_default` partial unique index** (`WHERE is_default = 1`) で二重防衛 | Aggregate 内 `_validate_provider_is_default_unique` の最終防衛線、SQLite 公式 partial index 機能を使用 |
| §確定 H | masking 不可逆性凍結 | 復元時 `prompt_body` は masked 文字列、LLM Adapter 配送は申し送り #1 で `feature/llm-adapter` に委譲 |
| §確定 I | テスト 4 ファイル分割を最初から | empire-repo PR #29 / workflow-repo PR #41 の Norman R-N1 教訓継承 |

## CI 三層防衛 Agent 拡張（**正/負のチェック併用**、workflow-repo §確定 E パターン）

- Layer 1 (`scripts/ci/check_masking_columns.sh`): `agents.prompt_body` の `MaskedText` 必須を **正のチェック**、残カラム masking なしを **負のチェック**
- Layer 2 (`backend/tests/architecture/test_masking_columns.py`): parametrize に Agent 3 テーブル追加、`agents.prompt_body` の `column.type.__class__ is MaskedText` を assert
- Layer 3 (`storage.md` §逆引き表): 既存 `Persona.prompt_body` 行を**本 PR で実適用済み**に更新 + Agent 残カラム masking なし行を追加

## Schneier #3 物理保証（test_masking_persona.py 7 経路）

| TC ID | 経路 | 期待 |
|---|---|---|
| TC-IT-AGR-006-masking-anthropic | `sk-ant-api03-XXX` | DB に `<REDACTED:ANTHROPIC_KEY>` |
| TC-IT-AGR-006-masking-github | `ghp_XXX` | DB に `<REDACTED:GITHUB_PAT>` |
| TC-IT-AGR-006-masking-openai | `sk-XXX` | DB に `<REDACTED:OPENAI_KEY>` |
| TC-IT-AGR-006-masking-bearer | `Authorization: Bearer XXX` | DB に `<REDACTED:BEARER>` |
| TC-IT-AGR-006-masking-no-secret | secret なし | passthrough |
| TC-IT-AGR-006-masking-roundtrip | save → find_by_id | masked 文字列、不可逆性物理確認 |
| TC-IT-AGR-006-masking-multiple | 複数 secret 混在 | すべて `<REDACTED:*>` 化 |

## 申し送り（後続 PR で完了）

| # | 内容 | 担当 PR |
|---|---|---|
| 1 | masked `prompt_body` の LLM Adapter 配送経路（`<REDACTED:*>` 検出 + 配送停止 + ログ警告）| `feature/llm-adapter`（後続）|

## Test plan

- [ ] markdownlint 5 ファイル
- [ ] 設計書 V-model 整合性レビュー（要件→基本→詳細→テスト追跡可能性）
- [ ] empire-repo §確定 A〜F + §BUG-EMR-001 + workflow-repo §確定 E（正のチェック）の継承確認
- [ ] §確定 R1-C `find_by_name` Empire スコープ検索の必要性レビュー（後続 PR テンプレート責務）
- [ ] §確定 R1-D partial unique index 二重防衛の根拠レビュー（SQLite partial index 機能依存）
- [ ] §確定 H masking 不可逆性 + 申し送り #1 の責務分離レビュー
- [ ] storage.md §逆引き表の Schneier #3 実適用済み更新確認
- [ ] M2 永続化基盤（PR #23）+ M1 agent（PR #17）+ empire-repo（#29/#30）+ workflow-repo（#41）マージ済みの前提が満たされている

Refs: #32