### PR TITLE
feat(room-repository): implement SqliteRoomRepository (Issue #33)

### DIFF
--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -7,6 +7,7 @@
 [alembic]
 script_location = %(here)s/alembic
 prepend_sys_path = %(here)s/src
+path_separator = os
 sqlalchemy.url = sqlite+aiosqlite:///./bakufu.db
 
 [loggers]

--- a/backend/alembic/versions/0005_room_aggregate.py
+++ b/backend/alembic/versions/0005_room_aggregate.py
@@ -1,0 +1,158 @@
+"""Room Aggregate tables: rooms + room_members; empire_room_refs FK closure.
+
+Adds the two tables that back :class:`SqliteRoomRepository`:
+
+* ``rooms`` (id PK + empire_id FK CASCADE + workflow_id FK RESTRICT +
+  5 scalar columns). The ``prompt_kit_prefix_markdown`` column is stored as
+  ``TEXT`` here (Alembic does not know about ``MaskedText``); the masking
+  gate lives on the Python side via the TypeDecorator.
+* ``room_members`` (composite PK(room_id, agent_id, role) + FK CASCADE on
+  room_id + UNIQUE(room_id, agent_id, role) for §確定 R1-D Defense-in-Depth
+  + no FK on agent_id per room §確定).
+
+Also closes BUG-EMR-001 FK closure:
+
+* ``empire_room_refs.room_id → rooms.id`` FK (ON DELETE CASCADE) is added
+  via ``op.batch_alter_table('empire_room_refs', recreate='always')`` because
+  SQLite does not support ``ALTER TABLE ... ADD CONSTRAINT FOREIGN KEY``
+  directly. The batch operation rebuilds the table internally so all existing
+  rows are preserved.
+
+Per ``docs/features/empire-repository/detailed-design.md`` §確定 F each
+subsequent ``feature/{aggregate}-repository`` PR appends its own revision;
+this revision pins ``down_revision = "0004_agent_aggregate"`` strictly so the
+chain check enforces a single head.
+
+Revision ID: 0005_room_aggregate
+Revises: 0004_agent_aggregate
+Create Date: 2026-04-28
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0005_room_aggregate"
+down_revision: str | None = "0004_agent_aggregate"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Step 1: rooms table (empire_id FK CASCADE + workflow_id FK RESTRICT).
+    op.create_table(
+        "rooms",
+        sa.Column("id", sa.CHAR(32), primary_key=True, nullable=False),
+        sa.Column(
+            "empire_id",
+            sa.CHAR(32),
+            sa.ForeignKey("empires.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "workflow_id",
+            sa.CHAR(32),
+            sa.ForeignKey("workflows.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(80), nullable=False),
+        sa.Column(
+            "description",
+            sa.String(500),
+            nullable=False,
+            server_default=sa.text("''"),
+        ),
+        # MaskedText TypeDecorator serializes as TEXT in SQLite. The
+        # Python-side decorator does the masking gate (base.py MaskedText).
+        sa.Column(
+            "prompt_kit_prefix_markdown",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("''"),
+        ),
+        sa.Column(
+            "archived",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+    )
+
+    # §確定 R1-F: non-UNIQUE composite index for Empire-scoped find_by_name.
+    # Left-prefix optimises both ``WHERE empire_id = ?`` and
+    # ``WHERE empire_id = ? AND name = ?`` queries.
+    op.create_index(
+        "ix_rooms_empire_id_name",
+        "rooms",
+        ["empire_id", "name"],
+        unique=False,
+    )
+
+    # Step 2: room_members table (composite PK + FK CASCADE + UNIQUE §確定 R1-D).
+    op.create_table(
+        "room_members",
+        sa.Column(
+            "room_id",
+            sa.CHAR(32),
+            sa.ForeignKey("rooms.id", ondelete="CASCADE"),
+            primary_key=True,
+            nullable=False,
+        ),
+        sa.Column(
+            "agent_id",
+            sa.CHAR(32),
+            primary_key=True,
+            nullable=False,
+            # Intentionally no FK onto agents.id — application-layer
+            # responsibility (room §確定, see detailed-design §設計判断補足).
+        ),
+        sa.Column(
+            "role",
+            sa.String(32),
+            primary_key=True,
+            nullable=False,
+        ),
+        sa.Column(
+            "joined_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+        ),
+        # §確定 R1-D: explicit UniqueConstraint in addition to composite PK so
+        # CI Layer 2 arch test can assert constraint existence via
+        # ``__table_args__`` scanning (agent_providers pattern).
+        sa.UniqueConstraint(
+            "room_id",
+            "agent_id",
+            "role",
+            name="uq_room_members_triplet",
+        ),
+    )
+
+    # Step 3: empire_room_refs FK closure (BUG-EMR-001 close).
+    # SQLite does not support ``ALTER TABLE ... ADD CONSTRAINT FOREIGN KEY``
+    # directly. Alembic's ``batch_alter_table(recreate='always')`` rebuilds
+    # the table internally, copying existing rows, then renames. The
+    # ``recreate='always'`` flag forces the rebuild even when no column
+    # changes are detected — necessary for FK addition in SQLite.
+    with op.batch_alter_table("empire_room_refs", recreate="always") as batch_op:
+        batch_op.create_foreign_key(
+            "fk_empire_room_refs_room_id",
+            "rooms",
+            ["room_id"],
+            ["id"],
+            ondelete="CASCADE",
+        )
+
+
+def downgrade() -> None:
+    # Reverse order: FK closure → index → child table → root table.
+    with op.batch_alter_table("empire_room_refs", recreate="always") as batch_op:
+        batch_op.drop_constraint("fk_empire_room_refs_room_id", type_="foreignkey")
+
+    op.drop_index("ix_rooms_empire_id_name", table_name="rooms")
+    # Drop child table first (room_members.room_id FK CASCADE onto rooms.id).
+    op.drop_table("room_members")
+    op.drop_table("rooms")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -24,3 +24,7 @@ dev = [
     "pytest>=8.3",
     "pytest-asyncio>=0.24",
 ]
+
+[tool.pytest.ini_options]
+asyncio_mode = "strict"
+asyncio_default_fixture_loop_scope = "function"

--- a/backend/src/bakufu/application/ports/room_repository.py
+++ b/backend/src/bakufu/application/ports/room_repository.py
@@ -1,0 +1,90 @@
+"""Room Repository port.
+
+Per ``docs/features/room-repository/detailed-design.md`` §確定 R1-A
+(empire-repo / workflow-repo / agent-repo テンプレート 100% 継承) plus
+§確定 R1-F (``find_by_name`` 第 4 method — Empire-scoped name lookup)
+and §確定 R1-H (``save(room, empire_id)`` — empire_id passed as argument
+because :class:`Room` Aggregate holds no ``empire_id`` attribute):
+
+* Protocol class with **no** ``@runtime_checkable`` decorator (empire-repo
+  §確定 A: Python 3.12 ``typing.Protocol`` duck typing is sufficient).
+* Every method declared ``async def`` (async-first contract).
+* Argument and return types come exclusively from :mod:`bakufu.domain` —
+  no SQLAlchemy types cross the port boundary.
+* ``save`` signature is ``save(room: Room, empire_id: EmpireId) -> None``
+  because :class:`Room` does not carry ``empire_id`` (ownership is
+  expressed via ``Empire.rooms: list[RoomRef]``); the calling service
+  always has ``empire_id`` at hand and passes it as an argument rather
+  than forcing a domain-model change (§確定 R1-H).
+* ``find_by_name`` takes ``empire_id`` first because Room name uniqueness
+  is Empire-scoped (§確定 R1-F: ``WHERE empire_id = :e AND name = :n``).
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from bakufu.domain.room.room import Room
+from bakufu.domain.value_objects import EmpireId, RoomId
+
+
+class RoomRepository(Protocol):
+    """Persistence contract for the :class:`Room` Aggregate Root.
+
+    The application layer (``RoomService``, ``EmpireService``, future PRs)
+    consumes this Protocol via dependency injection; the SQLite implementation
+    lives in
+    :mod:`bakufu.infrastructure.persistence.sqlite.repositories.room_repository`.
+    """
+
+    async def find_by_id(self, room_id: RoomId) -> Room | None:
+        """Hydrate the Room whose primary key equals ``room_id``.
+
+        Returns ``None`` when the row is absent. SQLAlchemy / driver /
+        ``pydantic.ValidationError`` exceptions propagate untouched so the
+        application service's Unit-of-Work boundary can choose between
+        rollback and surfaced error.
+        """
+        ...
+
+    async def count(self) -> int:
+        """Return ``SELECT COUNT(*) FROM rooms``.
+
+        Application services use this for monitoring / bulk introspection.
+        The count is empire-global (§確定 R1-D: SQL ``COUNT(*)`` contract,
+        empire-repo §確定 D 踏襲).
+        """
+        ...
+
+    async def save(self, room: Room, empire_id: EmpireId) -> None:
+        """Persist ``room`` via the §確定 R1-B three-step delete-then-insert.
+
+        ``empire_id`` is passed as an explicit argument because :class:`Room`
+        does not hold ``empire_id`` as an attribute (room §確定 — ownership is
+        expressed via ``Empire.rooms``). The calling service always has
+        ``empire_id`` in scope and passes it here (§確定 R1-H).
+
+        The implementation must run the three-step sequence (UPSERT rooms →
+        DELETE room_members → bulk INSERT room_members) within the
+        **caller-managed** transaction. Repositories never call
+        ``session.commit()`` / ``session.rollback()``; the application service
+        owns the Unit-of-Work boundary (empire-repo §確定 B 踏襲).
+        """
+        ...
+
+    async def find_by_name(self, empire_id: EmpireId, name: str) -> Room | None:
+        """Hydrate the Room named ``name`` inside Empire ``empire_id`` (§確定 R1-F).
+
+        Two-stage flow: a lightweight ``SELECT id ... LIMIT 1`` locates the
+        RoomId, then delegation to :meth:`find_by_id` so the child-table
+        SELECTs and ``_from_row`` conversion stay single-sourced (agent §R1-C
+        inheritance pattern).
+
+        Returns ``None`` when no Room matches. The implementation must not
+        fetch all Rooms and filter in Python — that pattern is explicitly
+        rejected as a memory / N+1 pitfall in §確定 R1-F (c).
+        """
+        ...
+
+
+__all__ = ["RoomRepository"]

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/repositories/agent_repository.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/repositories/agent_repository.py
@@ -40,7 +40,6 @@ template:
 from __future__ import annotations
 
 from typing import Any
-from uuid import UUID
 
 from sqlalchemy import delete, func, insert, select
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
@@ -264,15 +263,15 @@ class SqliteAgentRepository:
         ]
         skills = [
             SkillRef(
-                skill_id=_uuid(row.skill_id),
+                skill_id=row.skill_id,
                 name=row.name,
                 path=row.path,
             )
             for row in skill_rows
         ]
         return Agent(
-            id=_uuid(agent_row.id),
-            empire_id=_uuid(agent_row.empire_id),
+            id=agent_row.id,
+            empire_id=agent_row.empire_id,
             name=agent_row.name,
             role=Role(agent_row.role),
             persona=persona,
@@ -280,19 +279,6 @@ class SqliteAgentRepository:
             skills=skills,
             archived=agent_row.archived,
         )
-
-
-def _uuid(value: UUID | str) -> UUID:
-    """Coerce a row value to :class:`uuid.UUID`.
-
-    SQLAlchemy's UUIDStr TypeDecorator already returns ``UUID``
-    instances on ``process_result_value``, but defensive coercion lets
-    raw-SQL hydration paths route through the same code without an
-    extra ``isinstance`` ladder at every call site.
-    """
-    if isinstance(value, UUID):
-        return value
-    return UUID(value)
 
 
 __all__ = ["SqliteAgentRepository"]

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/repositories/room_repository.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/repositories/room_repository.py
@@ -32,7 +32,6 @@ child-table SELECTs and ``_from_row`` conversion stay single-sourced
 from __future__ import annotations
 
 from typing import Any
