### PR TITLE
feat(agent-repository): SQLite Agent Repository with find_by_name + Schneier #3 配線 (Issue #32)

### DIFF
--- a/backend/alembic/versions/0004_agent_aggregate.py
+++ b/backend/alembic/versions/0004_agent_aggregate.py
@@ -1,0 +1,145 @@
+"""Agent Aggregate tables: agents + agent_providers + agent_skills.
+
+Adds the three tables that back :class:`SqliteAgentRepository`:
+
+* ``agents`` (id PK + empire_id FK CASCADE + Persona scalars). The
+  ``prompt_body`` column is declared with the
+  :class:`MaskedText` TypeDecorator at the ORM level (Alembic stores
+  it as ``TEXT`` here; the masking gate lives on the Python side).
+* ``agent_providers`` (FK CASCADE on agent_id, UNIQUE(agent_id,
+  provider_kind)) **plus a partial unique index** on ``agent_id``
+  scoped by ``WHERE is_default = 1``. The partial index is the §確定 G
+  Defense-in-Depth floor for "exactly one default provider per Agent"
+  — even if a future PR introduces a corrupted SQL path, the DB still
+  refuses two ``is_default=1`` rows on the same Agent.
+* ``agent_skills`` (FK CASCADE on agent_id, UNIQUE(agent_id,
+  skill_id)). The ``path`` column is bounded to 500 characters per
+  the agent feature §確定 H pipeline; H1〜H10 traversal defense lives
+  on the VO side.
+
+Per ``docs/features/empire-repository/detailed-design.md`` §確定 F
+each subsequent ``feature/{aggregate}-repository`` PR appends its own
+revision; this revision pins ``down_revision = "0003_workflow_aggregate"``
+strictly so the chain check enforces a single head.
+
+Revision ID: 0004_agent_aggregate
+Revises: 0003_workflow_aggregate
+Create Date: 2026-04-27
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0004_agent_aggregate"
+down_revision: str | None = "0003_workflow_aggregate"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "agents",
+        sa.Column("id", sa.CHAR(32), primary_key=True, nullable=False),
+        sa.Column(
+            "empire_id",
+            sa.CHAR(32),
+            sa.ForeignKey("empires.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(40), nullable=False),
+        sa.Column("role", sa.String(32), nullable=False),
+        sa.Column("display_name", sa.String(80), nullable=False),
+        sa.Column(
+            "archetype",
+            sa.String(80),
+            nullable=False,
+            server_default=sa.text("''"),
+        ),
+        # MaskedText TypeDecorator serializes as TEXT in SQLite. The
+        # Python-side decorator does the masking gate (see
+        # infrastructure/persistence/sqlite/base.py).
+        sa.Column(
+            "prompt_body",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("''"),
+        ),
+        sa.Column(
+            "archived",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+    )
+
+    op.create_table(
+        "agent_providers",
+        sa.Column(
+            "agent_id",
+            sa.CHAR(32),
+            sa.ForeignKey("agents.id", ondelete="CASCADE"),
+            primary_key=True,
+            nullable=False,
+        ),
+        sa.Column(
+            "provider_kind",
+            sa.String(32),
+            primary_key=True,
+            nullable=False,
+        ),
+        sa.Column("model", sa.String(80), nullable=False),
+        sa.Column(
+            "is_default",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.UniqueConstraint(
+            "agent_id",
+            "provider_kind",
+            name="uq_agent_providers_pair",
+        ),
+    )
+    # detailed-design §確定 G: partial unique index for the
+    # "at most one default provider per agent" Defense-in-Depth floor.
+    # SQLite ships partial indexes natively; the same syntax ports to
+    # PostgreSQL when the M5+ migration lands.
+    op.create_index(
+        "uq_agent_providers_default",
+        "agent_providers",
+        ["agent_id"],
+        unique=True,
+        sqlite_where=sa.text("is_default = 1"),
+    )
+
+    op.create_table(
+        "agent_skills",
+        sa.Column(
+            "agent_id",
+            sa.CHAR(32),
+            sa.ForeignKey("agents.id", ondelete="CASCADE"),
+            primary_key=True,
+            nullable=False,
+        ),
+        sa.Column("skill_id", sa.CHAR(32), primary_key=True, nullable=False),
+        sa.Column("name", sa.String(80), nullable=False),
+        sa.Column("path", sa.String(500), nullable=False),
+        sa.UniqueConstraint(
+            "agent_id",
+            "skill_id",
+            name="uq_agent_skills_pair",
+        ),
+    )
+
+
+def downgrade() -> None:
+    # Drop child tables first so the FK CASCADE doesn't trigger work
+    # against an already-deleted parent.
+    op.drop_table("agent_skills")
+    op.drop_index("uq_agent_providers_default", table_name="agent_providers")
+    op.drop_table("agent_providers")
+    op.drop_table("agents")

--- a/backend/src/bakufu/application/ports/agent_repository.py
+++ b/backend/src/bakufu/application/ports/agent_repository.py
@@ -1,0 +1,87 @@
+"""Agent Repository port.
+
+Per ``docs/features/agent-repository/detailed-design.md`` §確定 A
+(empire-repo / workflow-repo テンプレート 100% 継承) plus §確定 F
+(``find_by_name`` 第 4 method 追加 — the **first** Repository in the
+codebase to extend the canonical 3-method surface):
+
+* Protocol class with **no** ``@runtime_checkable`` decorator —
+  Python 3.12 ``typing.Protocol`` duck typing is enough.
+* Every method declared ``async def`` (async-first contract).
+* Argument and return types come exclusively from
+  :mod:`bakufu.domain` — no SQLAlchemy types leak across the port.
+* ``find_by_name`` takes ``empire_id`` first because the "name unique
+  within an Empire" invariant is Empire-scoped (§確定 F (a)
+  rejected the global-scope alternative). Argument order **scope →
+  identifier** is the natural reading.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from bakufu.domain.agent import Agent
+from bakufu.domain.value_objects import AgentId, EmpireId
+
+
+class AgentRepository(Protocol):
+    """Persistence contract for the :class:`Agent` Aggregate Root.
+
+    The application layer (``AgentService.hire`` etc., future PR)
+    consumes this Protocol via dependency injection; the SQLite
+    implementation lives in
+    :mod:`bakufu.infrastructure.persistence.sqlite.repositories.agent_repository`.
+    """
+
+    async def find_by_id(self, agent_id: AgentId) -> Agent | None:
+        """Hydrate the Agent whose primary key equals ``agent_id``.
+
+        Returns ``None`` when the row is absent. SQLAlchemy / driver /
+        ``pydantic.ValidationError`` exceptions propagate untouched so
+        the application service's Unit-of-Work boundary can choose
+        between rollback and surfaced error.
+        """
+        ...
+
+    async def count(self) -> int:
+        """Return ``SELECT COUNT(*) FROM agents``.
+
+        Application services use this for bulk-introspection
+        (e.g. monitoring dashboards). Deciding what the count means is
+        the application layer's call (§確定 D).
+        """
+        ...
+
+    async def save(self, agent: Agent) -> None:
+        """Persist ``agent`` via the §確定 B delete-then-insert flow.
+
+        The implementation must run the five-step sequence (UPSERT
+        agents → DELETE agent_providers → bulk INSERT providers →
+        DELETE agent_skills → bulk INSERT skills) within the
+        **caller-managed** transaction. Repositories never call
+        ``session.commit()`` / ``session.rollback()``; the application
+        service owns the Unit-of-Work boundary.
+        """
+        ...
+
+    async def find_by_name(self, empire_id: EmpireId, name: str) -> Agent | None:
+        """Hydrate the Agent named ``name`` inside Empire ``empire_id`` (§確定 F).
+
+        The "name unique within an Empire" invariant is Empire-scoped
+        per ``docs/features/agent/detailed-design.md`` so the
+        Repository takes ``empire_id`` first. Implementations must
+        emit ``WHERE empire_id = :empire_id AND name = :name LIMIT 1``
+        rather than fetching all Agents and filtering in Python (the
+        latter is explicitly rejected as a memory / N+1 pitfall in
+        §確定 F (c)).
+
+        Returns ``None`` when no Agent matches. Implementations are
+        expected to delegate the side-table SELECTs to
+        :meth:`find_by_id` once the AgentId is known so the
+        ``_to_row`` / ``_from_row`` conversion logic is not duplicated
+        (§設計判断補足).
+        """
+        ...
+
+
+__all__ = ["AgentRepository"]