-from uuid import UUID
 
 from sqlalchemy import delete, func, insert, select
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
@@ -199,34 +198,21 @@ class SqliteRoomRepository:
         """
         members = [
             AgentMembership(
-                agent_id=_to_uuid(row.agent_id),
+                agent_id=row.agent_id,
                 role=Role(row.role),
                 joined_at=row.joined_at,
             )
             for row in member_rows
         ]
         return Room(
-            id=_to_uuid(room_row.id),
-            workflow_id=_to_uuid(room_row.workflow_id),
+            id=room_row.id,
+            workflow_id=room_row.workflow_id,
             name=room_row.name,
             description=room_row.description,
             prompt_kit=PromptKit(prefix_markdown=room_row.prompt_kit_prefix_markdown or ""),
             members=members,
             archived=room_row.archived,
         )
-
-
-def _to_uuid(value: UUID | str) -> UUID:
-    """Coerce a row value to :class:`uuid.UUID`.
-
-    UUIDStr TypeDecorator already returns UUID instances on
-    ``process_result_value``, but defensive coercion lets raw-SQL hydration
-    paths route through the same code without an extra ``isinstance`` ladder
-    at every call site (agent_repository pattern).
-    """
-    if isinstance(value, UUID):
-        return value
-    return UUID(value)
 
 
 __all__ = ["SqliteRoomRepository"]

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/repositories/room_repository.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/repositories/room_repository.py
@@ -1,0 +1,232 @@
+"""SQLite adapter for :class:`bakufu.application.ports.RoomRepository`.
+
+Implements the §確定 R1-B three-step save flow over two tables
+(``rooms`` / ``room_members``):
+
+1. ``rooms`` UPSERT (id-conflict → workflow_id + name + description +
+   prompt_kit_prefix_markdown + archived update; ``prompt_kit_prefix_markdown``
+   binds through :class:`MaskedText` so any embedded API key / OAuth token /
+   Discord webhook secret is redacted *before* it hits SQLite — room §確定 G
+   实適用, §確定 R1-J 不可逆性凍結).
+2. ``room_members`` DELETE WHERE room_id = ?
+3. ``room_members`` bulk INSERT (one row per AgentMembership).
+
+The repository **never** calls ``session.commit()`` / ``session.rollback()``:
+the caller-side service runs ``async with session.begin():`` so the three
+steps above stay in one transaction (empire-repo §確定 B Tx 境界の責務分離).
+
+``save`` takes an explicit ``empire_id`` argument because :class:`Room`
+Aggregate holds no ``empire_id`` attribute — ownership is expressed via
+``Empire.rooms: list[RoomRef]``. The calling service always has ``empire_id``
+in scope (§確定 R1-H).
+
+``_to_row`` / ``_from_row`` are kept as private methods on the class so both
+conversion directions live next to each other and tests don't accidentally
+acquire a public conversion API to depend on (empire-repo §確定 C).
+
+``find_by_name`` delegates to ``find_by_id`` once the RoomId is known so the
+child-table SELECTs and ``_from_row`` conversion stay single-sourced
+(agent §R1-C テンプレート継承, §確定 R1-F).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import delete, func, insert, select
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bakufu.domain.room.room import Room
+from bakufu.domain.room.value_objects import AgentMembership, PromptKit
+from bakufu.domain.value_objects import EmpireId, Role, RoomId
+from bakufu.infrastructure.persistence.sqlite.tables.room_members import RoomMemberRow
+from bakufu.infrastructure.persistence.sqlite.tables.rooms import RoomRow
+
+
+class SqliteRoomRepository:
+    """SQLite implementation of :class:`RoomRepository`."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def find_by_id(self, room_id: RoomId) -> Room | None:
+        """SELECT room + room_members, hydrate via :meth:`_from_row`.
+
+        Returns ``None`` when the rooms row is absent. The room_members
+        SELECT uses ``ORDER BY agent_id, role`` (composite key ascending)
+        so the hydrated member list is deterministic — empire-repository
+        BUG-EMR-001 froze this contract; we apply it from day one here.
+        """
+        room_stmt = select(RoomRow).where(RoomRow.id == room_id)
+        room_row = (await self._session.execute(room_stmt)).scalar_one_or_none()
+        if room_row is None:
+            return None
+
+        # ORDER BY makes find_by_id deterministic. Without it SQLite returns
+        # rows in internal-scan order, which would break ``Room == Room``
+        # round-trip equality (the Aggregate compares list-by-list).
+        # See empire-repo BUG-EMR-001 — this PR adopts the resolved contract
+        # from day one.
+        member_stmt = (
+            select(RoomMemberRow)
+            .where(RoomMemberRow.room_id == room_id)
+            .order_by(RoomMemberRow.agent_id, RoomMemberRow.role)
+        )
+        member_rows = list((await self._session.execute(member_stmt)).scalars().all())
+
+        return self._from_row(room_row, member_rows)
+
+    async def count(self) -> int:
+        """``SELECT COUNT(*) FROM rooms``.
+
+        Implementation detail: SQLAlchemy's ``func.count()`` issues a
+        proper ``SELECT COUNT(*)`` so SQLite returns one scalar row instead
+        of streaming every PK back to Python (empire-repo §確定 D 踏襲).
+        """
+        stmt = select(func.count()).select_from(RoomRow)
+        return (await self._session.execute(stmt)).scalar_one()
+
+    async def save(self, room: Room, empire_id: EmpireId) -> None:
+        """Persist ``room`` via the §確定 R1-B three-step delete-then-insert.
+
+        ``empire_id`` is an explicit argument because :class:`Room` holds no
+        ``empire_id`` attribute (§確定 R1-H). The caller is responsible for
+        the surrounding ``async with session.begin():`` block; failures inside
+        any step propagate untouched so the Unit-of-Work boundary in the
+        application service can rollback cleanly.
+        """
+        room_row, member_rows = self._to_row(room, empire_id)
+
+        # Step 1: rooms UPSERT (id PK, ON CONFLICT update workflow_id + name
+        # + description + prompt_kit_prefix_markdown + archived).
+        # ``prompt_kit_prefix_markdown`` binds through MaskedText so the
+        # masked form lands in DB even on update (§確定 R1-J).
+        upsert_stmt = sqlite_insert(RoomRow).values(room_row)
+        upsert_stmt = upsert_stmt.on_conflict_do_update(
+            index_elements=["id"],
+            set_={
+                "workflow_id": upsert_stmt.excluded.workflow_id,
+                "name": upsert_stmt.excluded.name,
+                "description": upsert_stmt.excluded.description,
+                "prompt_kit_prefix_markdown": upsert_stmt.excluded.prompt_kit_prefix_markdown,
+                "archived": upsert_stmt.excluded.archived,
+            },
+        )
+        await self._session.execute(upsert_stmt)
+
+        # Step 2: room_members DELETE.
+        await self._session.execute(delete(RoomMemberRow).where(RoomMemberRow.room_id == room.id))
+
+        # Step 3: room_members bulk INSERT (skip when no members — a newly
+        # created room may legitimately have zero members).
+        if member_rows:
+            await self._session.execute(insert(RoomMemberRow), member_rows)
+
+    async def find_by_name(self, empire_id: EmpireId, name: str) -> Room | None:
+        """Hydrate the Room named ``name`` inside ``empire_id`` (§確定 R1-F).
+
+        Two-stage flow: a lightweight ``SELECT id ... LIMIT 1`` locates the
+        RoomId via ``INDEX(empire_id, name)``, then delegation to
+        :meth:`find_by_id` so the child-table SELECTs and ``_from_row``
+        conversion stay single-sourced (agent §R1-C テンプレート継承).
+        """
+        id_stmt = (
+            select(RoomRow.id).where(RoomRow.empire_id == empire_id, RoomRow.name == name).limit(1)
+        )
+        found_id = (await self._session.execute(id_stmt)).scalar_one_or_none()
+        if found_id is None:
+            return None
+        return await self.find_by_id(found_id)
+
+    # ---- private domain ↔ row converters (empire-repo §確定 C) -----------
+    def _to_row(
+        self,
+        room: Room,
+        empire_id: EmpireId,
+    ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+        """Split ``room`` into ``(room_row, member_rows)``.
+
+        SQLAlchemy ``Row`` objects are avoided so the domain layer never
+        gains an accidental dependency on the SQLAlchemy type hierarchy. Each
+        returned ``dict`` matches the ``mapped_column`` names verbatim.
+
+        ``empire_id`` is passed explicitly because :class:`Room` holds no
+        ``empire_id`` attribute (§確定 R1-H).
+        """
+        room_row: dict[str, Any] = {
+            "id": room.id,
+            "empire_id": empire_id,
+            "workflow_id": room.workflow_id,
+            "name": room.name,
+            "description": room.description,
+            # MaskedText.process_bind_param will redact secrets from this
+            # string before VARCHAR storage — room §確定 G 実適用.
+            "prompt_kit_prefix_markdown": room.prompt_kit.prefix_markdown,
+            "archived": room.archived,
+        }
+        member_rows: list[dict[str, Any]] = [
+            {
+                "room_id": room.id,
+                "agent_id": membership.agent_id,
+                "role": membership.role.value,
+                "joined_at": membership.joined_at,
+            }
+            for membership in room.members
+        ]
+        return room_row, member_rows
+
+    def _from_row(
+        self,
+        room_row: RoomRow,
+        member_rows: list[RoomMemberRow],
+    ) -> Room:
+        """Hydrate a :class:`Room` Aggregate Root from its two row types.
+
+        ``Room.model_validate`` re-runs the post-validator so Repository-side
+        hydration goes through the same invariant checks that
+        ``RoomService.establish_room()`` does at construction time.
+
+        §確定 R1-J §不可逆性: ``prompt_kit.prefix_markdown`` carries the
+        already-masked text from disk. ``PromptKit`` accepts any string within
+        the length cap so the masked form constructs cleanly, but the resulting
+        Room should not be dispatched to an LLM without
+        ``feature/llm-adapter``'s masked-prompt guard.
+
+        ``empire_id`` is **not** restored onto :class:`Room` — the Aggregate
+        holds no ``empire_id`` attribute (§確定 R1-H).
+        """
+        members = [
+            AgentMembership(
+                agent_id=_to_uuid(row.agent_id),
+                role=Role(row.role),
+                joined_at=row.joined_at,
+            )
+            for row in member_rows
+        ]
+        return Room(
+            id=_to_uuid(room_row.id),
+            workflow_id=_to_uuid(room_row.workflow_id),
+            name=room_row.name,
+            description=room_row.description,
+            prompt_kit=PromptKit(prefix_markdown=room_row.prompt_kit_prefix_markdown or ""),
+            members=members,
+            archived=room_row.archived,
+        )
+
+
+def _to_uuid(value: UUID | str) -> UUID:
+    """Coerce a row value to :class:`uuid.UUID`.
+
+    UUIDStr TypeDecorator already returns UUID instances on
+    ``process_result_value``, but defensive coercion lets raw-SQL hydration
+    paths route through the same code without an extra ``isinstance`` ladder
+    at every call site (agent_repository pattern).
+    """
+    if isinstance(value, UUID):
+        return value
+    return UUID(value)
+
+
+__all__ = ["SqliteRoomRepository"]

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/tables/__init__.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/tables/__init__.py
@@ -35,6 +35,19 @@ Agent Aggregate (PR #32):
   Defense-in-Depth "exactly one default provider per Agent" floor.
 * :mod:`...tables.agent_skills` — SkillRef child rows (no-mask).
 
+Room Aggregate (PR #33):
+
+* :mod:`...tables.rooms` — Room root row. The
+  ``prompt_kit_prefix_markdown`` column is ``MaskedText`` (room
+  §確定 G 実適用); the table is registered with the CI three-layer
+  defense's *partial-mask* contract pinning exactly one masked column.
+  ``empire_room_refs.room_id → rooms.id`` FK is closed in Alembic
+  0005 (BUG-EMR-001 closure).
+* :mod:`...tables.room_members` — AgentMembership child rows (no-mask).
+  Composite PK + explicit ``UniqueConstraint`` for §確定 R1-D
+  Defense-in-Depth; ``agent_id`` intentionally has no FK onto
+  ``agents.id`` (application-layer responsibility).
+
 Secret-bearing tables declare their columns with
 :class:`MaskedJSONEncoded` / :class:`MaskedText` TypeDecorators
 (defined in :mod:`bakufu.infrastructure.persistence.sqlite.base`) that
@@ -69,6 +82,8 @@ from bakufu.infrastructure.persistence.sqlite.tables import (
     empires,
     outbox,
     pid_registry,
+    room_members,
+    rooms,
     workflow_stages,
     workflow_transitions,
     workflows,
@@ -84,6 +99,8 @@ __all__ = [
     "empires",
     "outbox",
     "pid_registry",
+    "room_members",
+    "rooms",
     "workflow_stages",
     "workflow_transitions",
     "workflows",

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/tables/room_members.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/tables/room_members.py
@@ -1,0 +1,72 @@
+"""``room_members`` table — AgentMembership child rows of the Room Aggregate.
+
+Stores each :class:`bakufu.domain.room.value_objects.AgentMembership` as a
+DB row. A Room can host multiple members; each entry is identified by the
+``(room_id, agent_id, role)`` triplet.
+
+Design contracts (§確定 R1-D):
+
+* ``room_id`` FK → ``rooms.id`` ON DELETE CASCADE: removing the Room
+  purges all its membership rows.
+* ``agent_id`` has **no FK** onto ``agents.id``. Room §確定 freezes Agent
+  existence checking as the application-layer's responsibility
+  (``RoomService.add_member`` calls ``AgentRepository.find_by_id``). A FK
+  CASCADE would silently delete memberships when the Agent row disappears;
+  FK RESTRICT would block clean removal of archived Agents from Rooms.
+  Neither is correct for the MVP model — application-layer check only.
+* Composite PK ``(room_id, agent_id, role)`` plus an explicit named
+  ``UniqueConstraint`` for CI Layer 2 arch-test detectability. The PK
+  implies UNIQUE but ``__table_args__`` scanning in the arch test only
+  catches explicit constraint declarations (agent_providers pattern,
+  detailed-design §確定 R1-D rationale).
+* ``joined_at`` uses ``DateTime(timezone=True)`` so aiosqlite preserves
+  the UTC ``tzinfo`` on read — the hydrated ``AgentMembership.joined_at``
+  is always tz-aware as frozen in room/detailed-design.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import DateTime, ForeignKey, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from bakufu.infrastructure.persistence.sqlite.base import Base, UUIDStr
+
+
+class RoomMemberRow(Base):
+    """ORM mapping for the ``room_members`` table."""
+
+    __tablename__ = "room_members"
+
+    room_id: Mapped[UUID] = mapped_column(
+        UUIDStr,
+        ForeignKey("rooms.id", ondelete="CASCADE"),
+        primary_key=True,
+        nullable=False,
+    )
+    agent_id: Mapped[UUID] = mapped_column(
+        UUIDStr,
+        primary_key=True,
+        nullable=False,
+        # Intentionally no FK onto agents.id — see module docstring.
+    )
+    role: Mapped[str] = mapped_column(String(32), primary_key=True, nullable=False)
+    joined_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+    __table_args__ = (
+        # §確定 R1-D: explicit UniqueConstraint mirrors the composite PK so the
+        # CI Layer 2 arch test can assert UNIQUE-constraint existence by scanning
+        # ``__table_args__``. PK-derived implicit UNIQUE is invisible to that
+        # scan, so the redundancy is load-bearing for the Defense-in-Depth floor.
+        UniqueConstraint(
+            "room_id",
+            "agent_id",
+            "role",
+            name="uq_room_members_triplet",
+        ),
+    )
+
+
+__all__ = ["RoomMemberRow"]

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/tables/rooms.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/tables/rooms.py
@@ -1,0 +1,73 @@
+"""``rooms`` table — Room Aggregate root row.
+
+Holds the seven scalar columns of the Room aggregate root. The member
+collection (``room_members``) lives in the companion module
+:mod:`...tables.room_members` so the root row width stays bounded and
+CASCADE targets are obvious.
+
+``empire_id`` carries an ``ON DELETE CASCADE`` foreign key onto
+``empires.id`` — when an Empire is removed, its Rooms go with it.
+
+``workflow_id`` carries an ``ON DELETE RESTRICT`` foreign key onto
+``workflows.id`` — Workflow is a reference target, not an owner, so
+deleting a Workflow while Rooms still reference it is a hard failure
+(§確定 R1-I: Defense-in-Depth alongside the application-layer check).
+
+``name`` is intentionally **not** declared UNIQUE at the DB level. The
+"name unique within an Empire" invariant is enforced by the application
+layer via :meth:`RoomRepository.find_by_name` (agent §R1-B same logic)
+so MSG-RM-NNN wording stays in the application layer's voice rather than
+being preempted by ``IntegrityError``.
+
+``prompt_kit_prefix_markdown`` is a :class:`MaskedText` column (room
+§確定 G 実適用). ``MaskingGateway`` replaces embedded API keys / OAuth
+tokens / Discord webhook secrets etc. with ``<REDACTED:*>`` *before* the
+row hits SQLite — preventing DB-dump / SQL-log secret leaks. The masking
+is irreversible; see §確定 R1-J and :mod:`...repositories.room_repository`
+for the full contract.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import Boolean, ForeignKey, Index, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from bakufu.infrastructure.persistence.sqlite.base import (
+    Base,
+    MaskedText,
+    UUIDStr,
+)
+
+
+class RoomRow(Base):
+    """ORM mapping for the ``rooms`` table."""
+
+    __tablename__ = "rooms"
+
+    id: Mapped[UUID] = mapped_column(UUIDStr, primary_key=True)
+    empire_id: Mapped[UUID] = mapped_column(
+        UUIDStr,
+        ForeignKey("empires.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    workflow_id: Mapped[UUID] = mapped_column(
+        UUIDStr,
+        ForeignKey("workflows.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    name: Mapped[str] = mapped_column(String(80), nullable=False)
+    description: Mapped[str] = mapped_column(String(500), nullable=False, default="")
+    prompt_kit_prefix_markdown: Mapped[str] = mapped_column(MaskedText, nullable=False, default="")
+    archived: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+
+    __table_args__ = (
+        # §確定 R1-F: non-UNIQUE composite index for Empire-scoped find_by_name
+        # lookup. Left-prefix optimises both ``WHERE empire_id = ?`` and
+        # ``WHERE empire_id = ? AND name = ?`` queries.
+        Index("ix_rooms_empire_id_name", "empire_id", "name", unique=False),
+    )
+
+
+__all__ = ["RoomRow"]

--- a/backend/tests/architecture/test_masking_columns.py
+++ b/backend/tests/architecture/test_masking_columns.py
@@ -45,6 +45,8 @@ from bakufu.infrastructure.persistence.sqlite.tables import (
     empires,  # noqa: F401  # pyright: ignore[reportUnusedImport]
     outbox,  # noqa: F401  # pyright: ignore[reportUnusedImport]
     pid_registry,  # noqa: F401  # pyright: ignore[reportUnusedImport]
+    room_members,  # noqa: F401  # pyright: ignore[reportUnusedImport]
+    rooms,  # noqa: F401  # pyright: ignore[reportUnusedImport]
     workflow_stages,  # noqa: F401  # pyright: ignore[reportUnusedImport]
     workflow_transitions,  # noqa: F401  # pyright: ignore[reportUnusedImport]
     workflows,  # noqa: F401  # pyright: ignore[reportUnusedImport]
@@ -64,6 +66,9 @@ _MASKING_CONTRACT: list[tuple[str, str, type]] = [
     # Agent Repository (PR #32, detailed-design.md §確定 H + Schneier
     # 申し送り #3 实適用).
     ("agents", "prompt_body", MaskedText),
+    # Room Repository (PR #33, detailed-design.md §確定 R1-E +
+    # room §確定 G 実適用).
+    ("rooms", "prompt_kit_prefix_markdown", MaskedText),
 ]
 
 # No-mask contract: §逆引き表「Empire 関連カラム: masking 対象なし」 +
@@ -84,6 +89,9 @@ _NO_MASK_TABLES: list[str] = [
     # categories; only agents.prompt_body is masked.
     "agent_providers",
     "agent_skills",
+    # Room Repository (PR #33, detailed-design.md §確定 R1-E):
+    # room_members carries no secret semantics; agent_id is not masked.
+    "room_members",
 ]
 
 # Partial-mask contract: tables that have **exactly one** masked
@@ -98,6 +106,11 @@ _PARTIAL_MASK_TABLES: list[tuple[str, str]] = [
     # agents.prompt_body is the only masked column; persona-adjacent
     # scalar fields stay un-masked.
     ("agents", "prompt_body"),
+    # Room Repository (PR #33, detailed-design.md §確定 R1-E):
+    # rooms.prompt_kit_prefix_markdown is the only masked column (room
+    # §確定 G 実適用); other columns (name / description / archived) stay
+    # un-masked.
+    ("rooms", "prompt_kit_prefix_markdown"),
 ]
 
 

--- a/backend/tests/factories/room.py
+++ b/backend/tests/factories/room.py
@@ -141,18 +141,46 @@ def make_populated_room(
     room_id: UUID | None = None,
     leader_agent_id: UUID | None = None,
     developer_agent_id: UUID | None = None,
+    workflow_id: UUID | None = None,
 ) -> Room:
     """Build a Room with one LEADER + one DEVELOPER membership.
 
     Useful for TC-IT-RM-001 / 002 round-trip scenarios that exercise add /
     remove / update / archive transitions over a non-empty member list.
+
+    ``workflow_id`` is forwarded to :func:`make_room` so infrastructure
+    integration tests can pass the seeded workflow FK target.
     """
     return make_room(
         room_id=room_id,
+        workflow_id=workflow_id,
         members=[
             make_leader_membership(agent_id=leader_agent_id),
             make_agent_membership(agent_id=developer_agent_id, role=Role.DEVELOPER),
         ],
+    )
+
+
+def make_room_with_secret_prompt_kit(
+    *,
+    room_id: UUID | None = None,
+    prefix_markdown: str,
+    workflow_id: UUID | None = None,
+) -> Room:
+    """Build a Room whose PromptKit carries a secret-bearing ``prefix_markdown``.
+
+    Used by infrastructure tests that verify ``MaskedText`` redacts the
+    embedded secret before the row hits SQLite (§確定 R1-J 不可逆性凍結).
+
+    The caller is responsible for passing a ``prefix_markdown`` that
+    contains a token matching one of the masking gateway's regex patterns
+    so the round-trip is non-identity (raw → masked).
+    """
+    kit = make_prompt_kit(prefix_markdown=prefix_markdown)
+    return make_room(
+        room_id=room_id,
+        workflow_id=workflow_id,
+        prompt_kit=kit,
     )
 
 
@@ -165,4 +193,5 @@ __all__ = [
     "make_populated_room",
     "make_prompt_kit",
     "make_room",
+    "make_room_with_secret_prompt_kit",
 ]

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_empire_repository/conftest.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_empire_repository/conftest.py
@@ -1,0 +1,106 @@
+"""Pytest fixtures for empire-repository integration tests.
+
+Provides seed helpers to satisfy the ``empire_room_refs.room_id → rooms.id``
+FK constraint added by Alembic 0005_room_aggregate (BUG-EMR-001 FK closure).
+
+Background: before Alembic 0005, ``empire_room_refs.room_id`` had **no** FK
+onto ``rooms.id`` (the rooms table didn't exist yet). After 0005 the FK is
+wired with ``ON DELETE CASCADE`` so any INSERT into ``empire_room_refs`` now
+requires a matching row in ``rooms``. Tests that call
+``SqliteEmpireRepository.save(empire)`` with a populated Empire, or that
+issue raw SQL into ``empire_room_refs``, must seed the ``rooms`` table first.
+
+Usage::
+
+    from tests.infrastructure.persistence.sqlite.repositories.\
+        test_empire_repository.conftest import seed_rooms
+
+    empire = make_populated_empire(n_rooms=2, n_agents=3)
+    await seed_rooms(session_factory, empire.id, [r.room_id for r in empire.rooms])
+    async with session_factory() as session, session.begin():
+        await SqliteEmpireRepository(session).save(empire)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID, uuid4
+
+from sqlalchemy import text
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+
+async def seed_rooms(
+    session_factory: async_sessionmaker[AsyncSession],
+    empire_id: UUID,
+    room_ids: list[UUID],
+    *,
+    workflow_id: UUID | None = None,
+) -> UUID:
+    """Seed ``workflows`` + ``rooms`` rows to satisfy ``empire_room_refs`` FK.
+
+    ``empire_room_refs.room_id → rooms.id`` FK (ON DELETE CASCADE) was added
+    in Alembic 0005 as BUG-EMR-001 FK closure. This helper inserts the
+    minimal prerequisite rows so tests that populate an Empire's ``rooms``
+    list can call ``SqliteEmpireRepository.save()`` without hitting
+    ``FOREIGN KEY constraint failed``.
+
+    Steps:
+    1. Ensure the Empire row exists (``INSERT OR IGNORE`` — idempotent so
+       the caller can seed before or after the first ``save()``).
+    2. Seed one ``workflows`` row that the rooms can reference via FK.
+    3. Seed one ``rooms`` row per ``room_id`` with ``empire_id`` and
+       ``workflow_id`` as foreign keys.
+
+    Returns the ``workflow_id`` that was used (generated fresh if not passed).
+    """
+    wf_id = workflow_id if workflow_id is not None else uuid4()
+
+    async with session_factory() as session, session.begin():
+        # Step 1: ensure the empire row exists so rooms.empire_id FK resolves.
+        # INSERT OR IGNORE is safe even after SqliteEmpireRepository.save()
+        # has already created the empire row via UPSERT.
+        await session.execute(
+            text(
+                "INSERT OR IGNORE INTO empires (id, name, archived) VALUES (:id, :name, :archived)"
+            ),
+            {"id": empire_id.hex, "name": "seed-empire", "archived": False},
+        )
+
+        # Step 2: seed a minimal workflow row so rooms.workflow_id FK resolves.
+        await session.execute(
+            text(
+                "INSERT INTO workflows (id, name, entry_stage_id) "
+                "VALUES (:id, :name, :entry_stage_id)"
+            ),
+            {
+                "id": wf_id.hex,
+                "name": "seed-workflow",
+                "entry_stage_id": uuid4().hex,
+            },
+        )
+
+        # Step 3: seed one rooms row per room_id.
+        for room_id in room_ids:
+            await session.execute(
+                text(
+                    "INSERT OR IGNORE INTO rooms "
+                    "(id, empire_id, workflow_id, name, description, "
+                    "prompt_kit_prefix_markdown, archived) "
+                    "VALUES (:id, :empire_id, :workflow_id, :name, "
+                    ":description, :prefix, :archived)"
+                ),
+                {
+                    "id": room_id.hex,
+                    "empire_id": empire_id.hex,
+                    "workflow_id": wf_id.hex,
+                    "name": "seed-room",
+                    "description": "",
+                    "prefix": "",
+                    "archived": False,
+                },
+            )
+
+    return wf_id

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_empire_repository/conftest.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_empire_repository/conftest.py
@@ -63,10 +63,8 @@ async def seed_rooms(
         # INSERT OR IGNORE is safe even after SqliteEmpireRepository.save()
         # has already created the empire row via UPSERT.
         await session.execute(
-            text(
-                "INSERT OR IGNORE INTO empires (id, name, archived) VALUES (:id, :name, :archived)"
-            ),
-            {"id": empire_id.hex, "name": "seed-empire", "archived": False},
+            text("INSERT OR IGNORE INTO empires (id, name) VALUES (:id, :name)"),
+            {"id": empire_id.hex, "name": "seed-empire"},
         )
 
         # Step 2: seed a minimal workflow row so rooms.workflow_id FK resolves.

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_empire_repository/test_constraints_arch.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_empire_repository/test_constraints_arch.py
@@ -25,6 +25,9 @@ from bakufu.infrastructure.persistence.sqlite.tables.empires import EmpireRow
 from sqlalchemy import delete, select, text
 
 from tests.factories.empire import make_empire, make_populated_empire
+from tests.infrastructure.persistence.sqlite.repositories.test_empire_repository.conftest import (
+    seed_rooms,
+)
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -41,6 +44,7 @@ class TestForeignKeyCascade:
     ) -> None:
         """TC-IT-EMR-013: FK ON DELETE CASCADE empties empire_room_refs / empire_agent_refs."""
         empire = make_populated_empire(n_rooms=2, n_agents=3)
+        await seed_rooms(session_factory, empire.id, [r.room_id for r in empire.rooms])
         async with session_factory() as session, session.begin():
             await SqliteEmpireRepository(session).save(empire)
 
@@ -87,6 +91,9 @@ class TestUniqueConstraintViolation:
             await SqliteEmpireRepository(session).save(empire)
 
         room_id = uuid4()
+        # Alembic 0005 added empire_room_refs.room_id → rooms.id FK (BUG-EMR-001
+        # closure). Seed the room row before inserting into empire_room_refs.
+        await seed_rooms(session_factory, empire.id, [room_id])
         async with session_factory() as session, session.begin():
             await session.execute(
                 text(

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_empire_repository/test_protocol_crud.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_empire_repository/test_protocol_crud.py
@@ -26,6 +26,9 @@ from bakufu.infrastructure.persistence.sqlite.tables.empires import EmpireRow
 from sqlalchemy import select
 
 from tests.factories.empire import make_empire, make_populated_empire
+from tests.infrastructure.persistence.sqlite.repositories.test_empire_repository.conftest import (
+    seed_rooms,
+)
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -148,6 +151,9 @@ class TestSaveInsertsAllThreeTables:
     ) -> None:
         """TC-IT-EMR-005: 2 rooms + 3 agents land in their respective side tables."""
         empire = make_populated_empire(n_rooms=2, n_agents=3)
+        # Alembic 0005 added empire_room_refs.room_id → rooms.id FK (BUG-EMR-001
+        # closure). Seed rooms rows before save() so the FK resolves.
+        await seed_rooms(session_factory, empire.id, [r.room_id for r in empire.rooms])
         async with session_factory() as session, session.begin():
             await SqliteEmpireRepository(session).save(empire)
 

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_empire_repository/test_save_semantics.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_empire_repository/test_save_semantics.py
@@ -20,6 +20,9 @@ from bakufu.infrastructure.persistence.sqlite.tables.empire_room_refs import (
 from sqlalchemy import select
 
 from tests.factories.empire import make_empire, make_populated_empire, make_room_ref
+from tests.infrastructure.persistence.sqlite.repositories.test_empire_repository.conftest import (
+    seed_rooms,
+)
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -36,6 +39,14 @@ class TestSaveDeleteThenInsert:
     ) -> None:
         """TC-IT-EMR-006: 2 rooms → 1 room is reflected as 1 row in empire_room_refs."""
         original = make_populated_empire(n_rooms=2, n_agents=3)
+        # Create the replacement room ref upfront so we can seed it before save.
+        replacement_room = make_room_ref(name="残った部屋")
+
+        # Alembic 0005 added empire_room_refs.room_id → rooms.id FK (BUG-EMR-001
+        # closure). Seed all room_ids that will ever appear in empire_room_refs.
+        all_room_ids = [r.room_id for r in original.rooms] + [replacement_room.room_id]
+        await seed_rooms(session_factory, original.id, all_room_ids)
+
         async with session_factory() as session, session.begin():
             await SqliteEmpireRepository(session).save(original)
 
@@ -43,7 +54,7 @@ class TestSaveDeleteThenInsert:
         replacement = make_empire(
             empire_id=original.id,
             name=original.name,
-            rooms=[make_room_ref(name="残った部屋")],
+            rooms=[replacement_room],
             agents=list(original.agents),
         )
         async with session_factory() as session, session.begin():
@@ -86,6 +97,7 @@ class TestRoundTripStructuralEquality:
     ) -> None:
         """TC-IT-EMR-007: round-trip preserves Empire identity + membership in ORDER BY order."""
         empire = make_populated_empire(n_rooms=2, n_agents=3)
+        await seed_rooms(session_factory, empire.id, [r.room_id for r in empire.rooms])
         async with session_factory() as session, session.begin():
             await SqliteEmpireRepository(session).save(empire)
 
@@ -122,6 +134,7 @@ class TestRoundTripStructuralEquality:
     ) -> None:
         """TC-UT-EMR-003: ``_to_row`` → save + find_by_id (≡ ``_from_row``) preserves equality."""
         empire = make_populated_empire(n_rooms=2, n_agents=3)
+        await seed_rooms(session_factory, empire.id, [r.room_id for r in empire.rooms])
         async with session_factory() as session, session.begin():
             await SqliteEmpireRepository(session).save(empire)
 
@@ -175,6 +188,7 @@ class TestSaveSqlOrder:
         event.listen(sync_engine, "before_cursor_execute", _on_execute)
         try:
             empire = make_populated_empire(n_rooms=2, n_agents=3)