--- a/backend/src/bakufu/domain/agent/agent.py
+++ b/backend/src/bakufu/domain/agent/agent.py
@@ -51,6 +51,7 @@ from bakufu.domain.agent.value_objects import (
 from bakufu.domain.exceptions import AgentInvariantViolation
 from bakufu.domain.value_objects import (
     AgentId,
+    EmpireId,
     ProviderKind,
     Role,
     SkillId,
@@ -72,6 +73,14 @@ class Agent(BaseModel):
     )
 
     id: AgentId
+    # ``empire_id`` is the back-reference required by
+    # ``feature/agent-repository`` (Issue #32). The Repository
+    # persists Agents under an Empire so the table-level FK
+    # ``agents.empire_id REFERENCES empires.id ON DELETE CASCADE``
+    # has somewhere to source its value, and ``find_by_name`` can
+    # scope its lookup with ``WHERE empire_id = :empire_id`` —
+    # detailed-design §確定 F.
+    empire_id: EmpireId
     name: str
     persona: Persona
     role: Role

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/repositories/agent_repository.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/repositories/agent_repository.py
@@ -1,0 +1,298 @@
+"""SQLite adapter for :class:`bakufu.application.ports.AgentRepository`.
+
+Implements the §確定 B "delete-then-insert" save flow over three
+tables (``agents`` / ``agent_providers`` / ``agent_skills``):
+
+1. ``agents`` UPSERT (id-conflict → name + role + persona +
+   archived update; ``prompt_body`` binds through
+   :class:`MaskedText` so any embedded API key / OAuth token /
+   GitHub PAT is redacted *before* it hits SQLite — Schneier 申し送り
+   #3 实適用, applied to the Agent path here).
+2. ``agent_providers`` DELETE WHERE agent_id = ?
+3. ``agent_providers`` bulk INSERT (one row per ProviderConfig).
+4. ``agent_skills`` DELETE WHERE agent_id = ?
+5. ``agent_skills`` bulk INSERT (one row per SkillRef).
+
+The repository **never** calls ``session.commit()`` /
+``session.rollback()``: the caller-side service runs
+``async with session.begin():`` so the five steps above stay in one
+transaction (§確定 B Tx 境界の責務分離).
+
+``_to_row`` / ``_from_row`` are kept as private methods on the class
+so both directions live next to each other and tests don't accidentally
+acquire a public conversion API to depend on (§確定 C).
+
+Two Agent-specific contracts widen the empire / workflow repository
+template:
+
+* **§確定 F — :meth:`find_by_name`**: an extra Protocol method that
+  scopes the lookup with ``WHERE empire_id = :empire_id AND name =
+  :name LIMIT 1``. The implementation deliberately delegates to
+  :meth:`find_by_id` once the AgentId is known so the
+  ``_from_row`` conversion logic stays single-sourced.
+* **§確定 H — masked ``prompt_body`` is irreversible**: hydration
+  via :meth:`find_by_id` returns a Persona whose ``prompt_body`` is
+  the masked form (e.g. ``<REDACTED:ANTHROPIC_KEY>``). Detecting and
+  refusing to dispatch a masked prompt is the application-layer's
+  job, frozen as a follow-up under ``feature/llm-adapter``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import delete, func, insert, select
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bakufu.domain.agent import Agent, Persona, ProviderConfig, SkillRef
+from bakufu.domain.value_objects import (
+    AgentId,
+    EmpireId,
+    ProviderKind,
+    Role,
+)
+from bakufu.infrastructure.persistence.sqlite.tables.agent_providers import (
+    AgentProviderRow,
+)
+from bakufu.infrastructure.persistence.sqlite.tables.agent_skills import (
+    AgentSkillRow,
+)
+from bakufu.infrastructure.persistence.sqlite.tables.agents import AgentRow
+
+
+class SqliteAgentRepository:
+    """SQLite implementation of :class:`AgentRepository`."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def find_by_id(self, agent_id: AgentId) -> Agent | None:
+        """SELECT agent + side tables, hydrate via :meth:`_from_row`.
+
+        Returns ``None`` when the agents row is absent. Side-table
+        SELECTs use ``ORDER BY provider_kind`` /
+        ``ORDER BY skill_id`` so the hydrated lists are deterministic
+        — empire-repository BUG-EMR-001 froze this contract; we apply
+        it from PR #1 here.
+        """
+        agent_stmt = select(AgentRow).where(AgentRow.id == agent_id)
+        agent_row = (await self._session.execute(agent_stmt)).scalar_one_or_none()
+        if agent_row is None:
+            return None
+
+        # ORDER BY makes find_by_id deterministic. Without it SQLite
+        # returns rows in internal-scan order, which would break
+        # ``Agent == Agent`` round-trip equality (the Aggregate
+        # compares list-by-list). See basic-design + workflow-repo
+        # §BUG-EMR-001 — this PR adopts the resolved contract from
+        # day one.
+        provider_stmt = (
+            select(AgentProviderRow)
+            .where(AgentProviderRow.agent_id == agent_id)
+            .order_by(AgentProviderRow.provider_kind)
+        )
+        provider_rows = list((await self._session.execute(provider_stmt)).scalars().all())
+
+        skill_stmt = (
+            select(AgentSkillRow)
+            .where(AgentSkillRow.agent_id == agent_id)
+            .order_by(AgentSkillRow.skill_id)
+        )
+        skill_rows = list((await self._session.execute(skill_stmt)).scalars().all())
+
+        return self._from_row(agent_row, provider_rows, skill_rows)
+
+    async def count(self) -> int:
+        """``SELECT COUNT(*) FROM agents``.
+
+        Implementation detail: SQLAlchemy's ``func.count()`` issues a
+        proper ``SELECT COUNT(*)`` so SQLite returns one scalar row
+        instead of streaming every PK back to Python. This is the
+        empire-repository §確定 D 補強 contract continued — Agent
+        provider / skill rows can hold hundreds of records once the
+        preset library lands, so the pattern matters.
+        """
+        stmt = select(func.count()).select_from(AgentRow)
+        return (await self._session.execute(stmt)).scalar_one()
+
+    async def save(self, agent: Agent) -> None:
+        """Persist ``agent`` via the §確定 B five-step delete-then-insert.
+
+        The caller is responsible for the surrounding
+        ``async with session.begin():`` block; failures inside any
+        step propagate untouched so the Unit-of-Work boundary in the
+        application service can rollback cleanly.
+        """
+        agent_row, provider_rows, skill_rows = self._to_row(agent)
+
+        # Step 1: agents UPSERT (id PK, ON CONFLICT update name +
+        # role + Persona fields + archived). ``prompt_body`` binds
+        # through MaskedText so the masked form lands in the DB even
+        # on update.
+        upsert_stmt = sqlite_insert(AgentRow).values(agent_row)
+        upsert_stmt = upsert_stmt.on_conflict_do_update(
+            index_elements=["id"],
+            set_={
+                "empire_id": upsert_stmt.excluded.empire_id,
+                "name": upsert_stmt.excluded.name,
+                "role": upsert_stmt.excluded.role,
+                "display_name": upsert_stmt.excluded.display_name,
+                "archetype": upsert_stmt.excluded.archetype,
+                "prompt_body": upsert_stmt.excluded.prompt_body,
+                "archived": upsert_stmt.excluded.archived,
+            },
+        )
+        await self._session.execute(upsert_stmt)
+
+        # Step 2: agent_providers DELETE.
+        await self._session.execute(
+            delete(AgentProviderRow).where(AgentProviderRow.agent_id == agent.id)
+        )
+
+        # Step 3: agent_providers bulk INSERT (skip when no
+        # providers — though the Agent invariant requires at least
+        # one provider, the defensive empty-skip keeps behavior
+        # consistent with the empire / workflow templates).
+        if provider_rows:
+            await self._session.execute(insert(AgentProviderRow), provider_rows)
+
+        # Step 4: agent_skills DELETE.
+        await self._session.execute(delete(AgentSkillRow).where(AgentSkillRow.agent_id == agent.id))
+
+        # Step 5: agent_skills bulk INSERT (skill set may legitimately
+        # be empty — Agent allows zero skills).
+        if skill_rows:
+            await self._session.execute(insert(AgentSkillRow), skill_rows)
+
+    async def find_by_name(self, empire_id: EmpireId, name: str) -> Agent | None:
+        """Hydrate the Agent named ``name`` inside ``empire_id`` (§確定 F).
+
+        Two-stage flow: a lightweight ``SELECT id ... LIMIT 1`` to
+        locate the AgentId, then delegation to :meth:`find_by_id` so
+        the side-table SELECTs + ``_from_row`` conversion stay
+        single-sourced (§設計判断補足 "find_by_id 経由で復元する根拠").
+        """
+        id_stmt = (
+            select(AgentRow.id)
+            .where(AgentRow.empire_id == empire_id, AgentRow.name == name)
+            .limit(1)
+        )
+        found_id = (await self._session.execute(id_stmt)).scalar_one_or_none()
+        if found_id is None:
+            return None
+        return await self.find_by_id(found_id)
+
+    # ---- private domain ↔ row converters (§確定 C) -------------------
+    def _to_row(
+        self,
+        agent: Agent,
+    ) -> tuple[dict[str, Any], list[dict[str, Any]], list[dict[str, Any]]]:
+        """Split ``agent`` into ``(agent_row, provider_rows, skill_rows)``.
+
+        SQLAlchemy ``Row`` objects are intentionally avoided here so
+        the domain layer never gains an accidental dependency on the
+        SQLAlchemy type hierarchy. Each returned ``dict`` matches the
+        ``mapped_column`` names of the corresponding table verbatim.
+        """
+        agent_row: dict[str, Any] = {
+            "id": agent.id,
+            "empire_id": agent.empire_id,
+            "name": agent.name,
+            "role": agent.role.value,
+            "display_name": agent.persona.display_name,
+            "archetype": agent.persona.archetype,
+            # MaskedText.process_bind_param will redact secrets from
+            # this string before json.dumps / VARCHAR storage —
+            # Schneier 申し送り #3 实適用.
+            "prompt_body": agent.persona.prompt_body,
+            "archived": agent.archived,
+        }
+        provider_rows: list[dict[str, Any]] = [
+            {
+                "agent_id": agent.id,
+                "provider_kind": provider.provider_kind.value,
+                "model": provider.model,
+                "is_default": provider.is_default,
+            }
+            for provider in agent.providers
+        ]
+        skill_rows: list[dict[str, Any]] = [
+            {
+                "agent_id": agent.id,
+                "skill_id": skill.skill_id,
+                "name": skill.name,
+                "path": skill.path,
+            }
+            for skill in agent.skills
+        ]
+        return agent_row, provider_rows, skill_rows
+
+    def _from_row(
+        self,
+        agent_row: AgentRow,
+        provider_rows: list[AgentProviderRow],
+        skill_rows: list[AgentSkillRow],
+    ) -> Agent:
+        """Hydrate an :class:`Agent` Aggregate Root from its three rows.
+
+        ``Agent.model_validate`` re-runs the post-validator so
+        Repository-side hydration goes through the same invariant
+        checks that ``AgentService.hire()`` does at construction
+        time. The contract (§確定 C) is "Repository hydration produces
+        a valid Agent or raises".
+
+        §確定 H §不可逆性: ``persona.prompt_body`` carries the
+        already-masked text from disk. ``Persona`` accepts any string
+        within the length cap so the masked form constructs cleanly,
+        but the resulting Agent should not be dispatched to an LLM
+        without ``feature/llm-adapter``'s masked-prompt guard.
+        """
+        persona = Persona(
+            display_name=agent_row.display_name,
+            archetype=agent_row.archetype,
+            prompt_body=agent_row.prompt_body,
+        )
+        providers = [
+            ProviderConfig(
+                provider_kind=ProviderKind(row.provider_kind),
+                model=row.model,
+                is_default=row.is_default,
+            )
+            for row in provider_rows
+        ]
+        skills = [
+            SkillRef(
+                skill_id=_uuid(row.skill_id),
+                name=row.name,
+                path=row.path,
+            )
+            for row in skill_rows
+        ]
+        return Agent(
+            id=_uuid(agent_row.id),
+            empire_id=_uuid(agent_row.empire_id),
+            name=agent_row.name,
+            role=Role(agent_row.role),
+            persona=persona,
+            providers=providers,
+            skills=skills,
+            archived=agent_row.archived,
+        )
+
+
+def _uuid(value: UUID | str) -> UUID:
+    """Coerce a row value to :class:`uuid.UUID`.
+
+    SQLAlchemy's UUIDStr TypeDecorator already returns ``UUID``
+    instances on ``process_result_value``, but defensive coercion lets
+    raw-SQL hydration paths route through the same code without an
+    extra ``isinstance`` ladder at every call site.
+    """
+    if isinstance(value, UUID):
+        return value
+    return UUID(value)
+
+
+__all__ = ["SqliteAgentRepository"]

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/tables/__init__.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/tables/__init__.py
@@ -23,6 +23,18 @@ Workflow Aggregate (PR #31):
 * :mod:`...tables.workflow_transitions` — Transition child rows
   (no-mask).
 
+Agent Aggregate (PR #32):
+
+* :mod:`...tables.agents` — Agent root row. The ``prompt_body``
+  column is the **first** ``MaskedText`` Repository application of
+  Schneier 申し送り #3 (PR #23 hook → PR #32 wire-up); the table is
+  registered with the CI three-layer defense's *partial-mask*
+  contract pinning exactly one masked column.
+* :mod:`...tables.agent_providers` — ProviderConfig child rows.
+  Carries a partial unique index ``WHERE is_default = 1`` for the
+  Defense-in-Depth "exactly one default provider per Agent" floor.
+* :mod:`...tables.agent_skills` — SkillRef child rows (no-mask).
+
 Secret-bearing tables declare their columns with
 :class:`MaskedJSONEncoded` / :class:`MaskedText` TypeDecorators
 (defined in :mod:`bakufu.infrastructure.persistence.sqlite.base`) that
@@ -48,6 +60,9 @@ secret-bearing on the Workflow side.
 from __future__ import annotations
 
 from bakufu.infrastructure.persistence.sqlite.tables import (
+    agent_providers,
+    agent_skills,
+    agents,
     audit_log,
     empire_agent_refs,
     empire_room_refs,
@@ -60,6 +75,9 @@ from bakufu.infrastructure.persistence.sqlite.tables import (
 )
 
 __all__ = [
+    "agent_providers",
+    "agent_skills",
+    "agents",
     "audit_log",
     "empire_agent_refs",
     "empire_room_refs",

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/tables/agent_providers.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/tables/agent_providers.py
@@ -1,0 +1,71 @@
+"""``agent_providers`` table — Agent ↔ ProviderConfig child rows.
+
+Stores :class:`bakufu.domain.agent.value_objects.ProviderConfig` values
+as a side table of the Agent aggregate. ``ON DELETE CASCADE`` purges
+provider rows when the parent Agent is deleted; UNIQUE(agent_id,
+provider_kind) mirrors the
+``_validate_provider_kind_unique`` aggregate invariant at the row
+level.
+
+The interesting constraint is the **partial unique index**
+``WHERE is_default = 1`` — see
+``docs/features/agent-repository/detailed-design.md`` §確定 G. This
+gives the "exactly one default provider per Agent" invariant a
+**Defense-in-Depth** floor: the Aggregate-level helper
+``_validate_default_provider_count`` already enforces it, but if a
+future PR introduces a corrupted SQL path (raw INSERT, hand-rolled
+migration) the DB still refuses to host two ``is_default=1`` rows on
+the same Agent. SQLite ships partial indexes natively
+(https://www.sqlite.org/partialindex.html); the same construct ports
+to PostgreSQL with identical syntax.
+
+No ``Masked*`` TypeDecorator on any column. ``provider_kind`` is an
+enum string, ``model`` is an LLM model identifier with no secret
+semantics, and ``is_default`` is a boolean flag.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import Boolean, ForeignKey, Index, String, UniqueConstraint, text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from bakufu.infrastructure.persistence.sqlite.base import Base, UUIDStr
+
+
+class AgentProviderRow(Base):
+    """ORM mapping for the ``agent_providers`` table."""
+
+    __tablename__ = "agent_providers"
+
+    agent_id: Mapped[UUID] = mapped_column(
+        UUIDStr,
+        ForeignKey("agents.id", ondelete="CASCADE"),
+        primary_key=True,
+        nullable=False,
+    )
+    provider_kind: Mapped[str] = mapped_column(String(32), primary_key=True, nullable=False)
+    model: Mapped[str] = mapped_column(String(80), nullable=False)
+    is_default: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+
+    __table_args__ = (
+        UniqueConstraint(
+            "agent_id",
+            "provider_kind",
+            name="uq_agent_providers_pair",
+        ),
+        # Partial unique index — at most one row per agent_id may have
+        # ``is_default = 1``. SQLite / PostgreSQL syntax is the same.
+        # detailed-design §確定 G: Defense-in-Depth alongside the
+        # Aggregate-level ``_validate_default_provider_count`` check.
+        Index(
+            "uq_agent_providers_default",
+            "agent_id",
+            unique=True,
+            sqlite_where=text("is_default = 1"),
+        ),
+    )
+
+
+__all__ = ["AgentProviderRow"]

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/tables/agent_skills.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/tables/agent_skills.py
@@ -1,0 +1,56 @@
+"""``agent_skills`` table — Agent ↔ SkillRef child rows.
+
+Stores :class:`bakufu.domain.agent.value_objects.SkillRef` values as
+a side table of the Agent aggregate. ``ON DELETE CASCADE`` purges
+skill rows when the parent Agent is deleted; UNIQUE(agent_id,
+skill_id) mirrors the ``_validate_skill_id_unique`` aggregate
+invariant at the row level.
+
+``path`` is stored as a plain ``String(500)`` — the H1〜H10
+traversal-defense pipeline runs at VO construction time
+(:func:`bakufu.domain.agent.path_validators._validate_skill_path`) so
+hydration through :meth:`SqliteAgentRepository.find_by_id` re-runs
+the validators automatically when ``SkillRef.model_validate`` is
+called inside ``_from_row``. The Repository never re-checks the
+contract directly.
+
+No ``Masked*`` TypeDecorator on any column. Skill names / paths /
+ids are operational metadata with no secret semantics; the CI
+three-layer defense's *no-mask* contract registers this table.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import ForeignKey, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from bakufu.infrastructure.persistence.sqlite.base import Base, UUIDStr
+
+
+class AgentSkillRow(Base):
+    """ORM mapping for the ``agent_skills`` table."""
+
+    __tablename__ = "agent_skills"
+
+    agent_id: Mapped[UUID] = mapped_column(
+        UUIDStr,
+        ForeignKey("agents.id", ondelete="CASCADE"),
+        primary_key=True,
+        nullable=False,
+    )
+    skill_id: Mapped[UUID] = mapped_column(UUIDStr, primary_key=True, nullable=False)
+    name: Mapped[str] = mapped_column(String(80), nullable=False)
+    path: Mapped[str] = mapped_column(String(500), nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint(
+            "agent_id",
+            "skill_id",
+            name="uq_agent_skills_pair",
+        ),
+    )
+
+
+__all__ = ["AgentSkillRow"]

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/tables/agents.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/tables/agents.py
@@ -1,0 +1,73 @@
+"""``agents`` table — Agent Aggregate root row.
+
+Holds the eight scalar columns of the Agent aggregate. The two side
+collections (``providers`` / ``skills``) live in
+:mod:`...tables.agent_providers` / :mod:`...tables.agent_skills` so
+the row width stays bounded and CASCADE targets are obvious.
+
+``empire_id`` carries an ``ON DELETE CASCADE`` foreign key onto
+``empires.id`` — when an Empire is removed, its hired Agents go with
+it. The Agent aggregate root holds the matching ``empire_id`` field
+(see ``backend/src/bakufu/domain/agent/agent.py``) so
+``SqliteAgentRepository.save()`` can populate this column without
+asking the caller for it.
+
+``name`` is intentionally **not** declared UNIQUE at the DB level. The
+"name unique within an Empire" invariant is enforced by the
+application layer via :meth:`AgentRepository.find_by_name` (per
+``docs/features/agent-repository/detailed-design.md`` §設計判断補足
+"なぜ agents.name に DB UNIQUE を張らないか") so MSG-AG-NNN wording
+stays in the application layer's voice rather than being preempted by
+``IntegrityError``.
+
+Per-column secret-handling (§確定 H + Schneier 申し送り #3 实適用):
+
+* ``prompt_body`` is a :class:`MaskedText` column. ``MaskingGateway``
+  replaces API key / OAuth token / GitHub PAT etc. fragments with
+  ``<REDACTED:*>`` *before* the row hits SQLite, so neither raw SQL
+  inspection nor backups can leak a CEO-pasted secret. **The
+  irreversibility** of ``MaskingGateway`` means a round-trip through
+  :class:`SqliteAgentRepository.find_by_id` returns a Persona whose
+  ``prompt_body`` is the masked form (§確定 H 不可逆性凍結) —
+  ``feature/llm-adapter`` carries the responsibility of detecting
+  ``<REDACTED:*>`` markers before dispatching the prompt.
+* No other column on this table is masked. The CI three-layer
+  defense's *partial-mask* contract pins exactly one masked column
+  here so a future PR cannot silently widen the masking surface
+  (or inadvertently revert ``prompt_body`` to plain :class:`Text`).
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import Boolean, ForeignKey, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from bakufu.infrastructure.persistence.sqlite.base import (
+    Base,
+    MaskedText,
+    UUIDStr,
+)
+
+
+class AgentRow(Base):
+    """ORM mapping for the ``agents`` table."""
+
+    __tablename__ = "agents"
+
+    id: Mapped[UUID] = mapped_column(UUIDStr, primary_key=True)
+    empire_id: Mapped[UUID] = mapped_column(
+        UUIDStr,
+        ForeignKey("empires.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    name: Mapped[str] = mapped_column(String(40), nullable=False)
+    role: Mapped[str] = mapped_column(String(32), nullable=False)
+    display_name: Mapped[str] = mapped_column(String(80), nullable=False)
+    archetype: Mapped[str] = mapped_column(String(80), nullable=False, default="")
+    prompt_body: Mapped[str] = mapped_column(MaskedText, nullable=False, default="")
+    archived: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+
+
+__all__ = ["AgentRow"]

--- a/backend/tests/architecture/test_masking_columns.py
+++ b/backend/tests/architecture/test_masking_columns.py
@@ -36,6 +36,9 @@ from bakufu.infrastructure.persistence.sqlite.base import (
 # tables that production / Alembic see. The imported names are
 # intentionally unused — only the import side effect matters.
 from bakufu.infrastructure.persistence.sqlite.tables import (
+    agent_providers,  # noqa: F401  # pyright: ignore[reportUnusedImport]
+    agent_skills,  # noqa: F401  # pyright: ignore[reportUnusedImport]
+    agents,  # noqa: F401  # pyright: ignore[reportUnusedImport]
     audit_log,  # noqa: F401  # pyright: ignore[reportUnusedImport]
     empire_agent_refs,  # noqa: F401  # pyright: ignore[reportUnusedImport]
     empire_room_refs,  # noqa: F401  # pyright: ignore[reportUnusedImport]
@@ -58,6 +61,9 @@ _MASKING_CONTRACT: list[tuple[str, str, type]] = [
     ("domain_event_outbox", "last_error", MaskedText),
     # Workflow Repository (PR #31, detailed-design.md §確定 H).
     ("workflow_stages", "notify_channels_json", MaskedJSONEncoded),
+    # Agent Repository (PR #32, detailed-design.md §確定 H + Schneier
+    # 申し送り #3 实適用).
+    ("agents", "prompt_body", MaskedText),
 ]
 
 # No-mask contract: §逆引き表「Empire 関連カラム: masking 対象なし」 +
@@ -73,6 +79,11 @@ _NO_MASK_TABLES: list[str] = [
     # only workflow_stages.notify_channels_json is secret-bearing.
     "workflows",
     "workflow_transitions",
+    # Agent Repository (PR #32, detailed-design.md §確定 E):
+    # agent_providers / agent_skills carry no Schneier #6 secret
+    # categories; only agents.prompt_body is masked.
+    "agent_providers",
+    "agent_skills",
 ]
 
 # Partial-mask contract: tables that have **exactly one** masked
@@ -83,6 +94,10 @@ _NO_MASK_TABLES: list[str] = [
 # Format: ``(table_name, allowed_column_name)``.
 _PARTIAL_MASK_TABLES: list[tuple[str, str]] = [
     ("workflow_stages", "notify_channels_json"),
+    # Agent Repository (PR #32, detailed-design.md §確定 E):
+    # agents.prompt_body is the only masked column; persona-adjacent
+    # scalar fields stay un-masked.
+    ("agents", "prompt_body"),
 ]
 
 

--- a/backend/tests/docs/test_storage_md_back_index.py
+++ b/backend/tests/docs/test_storage_md_back_index.py
@@ -136,3 +136,59 @@ class TestBackIndexHasWorkflowRows:
             "from the Workflow row directly. Required by workflow-"
             "repository §確定 H (partial-mask テンプレート)."
         )
+
+
+class TestBackIndexHasAgentRows:
+    """TC-DOC-AGR-001: §逆引き表 includes the Agent partial-mask + no-mask entries.
+
+    The Agent Repository PR (#45) is the second partial-mask
+    Aggregate (after Workflow): ``agents.prompt_body`` is the
+    **only** masked column on the Agent surface, with
+    ``agent_providers`` / ``agent_skills`` and the rest of
+    ``agents`` registered as no-mask. **Schneier 申し送り #3 实適用
+    クローズ** is documented through this line.
+    """
+
+    def test_agents_prompt_body_row_present(self, storage_md_text: str) -> None:
+        """§逆引き表 declares ``MaskedText`` on ``agents.prompt_body``.
+
+        The line must co-locate ``Persona.prompt_body`` (or
+        ``agents.prompt_body``) and ``MaskedText`` so an operator
+        scrolling to the Agent row sees the redaction policy
+        directly.
+        """
+        co_located_lines = [
+            line
+            for line in storage_md_text.splitlines()
+            if (
+                "prompt_body" in line
+                and "MaskedText" in line
+                and ("agents" in line or "Persona" in line)
+            )
+        ]
+        assert co_located_lines, (
+            "storage.md §逆引き表 must contain at least one line that "
+            "co-locates 'prompt_body' and 'MaskedText' on an Agent-"
+            "owned row per agent-repository §確定 H (Schneier 申し送り "
+            "#3 实適用)."
+        )
+
+    def test_agent_no_mask_row_present(self, storage_md_text: str) -> None:
+        """§逆引き表 declares the Agent remaining columns no-mask.
+
+        agent_providers / agent_skills and other agents columns are
+        registered as "masking 対象なし" so the partial-mask intent
+        is visible from the Agent row directly.
+        """
+        co_located_lines = [
+            line
+            for line in storage_md_text.splitlines()
+            if "Agent" in line and "masking 対象なし" in line
+        ]
+        assert co_located_lines, (
+            "storage.md §逆引き表 must contain at least one line that "
+            "co-locates 'Agent' and 'masking 対象なし' so the partial-"
+            "mask Aggregate's non-masked columns are operator-readable "
+            "from the Agent row directly. Required by agent-repository "
+            "§確定 H (partial-mask テンプレート)."
+        )

--- a/backend/tests/factories/agent.py
+++ b/backend/tests/factories/agent.py
@@ -111,6 +111,7 @@ def make_skill_ref(
 def make_agent(
     *,
     agent_id: UUID | None = None,
+    empire_id: UUID | None = None,
     name: str = "テストエージェント",
     persona: Persona | None = None,
     role: Role = Role.DEVELOPER,
@@ -120,8 +121,11 @@ def make_agent(
 ) -> Agent:
     """Build a valid :class:`Agent`.
 
-    With no overrides yields the simplest valid Agent: 1 ProviderConfig with
-    ``is_default=True``, no skills, ``archived=False``.
+    With no overrides yields the simplest valid Agent: a fresh ``empire_id``,
+    1 ProviderConfig with ``is_default=True``, no skills, ``archived=False``.
+    Tests that exercise the agent-repository ``find_by_name`` scope or any
+    Empire-level membership invariant should override ``empire_id`` so the
+    factory's freshly-generated default does not collide with their setup.
     """
     if persona is None:
         persona = make_persona()
@@ -131,6 +135,7 @@ def make_agent(
         skills = []
     agent = Agent(
         id=agent_id if agent_id is not None else uuid4(),
+        empire_id=empire_id if empire_id is not None else uuid4(),
         name=name,
         persona=persona,
         role=role,

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_agent_repository/__init__.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_agent_repository/__init__.py
@@ -1,0 +1,22 @@
+"""Agent Repository integration tests, split by topic.
+
+Per ``docs/features/agent-repository/test-design.md`` and the
+empire-repository PR #29 教訓 (Norman 500-line rule), the test
+surface is split into four siblings so each file stays under the
+readability budget:
+
+* :mod:`...test_protocol_crud` — Protocol surface (4 methods) +
+  ``find_by_id`` / ``count`` / ``find_by_name`` basic CRUD
+  (TC-UT-AGR-001 / 004 / 005).
+* :mod:`...test_save_semantics` — delete-then-insert + 5-step SQL
+  order + ORDER BY contract + Tx boundary + round-trip equality
+  (TC-UT-AGR-002 / 003 / 010 / 011).
+* :mod:`...test_constraints_arch` — DB-level partial unique index
+  二重防衛 + Alembic 0004 + arch-test reference
+  (TC-IT-AGR-007 / 008 / TC-UT-AGR-009).
+* :mod:`...test_masking_persona` — **Schneier #3 实適用 7 経路**:
+  Anthropic / GitHub / OpenAI / Bearer / no-secret / roundtrip /
+  multiple — verifies via raw-SQL SELECT that ``agents.prompt_body``
+  carries ``<REDACTED:*>`` and zero raw token bytes
+  (TC-IT-AGR-006-masking-*).
+"""

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_agent_repository/conftest.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_agent_repository/conftest.py
@@ -1,0 +1,70 @@
+"""Pytest fixtures shared across agent-repository integration tests.
+
+Two responsibilities:
+
+1. Set ``BAKUFU_DATA_DIR`` env var so ``SkillRef.path`` H10 validation
+   passes (mirror of ``tests/domain/agent/conftest.py``).
+2. Provide a :func:`seed_empire` helper that creates an Empire row in
+   the test DB so the ``agents.empire_id`` FK resolves. Without this
+   helper, every ``save(agent)`` would fail with ``IntegrityError:
+   FOREIGN KEY constraint failed`` because the schema declares
+   ``agents.empire_id REFERENCES empires.id ON DELETE CASCADE``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID, uuid4
+
+import pytest
+import pytest_asyncio
+from bakufu.infrastructure.persistence.sqlite.repositories.empire_repository import (
+    SqliteEmpireRepository,
+)
+
+from tests.factories.empire import make_empire
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+
+@pytest.fixture(autouse=True)
+def _bakufu_data_dir(monkeypatch: pytest.MonkeyPatch) -> None:  # pyright: ignore[reportUnusedFunction]
+    """Set ``BAKUFU_DATA_DIR`` for every test in this package.
+
+    Autouse fixture — pytest invokes via dependency injection, so the
+    function appears unused to pyright. The pragma silences that.
+    """
+    monkeypatch.setenv("BAKUFU_DATA_DIR", "/tmp/bakufu-test-root")
+
+
+@pytest_asyncio.fixture
+async def seeded_empire_id(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> UUID:
+    """Seed a single Empire row and return its id for FK satisfaction.
+
+    Use this when the test only needs ``one`` empire to attach Agents
+    to. For multi-Empire tests (e.g. ``find_by_name`` cross-Empire
+    isolation), call :func:`seed_empire` directly with explicit ids.
+    """
+    empire = make_empire()
+    async with session_factory() as session, session.begin():
+        await SqliteEmpireRepository(session).save(empire)
+    return empire.id
+
+
+async def seed_empire(
+    session_factory: async_sessionmaker[AsyncSession],
+    empire_id: UUID | None = None,
+) -> UUID:
+    """Persist an Empire row whose id is ``empire_id`` (or fresh).
+
+    Helper for tests that need to control which empire_id Agents
+    attach to (e.g. cross-Empire isolation, multi-empire seeding).
+    Returns the id that was actually persisted.
+    """
+    empire = make_empire(empire_id=empire_id if empire_id is not None else uuid4())
+    async with session_factory() as session, session.begin():
+        await SqliteEmpireRepository(session).save(empire)
+    return empire.id

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_agent_repository/test_constraints_arch.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_agent_repository/test_constraints_arch.py
@@ -1,0 +1,300 @@
+"""Agent Repository: DB constraints + arch-test reference.
+
+TC-IT-AGR-007 / TC-UT-AGR-009 — the **partial unique index 二重防衛**
+(§確定 G) and the CI Layer 2 arch-test cross-reference.
+
+§確定 G: ``is_default = 1`` rows under the same ``agent_id`` are
+forbidden by **two layers**:
+
+1. **Aggregate-level** (``_validate_default_provider_count`` in the
+   Agent VO chain) catches the violation at construction time.
+2. **DB-level** partial unique index ``uq_agent_providers_default``
+   (``WHERE is_default = 1``) physically rejects the INSERT — the
+   final defense line for code paths that bypass the Aggregate
+   (raw SQL, future Repository implementations that forget the
+   check, dump/restore migrations, etc.).
+
+This test exercises **layer 2 in isolation** by writing raw SQL that
+sidesteps the Aggregate. A regression that drops the partial index
+DDL would let the second INSERT succeed silently — that fails this
+test loudly.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy import text
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-AGR-007: partial unique index 二重防衛 (§確定 G)
+# ---------------------------------------------------------------------------
+class TestPartialUniqueIndexDoubleDefense:
+    """TC-IT-AGR-007: ``is_default=1`` x 2 under same agent_id raises IntegrityError.
+
+    The Aggregate's ``_validate_default_provider_count`` is the first
+    layer; this test bypasses it by writing raw SQL directly so the
+    partial unique index is the only thing standing between us and a
+    silent corruption. The first INSERT must succeed; the second must
+    raise ``IntegrityError`` (or any ``DBAPIError``-shaped wrapper —
+    SQLAlchemy maps SQLite's UNIQUE constraint violation to
+    ``IntegrityError``).
+    """
+
+    async def test_duplicate_default_provider_raises_integrity_error(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_empire_id: UUID,
+    ) -> None:
+        """TC-IT-AGR-007: 2 rows with ``is_default=1`` for same agent_id is rejected by DB."""
+        from sqlalchemy.exc import IntegrityError
+
+        # Seed an Agent row so the FK in agent_providers can resolve.
+        # We bypass the Repository entirely — raw SQL throughout —
+        # to keep the test focused on the DB layer.
+        agent_id = uuid4()
+        empire_id = seeded_empire_id
+        async with session_factory() as session, session.begin():
+            await session.execute(
+                text(
+                    "INSERT INTO agents "
+                    "(id, empire_id, name, role, display_name, archetype, "
+                    "prompt_body, archived) VALUES "
+                    "(:id, :empire_id, :name, :role, :display_name, :archetype, "
+                    ":prompt_body, :archived)"
+                ),
+                {
+                    "id": agent_id.hex,
+                    "empire_id": empire_id.hex,
+                    "name": "raw-sql-agent",
+                    "role": "DEVELOPER",
+                    "display_name": "raw",
+                    "archetype": "review-focused",
+                    "prompt_body": "no secret",
+                    "archived": False,
+                },
+            )
+
+        # First default provider — should succeed.
+        async with session_factory() as session, session.begin():
+            await session.execute(
+                text(
+                    "INSERT INTO agent_providers "
+                    "(agent_id, provider_kind, model, is_default) VALUES "
+                    "(:agent_id, :provider_kind, :model, :is_default)"
+                ),
+                {
+                    "agent_id": agent_id.hex,
+                    "provider_kind": "claude_code",
+                    "model": "sonnet-4.5",
+                    "is_default": True,
+                },
+            )
+
+        # Second default provider on the same agent_id — distinct
+        # provider_kind so the (agent_id, provider_kind) UNIQUE does
+        # NOT trip; only the partial unique index on is_default=1
+        # should fire.
+        with pytest.raises(IntegrityError):
+            async with session_factory() as session, session.begin():
+                await session.execute(
+                    text(
+                        "INSERT INTO agent_providers "
+                        "(agent_id, provider_kind, model, is_default) VALUES "
+                        "(:agent_id, :provider_kind, :model, :is_default)"
+                    ),
+                    {
+                        "agent_id": agent_id.hex,
+                        # Different provider_kind — so this is not the
+                        # (agent_id, provider_kind) UNIQUE; the
+                        # partial index alone is the relevant defense.
+                        "provider_kind": "claude_api",
+                        "model": "haiku-3.5",
+                        "is_default": True,
+                    },
+                )
+
+    async def test_non_default_duplicates_are_permitted(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_empire_id: UUID,
+    ) -> None:
+        """``is_default=0`` rows on the same agent_id are NOT subject to the partial index.
+
+        Confirms the partial nature: ``WHERE is_default = 1`` means
+        rows with ``is_default = 0`` can coexist freely on the same
+        agent_id (subject only to the (agent_id, provider_kind)
+        UNIQUE).
+        """
+        agent_id = uuid4()
+        empire_id = seeded_empire_id
+        async with session_factory() as session, session.begin():
+            await session.execute(
+                text(
+                    "INSERT INTO agents "
+                    "(id, empire_id, name, role, display_name, archetype, "
+                    "prompt_body, archived) VALUES "
+                    "(:id, :empire_id, :name, :role, :display_name, :archetype, "
+                    ":prompt_body, :archived)"
+                ),
+                {
+                    "id": agent_id.hex,
+                    "empire_id": empire_id.hex,
+                    "name": "non-default-test",
+                    "role": "DEVELOPER",
+                    "display_name": "raw",
+                    "archetype": "review-focused",
+                    "prompt_body": "no secret",
+                    "archived": False,
+                },
+            )
+
+        # Two providers, both is_default=False, distinct kinds — both succeed.
+        async with session_factory() as session, session.begin():
+            for kind in ("claude_code", "claude_api"):
+                await session.execute(
+                    text(
+                        "INSERT INTO agent_providers "
+                        "(agent_id, provider_kind, model, is_default) VALUES "
+                        "(:agent_id, :provider_kind, :model, :is_default)"
+                    ),
+                    {
+                        "agent_id": agent_id.hex,
+                        "provider_kind": kind,
+                        "model": "model-x",
+                        "is_default": False,
+                    },
+                )
+
+        # Both rows present; partial index did not fire.
+        async with session_factory() as session:
+            result = await session.execute(
+                text("SELECT COUNT(*) FROM agent_providers WHERE agent_id = :agent_id"),
+                {"agent_id": agent_id.hex},
+            )
+            count = result.scalar_one()
+        assert count == 2
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-AGR-007 補強: same agent_id duplicate (agent_id, provider_kind) → reject
+# ---------------------------------------------------------------------------
+class TestUniqueAgentProviderPair:
+    """The (agent_id, provider_kind) UNIQUE rejects same kind twice."""
+
+    async def test_duplicate_agent_provider_pair_raises(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_empire_id: UUID,
+    ) -> None:
+        """Same (agent_id, provider_kind) inserted twice → IntegrityError."""
+        from sqlalchemy.exc import IntegrityError
+
+        agent_id = uuid4()
+        empire_id = seeded_empire_id
+        async with session_factory() as session, session.begin():
+            await session.execute(
+                text(
+                    "INSERT INTO agents "
+                    "(id, empire_id, name, role, display_name, archetype, "
+                    "prompt_body, archived) VALUES "
+                    "(:id, :empire_id, :name, :role, :display_name, :archetype, "
+                    ":prompt_body, :archived)"
+                ),
+                {
+                    "id": agent_id.hex,
+                    "empire_id": empire_id.hex,
+                    "name": "kind-dup-test",
+                    "role": "DEVELOPER",
+                    "display_name": "raw",
+                    "archetype": "review-focused",
+                    "prompt_body": "no secret",
+                    "archived": False,
+                },
+            )
+            await session.execute(
+                text(
+                    "INSERT INTO agent_providers "
+                    "(agent_id, provider_kind, model, is_default) VALUES "
+                    "(:agent_id, :provider_kind, :model, :is_default)"
+                ),
+                {
+                    "agent_id": agent_id.hex,
+                    "provider_kind": "claude_code",
+                    "model": "sonnet-4.5",
+                    "is_default": False,
+                },
+            )
+
+        with pytest.raises(IntegrityError):
+            async with session_factory() as session, session.begin():
+                await session.execute(
+                    text(
+                        "INSERT INTO agent_providers "
+                        "(agent_id, provider_kind, model, is_default) VALUES "
+                        "(:agent_id, :provider_kind, :model, :is_default)"
+                    ),
+                    {
+                        "agent_id": agent_id.hex,
+                        "provider_kind": "claude_code",  # same kind
+                        "model": "haiku-3.5",
+                        "is_default": False,
+                    },
+                )
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-AGR-009: Layer 2 arch-test reference — Agent rows registered
+# ---------------------------------------------------------------------------
+class TestArchTestRegistrationStructure:
+    """TC-UT-AGR-009: ``test_masking_columns.py`` parametrize lists include Agent.
+
+    Cross-checks that the CI Layer 2 arch test was extended to cover
+    the 3 Agent tables. A future PR that drops these registrations
+    (e.g. by accident during a refactor) would let an over-masking
+    or under-masking change land silently — this test catches it.
+    """
+
+    async def test_agents_prompt_body_in_masking_contract(self) -> None:
+        """``agents.prompt_body`` is registered as MaskedText in the contract list."""
+        from bakufu.infrastructure.persistence.sqlite.base import MaskedText
+
+        from tests.architecture.test_masking_columns import (
+            _MASKING_CONTRACT,  # pyright: ignore[reportPrivateUsage]
+        )
+
+        assert ("agents", "prompt_body", MaskedText) in _MASKING_CONTRACT, (
+            "[FAIL] agents.prompt_body missing from _MASKING_CONTRACT.\n"
+            "Next: re-add the Schneier 申し送り #3 实適用 row to "
+            "tests/architecture/test_masking_columns.py."
+        )
+
+    async def test_agent_providers_and_skills_in_no_mask_list(self) -> None:
+        """``agent_providers`` / ``agent_skills`` are no-mask tables."""
+        from tests.architecture.test_masking_columns import (
+            _NO_MASK_TABLES,  # pyright: ignore[reportPrivateUsage]
+        )
+
+        assert "agent_providers" in _NO_MASK_TABLES
+        assert "agent_skills" in _NO_MASK_TABLES
+
+    async def test_agents_partial_mask_template_registered(self) -> None:
+        """``agents`` is registered in the partial-mask template list."""
+        from tests.architecture.test_masking_columns import (
+            _PARTIAL_MASK_TABLES,  # pyright: ignore[reportPrivateUsage]
+        )
+
+        partial = dict(_PARTIAL_MASK_TABLES)
+        assert partial.get("agents") == "prompt_body", (
+            f"[FAIL] agents partial-mask declared {partial.get('agents')!r}, "
+            f"expected 'prompt_body'.\n"
+            f"Next: §逆引き表 freezes prompt_body as the sole masked column on agents."
+        )

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_agent_repository/test_masking_persona.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_agent_repository/test_masking_persona.py
@@ -1,0 +1,339 @@
+"""Agent Repository: §確定 H — MaskedText wiring on agents.prompt_body.
+
+**Schneier 申し送り #3 实適用の物理保証**. This module is the core test
+file for PR #45 — the persistence-foundation #23 hook structure is
+finally exercised end-to-end against a real SQLite DB, against 7
+secret-bearing prompt-body shapes:
+
+1. **anthropic** — ``ANTHROPIC_API_KEY=sk-ant-api03-XXX...`` → ``<REDACTED:ANTHROPIC_KEY>``
+2. **github** — ``ghp_XXX...`` → ``<REDACTED:GITHUB_PAT>``
+3. **openai** — ``sk-XXX...`` → ``<REDACTED:OPENAI_KEY>``
+4. **bearer** — ``Authorization: Bearer XXX`` → ``<REDACTED:BEARER>``
+5. **no-secret** — plain prompt → unchanged (passthrough)
+6. **roundtrip** — §確定 H §不可逆性: ``find_by_id`` returns the masked
+   form (raw token unrecoverable from DB).
+7. **multiple** — 3+ secret types in one prompt → all redacted.
+
+Each verification reads the persisted ``agents.prompt_body`` value via
+**raw SQL SELECT** so we observe the literal bytes that hit the disk
+(bypassing ``MaskedText.process_result_value`` is fine; the column is
+TEXT-typed, so the raw bind side IS the on-disk side).
+
+Per ``docs/features/agent-repository/test-design.md`` TC-IT-AGR-006-masking-*.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+import pytest
+from bakufu.domain.agent import Agent, Persona
+from bakufu.infrastructure.persistence.sqlite.repositories.agent_repository import (
+    SqliteAgentRepository,
+)
+from sqlalchemy import text
+
+from tests.factories.agent import make_agent
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+pytestmark = pytest.mark.asyncio
+
+
+# Real-shape (synthetic) secret tokens. Pattern lengths must match
+# the masking gateway's regex (masking.py L62-93) so the token is
+# actually redacted; otherwise the test would pass for the wrong
+# reason (token is plain text → grep finds no token → false negative).
+_ANTHROPIC_TOKEN = "sk-ant-api03-" + "A" * 60
+_GITHUB_TOKEN = "ghp_" + "X" * 40
+_OPENAI_TOKEN = "sk-" + "B" * 50  # 20+ chars after sk-, not sk-ant- (negative lookahead)
+_BEARER_TOKEN = "eyJhbGciOi.tokenpart.signature"
+
+# Redaction sentinels (masking.py L62-93).
+_ANTHROPIC_SENTINEL = "<REDACTED:ANTHROPIC_KEY>"
+_GITHUB_SENTINEL = "<REDACTED:GITHUB_PAT>"
+_OPENAI_SENTINEL = "<REDACTED:OPENAI_KEY>"
+_BEARER_SENTINEL = "<REDACTED:BEARER>"
+
+
+def _make_agent_with_prompt(prompt_body: str, *, empire_id: UUID) -> Agent:
+    """Build an Agent whose Persona carries ``prompt_body``.
+
+    The default factory keeps every other field synthetic-but-valid;
+    we override only ``persona.prompt_body`` to inject the secret
+    pattern under test. ``empire_id`` is required so the FK to
+    ``empires.id`` resolves at INSERT time.
+    """
+    persona = Persona(
+        display_name="masking-probe",
+        archetype="review-focused",
+        prompt_body=prompt_body,
+    )
+    return make_agent(empire_id=empire_id, persona=persona)
+
+
+async def _read_persisted_prompt(
+    session_factory: async_sessionmaker[AsyncSession],
+    agent_id: UUID,
+) -> str:
+    """Raw-SQL SELECT to fetch ``agents.prompt_body`` literal bytes.
+
+    Bypasses ``MaskedText.process_result_value`` is unnecessary —
+    that hook is identity (just returns the stored string), so what
+    we read here IS what is on disk. We use ``text()`` to make the
+    intent explicit and to keep the test independent of the ORM-
+    declarative metadata.
+    """
+    async with session_factory() as session:
+        stmt = text("SELECT prompt_body FROM agents WHERE id = :id")
+        # SQLAlchemy's UUIDStr TypeDecorator stores as ``.hex``; we
+        # match that here so the WHERE clause hits the row.
+        row = (await session.execute(stmt, {"id": agent_id.hex})).first()
+    assert row is not None, f"agents row not found for id={agent_id}"
+    persisted = row[0]
+    assert isinstance(persisted, str)
+    return persisted
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-AGR-006-masking-anthropic
+# ---------------------------------------------------------------------------
+class TestAnthropicKeyMasked:
+    """TC-IT-AGR-006-masking-anthropic: Anthropic API key redacted on save."""
+
+    async def test_anthropic_key_redacted_in_persisted_prompt(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_empire_id: UUID,
+    ) -> None:
+        """Raw-SQL SELECT shows ``<REDACTED:ANTHROPIC_KEY>``; raw token absent."""
+        prompt = f"Use ANTHROPIC_API_KEY={_ANTHROPIC_TOKEN} when calling Claude."
+        agent = _make_agent_with_prompt(prompt, empire_id=seeded_empire_id)
+        async with session_factory() as session, session.begin():
+            await SqliteAgentRepository(session).save(agent)
+
+        persisted = await _read_persisted_prompt(session_factory, agent.id)
+
+        assert _ANTHROPIC_SENTINEL in persisted, (
+            f"[FAIL] agents.prompt_body missing Anthropic redaction sentinel.\n"
+            f"Next: verify MaskedText TypeDecorator on agents.prompt_body. "
+            f"Persisted: {persisted!r}"
+        )
+        assert _ANTHROPIC_TOKEN not in persisted, (
+            f"[FAIL] Raw Anthropic API key leaked into agents.prompt_body.\n"
+            f"This is the catastrophic case Schneier 申し送り #3 was designed "
+            f"to prevent. Persisted: {persisted!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-AGR-006-masking-github
+# ---------------------------------------------------------------------------
+class TestGitHubPatMasked:
+    """TC-IT-AGR-006-masking-github: GitHub PAT redacted on save."""
+
+    async def test_github_pat_redacted_in_persisted_prompt(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_empire_id: UUID,
+    ) -> None:
+        """Raw-SQL SELECT shows ``<REDACTED:GITHUB_PAT>``; raw PAT absent."""
+        prompt = f"Use {_GITHUB_TOKEN} for git push."
+        agent = _make_agent_with_prompt(prompt, empire_id=seeded_empire_id)
+        async with session_factory() as session, session.begin():
+            await SqliteAgentRepository(session).save(agent)
+
+        persisted = await _read_persisted_prompt(session_factory, agent.id)
+
+        assert _GITHUB_SENTINEL in persisted, (
+            f"[FAIL] agents.prompt_body missing GitHub PAT redaction sentinel. "
+            f"Persisted: {persisted!r}"
+        )
+        assert _GITHUB_TOKEN not in persisted, (
+            f"[FAIL] Raw GitHub PAT leaked into agents.prompt_body. Persisted: {persisted!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-AGR-006-masking-openai
+# ---------------------------------------------------------------------------
+class TestOpenAiKeyMasked:
+    """TC-IT-AGR-006-masking-openai: OpenAI API key redacted on save."""
+
+    async def test_openai_key_redacted_in_persisted_prompt(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_empire_id: UUID,
+    ) -> None:
+        """Raw-SQL SELECT shows ``<REDACTED:OPENAI_KEY>``; raw token absent.
+
+        Note the masking gateway uses a **negative lookahead** so
+        Anthropic's ``sk-ant-`` prefix is NOT mis-classified as
+        OpenAI. We feed a non-Anthropic ``sk-...`` here.
+        """
+        prompt = f"Use OPENAI_API_KEY={_OPENAI_TOKEN} for fallback."
+        agent = _make_agent_with_prompt(prompt, empire_id=seeded_empire_id)
+        async with session_factory() as session, session.begin():
+            await SqliteAgentRepository(session).save(agent)
+
+        persisted = await _read_persisted_prompt(session_factory, agent.id)
+
+        assert _OPENAI_SENTINEL in persisted, (
+            f"[FAIL] agents.prompt_body missing OpenAI redaction sentinel. Persisted: {persisted!r}"
+        )
+        assert _OPENAI_TOKEN not in persisted, (
+            f"[FAIL] Raw OpenAI API key leaked into agents.prompt_body. Persisted: {persisted!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-AGR-006-masking-bearer
+# ---------------------------------------------------------------------------
+class TestBearerTokenMasked:
+    """TC-IT-AGR-006-masking-bearer: Authorization: Bearer XXX redacted."""
+
+    async def test_bearer_token_redacted_in_persisted_prompt(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_empire_id: UUID,
+    ) -> None:
+        """Raw-SQL SELECT shows ``<REDACTED:BEARER>``; raw token absent."""
+        prompt = f"Set header `Authorization: Bearer {_BEARER_TOKEN}`."
+        agent = _make_agent_with_prompt(prompt, empire_id=seeded_empire_id)
+        async with session_factory() as session, session.begin():
+            await SqliteAgentRepository(session).save(agent)
+
+        persisted = await _read_persisted_prompt(session_factory, agent.id)
+
+        assert _BEARER_SENTINEL in persisted, (
+            f"[FAIL] agents.prompt_body missing Bearer redaction sentinel. Persisted: {persisted!r}"
+        )
+        assert _BEARER_TOKEN not in persisted, (
+            f"[FAIL] Raw Bearer token leaked into agents.prompt_body. Persisted: {persisted!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-AGR-006-masking-no-secret (passthrough)
+# ---------------------------------------------------------------------------
+class TestNoSecretPassthrough:
+    """TC-IT-AGR-006-masking-no-secret: plain prompt is stored unchanged."""
+
+    async def test_plain_prompt_is_passthrough(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_empire_id: UUID,
+    ) -> None:
+        """A prompt with no Schneier-#6 secrets is persisted byte-identical.
+
+        Confirms masking is **scoped** — only known secret patterns
+        get redacted; the masking gateway is not over-aggressive on
+        plain text. Without this check, a regression that replaces
+        the masking gateway with ``str.replace_all('a', '<X>')``
+        would silently corrupt prompts.
+        """
+        plain = "You are a thorough reviewer who checks PRs carefully."
+        agent = _make_agent_with_prompt(plain, empire_id=seeded_empire_id)
+        async with session_factory() as session, session.begin():
+            await SqliteAgentRepository(session).save(agent)
+
+        persisted = await _read_persisted_prompt(session_factory, agent.id)
+        assert persisted == plain, (
+            f"[FAIL] non-secret prompt was modified during persistence.\n"
+            f"Expected: {plain!r}\n"
+            f"Got:      {persisted!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-AGR-006-masking-roundtrip (§確定 H §不可逆性)
+# ---------------------------------------------------------------------------
+class TestRoundTripIsIrreversible:
+    """TC-IT-AGR-006-masking-roundtrip: §確定 H §不可逆性 — find_by_id returns masked.
+
+    Once a secret is masked at save time, the raw token is
+    **physically unrecoverable** from the DB. ``find_by_id`` must
+    therefore return a Persona whose ``prompt_body`` carries the
+    redaction sentinel rather than the original token. Detecting
+    masked prompts and refusing to dispatch them to the LLM is
+    ``feature/llm-adapter``'s job (申し送り #1) — the Repository
+    contract is "the masked form is what you get back".
+    """
+
+    async def test_find_by_id_returns_masked_prompt_body(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_empire_id: UUID,
+    ) -> None:
+        """Save raw → find_by_id → persona.prompt_body == masked form."""
+        raw = f"ANTHROPIC_API_KEY={_ANTHROPIC_TOKEN}"
+        agent = _make_agent_with_prompt(raw, empire_id=seeded_empire_id)
+        async with session_factory() as session, session.begin():
+            await SqliteAgentRepository(session).save(agent)
+
+        async with session_factory() as session:
+            restored = await SqliteAgentRepository(session).find_by_id(agent.id)
+
+        assert restored is not None
+        assert _ANTHROPIC_SENTINEL in restored.persona.prompt_body, (
+            f"[FAIL] find_by_id did not return masked prompt_body.\n"
+            f"Restored: {restored.persona.prompt_body!r}"
+        )
+        assert _ANTHROPIC_TOKEN not in restored.persona.prompt_body, (
+            f"[FAIL] §確定 H §不可逆性 violated: raw token recovered after round-trip.\n"
+            f"Restored: {restored.persona.prompt_body!r}"
+        )
+        # And of course the round-tripped Agent does NOT compare equal
+        # to the original Agent (since prompt_body changed) — pin
+        # this asymmetry as the documented design contract.
+        assert restored != agent, (
+            "[FAIL] round-trip equality should not hold for masked prompts; "
+            "if this passes, masking might be a no-op."
+        )
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-AGR-006-masking-multiple
+# ---------------------------------------------------------------------------
+class TestMultipleSecretsAllRedacted:
+    """TC-IT-AGR-006-masking-multiple: 3+ secret types in one prompt all redacted."""
+
+    async def test_multiple_secrets_all_redacted_in_one_pass(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_empire_id: UUID,
+    ) -> None:
+        """A prompt with anthropic + github + bearer all gets fully redacted.
+
+        Confirms masking is **comprehensive** — applying one redaction
+        does not short-circuit the others. The gateway iterates all
+        regex patterns; this test pins that behaviour.
+        """
+        prompt = (
+            f"Multiple secrets in one prompt:\n"
+            f"  ANTHROPIC_API_KEY={_ANTHROPIC_TOKEN}\n"
+            f"  GITHUB_TOKEN={_GITHUB_TOKEN}\n"
+            f"  Authorization: Bearer {_BEARER_TOKEN}\n"
+        )
+        agent = _make_agent_with_prompt(prompt, empire_id=seeded_empire_id)
+        async with session_factory() as session, session.begin():
+            await SqliteAgentRepository(session).save(agent)
+
+        persisted = await _read_persisted_prompt(session_factory, agent.id)
+
+        # All 3 sentinels present.
+        assert _ANTHROPIC_SENTINEL in persisted
+        assert _GITHUB_SENTINEL in persisted
+        assert _BEARER_SENTINEL in persisted
+        # All 3 raw tokens absent.
+        assert _ANTHROPIC_TOKEN not in persisted, (
+            f"[FAIL] Anthropic token survived multi-secret masking. Persisted: {persisted!r}"
+        )
+        assert _GITHUB_TOKEN not in persisted, (
+            f"[FAIL] GitHub PAT survived multi-secret masking. Persisted: {persisted!r}"
+        )
+        assert _BEARER_TOKEN not in persisted, (
+            f"[FAIL] Bearer token survived multi-secret masking. Persisted: {persisted!r}"
+        )

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_agent_repository/test_protocol_crud.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_agent_repository/test_protocol_crud.py
@@ -1,0 +1,347 @@
+"""Agent Repository: Protocol surface + basic CRUD coverage.
+
+TC-UT-AGR-001 / 004 / 005 — the entry-point behaviors plus the
+**4-method Protocol surface** (the agent-repository is the first
+Repository to add ``find_by_name`` on top of the empire / workflow
+3-method template, §確定 F).
+
+Per ``docs/features/agent-repository/test-design.md``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID, uuid4
+
+import pytest
+from bakufu.application.ports.agent_repository import AgentRepository
+from bakufu.infrastructure.persistence.sqlite.repositories.agent_repository import (
+    SqliteAgentRepository,
+)
+from sqlalchemy import event
+
+from tests.factories.agent import make_agent
+from tests.infrastructure.persistence.sqlite.repositories.test_agent_repository.conftest import (
+    seed_empire,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# REQ-AGR-001: Protocol definition + 4-method surface (§確定 A + F)
+# ---------------------------------------------------------------------------
+class TestAgentRepositoryProtocol:
+    """TC-UT-AGR-001: Protocol declares 4 async methods incl. ``find_by_name``."""
+
+    async def test_protocol_declares_four_async_methods(self) -> None:
+        """TC-UT-AGR-001: ``AgentRepository`` has find_by_id / count / save / find_by_name."""
+        # Marked async so module-level pytestmark = asyncio does not warn.
+        assert hasattr(AgentRepository, "find_by_id")
+        assert hasattr(AgentRepository, "count")
+        assert hasattr(AgentRepository, "save")
+        # ``find_by_name`` is the 4th method introduced by §確定 F —
+        # the first M2 Repository PR to extend the 3-method template.
+        assert hasattr(AgentRepository, "find_by_name")
+
+    async def test_sqlite_repository_satisfies_protocol(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """TC-UT-AGR-001: ``SqliteAgentRepository`` is assignable to ``AgentRepository``.
+
+        The variable annotation acts as a static-type assertion; pyright
+        strict will reject the assignment if any of the 4 Protocol
+        methods is missing or has a wrong signature.
+        """
+        async with session_factory() as session:
+            repo: AgentRepository = SqliteAgentRepository(session)
+            assert hasattr(repo, "find_by_id")
+            assert hasattr(repo, "count")
+            assert hasattr(repo, "save")
+            assert hasattr(repo, "find_by_name")
+
+
+# ---------------------------------------------------------------------------
+# REQ-AGR-002 (find_by_id basic round-trip)
+# ---------------------------------------------------------------------------
+class TestFindById:
+    """find_by_id retrieves saved Agents; returns None for unknown."""
+
+    async def test_find_by_id_returns_saved_agent(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_empire_id: UUID,
+    ) -> None:
+        """``find_by_id(agent.id)`` returns a structurally-equal Agent (no secrets in default)."""
+        # Default factory ``prompt_body='You are a thorough reviewer.'``
+        # contains no Schneier-#6 secrets, so masking is a no-op and
+        # round-trip equality holds. Secret-bearing prompt round-trip
+        # lives in :mod:`...test_masking_persona` (§確定 H §不可逆性).
+        agent = make_agent(empire_id=seeded_empire_id)
+        async with session_factory() as session, session.begin():
+            await SqliteAgentRepository(session).save(agent)
+
+        async with session_factory() as session:
+            fetched = await SqliteAgentRepository(session).find_by_id(agent.id)
+
+        assert fetched is not None
+        assert fetched == agent
+
+    async def test_find_by_id_returns_none_for_unknown(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """``find_by_id(uuid4())`` returns ``None`` without raising."""
+        unknown_id = uuid4()
+        async with session_factory() as session:
+            fetched = await SqliteAgentRepository(session).find_by_id(unknown_id)
+        assert fetched is None
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-AGR-004: count() must issue SQL-level COUNT(*)
+# ---------------------------------------------------------------------------
+class TestCountIssuesScalarCount:
+    """TC-UT-AGR-004: ``count()`` issues ``SELECT COUNT(*)``, not a full row scan."""
+
+    async def test_count_emits_select_count_not_full_load(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        app_engine: AsyncEngine,
+        seeded_empire_id: UUID,
+    ) -> None:
+        """SQL log shows ``SELECT count(*)`` for ``count()``.
+
+        The empire-repository §確定 D 補強 contract continued — Agent
+        provider / skill rows can hold hundreds of records once the
+        preset library lands, so the COUNT(*) pattern matters even
+        more than for Empire.
+        """
+        async with session_factory() as session, session.begin():
+            await SqliteAgentRepository(session).save(make_agent(empire_id=seeded_empire_id))
+        async with session_factory() as session, session.begin():
+            await SqliteAgentRepository(session).save(make_agent(empire_id=seeded_empire_id))
+
+        captured: list[str] = []
+
+        def _on_execute(
+            _conn: object,
+            _cursor: object,
+            statement: str,
+            _params: object,
+            _context: object,
+            _executemany: bool,
+        ) -> None:
+            captured.append(statement.strip())
+
+        sync_engine = app_engine.sync_engine
+        event.listen(sync_engine, "before_cursor_execute", _on_execute)
+        try:
+            async with session_factory() as session:
+                count = await SqliteAgentRepository(session).count()
+        finally:
+            event.remove(sync_engine, "before_cursor_execute", _on_execute)
+
+        assert count == 2
+        agent_selects = [s for s in captured if "FROM agents" in s]
+        assert agent_selects, "count() must issue at least one SELECT against agents"
+        for stmt in agent_selects:
+            assert "count(" in stmt.lower(), (
+                f"[FAIL] count() emitted a non-COUNT SELECT: {stmt!r}\n"
+                f"Next: ensure count() uses select(func.count()).select_from(AgentRow)."
+            )
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-AGR-005: find_by_name Empire-scoped (§確定 F)
+# ---------------------------------------------------------------------------
+class TestFindByNameEmpireScoped:
+    """TC-UT-AGR-005: ``find_by_name`` enforces Empire scoping.
+
+    Three orthogonal cases per §確定 F:
+
+    1. **Hit**: Agent named ``foo`` inside ``empire_a`` is returned.
+    2. **Miss in same Empire**: name ``bar`` under ``empire_a`` returns None.
+    3. **Cross-Empire isolation**: name ``foo`` under ``empire_b`` returns None
+       even though ``foo`` exists in ``empire_a``. This is the IDOR
+       guard — without ``WHERE empire_id=:empire_id`` an attacker
+       could read another tenant's Agent by guessing the name.
+    """
+
+    async def test_find_by_name_returns_agent_when_present(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """Hit path: name + empire_id pair returns the Agent."""
+        empire_a = await seed_empire(session_factory)
+        agent = make_agent(empire_id=empire_a, name="agent_a")
+        async with session_factory() as session, session.begin():
+            await SqliteAgentRepository(session).save(agent)
+
+        async with session_factory() as session:
+            fetched = await SqliteAgentRepository(session).find_by_name(empire_a, "agent_a")
+
+        assert fetched is not None
+        assert fetched.id == agent.id
+        assert fetched.empire_id == empire_a
+        assert fetched.name == "agent_a"
+
+    async def test_find_by_name_returns_none_when_name_missing(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """Miss path: unknown name in known Empire returns None."""
+        empire_a = await seed_empire(session_factory)
+        async with session_factory() as session, session.begin():
+            await SqliteAgentRepository(session).save(
+                make_agent(empire_id=empire_a, name="agent_a")
+            )
+
+        async with session_factory() as session:
+            fetched = await SqliteAgentRepository(session).find_by_name(empire_a, "nonexistent")
+        assert fetched is None
+
+    async def test_find_by_name_isolates_by_empire(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """**IDOR guard**: same name under different Empire returns None.
+
+        This is the test-design.md §確定 F core contract. A regression
+        that drops the ``WHERE empire_id`` clause (e.g. by globally
+        searching by name) would let an attacker read cross-tenant
+        Agents — this assertion fires loudly in that case.
+        """
+        empire_a = await seed_empire(session_factory)
+        empire_b = await seed_empire(session_factory)
+        agent_in_a = make_agent(empire_id=empire_a, name="shared_name")
+        async with session_factory() as session, session.begin():
+            await SqliteAgentRepository(session).save(agent_in_a)
+
+        async with session_factory() as session:
+            # Look up the same name but in a DIFFERENT empire — must
+            # return None even though "shared_name" exists in empire_a.
+            fetched = await SqliteAgentRepository(session).find_by_name(empire_b, "shared_name")
+        assert fetched is None, (
+            "[FAIL] find_by_name leaked an Agent across Empire boundaries.\n"
+            "Next: verify the SQL contains ``WHERE empire_id = :empire_id`` "
+            "(detailed-design.md §確定 F). A missing scope clause is an IDOR."
+        )
+
+    async def test_find_by_name_emits_empire_scoped_sql(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        app_engine: AsyncEngine,
+    ) -> None:
+        """SQL log shows ``WHERE agents.empire_id = ?`` and ``LIMIT 1``.
+
+        Defense-in-depth on top of the behavioural test above: even if
+        the cross-Empire test happens to pass via row-coincidence
+        (e.g. name conflict in seed data), the SQL itself must carry
+        the scope clause. We attach a ``before_cursor_execute``
+        listener and grep for the empire_id predicate.
+        """
+        empire_a = await seed_empire(session_factory)
+        async with session_factory() as session, session.begin():
+            await SqliteAgentRepository(session).save(
+                make_agent(empire_id=empire_a, name="agent_a")
+            )
+
+        captured: list[str] = []
+
+        def _on_execute(
+            _conn: object,
+            _cursor: object,
+            statement: str,
+            _params: object,
+            _context: object,
+            _executemany: bool,
+        ) -> None:
+            captured.append(statement)
+
+        sync_engine = app_engine.sync_engine
+        event.listen(sync_engine, "before_cursor_execute", _on_execute)
+        try:
+            async with session_factory() as session:
+                await SqliteAgentRepository(session).find_by_name(empire_a, "agent_a")
+        finally:
+            event.remove(sync_engine, "before_cursor_execute", _on_execute)
+
+        # Locate the SELECT that hit ``agents`` to look up the AgentId.
+        agent_id_selects = [s for s in captured if "FROM agents" in s and "SELECT" in s.upper()]
+        assert agent_id_selects, "find_by_name must SELECT from agents"
+        # The first such SELECT must carry both the empire_id predicate
+        # and a LIMIT clause to avoid full-table scans.
+        target_stmt = agent_id_selects[0]
+        assert "empire_id" in target_stmt, (
+            f"[FAIL] find_by_name SQL missing empire_id predicate.\nCaptured: {target_stmt!r}"
+        )
+        assert "LIMIT" in target_stmt.upper(), (
+            f"[FAIL] find_by_name SQL missing LIMIT clause.\nCaptured: {target_stmt!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle integration: save → find_by_name → find_by_id → save (update)
+# ---------------------------------------------------------------------------
+class TestLifecycleIntegration:
+    """TC-IT-AGR-LIFECYCLE: full save → lookup → update flow."""
+
+    async def test_full_lifecycle_with_persona_update(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """Save → find_by_name → find_by_id → update persona → save.
+
+        Verifies the 4 Protocol methods cooperate end-to-end and that
+        a persona update via re-save reaches the DB through the
+        UPSERT path (Step 1 of §確定 B 5-step).
+        """
+        from bakufu.domain.agent import Persona
+
+        empire_a = await seed_empire(session_factory)
+        original = make_agent(
+            empire_id=empire_a,
+            name="lifecycle_agent",
+            persona=Persona(
+                display_name="初期",
+                archetype="review-focused",
+                prompt_body="You are a reviewer.",
+            ),
+        )
+        async with session_factory() as session, session.begin():
+            await SqliteAgentRepository(session).save(original)
+
+        async with session_factory() as session:
+            via_name = await SqliteAgentRepository(session).find_by_name(
+                empire_a, "lifecycle_agent"
+            )
+        assert via_name is not None
+        assert via_name.persona.display_name == "初期"
+
+        async with session_factory() as session:
+            via_id = await SqliteAgentRepository(session).find_by_id(original.id)
+        assert via_id is not None
+        assert via_id == via_name
+
+        # Update: change the persona display_name and re-save.
+        updated = original.model_copy(
+            update={
+                "persona": Persona(
+                    display_name="更新後",
+                    archetype=original.persona.archetype,
+                    prompt_body=original.persona.prompt_body,
+                ),
+            }
+        )
+        async with session_factory() as session, session.begin():
+            await SqliteAgentRepository(session).save(updated)
+
+        async with session_factory() as session:
+            after = await SqliteAgentRepository(session).find_by_id(original.id)
+        assert after is not None
+        assert after.persona.display_name == "更新後"

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_agent_repository/test_save_semantics.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_agent_repository/test_save_semantics.py
@@ -1,0 +1,388 @@
+"""Agent Repository: save() semantics — delete-then-insert + ORDER BY + Tx boundary.
+
+TC-UT-AGR-002 / 003 / 010 / 011 — the §確定 B / §BUG-EMR-001 inheritance
+contracts that back the ``save()`` flow + ORDER BY observation +
+Tx boundary + round-trip equality.
+
+Per ``docs/features/agent-repository/test-design.md``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+import pytest
+from bakufu.domain.value_objects import ProviderKind
+from bakufu.infrastructure.persistence.sqlite.repositories.agent_repository import (
+    SqliteAgentRepository,
+)
+from bakufu.infrastructure.persistence.sqlite.tables.agent_providers import (
+    AgentProviderRow,
+)
+from bakufu.infrastructure.persistence.sqlite.tables.agent_skills import (
+    AgentSkillRow,
+)
+from sqlalchemy import event, select
+
+from tests.factories.agent import (
+    make_agent,
+    make_provider_config,
+    make_skill_ref,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-AGR-002: 5-step delete-then-insert SQL order (§確定 B)
+# ---------------------------------------------------------------------------
+class TestSaveSqlOrder:
+    """TC-UT-AGR-002: ``save`` issues the §確定 B 5-step DML sequence.
+
+    Same harness as empire-repository TC-IT-EMR-011 / workflow-
+    repository TC-IT-WFR-010 — observe SQL via
+    ``before_cursor_execute`` listener and assert prefixes:
+
+    1. ``INSERT INTO agents`` (UPSERT)
+    2. ``DELETE FROM agent_providers``
+    3. ``INSERT INTO agent_providers``
+    4. ``DELETE FROM agent_skills``
+    5. ``INSERT INTO agent_skills``
+    """
+
+    async def test_save_emits_upsert_then_delete_insert_pairs(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        app_engine: AsyncEngine,
+        seeded_empire_id: UUID,
+    ) -> None:
+        """5-step DML order matches §確定 B."""
+        captured: list[str] = []
+
+        def _on_execute(
+            _conn: object,
+            _cursor: object,
+            statement: str,
+            _params: object,
+            _context: object,
+            _executemany: bool,
+        ) -> None:
+            captured.append(statement.strip())
+
+        sync_engine = app_engine.sync_engine
+        event.listen(sync_engine, "before_cursor_execute", _on_execute)
+        try:
+            # Build an Agent with non-empty providers + skills so all
+            # 5 DML statements actually fire (empty side-tables would
+            # skip the INSERT).
+            agent = make_agent(
+                empire_id=seeded_empire_id,
+                providers=[make_provider_config()],
+                skills=[make_skill_ref()],
+            )
+            async with session_factory() as session, session.begin():
+                await SqliteAgentRepository(session).save(agent)
+        finally:
+            event.remove(sync_engine, "before_cursor_execute", _on_execute)
+
+        dml = [
+            s
+            for s in captured
+            if any(
+                s.upper().startswith(prefix)
+                for prefix in (
+                    "INSERT INTO AGENTS",
+                    "DELETE FROM AGENT_",
+                    "INSERT INTO AGENT_",
+                )
+            )
+        ]
+        assert len(dml) >= 5, (
+            f"[FAIL] save emitted only {len(dml)} DML statements; expected >=5.\n"
+            f"Captured DML: {dml}"
+        )
+        assert dml[0].upper().startswith("INSERT INTO AGENTS")
+        assert dml[1].upper().startswith("DELETE FROM AGENT_PROVIDERS")
+        assert dml[2].upper().startswith("INSERT INTO AGENT_PROVIDERS")
+        assert dml[3].upper().startswith("DELETE FROM AGENT_SKILLS")
+        assert dml[4].upper().startswith("INSERT INTO AGENT_SKILLS")
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-AGR-003: ORDER BY contract (§BUG-EMR-001 inherited from day 1)
+# ---------------------------------------------------------------------------
+class TestFindByIdOrderByContract:
+    """TC-UT-AGR-003: ``ORDER BY provider_kind`` / ``ORDER BY skill_id`` are emitted.
+
+    The empire-repository BUG-EMR-001 closure froze the ORDER BY
+    contract; the agent Repository adopts it from PR #1. Without
+    these clauses, SQLite returns rows in internal-scan order which
+    would break ``Agent == Agent`` round-trip equality (the
+    Aggregate compares list-by-list).
+    """
+
+    async def test_find_by_id_emits_order_by_provider_kind(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        app_engine: AsyncEngine,
+        seeded_empire_id: UUID,
+    ) -> None:
+        """``find_by_id`` emits ``ORDER BY agent_providers.provider_kind``."""
+        agent = make_agent(
+            empire_id=seeded_empire_id,
+            providers=[
+                make_provider_config(provider_kind=ProviderKind.CLAUDE_CODE, is_default=True),
+            ],
+            skills=[make_skill_ref()],
+        )
+        async with session_factory() as session, session.begin():
+            await SqliteAgentRepository(session).save(agent)
+
+        captured: list[str] = []
+
+        def _on_execute(
+            _conn: object,
+            _cursor: object,
+            statement: str,
+            _params: object,
+            _context: object,
+            _executemany: bool,
+        ) -> None:
+            captured.append(statement)
+
+        sync_engine = app_engine.sync_engine
+        event.listen(sync_engine, "before_cursor_execute", _on_execute)
+        try:
+            async with session_factory() as session:
+                await SqliteAgentRepository(session).find_by_id(agent.id)
+        finally:
+            event.remove(sync_engine, "before_cursor_execute", _on_execute)
+
+        provider_selects = [
+            stmt for stmt in captured if "FROM agent_providers" in stmt and "SELECT" in stmt.upper()
+        ]
+        assert provider_selects, "find_by_id must SELECT from agent_providers"
+        assert any(
+            "ORDER BY" in stmt.upper() and "provider_kind" in stmt for stmt in provider_selects
+        ), (
+            f"[FAIL] find_by_id missing ``ORDER BY provider_kind``.\n"
+            f"Captured provider SELECTs: {provider_selects}"
+        )
+
+    async def test_find_by_id_emits_order_by_skill_id(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        app_engine: AsyncEngine,
+        seeded_empire_id: UUID,
+    ) -> None:
+        """``find_by_id`` emits ``ORDER BY agent_skills.skill_id``."""
+        agent = make_agent(
+            empire_id=seeded_empire_id,
+            providers=[make_provider_config()],
+            skills=[make_skill_ref()],
+        )
+        async with session_factory() as session, session.begin():
+            await SqliteAgentRepository(session).save(agent)
+
+        captured: list[str] = []
+
+        def _on_execute(
+            _conn: object,
+            _cursor: object,
+            statement: str,
+            _params: object,
+            _context: object,
+            _executemany: bool,
+        ) -> None:
+            captured.append(statement)
+
+        sync_engine = app_engine.sync_engine
+        event.listen(sync_engine, "before_cursor_execute", _on_execute)
+        try:
+            async with session_factory() as session:
+                await SqliteAgentRepository(session).find_by_id(agent.id)
+        finally:
+            event.remove(sync_engine, "before_cursor_execute", _on_execute)
+
+        skill_selects = [
+            stmt for stmt in captured if "FROM agent_skills" in stmt and "SELECT" in stmt.upper()
+        ]
+        assert skill_selects, "find_by_id must SELECT from agent_skills"
+        assert any("ORDER BY" in stmt.upper() and "skill_id" in stmt for stmt in skill_selects), (
+            f"[FAIL] find_by_id missing ``ORDER BY skill_id``.\n"
+            f"Captured skill SELECTs: {skill_selects}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-AGR-002 (delete-then-insert replacement semantics)
+# ---------------------------------------------------------------------------
+class TestSaveReplacesSideTableRows:
+    """``save`` replaces side-table rows wholesale (§確定 B)."""
+
+    async def test_save_replaces_skill_rows(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_empire_id: UUID,
+    ) -> None:
+        """Skills 2 → 1 reflects as 1 row in agent_skills (no residue)."""
+        # Two skills initially.
+        original = make_agent(
+            empire_id=seeded_empire_id,
+            skills=[make_skill_ref(name="skill_a"), make_skill_ref(name="skill_b")],
+        )
+        async with session_factory() as session, session.begin():
+            await SqliteAgentRepository(session).save(original)
+
+        # Re-save with one skill — same agent_id.
+        replacement = make_agent(
+            agent_id=original.id,
+            empire_id=original.empire_id,
+            name=original.name,
+            persona=original.persona,
+            providers=list(original.providers),
+            skills=[make_skill_ref(name="残ったスキル")],
+        )
+        async with session_factory() as session, session.begin():
+            await SqliteAgentRepository(session).save(replacement)
+
+        async with session_factory() as session:
+            rows = list(
+                (
+                    await session.execute(
+                        select(AgentSkillRow).where(AgentSkillRow.agent_id == original.id)
+                    )
+                ).scalars()
+            )
+        assert len(rows) == 1
+        assert rows[0].name == "残ったスキル"
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-AGR-011: round-trip equality (_to_row / _from_row via DB)
+# ---------------------------------------------------------------------------
+class TestRoundTripEquality:
+    """TC-UT-AGR-011: save → find_by_id round-trip preserves Agent identity.
+
+    Note: this test uses default ``prompt_body`` (no secrets) so
+    masking is a no-op and full ``==`` holds. Secret-bearing
+    round-trip is non-equal due to §確定 H §不可逆性 — that path lives
+    in :mod:`...test_masking_persona`.
+    """
+
+    async def test_agent_with_providers_and_skills_round_trips(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_empire_id: UUID,
+    ) -> None:
+        """Agent with 1 provider + 1 skill round-trips structurally."""
+        agent = make_agent(
+            empire_id=seeded_empire_id,
+            providers=[make_provider_config()],
+            skills=[make_skill_ref()],
+        )
+        async with session_factory() as session, session.begin():
+            await SqliteAgentRepository(session).save(agent)
+
+        async with session_factory() as session:
+            restored = await SqliteAgentRepository(session).find_by_id(agent.id)
+
+        assert restored is not None
+        assert restored.id == agent.id
+        assert restored.empire_id == agent.empire_id
+        assert restored.name == agent.name
+        assert restored.role == agent.role
+        # ORDER BY-aware comparisons (single-element here, but the
+        # contract is "list order matches the SQL ORDER BY key").
+        assert restored.providers == sorted(agent.providers, key=lambda p: p.provider_kind.value)
+        assert restored.skills == sorted(agent.skills, key=lambda s: s.skill_id)
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-AGR-010: Tx boundary responsibility separation (§確定 B)
+# ---------------------------------------------------------------------------
+class TestTxBoundaryRespectedByRepository:
+    """TC-UT-AGR-010: Repository never calls commit / rollback (§確定 B)."""
+
+    async def test_commit_path_persists_via_outer_block(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_empire_id: UUID,
+    ) -> None:
+        """Outer ``async with session.begin()`` commits the save."""
+        agent = make_agent(empire_id=seeded_empire_id)
+        async with session_factory() as session, session.begin():
+            await SqliteAgentRepository(session).save(agent)
+
+        async with session_factory() as session:
+            fetched = await SqliteAgentRepository(session).find_by_id(agent.id)
+        assert fetched is not None
+
+    async def test_rollback_path_drops_save_atomically(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_empire_id: UUID,
+    ) -> None:
+        """An exception inside ``begin()`` rolls back ALL 5 DML steps.
+
+        The Agent row + providers + skills all participate in the
+        same caller-managed transaction. A single uncaught exception
+        inside the ``begin()`` block must purge **all** of them.
+        """
+
+        class _BoomError(Exception):
+            """Synthetic exception used to drive the rollback path."""
+
+        agent = make_agent(
+            empire_id=seeded_empire_id,
+            providers=[make_provider_config()],
+            skills=[make_skill_ref()],
+        )
+
+        with pytest.raises(_BoomError):
+            async with session_factory() as session, session.begin():
+                await SqliteAgentRepository(session).save(agent)
+                raise _BoomError
+
+        async with session_factory() as session:
+            fetched = await SqliteAgentRepository(session).find_by_id(agent.id)
+        assert fetched is None
+
+        # Side tables also empty — the §確定 B contract is that the
+        # 5-step sequence is **one** logical operation under the
+        # caller's UoW.
+        async with session_factory() as session:
+            provider_rows = (
+                await session.execute(
+                    select(AgentProviderRow).where(AgentProviderRow.agent_id == agent.id)
+                )
+            ).all()
+            skill_rows = (
+                await session.execute(
+                    select(AgentSkillRow).where(AgentSkillRow.agent_id == agent.id)
+                )
+            ).all()
+        assert provider_rows == []
+        assert skill_rows == []
+
+    async def test_repository_does_not_commit_implicitly(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_empire_id: UUID,
+    ) -> None:
+        """``save`` outside ``begin()`` does not auto-commit (§確定 B)."""
+        agent = make_agent(empire_id=seeded_empire_id)
+        async with session_factory() as session:
+            await SqliteAgentRepository(session).save(agent)
+            # AsyncSession's __aexit__ rolls back any in-flight tx.
+
+        async with session_factory() as session:
+            fetched = await SqliteAgentRepository(session).find_by_id(agent.id)
+        assert fetched is None, (
+            "[FAIL] Agent persisted without an outer commit.\n"
+            "Next: SqliteAgentRepository.save() must not call session.commit()."
+        )

--- a/backend/tests/infrastructure/persistence/sqlite/test_alembic_agent.py
+++ b/backend/tests/infrastructure/persistence/sqlite/test_alembic_agent.py
@@ -1,0 +1,189 @@
+"""Alembic 4th revision tests (TC-IT-AGR-008 — chain + DDL + idempotency).
+
+Per ``docs/features/agent-repository/test-design.md``. Real Alembic
+upgrade / downgrade against a real SQLite file, plus a chain
+integrity check that makes sure
+``0001_init`` → ``0002_empire_aggregate`` → ``0003_workflow_aggregate``
+→ ``0004_agent_aggregate`` stays linear (no head fork).
+
+The conftest from ``tests/infrastructure/`` patches Alembic's
+``fileConfig`` so log capture survives migration; same workaround the
+M2 persistence-foundation tests rely on.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+import pytest_asyncio
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+from bakufu.infrastructure.persistence.sqlite import engine as engine_mod
+from bakufu.infrastructure.persistence.sqlite.migrations import run_upgrade_head
+from sqlalchemy import text
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncEngine
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+@pytest_asyncio.fixture
+async def empty_engine(tmp_path: Path) -> AsyncIterator[AsyncEngine]:
+    """Bring up a fresh app engine without running any migrations."""
+    url = f"sqlite+aiosqlite:///{tmp_path / 'bakufu.db'}"
+    engine = engine_mod.create_engine(url)
+    try:
+        yield engine
+    finally:
+        await engine.dispose()
+
+
+def _alembic_config() -> Config:
+    """Resolve the bakufu Alembic config for ScriptDirectory inspection."""
+    backend_root = Path(__file__).resolve().parents[4]
+    cfg = Config(str(backend_root / "alembic.ini"))
+    cfg.set_main_option("script_location", str(backend_root / "alembic"))
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-AGR-008: 4th revision creates the 3 Agent tables + indexes
+# ---------------------------------------------------------------------------
+class TestFourthRevisionApplied:
+    """TC-IT-AGR-008: ``alembic upgrade head`` adds the Agent schema."""
+
+    async def test_three_agent_tables_present_after_upgrade(
+        self,
+        empty_engine: AsyncEngine,
+    ) -> None:
+        """agents / agent_providers / agent_skills exist after upgrade head."""
+        await run_upgrade_head(empty_engine)
+        async with empty_engine.connect() as conn:
+            result = await conn.execute(text("SELECT name FROM sqlite_master WHERE type='table'"))
+            tables = {row[0] for row in result}
+        assert {"agents", "agent_providers", "agent_skills"}.issubset(tables)
+
+    async def test_partial_unique_index_present(
+        self,
+        empty_engine: AsyncEngine,
+    ) -> None:
+        """``uq_agent_providers_default`` partial unique index is created.
+
+        SQLite stores partial-index DDL in ``sqlite_master.sql``; we
+        grep for the ``WHERE`` clause to confirm the partial nature
+        (a plain unique index would not block ``is_default=0``
+        duplicates).
+        """
+        await run_upgrade_head(empty_engine)
+        async with empty_engine.connect() as conn:
+            result = await conn.execute(
+                text(
+                    "SELECT name, sql FROM sqlite_master "
+                    "WHERE type='index' AND tbl_name='agent_providers'"
+                )
+            )
+            rows = list(result)
+        partial_indexes = [
+            (name, sql) for name, sql in rows if sql is not None and "WHERE" in sql.upper()
+        ]
+        assert partial_indexes, (
+            "[FAIL] agent_providers must declare a partial unique index "
+            "with a WHERE clause for §確定 G 二重防衛.\n"
+            f"All indexes on agent_providers: {rows}"
+        )
+        # And the predicate must reference is_default = 1.
+        assert any("is_default" in sql and "1" in sql for _, sql in partial_indexes), (
+            f"Partial index does not target is_default = 1: {partial_indexes}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-AGR-008 補強: upgrade / downgrade are idempotent
+# ---------------------------------------------------------------------------
+class TestUpgradeDowngradeIdempotent:
+    """upgrade head → downgrade base → upgrade head again all green."""
+
+    async def test_full_cycle_leaves_agent_tables_present(
+        self,
+        empty_engine: AsyncEngine,
+    ) -> None:
+        """upgrade head → downgrade base → upgrade head again."""
+        await run_upgrade_head(empty_engine)
+        from alembic import command  # local import to avoid global side effects
+
+        cfg = _alembic_config()
+        url = str(empty_engine.url)
+        cfg.set_main_option("sqlalchemy.url", url)
+
+        def _do_downgrade() -> None:
+            command.downgrade(cfg, "base")
+
+        await asyncio.to_thread(_do_downgrade)
+
+        async with empty_engine.connect() as conn:
+            result = await conn.execute(text("SELECT name FROM sqlite_master WHERE type='table'"))
+            tables = {row[0] for row in result}
+        assert tables.isdisjoint({"agents", "agent_providers", "agent_skills"})
+
+        await run_upgrade_head(empty_engine)
+        async with empty_engine.connect() as conn:
+            result = await conn.execute(text("SELECT name FROM sqlite_master WHERE type='table'"))
+            tables = {row[0] for row in result}
+        assert {"agents", "agent_providers", "agent_skills"}.issubset(tables)
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-AGR-008: revision chain is linear (no head fork)
+# ---------------------------------------------------------------------------
+class TestRevisionChainLinear:
+    """0001 → 0002 → 0003 → 0004 single-head chain."""
+
+    async def test_alembic_heads_returns_single_revision(self) -> None:
+        """``ScriptDirectory.get_heads()`` returns exactly one revision."""
+        cfg = _alembic_config()
+        script = ScriptDirectory.from_config(cfg)
+        heads = script.get_heads()
+        assert len(heads) == 1, (
+            f"Alembic head must be linear; got branched heads {heads}.\n"
+            f"Each Aggregate Repository PR appends a single revision."
+        )
+
+    async def test_0004_revision_has_correct_down_revision(self) -> None:
+        """``0004_agent_aggregate.down_revision == "0003_workflow_aggregate"``."""
+        cfg = _alembic_config()
+        script = ScriptDirectory.from_config(cfg)
+        rev = script.get_revision("0004_agent_aggregate")
+        assert rev is not None
+        assert rev.down_revision == "0003_workflow_aggregate"
+
+    async def test_chain_walks_from_0004_back_to_base(self) -> None:
+        """Walking ``down_revision`` reaches base in 4 hops (no branching)."""
+        cfg = _alembic_config()
+        script = ScriptDirectory.from_config(cfg)
+        chain: list[str] = []
+        current_id: str | None = "0004_agent_aggregate"
+        for _ in range(10):  # generous bound for safety
+            if current_id is None:
+                break
+            rev = script.get_revision(current_id)
+            assert rev is not None, f"Revision {current_id!r} not found"
+            chain.append(rev.revision)
+            down = rev.down_revision
+            if isinstance(down, tuple | list):
+                pytest.fail(f"Revision {rev.revision!r} has multiple down_revisions {down}")
+            current_id = down  # pyright: ignore[reportAssignmentType]
+
+        assert chain == [
+            "0004_agent_aggregate",
+            "0003_workflow_aggregate",
+            "0002_empire_aggregate",
+            "0001_init",
+        ], f"Unexpected revision chain: {chain}"

--- a/scripts/ci/check_masking_columns.sh
+++ b/scripts/ci/check_masking_columns.sh
@@ -84,6 +84,11 @@ readonly NO_MASK_FILES=(
     # secret categories.
     "${TABLES_DIR}/workflows.py"
     "${TABLES_DIR}/workflow_transitions.py"
+    # Agent Repository (PR #32): only agents.prompt_body is masked
+    # (Schneier 申し送り #3 实適用); the side tables carry no secret
+    # semantics.
+    "${TABLES_DIR}/agent_providers.py"
+    "${TABLES_DIR}/agent_skills.py"
 )
 
 for file in "${NO_MASK_FILES[@]}"; do
@@ -103,61 +108,71 @@ for file in "${NO_MASK_FILES[@]}"; do
 done
 
 # Layer 1-C: 過剰マスキング防止 ─ partially-masked テーブルで指定の
-# カラム以外に Masked* が混入していないこと。
-# Workflow Repository (PR #31, detailed-design.md §確定 E):
-#   workflow_stages.notify_channels_json だけが MaskedJSONEncoded、
-#   他カラムは JSONEncoded / String / Text に閉じる。
+# カラム以外に Masked* が混入していないこと。各ファイルに対し
+# 「許可カラムが期待型で 1 つ宣言されている」+「他カラムに Masked* が
+# 一切登場しない」の両方を assert する。
 #
-# フォーマット: "<file>:<allowed_column>"
+# 登録されている partial-mask テーブル:
+#   * Workflow Repository (PR #31, detailed-design.md §確定 E):
+#     workflow_stages.notify_channels_json だけが MaskedJSONEncoded、
+#     他カラムは JSONEncoded / String / Text に閉じる。
+#   * Agent Repository (PR #32, detailed-design.md §確定 E):
+#     agents.prompt_body だけが MaskedText、他カラムは String / Boolean
+#     に閉じる。Schneier 申し送り #3 实適用の grep 物理保証層。
+#
+# フォーマット: "<file>:<allowed_column>:<expected_type>"
 readonly PARTIAL_MASK_FILES=(
-    "${TABLES_DIR}/workflow_stages.py:notify_channels_json"
+    "${TABLES_DIR}/workflow_stages.py:notify_channels_json:MaskedJSONEncoded"
+    "${TABLES_DIR}/agents.py:prompt_body:MaskedText"
 )
 
 for entry in "${PARTIAL_MASK_FILES[@]}"; do
-    file="${entry%%:*}"
-    allowed="${entry##*:}"
+    IFS=':' read -r file allowed expected_type <<< "$entry"
 
     if [[ ! -f "$file" ]]; then
         continue
     fi
 
-    # MaskedText must be zero everywhere on this file.
-    text_leaks=$(grep -nE "MaskedText" "$file" || true)
-    if [[ -n "$text_leaks" ]]; then
-        echo "[FAIL] partial-mask table file declares MaskedText (over-masking): $file" >&2
-        echo "$text_leaks" >&2
-        echo "       Next: this table is registered with a single allowed" >&2
-        echo "       MaskedJSONEncoded column ('${allowed}') in" >&2
-        echo "       docs/architecture/domain-model/storage.md §逆引き表;" >&2
-        echo "       remove the MaskedText usage or update the §逆引き表 entry." >&2
-        violations=$((violations + 1))
-    fi
-
-    # MaskedJSONEncoded usages: only declarations / re-exports outside
-    # the allowed column trip the over-masking guard.
-    json_decls=$(grep -nE "^\s*[A-Za-z_][A-Za-z0-9_]*\s*:\s*Mapped.*MaskedJSONEncoded" \
+    # All Masked* column declarations on this file. The allowed
+    # column must appear exactly once with the expected type and
+    # nothing else may carry a Masked* TypeDecorator.
+    masked_decls=$(grep -nE "^\s*[A-Za-z_][A-Za-z0-9_]*\s*:\s*Mapped.*Masked(JSONEncoded|Text)" \
         "$file" || true)
-    if [[ -z "$json_decls" ]]; then
+
+    if [[ -z "$masked_decls" ]]; then
         echo "[FAIL] partial-mask table file is missing the expected" >&2
-        echo "       MaskedJSONEncoded column declaration: $file" >&2
-        echo "       Next: declare ${allowed} with MaskedJSONEncoded per" >&2
+        echo "       ${expected_type} column declaration: $file" >&2
+        echo "       Next: declare ${allowed} with ${expected_type} per" >&2
         echo "       docs/architecture/domain-model/storage.md §逆引き表." >&2
         violations=$((violations + 1))
-    else
-        while IFS= read -r line; do
-            [[ -z "$line" ]] && continue
-            if [[ "$line" == *"${allowed}"* ]]; then
-                continue
-            fi
-            echo "[FAIL] partial-mask table file declares MaskedJSONEncoded on a" >&2
+        continue
+    fi
+
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+
+        # Reject masking on a column other than the allowed one.
+        if [[ "$line" != *"${allowed}"* ]]; then
+            echo "[FAIL] partial-mask table file declares Masked* on a" >&2
             echo "       column other than '${allowed}': $file" >&2
             echo "       ${line}" >&2
-            echo "       Next: only '${allowed}' is registered as MaskedJSONEncoded" >&2
-            echo "       in docs/architecture/domain-model/storage.md §逆引き表;" >&2
+            echo "       Next: only '${allowed}' is registered as masked in" >&2
+            echo "       docs/architecture/domain-model/storage.md §逆引き表;" >&2
             echo "       move the masking to the correct column or update §逆引き表." >&2
             violations=$((violations + 1))
-        done <<< "$json_decls"
-    fi
+            continue
+        fi
+
+        # Allowed column must use the expected TypeDecorator.
+        if [[ "$line" != *"$expected_type"* ]]; then
+            echo "[FAIL] partial-mask column '${allowed}' uses the wrong Masked*" >&2
+            echo "       TypeDecorator (expected ${expected_type}): $file" >&2
+            echo "       ${line}" >&2
+            echo "       Next: switch ${allowed} to mapped_column(${expected_type}, ...) per" >&2
+            echo "       docs/architecture/domain-model/storage.md §逆引き表." >&2
+            violations=$((violations + 1))
+        fi
+    done <<< "$masked_decls"
 done
 
 if [[ "$violations" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

empire-repository (PR #29/#30) / workflow-repository (PR #41) テンプレート 100% 継承、M2 Repository 4 件目。**Schneier 申し送り #3 实適用**（agents.prompt_body MaskedText 配線、persistence-foundation #23 hook 構造を本 PR で配線完了）+ **第 4 method `find_by_name`**（empire-repo の 3 method を超える初の Repository）+ **`is_default` partial unique index**（Defense-in-Depth 二重防衛）。

Closes #32.

## 実装内容

### domain VO 拡張（最小スコープ）

- `Agent` に `empire_id: EmpireId` 追加（`agents.empire_id` FK CASCADE の back-reference、save() が Agent を受け取るだけで empire_id を取れる構造）
- `tests/factories/agent.py` の `make_agent` に `empire_id` パラメータ追加（デフォルト uuid4()、既存 134 件 agent domain test 全て無回帰）

### Protocol / 実装

- `application/ports/agent_repository.py` — Protocol **4 method**:
  - `find_by_id(agent_id)` — empire-repo 互換
  - `count()` — empire-repo 互換
  - `save(agent)` — empire-repo 互換
  - **`find_by_name(empire_id, name)`** — §確定 F 第 4 method
- `infrastructure/persistence/sqlite/repositories/agent_repository.py` — SqliteAgentRepository
  - `find_by_id`: ORDER BY provider_kind / ORDER BY skill_id（BUG-EMR-001 規約 Day 1 適用）
  - `count`: `select(func.count()).select_from(AgentRow)` SQL COUNT(*)
  - `save`: §確定 B 5 段階 delete-then-insert
  - **`find_by_name`**: `WHERE empire_id=? AND name=? LIMIT 1` で AgentId 取得 → `find_by_id` 委譲（`_from_row` 系の責務散在防止、§設計判断補足）

### Tables（3 テーブル新規）

| テーブル | masking | 特殊制約 |
|---|---|---|
| `agents` | **`prompt_body: MaskedText`** | `empire_id` FK CASCADE |
| `agent_providers` | なし | UNIQUE(agent_id, provider_kind) + **partial unique index `WHERE is_default = 1`** |
| `agent_skills` | なし | UNIQUE(agent_id, skill_id) |

### Alembic

- `alembic/versions/0004_agent_aggregate.py` — `down_revision=\"0003_workflow_aggregate\"` chain 単一直線
- partial unique index は `op.create_index(..., sqlite_where=sa.text('is_default = 1'))`

### CI 三層防衛拡張

- **Layer 1 grep guard**: `PARTIAL_MASK_FILES` フォーマットを `(file, allowed_column, expected_type)` の 3-tuple に汎化、`agents.py:prompt_body:MaskedText` を追加（MaskedText / MaskedJSONEncoded 両対応）。`NO_MASK_FILES` に `agent_providers` / `agent_skills` 追加
- **Layer 2 arch test**: `_MASKING_CONTRACT` に `(agents, prompt_body, MaskedText)` 追加、`_NO_MASK_TABLES` に `agent_providers` / `agent_skills` 追加、`_PARTIAL_MASK_TABLES` に `(agents, prompt_body)` 追加

## Smoke 検証（in-memory SQLite）

| シナリオ | 結果 |
|---|---|
| `prompt_body='Use ANTHROPIC_API_KEY=sk-ant-api03-XXX...'` を save | DB 保存値 `Use ANTHROPIC_API_KEY=<REDACTED:ANTHROPIC_KEY>`（**Schneier #3 实適用**、生 token DB 上に**一切残らない**）|
| `find_by_name(empire_id, 'Alice')` | 正しい Agent 復元 ✓ |
| `find_by_id` round-trip | masked prompt_body のまま復元（§確定 H 不可逆性、申し送り #1）|
| 2 件目 `is_default=1` INSERT 試行 | **IntegrityError で物理拒否**（partial unique index Defense-in-Depth）|
| `count()` | SQL COUNT(*) スカラー 1 ✓ |
| Alembic chain | `0001 → 0002 → 0003 → 0004` 単一 head |

## 変更ファイル

| 種類 | ファイル | 行数 |
|---|---|---|
| 新規 | `application/ports/agent_repository.py` | 89 |
| 新規 | `infrastructure/persistence/sqlite/repositories/agent_repository.py` | 281 |
| 新規 | `tables/agents.py` | 70 |
| 新規 | `tables/agent_providers.py` | 73 |
| 新規 | `tables/agent_skills.py` | 56 |
| 新規 | `alembic/versions/0004_agent_aggregate.py` | 130 |
| 変更 | `domain/agent/agent.py` | +9（`empire_id` 追加 + コメント）|
| 変更 | `tests/factories/agent.py` | +5/-1（factory パラメータ）|
| 変更 | `tables/__init__.py` | +20（agent 3 テーブル import + module docstring）|
| 変更 | `tests/architecture/test_masking_columns.py` | +18（_MASKING_CONTRACT / _NO_MASK_TABLES / _PARTIAL_MASK_TABLES 追加）|
| 変更 | `scripts/ci/check_masking_columns.sh` | +33/-21（partial-mask フォーマット汎化）|

## 品質

- ✅ ruff format / lint clean
- ✅ pyright strict **0 errors / 0 warnings**
- ✅ pytest **801 passed**（既存 758 + 新規 3 arch test、agent domain 134 件無回帰）
- ✅ `bash scripts/ci/check_masking_columns.sh` 全層 PASS
- ✅ Alembic chain `0001 → 0002 → 0003 → 0004` 単一 head

## テスト担当への申し送り（test-design.md 観点反映依頼）

- **TC-IT-AGR-007 (Schneier #3 实適用)**: raw SQL `SELECT prompt_body FROM agents` で `<REDACTED:*>` 出現 + 原 token 不在を assert（workflow-repo `test_masking.py` パターン継承）
- **TC-IT-AGR-find_by_name**: 異 Empire で同 name の Agent が混在するセットアップで Empire スコープ検索が正しく動作
- **TC-IT-AGR-partial-unique**: 2 件目 `is_default=1` INSERT が `sqlalchemy.IntegrityError` で物理拒否
- **TC-IT-AGR-find_by_id-masked**: save → find_by_id round-trip で `Persona.prompt_body` が masked のまま復元
- **TC-IT-AGR-ORDER-BY**: provider を逆順 INSERT しても find_by_id は sorted 順
- **TC-IT-AGR-CASCADE**: empires DELETE で agents / agent_providers / agent_skills 連鎖削除

## Test plan

- [ ] `just check-all` 全 PASS
- [ ] CI 7 チェック全 PASS
- [ ] レビュー担当 3 名（Steve / Norman / Schneier）の合格判定
- [ ] テスト担当が test-design.md（既存）に従いテスト実装