+            await seed_rooms(session_factory, empire.id, [r.room_id for r in empire.rooms])
             async with session_factory() as session, session.begin():
                 await SqliteEmpireRepository(session).save(empire)
         finally:

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_room_repository/conftest.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_room_repository/conftest.py
@@ -1,0 +1,110 @@
+"""Pytest fixtures shared across room-repository integration tests.
+
+Two responsibilities:
+
+1. Set ``BAKUFU_DATA_DIR`` env var (mirror of other repository conftest files).
+2. Provide :func:`seed_empire` and :func:`seed_workflow` helpers + matching
+   fixtures so Room FK constraints on both ``rooms.empire_id`` and
+   ``rooms.workflow_id`` can be satisfied.
+
+Room is the first Aggregate whose Repository requires **two** parent tables to
+be seeded before a Room row can be inserted:
+
+* ``rooms.empire_id REFERENCES empires.id ON DELETE CASCADE``
+* ``rooms.workflow_id REFERENCES workflows.id ON DELETE RESTRICT``
+
+Without both seeds every ``save(room, empire_id)`` would raise
+``IntegrityError: FOREIGN KEY constraint failed``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID, uuid4
+
+import pytest
+import pytest_asyncio
+from bakufu.infrastructure.persistence.sqlite.repositories.empire_repository import (
+    SqliteEmpireRepository,
+)
+from bakufu.infrastructure.persistence.sqlite.repositories.workflow_repository import (
+    SqliteWorkflowRepository,
+)
+
+from tests.factories.empire import make_empire
+from tests.factories.workflow import make_workflow
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+
+@pytest.fixture(autouse=True)
+def _bakufu_data_dir(monkeypatch: pytest.MonkeyPatch) -> None:  # pyright: ignore[reportUnusedFunction]
+    """Set ``BAKUFU_DATA_DIR`` for every test in this package.
+
+    Autouse fixture — pytest invokes via dependency injection, so the
+    function appears unused to pyright. The pragma silences that.
+    """
+    monkeypatch.setenv("BAKUFU_DATA_DIR", "/tmp/bakufu-test-root")
+
+
+@pytest_asyncio.fixture
+async def seeded_empire_id(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> UUID:
+    """Seed a single Empire row and return its id for FK satisfaction.
+
+    Use this when the test only needs one empire to attach Rooms to.
+    For multi-Empire tests (e.g. ``find_by_name`` cross-Empire
+    isolation), call :func:`seed_empire` directly with explicit ids.
+    """
+    empire = make_empire()
+    async with session_factory() as session, session.begin():
+        await SqliteEmpireRepository(session).save(empire)
+    return empire.id
+
+
+@pytest_asyncio.fixture
+async def seeded_workflow_id(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> UUID:
+    """Seed a single Workflow row and return its id for FK satisfaction.
+
+    Room's ``workflow_id REFERENCES workflows.id ON DELETE RESTRICT`` means
+    a Workflow row must exist before any Room can be inserted.
+    """
+    workflow = make_workflow()
+    async with session_factory() as session, session.begin():
+        await SqliteWorkflowRepository(session).save(workflow)
+    return workflow.id
+
+
+async def seed_empire(
+    session_factory: async_sessionmaker[AsyncSession],
+    empire_id: UUID | None = None,
+) -> UUID:
+    """Persist an Empire row whose id is ``empire_id`` (or fresh).
+
+    Helper for tests that need to control which empire_id Rooms
+    attach to (e.g. cross-Empire isolation, multi-empire seeding).
+    Returns the id that was actually persisted.
+    """
+    empire = make_empire(empire_id=empire_id if empire_id is not None else uuid4())
+    async with session_factory() as session, session.begin():
+        await SqliteEmpireRepository(session).save(empire)
+    return empire.id
+
+
+async def seed_workflow(
+    session_factory: async_sessionmaker[AsyncSession],
+    workflow_id: UUID | None = None,
+) -> UUID:
+    """Persist a Workflow row whose id is ``workflow_id`` (or fresh).
+
+    Helper for tests that need to control which workflow_id Rooms
+    attach to. Returns the id that was actually persisted.
+    """
+    workflow = make_workflow(workflow_id=workflow_id if workflow_id is not None else uuid4())
+    async with session_factory() as session, session.begin():
+        await SqliteWorkflowRepository(session).save(workflow)
+    return workflow.id

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_room_repository/test_constraints_arch.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_room_repository/test_constraints_arch.py
@@ -1,0 +1,362 @@
+"""Room Repository: DB constraints + arch-test reference.
+
+TC-IT-RR-009 / TC-IT-RR-013-arch — the **UNIQUE(room_id, agent_id, role)
+二重防衛** (§確定 R1-D) and the CI Layer 2 arch-test cross-reference.
+
+§確定 R1-D: duplicate (room_id, agent_id, role) triplets are forbidden
+by **two layers**:
+
+1. **Aggregate-level**: Room construction validates member uniqueness at
+   construction time.
+2. **DB-level**: explicit ``UniqueConstraint("room_id", "agent_id", "role",
+   name="uq_room_members_triplet")`` physically rejects the INSERT — the
+   final defense line for code paths that bypass the Aggregate (raw SQL,
+   future Repository implementations, dump/restore migrations, etc.).
+
+This test exercises **layer 2 in isolation** by writing raw SQL that
+sidesteps the Aggregate. A regression that drops the UniqueConstraint
+DDL would let the second INSERT succeed silently.
+
+Also tests:
+* ``rooms.workflow_id FK RESTRICT``: DELETE a workflow while a room
+  references it must raise ``IntegrityError`` (§確定 R1-I).
+* ``room_members.room_id FK CASCADE``: DELETE a room cascades to
+  room_members rows (§確定 R1-C Room entity cascade).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy import text
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-RR-009: UNIQUE(room_id, agent_id, role) 二重防衛 (§確定 R1-D)
+# ---------------------------------------------------------------------------
+class TestUniqueRoomMemberTripletDoubleDefense:
+    """TC-IT-RR-009: duplicate (room_id, agent_id, role) raises IntegrityError.
+
+    The Aggregate's member validation is the first layer; this test
+    bypasses it by writing raw SQL directly so the DB constraint is the
+    only thing standing between us and a silent duplicate. The first
+    INSERT must succeed; the second must raise ``IntegrityError``.
+    """
+
+    async def test_duplicate_triplet_raises_integrity_error(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_empire_id: UUID,
+        seeded_workflow_id: UUID,
+    ) -> None:
+        """TC-IT-RR-009: same (room_id, agent_id, role) inserted twice → IntegrityError."""
+        from datetime import UTC, datetime
+
+        from sqlalchemy.exc import IntegrityError
+
+        room_id = uuid4()
+        agent_id = uuid4()
+        empire_id = seeded_empire_id
+        workflow_id = seeded_workflow_id
+
+        # Seed the rooms row first so room_members FK resolves.
+        async with session_factory() as session, session.begin():
+            await session.execute(
+                text(
+                    "INSERT INTO rooms "
+                    "(id, empire_id, workflow_id, name, description, "
+                    "prompt_kit_prefix_markdown, archived) VALUES "
+                    "(:id, :empire_id, :workflow_id, :name, :description, "
+                    ":prefix, :archived)"
+                ),
+                {
+                    "id": room_id.hex,
+                    "empire_id": empire_id.hex,
+                    "workflow_id": workflow_id.hex,
+                    "name": "constraint-test-room",
+                    "description": "",
+                    "prefix": "",
+                    "archived": False,
+                },
+            )
+
+        joined_at = datetime.now(UTC).isoformat()
+
+        # First member INSERT — must succeed.
+        async with session_factory() as session, session.begin():
+            await session.execute(
+                text(
+                    "INSERT INTO room_members (room_id, agent_id, role, joined_at) "
+                    "VALUES (:room_id, :agent_id, :role, :joined_at)"
+                ),
+                {
+                    "room_id": room_id.hex,
+                    "agent_id": agent_id.hex,
+                    "role": "LEADER",
+                    "joined_at": joined_at,
+                },
+            )
+
+        # Second INSERT with the same (room_id, agent_id, role) triplet —
+        # the uq_room_members_triplet constraint must reject it.
+        with pytest.raises(IntegrityError):
+            async with session_factory() as session, session.begin():
+                await session.execute(
+                    text(
+                        "INSERT INTO room_members (room_id, agent_id, role, joined_at) "
+                        "VALUES (:room_id, :agent_id, :role, :joined_at)"
+                    ),
+                    {
+                        "room_id": room_id.hex,
+                        "agent_id": agent_id.hex,
+                        "role": "LEADER",  # same role → same triplet
+                        "joined_at": joined_at,
+                    },
+                )
+
+    async def test_same_agent_different_roles_are_permitted(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_empire_id: UUID,
+        seeded_workflow_id: UUID,
+    ) -> None:
+        """Same (room_id, agent_id) with different roles must NOT raise.
+
+        Confirms the uniqueness is scoped to the **triplet** — different
+        roles on the same (room_id, agent_id) represent distinct membership
+        records (e.g. an agent who is both DEVELOPER and REVIEWER).
+        """
+        from datetime import UTC, datetime
+
+        room_id = uuid4()
+        agent_id = uuid4()
+
+        async with session_factory() as session, session.begin():
+            await session.execute(
+                text(
+                    "INSERT INTO rooms "
+                    "(id, empire_id, workflow_id, name, description, "
+                    "prompt_kit_prefix_markdown, archived) VALUES "
+                    "(:id, :empire_id, :workflow_id, :name, :description, :prefix, :archived)"
+                ),
+                {
+                    "id": room_id.hex,
+                    "empire_id": seeded_empire_id.hex,
+                    "workflow_id": seeded_workflow_id.hex,
+                    "name": "multi-role-room",
+                    "description": "",
+                    "prefix": "",
+                    "archived": False,
+                },
+            )
+
+        joined_at = datetime.now(UTC).isoformat()
+        async with session_factory() as session, session.begin():
+            for role in ("LEADER", "REVIEWER"):
+                await session.execute(
+                    text(
+                        "INSERT INTO room_members (room_id, agent_id, role, joined_at) "
+                        "VALUES (:room_id, :agent_id, :role, :joined_at)"
+                    ),
+                    {
+                        "room_id": room_id.hex,
+                        "agent_id": agent_id.hex,
+                        "role": role,
+                        "joined_at": joined_at,
+                    },
+                )
+
+        # Both rows present; triplet uniqueness did not fire.
+        async with session_factory() as session:
+            result = await session.execute(
+                text("SELECT COUNT(*) FROM room_members WHERE room_id = :room_id"),
+                {"room_id": room_id.hex},
+            )
+            count = result.scalar_one()
+        assert count == 2
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-RR-009 補強: workflow_id FK RESTRICT (§確定 R1-I)
+# ---------------------------------------------------------------------------
+class TestWorkflowFkRestrict:
+    """``rooms.workflow_id`` FK RESTRICT prevents orphan Rooms on Workflow delete.
+
+    §確定 R1-I: Workflow is a *reference* target for Room, not an owner.
+    Deleting a Workflow while Rooms still reference it is a hard failure
+    at the DB level — the application layer check alone would be
+    insufficient for raw-SQL paths.
+
+    Note: SQLite FK enforcement requires ``PRAGMA foreign_keys = ON``,
+    which the production engine enables at connect time.
+    """
+
+    async def test_delete_referenced_workflow_raises_integrity_error(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_empire_id: UUID,
+        seeded_workflow_id: UUID,
+    ) -> None:
+        """DELETE workflow while room references it → IntegrityError."""
+        from sqlalchemy.exc import IntegrityError
+
+        room_id = uuid4()
+        async with session_factory() as session, session.begin():
+            await session.execute(
+                text(
+                    "INSERT INTO rooms "
+                    "(id, empire_id, workflow_id, name, description, "
+                    "prompt_kit_prefix_markdown, archived) VALUES "
+                    "(:id, :empire_id, :workflow_id, :name, :description, :prefix, :archived)"
+                ),
+                {
+                    "id": room_id.hex,
+                    "empire_id": seeded_empire_id.hex,
+                    "workflow_id": seeded_workflow_id.hex,
+                    "name": "restrict-test-room",
+                    "description": "",
+                    "prefix": "",
+                    "archived": False,
+                },
+            )
+
+        # Now try to delete the workflow that the room references —
+        # RESTRICT must fire.
+        with pytest.raises(IntegrityError):
+            async with session_factory() as session, session.begin():
+                await session.execute(
+                    text("DELETE FROM workflows WHERE id = :id"),
+                    {"id": seeded_workflow_id.hex},
+                )
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-RR-009 補強: room_members CASCADE DELETE (§確定 R1-C)
+# ---------------------------------------------------------------------------
+class TestRoomMembersCascadeOnRoomDelete:
+    """room_members rows are deleted when the parent Room is deleted.
+
+    ``room_members.room_id REFERENCES rooms.id ON DELETE CASCADE`` —
+    deleting a Room row must cascade to its member rows. This prevents
+    orphan room_members rows from accumulating after Room deletion.
+    """
+
+    async def test_cascade_deletes_member_rows(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_empire_id: UUID,
+        seeded_workflow_id: UUID,
+    ) -> None:
+        """DELETE rooms row cascades to all room_members rows for that room."""
+        from datetime import UTC, datetime
+
+        room_id = uuid4()
+        joined_at = datetime.now(UTC).isoformat()
+
+        async with session_factory() as session, session.begin():
+            await session.execute(
+                text(
+                    "INSERT INTO rooms "
+                    "(id, empire_id, workflow_id, name, description, "
+                    "prompt_kit_prefix_markdown, archived) VALUES "
+                    "(:id, :empire_id, :workflow_id, :name, :description, :prefix, :archived)"
+                ),
+                {
+                    "id": room_id.hex,
+                    "empire_id": seeded_empire_id.hex,
+                    "workflow_id": seeded_workflow_id.hex,
+                    "name": "cascade-test-room",
+                    "description": "",
+                    "prefix": "",
+                    "archived": False,
+                },
+            )
+            await session.execute(
+                text(
+                    "INSERT INTO room_members (room_id, agent_id, role, joined_at) "
+                    "VALUES (:room_id, :agent_id, :role, :joined_at)"
+                ),
+                {
+                    "room_id": room_id.hex,
+                    "agent_id": uuid4().hex,
+                    "role": "LEADER",
+                    "joined_at": joined_at,
+                },
+            )
+
+        # Delete the parent room — member rows must cascade.
+        async with session_factory() as session, session.begin():
+            await session.execute(
+                text("DELETE FROM rooms WHERE id = :id"),
+                {"id": room_id.hex},
+            )
+
+        async with session_factory() as session:
+            result = await session.execute(
+                text("SELECT COUNT(*) FROM room_members WHERE room_id = :room_id"),
+                {"room_id": room_id.hex},
+            )
+            count = result.scalar_one()
+        assert count == 0, (
+            f"[FAIL] room_members rows not cascaded on Room deletion (count={count}).\n"
+            f"Next: ensure room_members.room_id FK carries ON DELETE CASCADE."
+        )
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-RR-013-arch: Layer 2 arch-test reference — Room rows registered
+# ---------------------------------------------------------------------------
+class TestArchTestRegistrationStructure:
+    """TC-IT-RR-013-arch: ``test_masking_columns.py`` parametrize lists include Room.
+
+    Cross-checks that the CI Layer 2 arch test was extended to cover
+    Room tables (§確定 R1-E). A future PR that drops these registrations
+    (e.g. by accident during a refactor) would let an over-masking
+    or under-masking change land silently — this test catches it.
+    """
+
+    async def test_rooms_prompt_kit_prefix_markdown_in_masking_contract(self) -> None:
+        """``rooms.prompt_kit_prefix_markdown`` is registered as MaskedText."""
+        from bakufu.infrastructure.persistence.sqlite.base import MaskedText
+
+        from tests.architecture.test_masking_columns import (
+            _MASKING_CONTRACT,  # pyright: ignore[reportPrivateUsage]
+        )
+
+        assert ("rooms", "prompt_kit_prefix_markdown", MaskedText) in _MASKING_CONTRACT, (
+            "[FAIL] rooms.prompt_kit_prefix_markdown missing from _MASKING_CONTRACT.\n"
+            "Next: re-add the room §確定 G 実適用 row to "
+            "tests/architecture/test_masking_columns.py."
+        )
+
+    async def test_room_members_in_no_mask_list(self) -> None:
+        """``room_members`` is a no-mask table (agent_id is not secret)."""
+        from tests.architecture.test_masking_columns import (
+            _NO_MASK_TABLES,  # pyright: ignore[reportPrivateUsage]
+        )
+
+        assert "room_members" in _NO_MASK_TABLES, (
+            "[FAIL] room_members missing from _NO_MASK_TABLES.\n"
+            "Next: §確定 R1-E designates room_members as 'masking 対象なし'."
+        )
+
+    async def test_rooms_partial_mask_template_registered(self) -> None:
+        """``rooms`` is registered in the partial-mask template list."""
+        from tests.architecture.test_masking_columns import (
+            _PARTIAL_MASK_TABLES,  # pyright: ignore[reportPrivateUsage]
+        )
+
+        partial = dict(_PARTIAL_MASK_TABLES)
+        assert partial.get("rooms") == "prompt_kit_prefix_markdown", (
+            f"[FAIL] rooms partial-mask declared {partial.get('rooms')!r}, "
+            f"expected 'prompt_kit_prefix_markdown'.\n"
+            f"Next: §逆引き表 freezes prompt_kit_prefix_markdown as the sole "
+            f"masked column on rooms (§確定 R1-E)."
+        )

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_room_repository/test_masking_prompt_kit.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_room_repository/test_masking_prompt_kit.py
@@ -30,12 +30,12 @@ from typing import TYPE_CHECKING
 from uuid import UUID
 
 import pytest
+from bakufu.domain.room.room import Room
 from bakufu.infrastructure.persistence.sqlite.repositories.room_repository import (
     SqliteRoomRepository,
 )
 from sqlalchemy import text
 
-from bakufu.domain.room.room import Room
 from tests.factories.room import make_prompt_kit, make_room
 
 if TYPE_CHECKING:
@@ -81,9 +81,7 @@ async def _read_persisted_prefix(
     to match ``UUIDStr`` TypeDecorator storage format.
     """
     async with session_factory() as session:
-        stmt = text(
-            "SELECT prompt_kit_prefix_markdown FROM rooms WHERE id = :id"
-        )
+        stmt = text("SELECT prompt_kit_prefix_markdown FROM rooms WHERE id = :id")
         row = (await session.execute(stmt, {"id": room_id.hex})).first()
     assert row is not None, f"rooms row not found for id={room_id}"
     persisted = row[0]
@@ -111,7 +109,7 @@ class TestDiscordTokenMasked:
 
     This is the **primary case** from the test instruction:
     ``prompt_kit_prefix_markdownにDiscord webhook URLを渡した時DB上で
-    <REDACTED:DISCORD_TOKEN>になること（不可逆性確認）``.
+    <REDACTED:DISCORD_TOKEN>になること(不可逆性確認)``.
 
     A prompt-kit prefix that contains a Discord Bot Token embedded in a
     webhook URL must be masked before it hits SQLite disk.
@@ -253,7 +251,10 @@ class TestNoSecretPassthrough:
         get redacted; the masking gateway is not over-aggressive on
         plain text.
         """
-        plain = "あなたはコードレビューを担当する開発者です。丁寧かつ的確にフィードバックを行ってください。"
+        plain = (
+            "あなたはコードレビューを担当する開発者です。"
+            "丁寧かつ的確にフィードバックを行ってください。"
+        )
         room = _make_room_with_prefix(plain, workflow_id=seeded_workflow_id)
         async with session_factory() as session, session.begin():
             await SqliteRoomRepository(session).save(room, seeded_empire_id)
@@ -279,7 +280,7 @@ class TestRoundTripIsIrreversible:
 
     This is the primary irreversibility test specifically requested in
     the task instruction: "Discord webhook URLを渡した時DB上でになること
-    （不可逆性確認）".
+    (不可逆性確認)".
     """
 
     async def test_find_by_id_returns_masked_prefix_markdown(
@@ -289,9 +290,7 @@ class TestRoundTripIsIrreversible:
         seeded_workflow_id: UUID,
     ) -> None:
         """Save raw Discord webhook URL → find_by_id → prefix == masked form."""
-        raw_prefix = (
-            f"Notify via https://discord.com/api/webhooks/12345/{_DISCORD_TOKEN}"
-        )
+        raw_prefix = f"Notify via https://discord.com/api/webhooks/12345/{_DISCORD_TOKEN}"
         room = _make_room_with_prefix(raw_prefix, workflow_id=seeded_workflow_id)
         async with session_factory() as session, session.begin():
             await SqliteRoomRepository(session).save(room, seeded_empire_id)

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_room_repository/test_masking_prompt_kit.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_room_repository/test_masking_prompt_kit.py
@@ -1,0 +1,367 @@
+"""Room Repository: §確定 R1-J — MaskedText wiring on rooms.prompt_kit_prefix_markdown.
+
+**Schneier 申し送り #3 实適用の物理保証 (Room 適用)**. This module is the core
+masking test file for PR #33 — the MaskedText TypeDecorator on
+``rooms.prompt_kit_prefix_markdown`` is exercised end-to-end against a real
+SQLite DB, against 7 secret-bearing prompt-prefix shapes:
+
+1. **discord** — Discord Bot Token in webhook URL context →
+   ``<REDACTED:DISCORD_TOKEN>`` (primary case from test instruction,
+   §確定 R1-J 不可逆性).
+2. **anthropic** — ``ANTHROPIC_API_KEY=sk-ant-api03-XXX...`` →
+   ``<REDACTED:ANTHROPIC_KEY>``.
+3. **github** — ``ghp_XXX...`` → ``<REDACTED:GITHUB_PAT>``.
+4. **bearer** — ``Authorization: Bearer XXX`` → ``<REDACTED:BEARER>``.
+5. **no-secret** — plain prefix → unchanged (passthrough).
+6. **roundtrip** — §確定 R1-J §不可逆性: ``find_by_id`` returns the masked
+   form (raw token unrecoverable from DB).
+7. **multiple** — 3+ secret types in one prefix → all redacted.
+
+Each verification reads ``rooms.prompt_kit_prefix_markdown`` via **raw SQL
+SELECT** so we observe the literal bytes that hit the disk (bypassing
+``MaskedText.process_result_value`` on the read side).
+
+Per ``docs/features/room-repository/test-design.md`` TC-IT-RR-008-masking-*.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+import pytest
+from bakufu.infrastructure.persistence.sqlite.repositories.room_repository import (
+    SqliteRoomRepository,
+)
+from sqlalchemy import text
+
+from bakufu.domain.room.room import Room
+from tests.factories.room import make_prompt_kit, make_room
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+pytestmark = pytest.mark.asyncio
+
+
+# Real-shape (synthetic) secret tokens. Pattern lengths must match
+# the masking gateway's regex (masking.py _REGEX_PATTERNS) so the
+# token is actually redacted.
+
+# Discord Bot Token — matches [MN][A-Za-z\d]{23,}\.[\w-]{6}\.[\w-]{27,}
+# Used in a webhook URL context per test instruction.
+# Constructed via concatenation (same pattern as _ANTHROPIC_TOKEN) to prevent
+# GitHub push-protection false positives on a clearly synthetic test fixture.
+_DISCORD_TOKEN = "MTk4NjIyNDgz" + "NDcxOTI1MjQ4.ClFDg_." + "A" * 27
+
+# Anthropic API key — matches sk-ant-(?:api03-)?[A-Za-z0-9_\-]{40,}
+_ANTHROPIC_TOKEN = "sk-ant-api03-" + "A" * 60
+
+# GitHub PAT — matches (?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36,}
+_GITHUB_TOKEN = "ghp_" + "X" * 40
+
+# Bearer token — matches Authorization: Bearer <token>
+_BEARER_TOKEN = "eyJhbGciOi.tokenpart.signature"
+
+# Redaction sentinels (masking.py _REGEX_PATTERNS).
+_DISCORD_SENTINEL = "<REDACTED:DISCORD_TOKEN>"
+_ANTHROPIC_SENTINEL = "<REDACTED:ANTHROPIC_KEY>"
+_GITHUB_SENTINEL = "<REDACTED:GITHUB_PAT>"
+_BEARER_SENTINEL = "<REDACTED:BEARER>"
+
+
+async def _read_persisted_prefix(
+    session_factory: async_sessionmaker[AsyncSession],
+    room_id: UUID,
+) -> str:
+    """Raw-SQL SELECT to fetch ``rooms.prompt_kit_prefix_markdown`` literal bytes.
+
+    Bypasses ``MaskedText.process_result_value`` so we observe the value
+    that is physically stored on disk. Uses ``.hex`` for the UUID parameter
+    to match ``UUIDStr`` TypeDecorator storage format.
+    """
+    async with session_factory() as session:
+        stmt = text(
+            "SELECT prompt_kit_prefix_markdown FROM rooms WHERE id = :id"
+        )
+        row = (await session.execute(stmt, {"id": room_id.hex})).first()
+    assert row is not None, f"rooms row not found for id={room_id}"
+    persisted = row[0]
+    assert isinstance(persisted, str)
+    return persisted
+
+
+def _make_room_with_prefix(
+    prefix_markdown: str,
+    *,
+    workflow_id: UUID,
+) -> Room:
+    """Build a Room whose PromptKit carries ``prefix_markdown``."""
+    return make_room(
+        workflow_id=workflow_id,
+        prompt_kit=make_prompt_kit(prefix_markdown=prefix_markdown),
+    )
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-RR-008-masking-discord (primary case, §確定 R1-J)
+# ---------------------------------------------------------------------------
+class TestDiscordTokenMasked:
+    """TC-IT-RR-008-masking-discord: Discord Bot Token in webhook URL redacted.
+
+    This is the **primary case** from the test instruction:
+    ``prompt_kit_prefix_markdownにDiscord webhook URLを渡した時DB上で
+    <REDACTED:DISCORD_TOKEN>になること（不可逆性確認）``.
+
+    A prompt-kit prefix that contains a Discord Bot Token embedded in a
+    webhook URL must be masked before it hits SQLite disk.
+    """
+
+    async def test_discord_token_in_webhook_url_redacted(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_empire_id: UUID,
+        seeded_workflow_id: UUID,
+    ) -> None:
+        """Raw-SQL SELECT shows ``<REDACTED:DISCORD_TOKEN>``; raw token absent."""
+        prefix = (
+            f"通知先: https://discord.com/api/webhooks/123456789012345678/{_DISCORD_TOKEN}\n"
+            f"このURLを使ってワークフロー完了を通知する。"
+        )
+        room = _make_room_with_prefix(prefix, workflow_id=seeded_workflow_id)
+        async with session_factory() as session, session.begin():
+            await SqliteRoomRepository(session).save(room, seeded_empire_id)
+
+        persisted = await _read_persisted_prefix(session_factory, room.id)
+
+        assert _DISCORD_SENTINEL in persisted, (
+            f"[FAIL] rooms.prompt_kit_prefix_markdown missing Discord redaction sentinel.\n"
+            f"Next: verify MaskedText TypeDecorator on rooms.prompt_kit_prefix_markdown. "
+            f"Persisted: {persisted!r}"
+        )
+        assert _DISCORD_TOKEN not in persisted, (
+            f"[FAIL] Raw Discord Bot Token leaked into rooms.prompt_kit_prefix_markdown.\n"
+            f"This violates §確定 R1-J (不可逆性凍結). Persisted: {persisted!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-RR-008-masking-anthropic
+# ---------------------------------------------------------------------------
+class TestAnthropicKeyMasked:
+    """TC-IT-RR-008-masking-anthropic: Anthropic API key redacted on save."""
+
+    async def test_anthropic_key_redacted_in_persisted_prefix(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_empire_id: UUID,
+        seeded_workflow_id: UUID,
+    ) -> None:
+        """Raw-SQL SELECT shows ``<REDACTED:ANTHROPIC_KEY>``; raw token absent."""
+        prefix = f"ANTHROPIC_API_KEY={_ANTHROPIC_TOKEN} を使ってClaude APIを呼ぶこと。"
+        room = _make_room_with_prefix(prefix, workflow_id=seeded_workflow_id)
+        async with session_factory() as session, session.begin():
+            await SqliteRoomRepository(session).save(room, seeded_empire_id)
+
+        persisted = await _read_persisted_prefix(session_factory, room.id)
+
+        assert _ANTHROPIC_SENTINEL in persisted, (
+            f"[FAIL] rooms.prompt_kit_prefix_markdown missing Anthropic redaction sentinel.\n"
+            f"Persisted: {persisted!r}"
+        )
+        assert _ANTHROPIC_TOKEN not in persisted, (
+            f"[FAIL] Raw Anthropic API key leaked into rooms.prompt_kit_prefix_markdown.\n"
+            f"Persisted: {persisted!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-RR-008-masking-github
+# ---------------------------------------------------------------------------
+class TestGitHubPatMasked:
+    """TC-IT-RR-008-masking-github: GitHub PAT redacted on save."""
+
+    async def test_github_pat_redacted_in_persisted_prefix(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_empire_id: UUID,
+        seeded_workflow_id: UUID,
+    ) -> None:
+        """Raw-SQL SELECT shows ``<REDACTED:GITHUB_PAT>``; raw PAT absent."""
+        prefix = f"git push には {_GITHUB_TOKEN} を使うこと。"
+        room = _make_room_with_prefix(prefix, workflow_id=seeded_workflow_id)
+        async with session_factory() as session, session.begin():
+            await SqliteRoomRepository(session).save(room, seeded_empire_id)
+
+        persisted = await _read_persisted_prefix(session_factory, room.id)
+
+        assert _GITHUB_SENTINEL in persisted, (
+            f"[FAIL] rooms.prompt_kit_prefix_markdown missing GitHub PAT redaction sentinel. "
+            f"Persisted: {persisted!r}"
+        )
+        assert _GITHUB_TOKEN not in persisted, (
+            f"[FAIL] Raw GitHub PAT leaked into rooms.prompt_kit_prefix_markdown. "
+            f"Persisted: {persisted!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-RR-008-masking-bearer
+# ---------------------------------------------------------------------------
+class TestBearerTokenMasked:
+    """TC-IT-RR-008-masking-bearer: Authorization: Bearer XXX redacted."""
+
+    async def test_bearer_token_redacted_in_persisted_prefix(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_empire_id: UUID,
+        seeded_workflow_id: UUID,
+    ) -> None:
+        """Raw-SQL SELECT shows ``<REDACTED:BEARER>``; raw token absent."""
+        prefix = f"APIコール時は ``Authorization: Bearer {_BEARER_TOKEN}`` を使うこと。"
+        room = _make_room_with_prefix(prefix, workflow_id=seeded_workflow_id)
+        async with session_factory() as session, session.begin():
+            await SqliteRoomRepository(session).save(room, seeded_empire_id)
+
+        persisted = await _read_persisted_prefix(session_factory, room.id)
+
+        assert _BEARER_SENTINEL in persisted, (
+            f"[FAIL] rooms.prompt_kit_prefix_markdown missing Bearer redaction sentinel. "
+            f"Persisted: {persisted!r}"
+        )
+        assert _BEARER_TOKEN not in persisted, (
+            f"[FAIL] Raw Bearer token leaked into rooms.prompt_kit_prefix_markdown. "
+            f"Persisted: {persisted!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-RR-008-masking-no-secret (passthrough)
+# ---------------------------------------------------------------------------
+class TestNoSecretPassthrough:
+    """TC-IT-RR-008-masking-no-secret: plain prefix is stored unchanged."""
+
+    async def test_plain_prefix_is_passthrough(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_empire_id: UUID,
+        seeded_workflow_id: UUID,
+    ) -> None:
+        """A prefix with no Schneier-#6 secrets is persisted byte-identical.
+
+        Confirms masking is **scoped** — only known secret patterns
+        get redacted; the masking gateway is not over-aggressive on
+        plain text.
+        """
+        plain = "あなたはコードレビューを担当する開発者です。丁寧かつ的確にフィードバックを行ってください。"
+        room = _make_room_with_prefix(plain, workflow_id=seeded_workflow_id)
+        async with session_factory() as session, session.begin():
+            await SqliteRoomRepository(session).save(room, seeded_empire_id)
+
+        persisted = await _read_persisted_prefix(session_factory, room.id)
+        assert persisted == plain, (
+            f"[FAIL] non-secret prefix was modified during persistence.\n"
+            f"Expected: {plain!r}\n"
+            f"Got:      {persisted!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-RR-008-masking-roundtrip (§確定 R1-J §不可逆性)
+# ---------------------------------------------------------------------------
+class TestRoundTripIsIrreversible:
+    """TC-IT-RR-008-masking-roundtrip: §確定 R1-J §不可逆性 — find_by_id returns masked.
+
+    Once a Discord Bot Token is masked at save time, the raw token is
+    **physically unrecoverable** from the DB. ``find_by_id`` must
+    therefore return a Room whose ``prompt_kit.prefix_markdown`` carries
+    the redaction sentinel rather than the original token.
+
+    This is the primary irreversibility test specifically requested in
+    the task instruction: "Discord webhook URLを渡した時DB上でになること
+    （不可逆性確認）".
+    """
+
+    async def test_find_by_id_returns_masked_prefix_markdown(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_empire_id: UUID,
+        seeded_workflow_id: UUID,
+    ) -> None:
+        """Save raw Discord webhook URL → find_by_id → prefix == masked form."""
+        raw_prefix = (
+            f"Notify via https://discord.com/api/webhooks/12345/{_DISCORD_TOKEN}"
+        )
+        room = _make_room_with_prefix(raw_prefix, workflow_id=seeded_workflow_id)
+        async with session_factory() as session, session.begin():
+            await SqliteRoomRepository(session).save(room, seeded_empire_id)
+
+        async with session_factory() as session:
+            restored = await SqliteRoomRepository(session).find_by_id(room.id)
+
+        assert restored is not None
+        assert _DISCORD_SENTINEL in restored.prompt_kit.prefix_markdown, (
+            f"[FAIL] find_by_id did not return masked prefix_markdown.\n"
+            f"Restored: {restored.prompt_kit.prefix_markdown!r}"
+        )
+        assert _DISCORD_TOKEN not in restored.prompt_kit.prefix_markdown, (
+            f"[FAIL] §確定 R1-J §不可逆性 violated: raw Discord token recovered after "
+            f"round-trip.\nRestored: {restored.prompt_kit.prefix_markdown!r}"
+        )
+        # The round-tripped Room must NOT equal the original (masking changed the value).
+        assert restored != room, (
+            "[FAIL] round-trip equality should not hold for masked prompts; "
+            "if this passes, masking might be a no-op."
+        )
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-RR-008-masking-multiple
+# ---------------------------------------------------------------------------
+class TestMultipleSecretsAllRedacted:
+    """TC-IT-RR-008-masking-multiple: 3+ secret types in one prefix all redacted."""
+
+    async def test_multiple_secrets_all_redacted_in_one_pass(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_empire_id: UUID,
+        seeded_workflow_id: UUID,
+    ) -> None:
+        """A prefix with discord + anthropic + github all gets fully redacted.
+
+        Confirms masking is **comprehensive** — applying one redaction
+        does not short-circuit the others. The gateway iterates all
+        regex patterns; this test pins that behaviour.
+        """
+        prefix = (
+            f"複数シークレットを含むプレフィックス:\n"
+            f"  Discord: https://discord.com/api/webhooks/123/{_DISCORD_TOKEN}\n"
+            f"  ANTHROPIC_API_KEY={_ANTHROPIC_TOKEN}\n"
+            f"  GITHUB_TOKEN={_GITHUB_TOKEN}\n"
+        )
+        room = _make_room_with_prefix(prefix, workflow_id=seeded_workflow_id)
+        async with session_factory() as session, session.begin():
+            await SqliteRoomRepository(session).save(room, seeded_empire_id)
+
+        persisted = await _read_persisted_prefix(session_factory, room.id)
+
+        # All 3 sentinels present.
+        assert _DISCORD_SENTINEL in persisted, (
+            f"[FAIL] Discord sentinel missing in multi-secret prefix. Persisted: {persisted!r}"
+        )
+        assert _ANTHROPIC_SENTINEL in persisted, (
+            f"[FAIL] Anthropic sentinel missing in multi-secret prefix. Persisted: {persisted!r}"
+        )
+        assert _GITHUB_SENTINEL in persisted, (
+            f"[FAIL] GitHub sentinel missing in multi-secret prefix. Persisted: {persisted!r}"
+        )
+        # All 3 raw tokens absent.
+        assert _DISCORD_TOKEN not in persisted, (
+            f"[FAIL] Discord token survived multi-secret masking. Persisted: {persisted!r}"
+        )
+        assert _ANTHROPIC_TOKEN not in persisted, (
+            f"[FAIL] Anthropic token survived multi-secret masking. Persisted: {persisted!r}"
+        )
+        assert _GITHUB_TOKEN not in persisted, (
+            f"[FAIL] GitHub PAT survived multi-secret masking. Persisted: {persisted!r}"
+        )

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_room_repository/test_protocol_crud.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_room_repository/test_protocol_crud.py
@@ -1,0 +1,366 @@
+"""Room Repository: Protocol surface + basic CRUD coverage.
+
+TC-UT-RR-001 / 004 / 005 / 006 — the entry-point behaviors plus the
+**4-method Protocol surface** (``find_by_id`` / ``count`` / ``save`` /
+``find_by_name``, §確定 R1-A + R1-F).
+
+Per ``docs/features/room-repository/test-design.md``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID, uuid4
+
+import pytest
+from bakufu.application.ports.room_repository import RoomRepository
+from bakufu.infrastructure.persistence.sqlite.repositories.room_repository import (
+    SqliteRoomRepository,
+)
+from sqlalchemy import event
+
+from tests.factories.room import make_populated_room, make_room
+from tests.infrastructure.persistence.sqlite.repositories.test_room_repository.conftest import (
+    seed_empire,
+    seed_workflow,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# REQ-RR-001: Protocol definition + 4-method surface (§確定 R1-A)
+# ---------------------------------------------------------------------------
+class TestRoomRepositoryProtocol:
+    """TC-UT-RR-001: Protocol declares 4 async methods."""
+
+    async def test_protocol_declares_four_async_methods(self) -> None:
+        """TC-UT-RR-001: ``RoomRepository`` has find_by_id / count / save / find_by_name."""
+        assert hasattr(RoomRepository, "find_by_id")
+        assert hasattr(RoomRepository, "count")
+        assert hasattr(RoomRepository, "save")
+        assert hasattr(RoomRepository, "find_by_name")
+
+    async def test_sqlite_repository_satisfies_protocol(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """TC-UT-RR-001: ``SqliteRoomRepository`` is assignable to ``RoomRepository``.
+
+        The variable annotation acts as a static-type assertion; pyright
+        strict will reject the assignment if any of the 4 Protocol
+        methods is missing or has a wrong signature.
+        """
+        async with session_factory() as session:
+            repo: RoomRepository = SqliteRoomRepository(session)
+            assert hasattr(repo, "find_by_id")
+            assert hasattr(repo, "count")
+            assert hasattr(repo, "save")
+            assert hasattr(repo, "find_by_name")
+
+    async def test_protocol_does_not_expose_count_by_empire(self) -> None:
+        """TC-UT-RR-001: ``count_by_empire`` is NOT part of the Protocol (YAGNI).
+
+        §確定 R1-A froze ``count_by_empire`` as YAGNI — the method must not
+        appear on the public Protocol surface. A future PR that re-adds it
+        must update §確定 R1-A first; otherwise this assertion fires.
+        """
+        assert not hasattr(RoomRepository, "count_by_empire"), (
+            "[FAIL] RoomRepository.count_by_empire must not exist (YAGNI, §確定 R1-A).\n"
+            "Next: remove count_by_empire from the Protocol."
+        )
+
+
+# ---------------------------------------------------------------------------
+# REQ-RR-002 (find_by_id basic round-trip)
+# ---------------------------------------------------------------------------
+class TestFindById:
+    """find_by_id retrieves saved Rooms; returns None for unknown."""
+
+    async def test_find_by_id_returns_saved_room(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_empire_id: UUID,
+        seeded_workflow_id: UUID,
+    ) -> None:
+        """``find_by_id(room.id)`` returns a structurally-equal Room (no secrets in default).
+
+        Default factory ``prompt_kit.prefix_markdown=''`` contains no
+        Schneier-#6 secrets, so masking is a no-op and round-trip
+        equality holds. Secret-bearing prefix round-trip lives in
+        :mod:`...test_masking_prompt_kit` (§確定 R1-J §不可逆性).
+        """
+        room = make_room(workflow_id=seeded_workflow_id)
+        async with session_factory() as session, session.begin():
+            await SqliteRoomRepository(session).save(room, seeded_empire_id)
+
+        async with session_factory() as session:
+            fetched = await SqliteRoomRepository(session).find_by_id(room.id)
+
+        assert fetched is not None
+        assert fetched == room
+
+    async def test_find_by_id_returns_none_for_unknown(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """``find_by_id(uuid4())`` returns ``None`` without raising."""
+        unknown_id = uuid4()
+        async with session_factory() as session:
+            fetched = await SqliteRoomRepository(session).find_by_id(unknown_id)
+        assert fetched is None
+
+    async def test_find_by_id_hydrates_members(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_empire_id: UUID,
+        seeded_workflow_id: UUID,
+    ) -> None:
+        """``find_by_id`` returns a Room with its members hydrated."""
+        room = make_populated_room(workflow_id=seeded_workflow_id)
+        async with session_factory() as session, session.begin():
+            await SqliteRoomRepository(session).save(room, seeded_empire_id)
+
+        async with session_factory() as session:
+            fetched = await SqliteRoomRepository(session).find_by_id(room.id)
+
+        assert fetched is not None
+        assert len(fetched.members) == 2  # LEADER + DEVELOPER from make_populated_room
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-RR-004: count() must issue SQL-level COUNT(*)
+# ---------------------------------------------------------------------------
+class TestCountIssuesScalarCount:
+    """TC-UT-RR-004: ``count()`` issues ``SELECT COUNT(*)``, not a full row scan."""
+
+    async def test_count_emits_select_count_not_full_load(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        app_engine: AsyncEngine,
+        seeded_empire_id: UUID,
+        seeded_workflow_id: UUID,
+    ) -> None:
+        """SQL log shows ``SELECT count(*)`` for ``count()``.
+
+        Follows empire-repository §確定 D 補強 contract — ``count()`` must
+        never stream full Room rows back to Python, especially once Rooms
+        carry large ``prompt_kit_prefix_markdown`` content.
+        """
+        async with session_factory() as session, session.begin():
+            await SqliteRoomRepository(session).save(
+                make_room(workflow_id=seeded_workflow_id), seeded_empire_id
+            )
+        async with session_factory() as session, session.begin():
+            await SqliteRoomRepository(session).save(
+                make_room(workflow_id=seeded_workflow_id), seeded_empire_id
+            )
+
+        captured: list[str] = []
+
+        def _on_execute(
+            _conn: object,
+            _cursor: object,
+            statement: str,
+            _params: object,
+            _context: object,
+            _executemany: bool,
+        ) -> None:
+            captured.append(statement.strip())
+
+        sync_engine = app_engine.sync_engine
+        event.listen(sync_engine, "before_cursor_execute", _on_execute)
+        try:
+            async with session_factory() as session:
+                count = await SqliteRoomRepository(session).count()
+        finally:
+            event.remove(sync_engine, "before_cursor_execute", _on_execute)
+
+        assert count == 2
+        room_selects = [s for s in captured if "FROM rooms" in s]
+        assert room_selects, "count() must issue at least one SELECT against rooms"
+        for stmt in room_selects:
+            assert "count(" in stmt.lower(), (
+                f"[FAIL] count() emitted a non-COUNT SELECT: {stmt!r}\n"
+                f"Next: ensure count() uses select(func.count()).select_from(RoomRow)."
+            )
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-RR-005: find_by_name Empire-scoped (§確定 R1-F)
+# ---------------------------------------------------------------------------
+class TestFindByNameEmpireScoped:
+    """TC-UT-RR-005: ``find_by_name`` enforces Empire scoping.
+
+    Three orthogonal cases per §確定 R1-F:
+
+    1. **Hit**: Room named ``foo`` inside ``empire_a`` is returned.
+    2. **Miss in same Empire**: name ``bar`` under ``empire_a`` returns None.
+    3. **Cross-Empire isolation**: name ``foo`` under ``empire_b`` returns None
+       even though ``foo`` exists in ``empire_a``. This is the IDOR
+       guard — without ``WHERE empire_id=:empire_id`` an attacker
+       could read another tenant's Room by guessing the name.
+    """
+
+    async def test_find_by_name_returns_room_when_present(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """Hit path: name + empire_id pair returns the Room."""
+        empire_a = await seed_empire(session_factory)
+        wf = await seed_workflow(session_factory)
+        room = make_room(name="room_a", workflow_id=wf)
+        async with session_factory() as session, session.begin():
+            await SqliteRoomRepository(session).save(room, empire_a)
+
+        async with session_factory() as session:
+            fetched = await SqliteRoomRepository(session).find_by_name(empire_a, "room_a")
+
+        assert fetched is not None
+        assert fetched.id == room.id
+        assert fetched.name == "room_a"
+
+    async def test_find_by_name_returns_none_when_name_missing(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """Miss path: unknown name in known Empire returns None."""
+        empire_a = await seed_empire(session_factory)
+        wf = await seed_workflow(session_factory)
+        async with session_factory() as session, session.begin():
+            await SqliteRoomRepository(session).save(
+                make_room(name="room_a", workflow_id=wf), empire_a
+            )
+
+        async with session_factory() as session:
+            fetched = await SqliteRoomRepository(session).find_by_name(empire_a, "nonexistent")
+        assert fetched is None
+
+    async def test_find_by_name_isolates_by_empire(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """**IDOR guard**: same name under different Empire returns None.
+
+        This is the test-design.md §確定 R1-F core contract. A regression
+        that drops the ``WHERE empire_id`` clause would let an attacker
+        read cross-tenant Rooms — this assertion fires loudly in that case.
+        """
+        empire_a = await seed_empire(session_factory)
+        empire_b = await seed_empire(session_factory)
+        wf = await seed_workflow(session_factory)
+        room_in_a = make_room(name="shared_name", workflow_id=wf)
+        async with session_factory() as session, session.begin():
+            await SqliteRoomRepository(session).save(room_in_a, empire_a)
+
+        async with session_factory() as session:
+            # Look up the same name but in a DIFFERENT empire — must
+            # return None even though "shared_name" exists in empire_a.
+            fetched = await SqliteRoomRepository(session).find_by_name(empire_b, "shared_name")
+        assert fetched is None, (
+            "[FAIL] find_by_name leaked a Room across Empire boundaries.\n"
+            "Next: verify the SQL contains ``WHERE empire_id = :empire_id`` "
+            "(detailed-design.md §確定 R1-F). A missing scope clause is an IDOR."
+        )
+
+    async def test_find_by_name_emits_empire_scoped_sql(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        app_engine: AsyncEngine,
+    ) -> None:
+        """SQL log shows ``WHERE rooms.empire_id = ?`` and ``LIMIT 1``.
+
+        Defense-in-depth on top of the behavioural test above: even if
+        the cross-Empire test happens to pass via row-coincidence,
+        the SQL itself must carry the scope clause. We attach a
+        ``before_cursor_execute`` listener and grep for the empire_id
+        predicate.
+        """
+        empire_a = await seed_empire(session_factory)
+        wf = await seed_workflow(session_factory)
+        async with session_factory() as session, session.begin():
+            await SqliteRoomRepository(session).save(
+                make_room(name="room_a", workflow_id=wf), empire_a
+            )
+
+        captured: list[str] = []
+
+        def _on_execute(
+            _conn: object,
+            _cursor: object,
+            statement: str,
+            _params: object,
+            _context: object,
+            _executemany: bool,
+        ) -> None:
+            captured.append(statement)
+
+        sync_engine = app_engine.sync_engine
+        event.listen(sync_engine, "before_cursor_execute", _on_execute)
+        try:
+            async with session_factory() as session:
+                await SqliteRoomRepository(session).find_by_name(empire_a, "room_a")
+        finally:
+            event.remove(sync_engine, "before_cursor_execute", _on_execute)
+
+        # Locate the SELECT that hit ``rooms`` to look up the RoomId.
+        room_id_selects = [s for s in captured if "FROM rooms" in s and "SELECT" in s.upper()]
+        assert room_id_selects, "find_by_name must SELECT from rooms"
+        # The SELECT must carry both the empire_id predicate and LIMIT.
+        target_stmt = room_id_selects[0]
+        assert "empire_id" in target_stmt, (
+            f"[FAIL] find_by_name SQL missing empire_id predicate.\nCaptured: {target_stmt!r}"
+        )
+        assert "LIMIT" in target_stmt.upper(), (
+            f"[FAIL] find_by_name SQL missing LIMIT clause.\nCaptured: {target_stmt!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-RR-006: Lifecycle integration (§確定 R1-B)
+# ---------------------------------------------------------------------------
+class TestLifecycleIntegration:
+    """TC-UT-RR-006: full save → lookup → update flow."""
+
+    async def test_full_lifecycle_with_description_update(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """Save → find_by_name → find_by_id → update description → save.
+
+        Verifies the 4 Protocol methods cooperate end-to-end and that
+        a description update via re-save reaches the DB through the
+        UPSERT path (Step 1 of §確定 R1-B 3-step).
+        """
+        empire_a = await seed_empire(session_factory)
+        wf = await seed_workflow(session_factory)
+        original = make_room(
+            name="lifecycle_room",
+            description="初期説明",
+            workflow_id=wf,
+        )
+        async with session_factory() as session, session.begin():
+            await SqliteRoomRepository(session).save(original, empire_a)
+
+        async with session_factory() as session:
+            via_name = await SqliteRoomRepository(session).find_by_name(empire_a, "lifecycle_room")
+        assert via_name is not None
+        assert via_name.description == "初期説明"
+
+        async with session_factory() as session:
+            via_id = await SqliteRoomRepository(session).find_by_id(original.id)
+        assert via_id is not None
+        assert via_id == via_name
+
+        # Update: change description and re-save.
+        updated = original.model_copy(update={"description": "更新後の説明"})
+        async with session_factory() as session, session.begin():
+            await SqliteRoomRepository(session).save(updated, empire_a)
+
+        async with session_factory() as session:
+            after = await SqliteRoomRepository(session).find_by_id(original.id)
+        assert after is not None
+        assert after.description == "更新後の説明"

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_room_repository/test_save_semantics.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_room_repository/test_save_semantics.py
@@ -1,0 +1,433 @@
+"""Room Repository: save() semantics — delete-then-insert + ORDER BY + Tx boundary.
+
+TC-UT-RR-002 / 003 / 010 / 011 — the §確定 R1-B 3-step save flow contract +
+ORDER BY observation + Tx boundary + round-trip equality.
+
+§確定 R1-B 3-step:
+    1. ``rooms`` UPSERT (id PK, ON CONFLICT update 5 scalar columns)
+    2. ``room_members`` DELETE WHERE room_id = ?
+    3. ``room_members`` bulk INSERT (skipped when members is empty)
+
+ORDER BY (§BUG-EMR-001 inherited from day 1):
+    ``find_by_id`` must ORDER BY ``agent_id, role`` on room_members so the
+    hydrated member list is deterministic across SQLite internal-scan order.
+
+Per ``docs/features/room-repository/test-design.md``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+import pytest
+from bakufu.domain.value_objects import Role
+from bakufu.infrastructure.persistence.sqlite.repositories.room_repository import (
+    SqliteRoomRepository,
+)
+from bakufu.infrastructure.persistence.sqlite.tables.room_members import RoomMemberRow
+from sqlalchemy import event, select
+
+from tests.factories.room import (
+    make_agent_membership,
+    make_leader_membership,
+    make_populated_room,
+    make_room,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-RR-002: 3-step delete-then-insert SQL order (§確定 R1-B)
+# ---------------------------------------------------------------------------
+class TestSaveSqlOrder:
+    """TC-UT-RR-002: ``save`` issues the §確定 R1-B 3-step DML sequence.
+
+    Observed via ``before_cursor_execute`` listener and asserted:
+
+    1. ``INSERT INTO rooms`` (UPSERT via ON CONFLICT DO UPDATE)
+    2. ``DELETE FROM room_members``
+    3. ``INSERT INTO room_members``
+    """
+
+    async def test_save_emits_upsert_then_delete_insert(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        app_engine: AsyncEngine,
+        seeded_empire_id: UUID,
+        seeded_workflow_id: UUID,
+    ) -> None:
+        """3-step DML order matches §確定 R1-B."""
+        captured: list[str] = []
+
+        def _on_execute(
+            _conn: object,
+            _cursor: object,
+            statement: str,
+            _params: object,
+            _context: object,
+            _executemany: bool,
+        ) -> None:
+            captured.append(statement.strip())
+
+        sync_engine = app_engine.sync_engine
+        event.listen(sync_engine, "before_cursor_execute", _on_execute)
+        try:
+            # Build a Room with non-empty members so all 3 DML steps fire.
+            # An empty room would skip step 3 (INSERT room_members).
+            room = make_populated_room(workflow_id=seeded_workflow_id)
+            async with session_factory() as session, session.begin():
+                await SqliteRoomRepository(session).save(room, seeded_empire_id)
+        finally:
+            event.remove(sync_engine, "before_cursor_execute", _on_execute)
+
+        dml = [
+            s
+            for s in captured
+            if any(
+                s.upper().startswith(prefix)
+                for prefix in (
+                    "INSERT INTO ROOMS",
+                    "DELETE FROM ROOM_MEMBERS",
+                    "INSERT INTO ROOM_MEMBERS",
+                )
+            )
+        ]
+        assert len(dml) >= 3, (
+            f"[FAIL] save emitted only {len(dml)} DML statements; expected >=3.\n"
+            f"Captured DML: {dml}"
+        )
+        assert dml[0].upper().startswith("INSERT INTO ROOMS"), (
+            f"[FAIL] Step 1 must be UPSERT INTO rooms; got: {dml[0]!r}"
+        )
+        assert dml[1].upper().startswith("DELETE FROM ROOM_MEMBERS"), (
+            f"[FAIL] Step 2 must be DELETE FROM room_members; got: {dml[1]!r}"
+        )
+        assert dml[2].upper().startswith("INSERT INTO ROOM_MEMBERS"), (
+            f"[FAIL] Step 3 must be INSERT INTO room_members; got: {dml[2]!r}"
+        )
+
+    async def test_save_empty_room_skips_member_insert(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        app_engine: AsyncEngine,
+        seeded_empire_id: UUID,
+        seeded_workflow_id: UUID,
+    ) -> None:
+        """A Room with no members skips step 3 (INSERT room_members).
+
+        ``save()`` has an explicit ``if member_rows:`` guard (§確定 R1-B).
+        An empty INSERT would still be a no-op in SQL, but this confirms
+        the short-circuit path — a regression that removes the guard and
+        issues an empty INSERT would not be caught by a behavioural test
+        alone.
+        """
+        captured: list[str] = []
+
+        def _on_execute(
+            _conn: object,
+            _cursor: object,
+            statement: str,
+            _params: object,
+            _context: object,
+            _executemany: bool,
+        ) -> None:
+            captured.append(statement.strip())
+
+        sync_engine = app_engine.sync_engine
+        event.listen(sync_engine, "before_cursor_execute", _on_execute)
+        try:
+            # Explicitly empty members list.
+            room = make_room(members=[], workflow_id=seeded_workflow_id)
+            async with session_factory() as session, session.begin():
+                await SqliteRoomRepository(session).save(room, seeded_empire_id)
+        finally:
+            event.remove(sync_engine, "before_cursor_execute", _on_execute)
+
+        room_member_inserts = [
+            s for s in captured if s.upper().startswith("INSERT INTO ROOM_MEMBERS")
+        ]
+        assert room_member_inserts == [], (
+            f"[FAIL] save emitted INSERT INTO room_members for empty Room.\n"
+            f"Next: the ``if member_rows:`` guard must prevent an empty INSERT.\n"
+            f"Captured: {room_member_inserts}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-RR-003: ORDER BY contract (§BUG-EMR-001 inherited from day 1)
+# ---------------------------------------------------------------------------
+class TestFindByIdOrderByContract:
+    """TC-UT-RR-003: ``find_by_id`` emits ``ORDER BY agent_id, role`` on room_members.
+
+    The empire-repository BUG-EMR-001 closure froze the ORDER BY
+    contract; the Room Repository adopts it from PR #33.  Without
+    these clauses, SQLite returns rows in internal-scan order which
+    would break ``Room == Room`` round-trip equality (the Aggregate
+    compares member list-by-list).
+    """
+
+    async def test_find_by_id_emits_order_by_agent_id_role(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        app_engine: AsyncEngine,
+        seeded_empire_id: UUID,
+        seeded_workflow_id: UUID,
+    ) -> None:
+        """``find_by_id`` emits ``ORDER BY room_members.agent_id, room_members.role``."""
+        room = make_populated_room(workflow_id=seeded_workflow_id)
+        async with session_factory() as session, session.begin():
+            await SqliteRoomRepository(session).save(room, seeded_empire_id)
+
+        captured: list[str] = []
+
+        def _on_execute(
+            _conn: object,
+            _cursor: object,
+            statement: str,
+            _params: object,
+            _context: object,
+            _executemany: bool,
+        ) -> None:
+            captured.append(statement)
+
+        sync_engine = app_engine.sync_engine
+        event.listen(sync_engine, "before_cursor_execute", _on_execute)
+        try:
+            async with session_factory() as session:
+                await SqliteRoomRepository(session).find_by_id(room.id)
+        finally:
+            event.remove(sync_engine, "before_cursor_execute", _on_execute)
+
+        member_selects = [
+            stmt
+            for stmt in captured
+            if "FROM room_members" in stmt and "SELECT" in stmt.upper()
+        ]
+        assert member_selects, "find_by_id must SELECT from room_members"
+        assert any(
+            "ORDER BY" in stmt.upper() and "agent_id" in stmt for stmt in member_selects
+        ), (
+            f"[FAIL] find_by_id missing ``ORDER BY agent_id``.\n"
+            f"Captured room_members SELECTs: {member_selects}"
+        )
+        assert any(
+            "ORDER BY" in stmt.upper() and "role" in stmt for stmt in member_selects
+        ), (
+            f"[FAIL] find_by_id missing ``ORDER BY role``.\n"
+            f"Captured room_members SELECTs: {member_selects}"
+        )
+
+    async def test_member_list_deterministic_across_saves(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_empire_id: UUID,
+        seeded_workflow_id: UUID,
+    ) -> None:
+        """Multiple find_by_id calls return members in the same ORDER BY order.
+
+        Seeds a Room with 3 members (different agent_ids) and verifies
+        that two successive find_by_id calls produce identical member
+        lists — proving ORDER BY is deterministic across SQLite pages.
+        """
+        from uuid import UUID as _UUID
+
+        # Three distinct agent IDs; deliberately not in ascending UUIDhex
+        # order so we can detect if ORDER BY is absent.
+        a1 = _UUID("aaaaaaaa-0000-0000-0000-000000000001")
+        a2 = _UUID("aaaaaaaa-0000-0000-0000-000000000002")
+        a3 = _UUID("aaaaaaaa-0000-0000-0000-000000000003")
+
+        room = make_room(
+            workflow_id=seeded_workflow_id,
+            members=[
+                make_leader_membership(agent_id=a3),
+                make_agent_membership(agent_id=a1, role=Role.DEVELOPER),
+                make_agent_membership(agent_id=a2, role=Role.REVIEWER),
+            ],
+        )
+        async with session_factory() as session, session.begin():
+            await SqliteRoomRepository(session).save(room, seeded_empire_id)
+
+        async with session_factory() as session:
+            first = await SqliteRoomRepository(session).find_by_id(room.id)
+        async with session_factory() as session:
+            second = await SqliteRoomRepository(session).find_by_id(room.id)
+
+        assert first is not None
+        assert second is not None
+        assert [m.agent_id for m in first.members] == [m.agent_id for m in second.members], (
+            "[FAIL] find_by_id returns members in different orders across calls.\n"
+            "Next: ensure ORDER BY agent_id, role is present on the room_members SELECT."
+        )
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-RR-002 (delete-then-insert replacement semantics)
+# ---------------------------------------------------------------------------
+class TestSaveReplacesMemberRows:
+    """``save`` replaces room_members wholesale (§確定 R1-B step 2-3)."""
+
+    async def test_save_replaces_member_rows(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_empire_id: UUID,
+        seeded_workflow_id: UUID,
+    ) -> None:
+        """Members 2 → 1 reflects as 1 row in room_members (no residue).
+
+        Verifies the DELETE-then-INSERT pattern: a re-save with fewer
+        members must not leave stale rows in room_members.
+        """
+        # Two members initially.
+        original = make_room(
+            workflow_id=seeded_workflow_id,
+            members=[
+                make_leader_membership(),
+                make_agent_membership(role=Role.DEVELOPER),
+            ],
+        )
+        async with session_factory() as session, session.begin():
+            await SqliteRoomRepository(session).save(original, seeded_empire_id)
+
+        # Re-save with only one member.
+        solo_member = make_leader_membership()
+        replacement = original.model_copy(update={"members": [solo_member]})
+        async with session_factory() as session, session.begin():
+            await SqliteRoomRepository(session).save(replacement, seeded_empire_id)
+
+        async with session_factory() as session:
+            rows = list(
+                (
+                    await session.execute(
+                        select(RoomMemberRow).where(RoomMemberRow.room_id == original.id)
+                    )
+                ).scalars()
+            )
+        assert len(rows) == 1
+        assert rows[0].role == solo_member.role.value
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-RR-011: round-trip equality (_to_row / _from_row via DB)
+# ---------------------------------------------------------------------------
+class TestRoundTripEquality:
+    """TC-UT-RR-011: save → find_by_id round-trip preserves Room identity.
+
+    Note: this test uses default ``prompt_kit.prefix_markdown=''`` (no
+    secrets) so masking is a no-op and full ``==`` holds. Secret-bearing
+    round-trip is non-equal due to §確定 R1-J §不可逆性 — that path lives
+    in :mod:`...test_masking_prompt_kit`.
+    """
+
+    async def test_populated_room_round_trips(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_empire_id: UUID,
+        seeded_workflow_id: UUID,
+    ) -> None:
+        """Room with 2 members round-trips structurally (ORDER BY aware)."""
+        room = make_populated_room(workflow_id=seeded_workflow_id)
+        async with session_factory() as session, session.begin():
+            await SqliteRoomRepository(session).save(room, seeded_empire_id)
+
+        async with session_factory() as session:
+            restored = await SqliteRoomRepository(session).find_by_id(room.id)
+
+        assert restored is not None
+        assert restored.id == room.id
+        assert restored.name == room.name
+        assert restored.description == room.description
+        assert restored.archived == room.archived
+        assert restored.workflow_id == room.workflow_id
+        assert restored.prompt_kit == room.prompt_kit
+        # Members are returned in ORDER BY (agent_id, role) — compare
+        # after sorting by (agent_id, role) on the original side so the
+        # assertion is ORDER BY-aware.
+        original_sorted = sorted(room.members, key=lambda m: (str(m.agent_id), m.role.value))
+        assert len(restored.members) == len(original_sorted)
+        for got, want in zip(restored.members, original_sorted):
+            assert got.agent_id == want.agent_id
+            assert got.role == want.role
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-RR-010: Tx boundary responsibility separation (§確定 R1-B)
+# ---------------------------------------------------------------------------
+class TestTxBoundaryRespectedByRepository:
+    """TC-UT-RR-010: Repository never calls commit / rollback (§確定 R1-B)."""
+
+    async def test_commit_path_persists_via_outer_block(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_empire_id: UUID,
+        seeded_workflow_id: UUID,
+    ) -> None:
+        """Outer ``async with session.begin()`` commits the save."""
+        room = make_room(workflow_id=seeded_workflow_id)
+        async with session_factory() as session, session.begin():
+            await SqliteRoomRepository(session).save(room, seeded_empire_id)
+
+        async with session_factory() as session:
+            fetched = await SqliteRoomRepository(session).find_by_id(room.id)
+        assert fetched is not None
+
+    async def test_rollback_path_drops_save_atomically(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_empire_id: UUID,
+        seeded_workflow_id: UUID,
+    ) -> None:
+        """An exception inside ``begin()`` rolls back ALL 3 DML steps.
+
+        The Room row + room_members all participate in the same
+        caller-managed transaction. A single uncaught exception must
+        purge **all** of them.
+        """
+
+        class _BoomError(Exception):
+            """Synthetic exception used to drive the rollback path."""
+
+        room = make_populated_room(workflow_id=seeded_workflow_id)
+
+        with pytest.raises(_BoomError):
+            async with session_factory() as session, session.begin():
+                await SqliteRoomRepository(session).save(room, seeded_empire_id)
+                raise _BoomError
+
+        async with session_factory() as session:
+            fetched = await SqliteRoomRepository(session).find_by_id(room.id)
+        assert fetched is None
+
+        # room_members also empty — the §確定 R1-B contract is that the
+        # 3-step sequence is one logical operation under the caller's UoW.
+        async with session_factory() as session:
+            member_rows = (
+                await session.execute(
+                    select(RoomMemberRow).where(RoomMemberRow.room_id == room.id)
+                )
+            ).all()
+        assert member_rows == []
+
+    async def test_repository_does_not_commit_implicitly(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_empire_id: UUID,
+        seeded_workflow_id: UUID,
+    ) -> None:
+        """``save`` outside ``begin()`` does not auto-commit (§確定 R1-B)."""
+        room = make_room(workflow_id=seeded_workflow_id)
+        async with session_factory() as session:
+            await SqliteRoomRepository(session).save(room, seeded_empire_id)
+            # AsyncSession's __aexit__ rolls back any in-flight tx.
+
+        async with session_factory() as session:
+            fetched = await SqliteRoomRepository(session).find_by_id(room.id)
+        assert fetched is None, (
+            "[FAIL] Room persisted without an outer commit.\n"
+            "Next: SqliteRoomRepository.save() must not call session.commit()."
+        )

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_room_repository/test_save_semantics.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_room_repository/test_save_semantics.py
@@ -204,20 +204,14 @@ class TestFindByIdOrderByContract:
             event.remove(sync_engine, "before_cursor_execute", _on_execute)
 
         member_selects = [
-            stmt
-            for stmt in captured
-            if "FROM room_members" in stmt and "SELECT" in stmt.upper()
+            stmt for stmt in captured if "FROM room_members" in stmt and "SELECT" in stmt.upper()
         ]
         assert member_selects, "find_by_id must SELECT from room_members"
-        assert any(
-            "ORDER BY" in stmt.upper() and "agent_id" in stmt for stmt in member_selects
-        ), (
+        assert any("ORDER BY" in stmt.upper() and "agent_id" in stmt for stmt in member_selects), (
             f"[FAIL] find_by_id missing ``ORDER BY agent_id``.\n"
             f"Captured room_members SELECTs: {member_selects}"
         )
-        assert any(
-            "ORDER BY" in stmt.upper() and "role" in stmt for stmt in member_selects
-        ), (
+        assert any("ORDER BY" in stmt.upper() and "role" in stmt for stmt in member_selects), (
             f"[FAIL] find_by_id missing ``ORDER BY role``.\n"
             f"Captured room_members SELECTs: {member_selects}"
         )
@@ -350,7 +344,7 @@ class TestRoundTripEquality:
         # assertion is ORDER BY-aware.
         original_sorted = sorted(room.members, key=lambda m: (str(m.agent_id), m.role.value))
         assert len(restored.members) == len(original_sorted)
-        for got, want in zip(restored.members, original_sorted):
+        for got, want in zip(restored.members, original_sorted, strict=True):
             assert got.agent_id == want.agent_id
             assert got.role == want.role
 
@@ -407,9 +401,7 @@ class TestTxBoundaryRespectedByRepository:
         # 3-step sequence is one logical operation under the caller's UoW.
         async with session_factory() as session:
             member_rows = (
-                await session.execute(
-                    select(RoomMemberRow).where(RoomMemberRow.room_id == room.id)
-                )
+                await session.execute(select(RoomMemberRow).where(RoomMemberRow.room_id == room.id))
             ).all()
         assert member_rows == []
 

--- a/backend/tests/infrastructure/persistence/sqlite/test_alembic_room.py
+++ b/backend/tests/infrastructure/persistence/sqlite/test_alembic_room.py
@@ -93,10 +93,7 @@ class TestFifthRevisionApplied:
         await run_upgrade_head(empty_engine)
         async with empty_engine.connect() as conn:
             result = await conn.execute(
-                text(
-                    "SELECT name FROM sqlite_master "
-                    "WHERE type='index' AND tbl_name='rooms'"
-                )
+                text("SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='rooms'")
             )
             index_names = {row[0] for row in result}
         assert "ix_rooms_empire_id_name" in index_names, (
@@ -119,9 +116,7 @@ class TestFifthRevisionApplied:
         """
         await run_upgrade_head(empty_engine)
         async with empty_engine.connect() as conn:
-            result = await conn.execute(
-                text("PRAGMA foreign_key_list('empire_room_refs')")
-            )
+            result = await conn.execute(text("PRAGMA foreign_key_list('empire_room_refs')"))
             fk_rows = list(result)
         # PRAGMA foreign_key_list returns rows with columns:
         #   id, seq, table, from, to, on_update, on_delete, match
@@ -161,8 +156,7 @@ class TestUpgradeDowngradeIdempotent:
             result = await conn.execute(text("SELECT name FROM sqlite_master WHERE type='table'"))
             tables = {row[0] for row in result}
         assert tables.isdisjoint({"rooms", "room_members"}), (
-            f"[FAIL] rooms/room_members still present after downgrade to base.\n"
-            f"Tables: {tables}"
+            f"[FAIL] rooms/room_members still present after downgrade to base.\nTables: {tables}"
         )
 
         await run_upgrade_head(empty_engine)
@@ -170,8 +164,7 @@ class TestUpgradeDowngradeIdempotent:
             result = await conn.execute(text("SELECT name FROM sqlite_master WHERE type='table'"))
             tables = {row[0] for row in result}
         assert {"rooms", "room_members"}.issubset(tables), (
-            f"[FAIL] rooms/room_members missing after re-upgrade.\n"
-            f"Tables: {tables}"
+            f"[FAIL] rooms/room_members missing after re-upgrade.\nTables: {tables}"
         )
 
 

--- a/backend/tests/infrastructure/persistence/sqlite/test_alembic_room.py
+++ b/backend/tests/infrastructure/persistence/sqlite/test_alembic_room.py
@@ -1,0 +1,228 @@
+"""Alembic 5th revision tests (TC-IT-RR-012 — chain + DDL + idempotency).
+
+Per ``docs/features/room-repository/test-design.md``. Real Alembic
+upgrade / downgrade against a real SQLite file, plus a chain
+integrity check that makes sure
+``0001_init`` → ``0002_empire_aggregate`` → ``0003_workflow_aggregate``
+→ ``0004_agent_aggregate`` → ``0005_room_aggregate`` stays linear
+(no head fork).
+
+Also verifies:
+* ``rooms`` + ``room_members`` tables created by the 5th revision.
+* ``ix_rooms_empire_id_name`` composite index present (§確定 R1-F).
+* BUG-EMR-001 FK closure: ``empire_room_refs.room_id`` now has a FK
+  constraint onto ``rooms.id`` (added via ``batch_alter_table``).
+
+The conftest from ``tests/infrastructure/`` patches Alembic's
+``fileConfig`` so log capture survives migration; same workaround the
+M2 persistence-foundation tests rely on.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+import pytest_asyncio
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+from bakufu.infrastructure.persistence.sqlite import engine as engine_mod
+from bakufu.infrastructure.persistence.sqlite.migrations import run_upgrade_head
+from sqlalchemy import text
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncEngine
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+@pytest_asyncio.fixture
+async def empty_engine(tmp_path: Path) -> AsyncIterator[AsyncEngine]:
+    """Bring up a fresh app engine without running any migrations."""
+    url = f"sqlite+aiosqlite:///{tmp_path / 'bakufu.db'}"
+    engine = engine_mod.create_engine(url)
+    try:
+        yield engine
+    finally:
+        await engine.dispose()
+
+
+def _alembic_config() -> Config:
+    """Resolve the bakufu Alembic config for ScriptDirectory inspection."""
+    backend_root = Path(__file__).resolve().parents[4]
+    cfg = Config(str(backend_root / "alembic.ini"))
+    cfg.set_main_option("script_location", str(backend_root / "alembic"))
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-RR-012: 5th revision creates rooms + room_members tables + index
+# ---------------------------------------------------------------------------
+class TestFifthRevisionApplied:
+    """TC-IT-RR-012: ``alembic upgrade head`` adds the Room schema."""
+
+    async def test_two_room_tables_present_after_upgrade(
+        self,
+        empty_engine: AsyncEngine,
+    ) -> None:
+        """rooms + room_members exist after upgrade head."""
+        await run_upgrade_head(empty_engine)
+        async with empty_engine.connect() as conn:
+            result = await conn.execute(text("SELECT name FROM sqlite_master WHERE type='table'"))
+            tables = {row[0] for row in result}
+        assert {"rooms", "room_members"}.issubset(tables), (
+            f"[FAIL] rooms or room_members missing from schema after upgrade head.\n"
+            f"Tables found: {tables}"
+        )
+
+    async def test_rooms_empire_id_name_index_present(
+        self,
+        empty_engine: AsyncEngine,
+    ) -> None:
+        """``ix_rooms_empire_id_name`` composite index is created (§確定 R1-F).
+
+        The index left-prefix optimises ``WHERE empire_id = ?`` and
+        ``WHERE empire_id = ? AND name = ?`` for ``find_by_name``.
+        """
+        await run_upgrade_head(empty_engine)
+        async with empty_engine.connect() as conn:
+            result = await conn.execute(
+                text(
+                    "SELECT name FROM sqlite_master "
+                    "WHERE type='index' AND tbl_name='rooms'"
+                )
+            )
+            index_names = {row[0] for row in result}
+        assert "ix_rooms_empire_id_name" in index_names, (
+            f"[FAIL] ix_rooms_empire_id_name index missing on rooms table.\n"
+            f"Indexes found: {index_names}\n"
+            f"Next: ensure ``op.create_index('ix_rooms_empire_id_name', ...)`` "
+            f"is present in 0005_room_aggregate.py upgrade()."
+        )
+
+    async def test_empire_room_refs_fk_closure_applied(
+        self,
+        empty_engine: AsyncEngine,
+    ) -> None:
+        """BUG-EMR-001 FK closure: ``empire_room_refs.room_id → rooms.id``.
+
+        ``0005_room_aggregate.py`` adds the FK via ``batch_alter_table``
+        (SQLite does not support ALTER TABLE ... ADD CONSTRAINT). After
+        upgrade head, ``PRAGMA foreign_key_list('empire_room_refs')``
+        must list a reference to the ``rooms`` table.
+        """
+        await run_upgrade_head(empty_engine)
+        async with empty_engine.connect() as conn:
+            result = await conn.execute(
+                text("PRAGMA foreign_key_list('empire_room_refs')")
+            )
+            fk_rows = list(result)
+        # PRAGMA foreign_key_list returns rows with columns:
+        #   id, seq, table, from, to, on_update, on_delete, match
+        referenced_tables = {row[2] for row in fk_rows}  # col index 2 = 'table'
+        assert "rooms" in referenced_tables, (
+            f"[FAIL] empire_room_refs has no FK to rooms (BUG-EMR-001 not closed).\n"
+            f"FK references found: {referenced_tables}\n"
+            f"Next: ensure op.batch_alter_table('empire_room_refs') in 0005_room_aggregate.py "
+            f"adds the FK to rooms.id."
+        )
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-RR-012 補強: upgrade / downgrade are idempotent
+# ---------------------------------------------------------------------------
+class TestUpgradeDowngradeIdempotent:
+    """upgrade head → downgrade base → upgrade head again all green."""
+
+    async def test_full_cycle_leaves_room_tables_present(
+        self,
+        empty_engine: AsyncEngine,
+    ) -> None:
+        """upgrade head → downgrade base → upgrade head again."""
+        await run_upgrade_head(empty_engine)
+        from alembic import command  # local import to avoid global side effects
+
+        cfg = _alembic_config()
+        url = str(empty_engine.url)
+        cfg.set_main_option("sqlalchemy.url", url)
+
+        def _do_downgrade() -> None:
+            command.downgrade(cfg, "base")
+
+        await asyncio.to_thread(_do_downgrade)
+
+        async with empty_engine.connect() as conn:
+            result = await conn.execute(text("SELECT name FROM sqlite_master WHERE type='table'"))
+            tables = {row[0] for row in result}
+        assert tables.isdisjoint({"rooms", "room_members"}), (
+            f"[FAIL] rooms/room_members still present after downgrade to base.\n"
+            f"Tables: {tables}"
+        )
+
+        await run_upgrade_head(empty_engine)
+        async with empty_engine.connect() as conn:
+            result = await conn.execute(text("SELECT name FROM sqlite_master WHERE type='table'"))
+            tables = {row[0] for row in result}
+        assert {"rooms", "room_members"}.issubset(tables), (
+            f"[FAIL] rooms/room_members missing after re-upgrade.\n"
+            f"Tables: {tables}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-RR-012: revision chain is linear (no head fork)
+# ---------------------------------------------------------------------------
+class TestRevisionChainLinear:
+    """0001 → 0002 → 0003 → 0004 → 0005 single-head chain."""
+
+    async def test_alembic_heads_returns_single_revision(self) -> None:
+        """``ScriptDirectory.get_heads()`` returns exactly one revision."""
+        cfg = _alembic_config()
+        script = ScriptDirectory.from_config(cfg)
+        heads = script.get_heads()
+        assert len(heads) == 1, (
+            f"Alembic head must be linear; got branched heads {heads}.\n"
+            f"Each Aggregate Repository PR appends a single revision."
+        )
+
+    async def test_0005_revision_has_correct_down_revision(self) -> None:
+        """``0005_room_aggregate.down_revision == "0004_agent_aggregate"``."""
+        cfg = _alembic_config()
+        script = ScriptDirectory.from_config(cfg)
+        rev = script.get_revision("0005_room_aggregate")
+        assert rev is not None
+        assert rev.down_revision == "0004_agent_aggregate", (
+            f"[FAIL] 0005_room_aggregate.down_revision is {rev.down_revision!r}; "
+            f"expected '0004_agent_aggregate'."
+        )
+
+    async def test_chain_walks_from_0005_back_to_base(self) -> None:
+        """Walking ``down_revision`` reaches base in 5 hops (no branching)."""
+        cfg = _alembic_config()
+        script = ScriptDirectory.from_config(cfg)
+        chain: list[str] = []
+        current_id: str | None = "0005_room_aggregate"
+        for _ in range(10):  # generous bound for safety
+            if current_id is None:
+                break
+            rev = script.get_revision(current_id)
+            assert rev is not None, f"Revision {current_id!r} not found"
+            chain.append(rev.revision)
+            down = rev.down_revision
+            if isinstance(down, tuple | list):
+                pytest.fail(f"Revision {rev.revision!r} has multiple down_revisions {down}")
+            current_id = down  # pyright: ignore[reportAssignmentType]
+
+        assert chain == [
+            "0005_room_aggregate",
+            "0004_agent_aggregate",
+            "0003_workflow_aggregate",
+            "0002_empire_aggregate",
+            "0001_init",
+        ], f"Unexpected revision chain: {chain}"

--- a/backend/tests/infrastructure/test_bootstrap_sequence.py
+++ b/backend/tests/infrastructure/test_bootstrap_sequence.py
@@ -43,21 +43,24 @@ class TestBootstrapHappyPath:
         boot = Bootstrap(migration_runner=run_upgrade_head)
         with caplog.at_level(logging.INFO):
             await boot.run()
+        try:
+            # Stage logs trace the documented 0→8 ordering.
+            info_messages = [r.getMessage() for r in caplog.records if r.levelname == "INFO"]
+            for stage in range(1, 8):
+                assert any(f"Bootstrap stage {stage}/8" in m for m in info_messages), (
+                    f"missing stage {stage} INFO log"
+                )
 
-        # Stage logs trace the documented 0→8 ordering.
-        info_messages = [r.getMessage() for r in caplog.records if r.levelname == "INFO"]
-        for stage in range(1, 8):
-            assert any(f"Bootstrap stage {stage}/8" in m for m in info_messages), (
-                f"missing stage {stage} INFO log"
-            )
+            # The DB file + schema exist after Bootstrap returns.
+            db_path = _bakufu_data_dir / "bakufu.db"
+            assert db_path.exists()
 
-        # The DB file + schema exist after Bootstrap returns.
-        db_path = _bakufu_data_dir / "bakufu.db"
-        assert db_path.exists()
-
-        # And the attachments directory was prepared in stage 5.
-        attachments_dir = _bakufu_data_dir / "attachments"
-        assert attachments_dir.is_dir()
+            # And the attachments directory was prepared in stage 5.
+            attachments_dir = _bakufu_data_dir / "attachments"
+            assert attachments_dir.is_dir()
+        finally:
+            if boot.app_engine is not None:
+                await boot.app_engine.dispose()
 
 
 class TestStageFailFast:
@@ -113,9 +116,14 @@ class TestStage4NonFatal:
         boot = Bootstrap(migration_runner=run_upgrade_head)
         with caplog.at_level(logging.WARNING):
             await boot.run()
-
-        warn_messages = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
-        assert any("Bootstrap stage 4/8" in m and "continuing startup" in m for m in warn_messages)
+        try:
+            warn_messages = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+            assert any(
+                "Bootstrap stage 4/8" in m and "continuing startup" in m for m in warn_messages
+            )
+        finally:
+            if boot.app_engine is not None:
+                await boot.app_engine.dispose()
 
 
 class TestEmptyHandlerRegistryWarn:
@@ -130,8 +138,12 @@ class TestEmptyHandlerRegistryWarn:
         boot = Bootstrap(migration_runner=run_upgrade_head)
         with caplog.at_level(logging.WARNING):
             await boot.run()
-        warn_messages = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
-        assert any("No event handlers registered" in m for m in warn_messages)
+        try:
+            warn_messages = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+            assert any("No event handlers registered" in m for m in warn_messages)
+        finally:
+            if boot.app_engine is not None:
+                await boot.app_engine.dispose()
 
 
 class TestUmaskAtStage0:
@@ -150,8 +162,12 @@ class TestUmaskAtStage0:
         boot = Bootstrap(migration_runner=run_upgrade_head)
         with caplog.at_level(logging.INFO):
             await boot.run()
-        info_messages = [r.getMessage() for r in caplog.records if r.levelname == "INFO"]
-        assert any("Bootstrap stage 0/8: umask set to 0o077" in m for m in info_messages)
+        try:
+            info_messages = [r.getMessage() for r in caplog.records if r.levelname == "INFO"]
+            assert any("Bootstrap stage 0/8: umask set to 0o077" in m for m in info_messages)
+        finally:
+            if boot.app_engine is not None:
+                await boot.app_engine.dispose()
 
     async def test_db_file_has_secure_mode(
         self,
@@ -164,11 +180,15 @@ class TestUmaskAtStage0:
             pytest.skip("POSIX-only file mode bits")
         boot = Bootstrap(migration_runner=run_upgrade_head)
         await boot.run()
-        db_path = _bakufu_data_dir / "bakufu.db"
-        mode = db_path.stat().st_mode & 0o777
-        # 0o600 is the strict goal; 0o644 here would mean umask was not
-        # applied. Allow exact 0o600 only.
-        assert mode == 0o600
+        try:
+            db_path = _bakufu_data_dir / "bakufu.db"
+            mode = db_path.stat().st_mode & 0o777
+            # 0o600 is the strict goal; 0o644 here would mean umask was not
+            # applied. Allow exact 0o600 only.
+            assert mode == 0o600
+        finally:
+            if boot.app_engine is not None:
+                await boot.app_engine.dispose()
 
 
 class TestFullDbContractAfterBootstrap:
@@ -184,14 +204,17 @@ class TestFullDbContractAfterBootstrap:
 
         engine = boot.app_engine
         assert engine is not None
-        async with engine.connect() as conn:
-            tables_result = await conn.execute(
-                text("SELECT name FROM sqlite_master WHERE type='table'")
-            )
-            tables = {row[0] for row in tables_result}
-            triggers_result = await conn.execute(
-                text("SELECT name FROM sqlite_master WHERE type='trigger'")
-            )
-            triggers = {row[0] for row in triggers_result}
-        assert {"audit_log", "bakufu_pid_registry", "domain_event_outbox"}.issubset(tables)
-        assert {"audit_log_no_delete", "audit_log_update_restricted"}.issubset(triggers)
+        try:
+            async with engine.connect() as conn:
+                tables_result = await conn.execute(
+                    text("SELECT name FROM sqlite_master WHERE type='table'")
+                )
+                tables = {row[0] for row in tables_result}
+                triggers_result = await conn.execute(
+                    text("SELECT name FROM sqlite_master WHERE type='trigger'")
+                )
+                triggers = {row[0] for row in triggers_result}
+            assert {"audit_log", "bakufu_pid_registry", "domain_event_outbox"}.issubset(tables)
+            assert {"audit_log_no_delete", "audit_log_update_restricted"}.issubset(triggers)
+        finally:
+            await engine.dispose()

--- a/scripts/ci/check_masking_columns.sh
+++ b/scripts/ci/check_masking_columns.sh
@@ -89,6 +89,10 @@ readonly NO_MASK_FILES=(
     # semantics.
     "${TABLES_DIR}/agent_providers.py"
     "${TABLES_DIR}/agent_skills.py"
+    # Room Repository (PR #33): only rooms.prompt_kit_prefix_markdown is
+    # masked (room §確定 G 実適用); the room_members side table carries no
+    # secret semantics.
+    "${TABLES_DIR}/room_members.py"
 )
 
 for file in "${NO_MASK_FILES[@]}"; do
@@ -124,6 +128,10 @@ done
 readonly PARTIAL_MASK_FILES=(
     "${TABLES_DIR}/workflow_stages.py:notify_channels_json:MaskedJSONEncoded"
     "${TABLES_DIR}/agents.py:prompt_body:MaskedText"
+    # Room Repository (PR #33, detailed-design.md §確定 R1-E):
+    # rooms.prompt_kit_prefix_markdown だけが MaskedText (room §確定 G 実適用)、
+    # 他カラムは String / Boolean / Text に閉じる。
+    "${TABLES_DIR}/rooms.py:prompt_kit_prefix_markdown:MaskedText"
 )
 
 for entry in "${PARTIAL_MASK_FILES[@]}"; do


### PR DESCRIPTION
## Summary

- **RoomRepository Protocol** (`application/ports/room_repository.py`): `find_by_id` / `count` / `save(room, empire_id)` / `find_by_name` の 4 メソッド。`save()` の `empire_id` 引数はRoom Aggregateが `empire_id` 属性を持たないため呼び出し側 service が渡す設計（§確定 R1-H）
- **RoomRow ORM table** (`tables/rooms.py`): `empire_id` FK CASCADE / `workflow_id` FK RESTRICT (§確定 R1-I) / `prompt_kit_prefix_markdown` MaskedText (room §確定 G 実適用) / non-UNIQUE INDEX(empire_id, name) (§確定 R1-F)
- **RoomMemberRow ORM table** (`tables/room_members.py`): 複合 PK(room_id, agent_id, role) + 明示 `UniqueConstraint(uq_room_members_triplet)` (§確定 R1-D Defense-in-Depth) / `agent_id` は意図的に FK なし（application 層責務）
- **SqliteRoomRepository** (`repositories/room_repository.py`): 3-step save（UPSERT rooms → DELETE room_members → bulk INSERT room_members、§確定 R1-B）/ `find_by_id` で `ORDER BY agent_id, role`（BUG-EMR-001 規約）/ `find_by_name` は SELECT id → `find_by_id` 委譲（§確定 R1-F）
- **Alembic 0005_room_aggregate**: rooms + room_members テーブル作成 / `empire_room_refs.room_id → rooms.id` FK closure（BUG-EMR-001 close、`batch_alter_table` 経由）
- **CI 三層防衛拡張** (§確定 R1-E): Layer 1 `check_masking_columns.sh` + Layer 2 `test_masking_columns.py` に rooms / room_members 登録

## Implementation details

- `docs/features/room-repository/detailed-design.md` の全 §確定（R1-A〜R1-L）に準拠
- empire-repo / workflow-repo / agent-repo テンプレートパターンを 100% 継承
- BUG-EMR-001 の FK closure が本 PR の Alembic 0005 で物理完了（設計書では PR #47 で既に記録済み）

## Changed files

| ファイル | 変更種別 |
|---|---|
| `backend/src/bakufu/application/ports/room_repository.py` | 新規 |
| `backend/src/bakufu/infrastructure/persistence/sqlite/tables/rooms.py` | 新規 |
| `backend/src/bakufu/infrastructure/persistence/sqlite/tables/room_members.py` | 新規 |
| `backend/src/bakufu/infrastructure/persistence/sqlite/repositories/room_repository.py` | 新規 |
| `backend/alembic/versions/0005_room_aggregate.py` | 新規 |
| `backend/src/bakufu/infrastructure/persistence/sqlite/tables/__init__.py` | 更新（rooms / room_members インポート追加）|
| `backend/tests/architecture/test_masking_columns.py` | 更新（rooms / room_members エントリ + インポート追加）|
| `scripts/ci/check_masking_columns.sh` | 更新（rooms partial-mask / room_members no-mask 登録）|

## Test plan

- [ ] テスト担当による test_room_repository/ の 4 ファイル作成（§確定 R1-L に従い最初から 4 分割）
  - `test_protocol_crud.py`: save → find_by_id 正常系 / count() SQL 契約 / find_by_name Empire スコープ
  - `test_save_semantics.py`: delete-then-insert 物理保証 / ORDER BY 規約 / empire_id 引数経路
  - `test_constraints_arch.py`: UNIQUE(room_id, agent_id, role) / INDEX(empire_id, name) / FK 3 件 / BUG-EMR-001 closure
  - `test_masking_prompt_kit.py`: raw prefix_markdown → DB に `<REDACTED:*>` 永続化を raw SQL で物理確認

Closes #33