### PR TITLE
feat(external-review-gate-repository): SqliteExternalReviewGateRepository — Issue #36

### DIFF
--- a/backend/alembic/versions/0008_external_review_gate_aggregate.py
+++ b/backend/alembic/versions/0008_external_review_gate_aggregate.py
@@ -1,0 +1,195 @@
+"""ExternalReviewGate Aggregate tables: 3 tables + 3 indexes.
+
+Adds the three tables that back :class:`SqliteExternalReviewGateRepository`:
+
+* ``external_review_gates`` (id PK + task_id FK CASCADE + stage_id NOT NULL
+  (no FK, Aggregate boundary §設計決定 ERGR-001) + reviewer_id NOT NULL (no FK,
+  Owner Aggregate M2 scope) + decision String(32) NOT NULL + feedback_text
+  MaskedText NOT NULL + snapshot_stage_id NOT NULL (no FK) +
+  snapshot_body_markdown MaskedText NOT NULL + snapshot_committed_by NOT NULL
+  (no FK) + snapshot_committed_at UTCDateTime NOT NULL + created_at UTCDateTime
+  NOT NULL + decided_at UTCDateTime NULL).
+  Three indexes: ``ix_external_review_gates_task_id_created`` (composite),
+  ``ix_external_review_gates_reviewer_decision`` (composite),
+  ``ix_external_review_gates_decision`` (single-column).
+
+* ``external_review_gate_attachments`` (id PK (save-internal, uuid4() per save)
+  + gate_id FK CASCADE + sha256 String(64) NOT NULL + filename String(255)
+  NOT NULL + mime_type String(128) NOT NULL + size_bytes Integer NOT NULL +
+  UNIQUE(gate_id, sha256)).
+
+* ``external_review_audit_entries`` (id PK (domain AuditEntry.id) + gate_id
+  FK CASCADE + actor_id NOT NULL (no FK, Owner Aggregate boundary) +
+  action String(32) NOT NULL + comment MaskedText NOT NULL + occurred_at
+  UTCDateTime NOT NULL).
+
+``external_review_gates.task_id → tasks.id`` ON DELETE CASCADE: when a Task
+is removed, its associated Gates go with it. This is the only inter-Aggregate
+FK (§設計決定 ERGR-001 — all other UUID references are boundary-crossing and
+intentionally FK-free).
+
+``stage_id``, ``reviewer_id``, ``snapshot_stage_id``, ``snapshot_committed_by``,
+and ``actor_id`` intentionally have **no FK** (§設計決定 ERGR-001):
+- Stage / Workflow Aggregate boundary (Gate must not depend on
+  workflow_stages).
+- Owner Aggregate not yet implemented (M2 scope; MVP uses fixed UUID).
+- snapshot_committed_by: Agent deletion with CASCADE would destroy the
+  audit-frozen snapshot (task-repository §設計決定 TR-001 同論理).
+- actor_id: Owner Aggregate same as reviewer_id rationale.
+
+No inter-Aggregate FK申し送り is added: §設計決定 ERGR-001 resolves this as
+a permanent design decision (not a BUG申し送り).
+
+Per ``docs/features/external-review-gate-repository/detailed-design.md``
+§確定 R1-B, §設計決定 ERGR-001, §確定 R1-K.
+
+Revision ID: 0008_external_review_gate_aggregate
+Revises: 0007_task_aggregate
+Create Date: 2026-04-28
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0008_external_review_gate_aggregate"
+down_revision: str | None = "0007_task_aggregate"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # ---- external_review_gates table ----------------------------------------
+    op.create_table(
+        "external_review_gates",
+        sa.Column("id", sa.CHAR(32), primary_key=True, nullable=False),
+        sa.Column(
+            "task_id",
+            sa.CHAR(32),
+            sa.ForeignKey("tasks.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        # stage_id: intentionally NO FK onto workflow_stages.id —
+        # Aggregate boundary (§設計決定 ERGR-001). GateService validates existence.
+        sa.Column("stage_id", sa.CHAR(32), nullable=False),
+        # reviewer_id: intentionally NO FK — Owner Aggregate not yet implemented
+        # (§設計決定 ERGR-001). MVP: CEO = single system owner with fixed UUID.
+        sa.Column("reviewer_id", sa.CHAR(32), nullable=False),
+        sa.Column("decision", sa.String(32), nullable=False),
+        # feedback_text: MaskedText serialises as TEXT (§設計決定 ERGR-002,
+        # §確定 R1-E). CEO review comment; can carry webhook URLs / API keys.
+        sa.Column("feedback_text", sa.Text(), nullable=False),
+        # Inline snapshot_* columns — immutable after Gate creation (§確定 D).
+        # snapshot_stage_id: NO FK onto workflow_stages.id — Aggregate boundary.
+        sa.Column("snapshot_stage_id", sa.CHAR(32), nullable=False),
+        # snapshot_body_markdown: MaskedText serialises as TEXT (§確定 R1-E).
+        # Agent-authored deliverable body; LLM output may contain secrets.
+        sa.Column("snapshot_body_markdown", sa.Text(), nullable=False),
+        # snapshot_committed_by: NO FK onto agents.id — Agent deletion with
+        # CASCADE would destroy audit-frozen snapshot (§設計決定 ERGR-001).
+        sa.Column("snapshot_committed_by", sa.CHAR(32), nullable=False),
+        # UTCDateTime TypeDecorator stores ISO-8601 text; always tz-aware at Python.
+        sa.Column("snapshot_committed_at", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.Text(), nullable=False),
+        # decided_at: NULL iff decision == PENDING (domain invariant).
+        sa.Column("decided_at", sa.Text(), nullable=True),
+    )
+
+    # §確定 R1-K: composite (task_id, created_at) index for find_by_task_id.
+    op.create_index(
+        "ix_external_review_gates_task_id_created",
+        "external_review_gates",
+        ["task_id", "created_at"],
+        unique=False,
+    )
+
+    # §確定 R1-K: composite (reviewer_id, decision) for find_pending_by_reviewer.
+    op.create_index(
+        "ix_external_review_gates_reviewer_decision",
+        "external_review_gates",
+        ["reviewer_id", "decision"],
+        unique=False,
+    )
+
+    # §確定 R1-K: single-column (decision) for count_by_decision.
+    op.create_index(
+        "ix_external_review_gates_decision",
+        "external_review_gates",
+        ["decision"],
+        unique=False,
+    )
+
+    # ---- external_review_gate_attachments table ----------------------------
+    op.create_table(
+        "external_review_gate_attachments",
+        # id: save-internal PK (uuid4() regenerated on each save()).
+        # Business key: UNIQUE(gate_id, sha256).
+        sa.Column("id", sa.CHAR(32), primary_key=True, nullable=False),
+        sa.Column(
+            "gate_id",
+            sa.CHAR(32),
+            sa.ForeignKey("external_review_gates.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        # sha256: 64-char lowercase hex; validated by Attachment VO.
+        sa.Column("sha256", sa.String(64), nullable=False),
+        sa.Column("filename", sa.String(255), nullable=False),
+        sa.Column("mime_type", sa.String(128), nullable=False),
+        sa.Column("size_bytes", sa.Integer(), nullable=False),
+        # UNIQUE(gate_id, sha256): prevents duplicate content within one Gate;
+        # sha256 provides deterministic ORDER BY anchor (§確定 R1-H).
+        sa.UniqueConstraint(
+            "gate_id",
+            "sha256",
+            name="uq_erg_attachments_gate_sha256",
+        ),
+    )
+
+    # ---- external_review_audit_entries table -------------------------------
+    op.create_table(
+        "external_review_audit_entries",
+        # id: taken from domain AuditEntry.id (NOT regenerated on save).
+        sa.Column("id", sa.CHAR(32), primary_key=True, nullable=False),
+        sa.Column(
+            "gate_id",
+            sa.CHAR(32),
+            sa.ForeignKey("external_review_gates.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        # actor_id: intentionally NO FK — Owner Aggregate not yet implemented
+        # (§設計決定 ERGR-001). Same rationale as reviewer_id above.
+        sa.Column("actor_id", sa.CHAR(32), nullable=False),
+        sa.Column("action", sa.String(32), nullable=False),
+        # comment: MaskedText serialises as TEXT (§確定 R1-E).
+        # CEO-authored text; can carry webhook URLs / API keys.
+        sa.Column("comment", sa.Text(), nullable=False),
+        # UTCDateTime TypeDecorator stores ISO-8601 text.
+        sa.Column("occurred_at", sa.Text(), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    # Reverse order: child tables first (CASCADE FK order), then root.
+    # 1. Drop deepest child tables (no dependents within this migration).
+    op.drop_table("external_review_audit_entries")
+    op.drop_table("external_review_gate_attachments")
+
+    # 2. Drop indexes before dropping root table.
+    op.drop_index(
+        "ix_external_review_gates_decision",
+        table_name="external_review_gates",
+    )
+    op.drop_index(
+        "ix_external_review_gates_reviewer_decision",
+        table_name="external_review_gates",
+    )
+    op.drop_index(
+        "ix_external_review_gates_task_id_created",
+        table_name="external_review_gates",
+    )
+
+    # 3. Drop root table.
+    op.drop_table("external_review_gates")

--- a/backend/src/bakufu/application/ports/external_review_gate_repository.py
+++ b/backend/src/bakufu/application/ports/external_review_gate_repository.py
@@ -1,0 +1,109 @@
+"""ExternalReviewGate Repository port.
+
+Per ``docs/features/external-review-gate-repository/detailed-design.md``
+§確定 R1-A (empire-repo / workflow-repo / agent-repo / room-repo /
+directive-repo / task-repo テンプレート 100% 継承) plus Gate-specific
+query methods:
+
+* Protocol class with **no** ``@runtime_checkable`` decorator (empire-repo
+  §確定 A: Python 3.12 ``typing.Protocol`` duck typing is sufficient).
+* Every method declared ``async def`` (async-first contract).
+* Argument and return types come exclusively from :mod:`bakufu.domain` —
+  no SQLAlchemy types cross the port boundary.
+* ``save`` signature is ``save(gate: ExternalReviewGate) -> None`` (standard
+  1-argument pattern): :class:`ExternalReviewGate` carries all own attributes
+  so the Repository reads them directly.
+* Four Gate-specific query methods beyond the empire-repo §確定 B baseline
+  (``find_pending_by_reviewer`` / ``find_by_task_id`` / ``count_by_decision``).
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from bakufu.domain.external_review_gate.gate import ExternalReviewGate
+from bakufu.domain.value_objects import GateId, OwnerId, ReviewDecision, TaskId
+
+
+class ExternalReviewGateRepository(Protocol):
+    """Persistence contract for the :class:`ExternalReviewGate` Aggregate Root.
+
+    The application layer (``GateService``, future PRs) consumes this
+    Protocol via dependency injection; the SQLite implementation lives in
+    :mod:`bakufu.infrastructure.persistence.sqlite.repositories.external_review_gate_repository`.
+    """
+
+    async def find_by_id(self, gate_id: GateId) -> ExternalReviewGate | None:
+        """Hydrate the Gate whose primary key equals ``gate_id``.
+
+        Returns ``None`` when the row is absent. Both child tables
+        (external_review_gate_attachments / external_review_audit_entries)
+        are fetched and included in the hydrated Gate. SQLAlchemy / driver /
+        ``pydantic.ValidationError`` exceptions propagate untouched so the
+        application service's Unit-of-Work boundary can choose between
+        rollback and surfaced error.
+        """
+        ...
+
+    async def count(self) -> int:
+        """Return ``SELECT COUNT(*) FROM external_review_gates``.
+
+        Global count across all Gates regardless of decision or reviewer.
+        Application services use this for monitoring / bulk introspection
+        (empire-repo §確定 D 踏襲).
+        """
+        ...
+
+    async def save(self, gate: ExternalReviewGate) -> None:
+        """Persist ``gate`` via the §確定 R1-B 5-step delete-then-insert.
+
+        The save flow covers all three tables:
+
+        1. DELETE external_review_gate_attachments WHERE gate_id = :id
+        2. DELETE external_review_audit_entries WHERE gate_id = :id
+        3. UPSERT external_review_gates (ON CONFLICT id DO UPDATE mutable fields)
+        4. INSERT external_review_gate_attachments (per Attachment in snapshot)
+        5. INSERT external_review_audit_entries (per AuditEntry in audit_trail)
+
+        The implementation must not call ``session.commit()`` /
+        ``session.rollback()``; the application service owns the
+        Unit-of-Work boundary (empire-repo §確定 B 踏襲).
+        """
+        ...
+
+    async def find_pending_by_reviewer(self, reviewer_id: OwnerId) -> list[ExternalReviewGate]:
+        """Return all PENDING Gates for ``reviewer_id`` ordered ``created_at DESC, id DESC``.
+
+        Used by ``GateService`` to surface a reviewer's open review queue.
+        Returns ``[]`` when no PENDING Gates exist for the given reviewer.
+
+        ORDER BY ``created_at DESC, id DESC`` (BUG-EMR-001 規約: composite
+        key for deterministic ordering — ``created_at`` alone is
+        insufficient when multiple Gates share the same timestamp; ``id``
+        (PK, UUID) is the tiebreaker that makes the result fully
+        deterministic).
+        """
+        ...
+
+    async def find_by_task_id(self, task_id: TaskId) -> list[ExternalReviewGate]:
+        """Return all Gates for ``task_id`` ordered ``created_at ASC, id ASC``.
+
+        Used by ``GateService`` to fetch the full review history for a Task.
+        Returns ``[]`` when no Gates exist for the given Task.
+
+        ORDER BY ``created_at ASC, id ASC`` — chronological ordering matches
+        the "review history" read pattern where older gates appear first.
+        """
+        ...
+
+    async def count_by_decision(self, decision: ReviewDecision) -> int:
+        """Return ``SELECT COUNT(*) FROM external_review_gates WHERE decision = :decision``.
+
+        Used for dashboard metrics (PENDING backlog size, APPROVED / REJECTED /
+        CANCELLED historical counts).
+        Returns 0 when no Gates exist with the given decision.
+        """
+        ...
+
+
+__all__ = ["ExternalReviewGateRepository"]

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/repositories/external_review_gate_repository.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/repositories/external_review_gate_repository.py
@@ -182,9 +182,7 @@ class SqliteExternalReviewGateRepository:
 
         results: list[ExternalReviewGate] = []
         for gate_row in gate_rows:
-            gate = await self.find_by_id(gate_row.id)
-            if gate is not None:
-                results.append(gate)
+            results.append(await self._hydrate_row(gate_row))
         return results
 
     async def find_by_task_id(self, task_id: TaskId) -> list[ExternalReviewGate]:
@@ -214,9 +212,7 @@ class SqliteExternalReviewGateRepository:
 
         results: list[ExternalReviewGate] = []
         for gate_row in gate_rows:
-            gate = await self.find_by_id(gate_row.id)
-            if gate is not None:
-                results.append(gate)
+            results.append(await self._hydrate_row(gate_row))
         return results
 
     async def count_by_decision(self, decision: ReviewDecision) -> int:

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/repositories/external_review_gate_repository.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/repositories/external_review_gate_repository.py
@@ -1,0 +1,428 @@
+"""SQLite adapter for :class:`bakufu.application.ports.ExternalReviewGateRepository`.
+
+Implements the §確定 R1-B 5-step save flow over three tables
+(``external_review_gates`` / ``external_review_gate_attachments`` /
+``external_review_audit_entries``):
+
+1. ``DELETE FROM external_review_gate_attachments WHERE gate_id = :id`` —
+   no CASCADE parent; direct DELETE. New Gates produce 0 rows (no-op).
+2. ``DELETE FROM external_review_audit_entries WHERE gate_id = :id`` —
+   same. Direct DELETE, no CASCADE parent.
+3. ``external_review_gates`` UPSERT (id-conflict → mutable fields update;
+   ``task_id``, ``stage_id``, ``reviewer_id``, ``created_at``, and all
+   ``snapshot_*`` columns are intentionally **not** updated — Gate origin,
+   reviewer assignment, and deliverable snapshot are immutable after
+   creation).
+4. ``INSERT INTO external_review_gate_attachments`` — one row per
+   :class:`Attachment` in ``gate.deliverable_snapshot.attachments``. A
+   fresh ``uuid4()`` PK is generated for each row on every save
+   (DELETE-then-INSERT pattern guarantees no PK collision). Business key
+   remains ``UNIQUE(gate_id, sha256)``.
+5. ``INSERT INTO external_review_audit_entries`` — one row per
+   :class:`AuditEntry` in ``gate.audit_trail``. PKs come directly from
+   ``AuditEntry.id`` (domain-assigned UUIDs, not regenerated).
+
+The repository **never** calls ``session.commit()`` / ``session.rollback()``:
+the caller-side service runs ``async with session.begin():`` so all 5 steps
+stay in one transaction (empire-repo §確定 B Tx 境界の責務分離).
+
+``save(gate)`` uses the **standard 1-argument pattern** (§確定 R1-F):
+:class:`ExternalReviewGate` carries all own attributes so the Repository
+reads them directly.
+
+``_to_rows`` / ``_from_rows`` are kept as private methods on the class so
+both conversion directions live next to each other and tests don't
+accidentally acquire a public conversion API to depend on (empire-repo
+§確定 C).
+
+TypeDecorator-trust pattern (§確定 R1-A): :class:`UUIDStr` returns
+``UUID`` instances from ``process_result_value``, so ``row.id`` etc. are
+already ``UUID``. Direct attribute access without defensive ``UUID(row.id)``
+wrapping is correct and required. :class:`MaskedText` returns the already-
+masked string on SELECT; raw domain strings are passed on INSERT and
+``process_bind_param`` applies the masking gate automatically.
+"""
+
+from __future__ import annotations
+
+import uuid as _uuid
+from typing import Any
+
+from sqlalchemy import delete, func, insert, select
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bakufu.domain.external_review_gate.gate import ExternalReviewGate
+from bakufu.domain.value_objects import (
+    Attachment,
+    AuditAction,
+    AuditEntry,
+    Deliverable,
+    GateId,
+    OwnerId,
+    ReviewDecision,
+    TaskId,
+)
+from bakufu.infrastructure.persistence.sqlite.tables.external_review_audit_entries import (
+    ExternalReviewAuditEntryRow,
+)
+from bakufu.infrastructure.persistence.sqlite.tables.external_review_gate_attachments import (
+    ExternalReviewGateAttachmentRow,
+)
+from bakufu.infrastructure.persistence.sqlite.tables.external_review_gates import (
+    ExternalReviewGateRow,
+)
+
+
+class SqliteExternalReviewGateRepository:
+    """SQLite implementation of :class:`ExternalReviewGateRepository`."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def find_by_id(self, gate_id: GateId) -> ExternalReviewGate | None:
+        """SELECT gate row + 2 child tables, hydrate via :meth:`_from_rows`.
+
+        Returns ``None`` when the gate row is absent. On success, both
+        child tables are queried with their §確定 R1-H ORDER BY clauses so
+        the hydrated Aggregate is deterministic.
+        """
+        gate_row = (
+            await self._session.execute(
+                select(ExternalReviewGateRow).where(ExternalReviewGateRow.id == gate_id)
+            )
+        ).scalar_one_or_none()
+        if gate_row is None:
+            return None
+        return await self._hydrate_row(gate_row)
+
+    async def count(self) -> int:
+        """``SELECT COUNT(*) FROM external_review_gates``.
+
+        SQLAlchemy's ``func.count()`` issues a proper ``SELECT COUNT(*)``
+        so SQLite returns one scalar row instead of streaming every PK back
+        to Python (empire-repo §確定 D 踏襲).
+        """
+        return (
+            await self._session.execute(select(func.count()).select_from(ExternalReviewGateRow))
+        ).scalar_one()
+
+    async def save(self, gate: ExternalReviewGate) -> None:
+        """Persist ``gate`` via the §確定 R1-B 5-step delete-then-insert.
+
+        The caller is responsible for the surrounding
+        ``async with session.begin():`` block; failures propagate untouched
+        so the Unit-of-Work boundary in the application service can rollback
+        cleanly (empire-repo §確定 B 踏襲).
+        """
+        gate_row, attach_rows, audit_rows = self._to_rows(gate)
+
+        # Step 1: DELETE external_review_gate_attachments (no CASCADE, direct).
+        await self._session.execute(
+            delete(ExternalReviewGateAttachmentRow).where(
+                ExternalReviewGateAttachmentRow.gate_id == gate.id
+            )
+        )
+
+        # Step 2: DELETE external_review_audit_entries (no CASCADE, direct).
+        await self._session.execute(
+            delete(ExternalReviewAuditEntryRow).where(
+                ExternalReviewAuditEntryRow.gate_id == gate.id
+            )
+        )
+
+        # Step 3: external_review_gates UPSERT.
+        # Immutable fields excluded from DO UPDATE — Gate origin, reviewer
+        # assignment, and deliverable snapshot never change after creation.
+        upsert_stmt = sqlite_insert(ExternalReviewGateRow).values(gate_row)
+        upsert_stmt = upsert_stmt.on_conflict_do_update(
+            index_elements=["id"],
+            set_={
+                "decision": upsert_stmt.excluded.decision,
+                "feedback_text": upsert_stmt.excluded.feedback_text,
+                "decided_at": upsert_stmt.excluded.decided_at,
+            },
+        )
+        await self._session.execute(upsert_stmt)
+
+        # Step 4: INSERT external_review_gate_attachments.
+        if attach_rows:
+            await self._session.execute(insert(ExternalReviewGateAttachmentRow), attach_rows)
+
+        # Step 5: INSERT external_review_audit_entries.
+        if audit_rows:
+            await self._session.execute(insert(ExternalReviewAuditEntryRow), audit_rows)
+
+    async def find_pending_by_reviewer(self, reviewer_id: OwnerId) -> list[ExternalReviewGate]:
+        """Return all PENDING Gates for ``reviewer_id`` ordered ``created_at DESC, id DESC``.
+
+        The composite INDEX ``ix_external_review_gates_reviewer_decision``
+        on ``(reviewer_id, decision)`` covers the WHERE filter (§確定 R1-K).
+        Returns ``[]`` when no PENDING Gates exist for the given reviewer.
+        """
+        gate_rows = list(
+            (
+                await self._session.execute(
+                    select(ExternalReviewGateRow)
+                    .where(
+                        ExternalReviewGateRow.reviewer_id == reviewer_id,
+                        ExternalReviewGateRow.decision == ReviewDecision.PENDING.value,
+                    )
+                    .order_by(
+                        ExternalReviewGateRow.created_at.desc(),
+                        ExternalReviewGateRow.id.desc(),
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        if not gate_rows:
+            return []
+
+        results: list[ExternalReviewGate] = []
+        for gate_row in gate_rows:
+            gate = await self.find_by_id(gate_row.id)
+            if gate is not None:
+                results.append(gate)
+        return results
+
+    async def find_by_task_id(self, task_id: TaskId) -> list[ExternalReviewGate]:
+        """Return all Gates for ``task_id`` ordered ``created_at ASC, id ASC``.
+
+        The composite INDEX ``ix_external_review_gates_task_id_created``
+        on ``(task_id, created_at)`` covers the WHERE + ORDER BY in one
+        B-tree scan (§確定 R1-K). Returns ``[]`` when no Gates exist for
+        the given Task.
+        """
+        gate_rows = list(
+            (
+                await self._session.execute(
+                    select(ExternalReviewGateRow)
+                    .where(ExternalReviewGateRow.task_id == task_id)
+                    .order_by(
+                        ExternalReviewGateRow.created_at.asc(),
+                        ExternalReviewGateRow.id.asc(),
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        if not gate_rows:
+            return []
+
+        results: list[ExternalReviewGate] = []
+        for gate_row in gate_rows:
+            gate = await self.find_by_id(gate_row.id)
+            if gate is not None:
+                results.append(gate)
+        return results
+
+    async def count_by_decision(self, decision: ReviewDecision) -> int:
+        """``SELECT COUNT(*) FROM external_review_gates WHERE decision = :decision``.
+
+        The INDEX ``ix_external_review_gates_decision`` on ``(decision)``
+        accelerates this WHERE filter (§確定 R1-K).
+        Returns 0 when no Gates exist with the given decision.
+        """
+        return (
+            await self._session.execute(
+                select(func.count())
+                .select_from(ExternalReviewGateRow)
+                .where(ExternalReviewGateRow.decision == decision.value)
+            )
+        ).scalar_one()
+
+    # ---- private domain ↔ row converters (empire-repo §確定 C) -----------
+
+    async def _hydrate_row(self, gate_row: ExternalReviewGateRow) -> ExternalReviewGate:
+        """Fetch child tables for an already-loaded gate row and reconstruct.
+
+        Shared by :meth:`find_by_id`, :meth:`find_pending_by_reviewer`, and
+        :meth:`find_by_task_id` to avoid redundant root-table re-fetches.
+        """
+        # §確定 R1-H: ORDER BY sha256 ASC (UNIQUE per gate scope, deterministic).
+        attach_rows = list(
+            (
+                await self._session.execute(
+                    select(ExternalReviewGateAttachmentRow)
+                    .where(ExternalReviewGateAttachmentRow.gate_id == gate_row.id)
+                    .order_by(ExternalReviewGateAttachmentRow.sha256.asc())
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+        # §確定 R1-H: ORDER BY occurred_at ASC, id ASC (append-only audit trail
+        # must reconstruct in temporal order; id breaks timestamp ties).
+        audit_rows = list(
+            (
+                await self._session.execute(
+                    select(ExternalReviewAuditEntryRow)
+                    .where(ExternalReviewAuditEntryRow.gate_id == gate_row.id)
+                    .order_by(
+                        ExternalReviewAuditEntryRow.occurred_at.asc(),
+                        ExternalReviewAuditEntryRow.id.asc(),
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+        return self._from_rows(gate_row, attach_rows, audit_rows)
+
+    def _to_rows(
+        self,
+        gate: ExternalReviewGate,
+    ) -> tuple[
+        dict[str, Any],
+        list[dict[str, Any]],
+        list[dict[str, Any]],
+    ]:
+        """Convert ``gate`` to ``(gate_row, attach_rows, audit_rows)``.
+
+        SQLAlchemy ``Row`` objects are avoided so the domain layer never
+        gains an accidental dependency on the SQLAlchemy type hierarchy.
+
+        TypeDecorator-trust (§確定 R1-A): raw domain values are passed
+        directly; ``UUIDStr`` / ``MaskedText`` / ``UTCDateTime``
+        TypeDecorators perform all conversions at bind-parameter time.
+        ``feedback_text``, ``snapshot_body_markdown``, and ``comment`` are
+        passed as plain strings — ``MaskedText.process_bind_param`` applies
+        the masking gate automatically without manual
+        ``MaskingGateway.mask()`` calls.
+
+        Attachment PKs: ``external_review_gate_attachments.id`` has no
+        domain-level identity (the business key is ``UNIQUE(gate_id, sha256)``).
+        A fresh ``uuid4()`` is generated for each attachment row on every
+        save. Because step 1 DELETE-then-step 4 INSERT, there is never a PK
+        collision.
+
+        Audit entry PKs: ``external_review_audit_entries.id`` is taken
+        directly from ``AuditEntry.id`` (domain-assigned UUID). The DELETE-
+        then-INSERT flow in steps 2+5 guarantees no PK collision even as the
+        trail grows.
+        """
+        gate_row: dict[str, Any] = {
+            "id": gate.id,
+            "task_id": gate.task_id,
+            "stage_id": gate.stage_id,
+            "reviewer_id": gate.reviewer_id,
+            "decision": gate.decision.value,
+            # MaskedText.process_bind_param redacts secrets at bind time.
+            "feedback_text": gate.feedback_text,
+            # Inline snapshot copy — immutable after construction (§確定 D).
+            "snapshot_stage_id": gate.deliverable_snapshot.stage_id,
+            # MaskedText.process_bind_param redacts secrets at bind time.
+            "snapshot_body_markdown": gate.deliverable_snapshot.body_markdown,
+            "snapshot_committed_by": gate.deliverable_snapshot.committed_by,
+            "snapshot_committed_at": gate.deliverable_snapshot.committed_at,
+            "created_at": gate.created_at,
+            "decided_at": gate.decided_at,
+        }
+
+        attach_rows: list[dict[str, Any]] = [
+            {
+                # Fresh UUID PK — business key is UNIQUE(gate_id, sha256).
+                "id": _uuid.uuid4(),
+                "gate_id": gate.id,
+                "sha256": attachment.sha256,
+                "filename": attachment.filename,
+                "mime_type": attachment.mime_type,
+                "size_bytes": attachment.size_bytes,
+            }
+            for attachment in gate.deliverable_snapshot.attachments
+        ]
+
+        audit_rows: list[dict[str, Any]] = [
+            {
+                # AuditEntry.id is domain-assigned — preserve it verbatim.
+                "id": entry.id,
+                "gate_id": gate.id,
+                "actor_id": entry.actor_id,
+                "action": entry.action.value,
+                # MaskedText.process_bind_param redacts secrets at bind time.
+                "comment": entry.comment,
+                "occurred_at": entry.occurred_at,
+            }
+            for entry in gate.audit_trail
+        ]
+
+        return gate_row, attach_rows, audit_rows
+
+    def _from_rows(
+        self,
+        gate_row: ExternalReviewGateRow,
+        attach_rows: list[ExternalReviewGateAttachmentRow],
+        audit_rows: list[ExternalReviewAuditEntryRow],
+    ) -> ExternalReviewGate:
+        """Hydrate an :class:`ExternalReviewGate` from its row types.
+
+        ``ExternalReviewGate(...)`` direct construction re-runs the
+        post-validator so Repository-side hydration goes through the same
+        invariant checks that ``GateService.create()`` does at construction
+        time (empire §確定 C contract: "Repository hydration produces a valid
+        Gate or raises").
+
+        TypeDecorator-trust (§確定 R1-A): ``UUIDStr`` returns ``UUID``
+        instances from ``process_result_value``; ``UTCDateTime`` returns
+        tz-aware ``datetime``; ``MaskedText`` returns the already-masked
+        string. No defensive wrapping (e.g. ``UUID(row.id)``) needed.
+
+        §確定 R1-J §不可逆性: ``feedback_text``, ``snapshot_body_markdown``,
+        and ``comment`` carry the already-masked text from disk. All fields
+        accept any string within their length caps so the masked form
+        constructs cleanly.
+        """
+        # §確定 R1-C: reconstruct deliverable_snapshot from gate_row scalars
+        # + attach_rows (attach_rows already sorted sha256 ASC by caller).
+        attachments = [
+            Attachment(
+                sha256=a.sha256,
+                filename=a.filename,
+                mime_type=a.mime_type,
+                size_bytes=a.size_bytes,
+            )
+            for a in attach_rows
+        ]
+        deliverable_snapshot = Deliverable(
+            stage_id=gate_row.snapshot_stage_id,
+            body_markdown=gate_row.snapshot_body_markdown,
+            attachments=attachments,
+            committed_by=gate_row.snapshot_committed_by,
+            committed_at=gate_row.snapshot_committed_at,
+        )
+
+        # §確定 R1-C: reconstruct audit_trail from audit_rows (already sorted
+        # occurred_at ASC, id ASC by caller — matches append-only domain order).
+        # TypeDecorator-trust (§確定 R1-A): UUIDStr.process_result_value
+        # already returns UUID instances — no defensive wrapping needed.
+        audit_trail: list[AuditEntry] = [
+            AuditEntry(
+                id=r.id,
+                actor_id=r.actor_id,
+                action=AuditAction(r.action),
+                comment=r.comment,
+                occurred_at=r.occurred_at,
+            )
+            for r in audit_rows
+        ]
+
+        return ExternalReviewGate(
+            id=gate_row.id,
+            task_id=gate_row.task_id,
+            stage_id=gate_row.stage_id,
+            deliverable_snapshot=deliverable_snapshot,
+            reviewer_id=gate_row.reviewer_id,
+            decision=ReviewDecision(gate_row.decision),
+            feedback_text=gate_row.feedback_text,
+            audit_trail=audit_trail,
+            created_at=gate_row.created_at,
+            decided_at=gate_row.decided_at,
+        )
+
+
+__all__ = ["SqliteExternalReviewGateRepository"]

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/tables/__init__.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/tables/__init__.py
@@ -75,6 +75,23 @@ Task Aggregate (PR #35):
   (no-mask). Metadata only — physical file bytes are ``feature/attachment-
   storage`` scope (§確定 R1-I).
 
+ExternalReviewGate Aggregate (PR #36):
+
+* :mod:`...tables.external_review_gates` — Gate root row. Two masked
+  columns: ``feedback_text`` (MaskedText, §設計決定 ERGR-002) and
+  ``snapshot_body_markdown`` (MaskedText, §確定 R1-E 実適用); both are
+  registered with the CI three-layer defense's *partial-mask* contract.
+  Three indexes (§確定 R1-K): ``ix_external_review_gates_task_id_created``
+  (composite), ``ix_external_review_gates_reviewer_decision`` (composite),
+  ``ix_external_review_gates_decision`` (single-column).
+* :mod:`...tables.external_review_gate_attachments` — snapshot Attachment
+  metadata child rows (no-mask). Business key ``UNIQUE(gate_id, sha256)``;
+  PK is save-internal (uuid4() regenerated on each save).
+* :mod:`...tables.external_review_audit_entries` — AuditEntry child rows.
+  ``comment`` is ``MaskedText`` (§確定 R1-E 実適用); registered with CI
+  three-layer defense *partial-mask* contract pinning exactly one masked
+  column. PK is domain-assigned (AuditEntry.id, not regenerated).
+
 Note: ``conversations`` / ``conversation_messages`` tables are excluded
 (§BUG-TR-002 凍結済み). They will be registered here when Task domain gains
 a ``conversations: list[Conversation]`` attribute.
@@ -114,6 +131,9 @@ from bakufu.infrastructure.persistence.sqlite.tables import (
     empire_agent_refs,
     empire_room_refs,
     empires,
+    external_review_audit_entries,
+    external_review_gate_attachments,
+    external_review_gates,
     outbox,
     pid_registry,
     room_members,
@@ -136,6 +156,9 @@ __all__ = [
     "empire_agent_refs",
     "empire_room_refs",
     "empires",
+    "external_review_audit_entries",
+    "external_review_gate_attachments",
+    "external_review_gates",
     "outbox",
     "pid_registry",
     "room_members",

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/tables/external_review_audit_entries.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/tables/external_review_audit_entries.py
@@ -1,0 +1,65 @@
+"""``external_review_audit_entries`` table — AuditEntry child rows.
+
+Stores the append-only audit trail for each :class:`ExternalReviewGate`.
+Every ``approve`` / ``reject`` / ``cancel`` / ``record_view`` call on the
+domain Gate appends exactly one :class:`AuditEntry`; the Repository persists
+all entries on each ``save()`` via the §確定 R1-B DELETE-then-INSERT flow.
+
+``gate_id`` carries an ``ON DELETE CASCADE`` foreign key onto
+``external_review_gates.id`` — when a Gate is removed, its audit entries
+go with it.
+
+``actor_id`` intentionally has **no FK** — Owner Aggregate is not yet
+implemented in M2 scope (§設計決定 ERGR-001). Reference integrity is the
+application layer's responsibility (``GateService``).
+
+``id`` is taken directly from :class:`AuditEntry.id` (domain-assigned UUID),
+**not** regenerated on save. Unlike attachment rows (which use save-internal
+PKs), audit entries carry their own stable identity so the Repository can
+reconstruct the exact :class:`AuditEntry` instances the domain produced.
+
+**masking 対象カラム**: ``comment`` (MaskedText) — CEO-authored free-form
+text in the same input path as ``feedback_text``; can carry webhook URLs /
+API keys (§確定 R1-E 3-column CI defense).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import ForeignKey, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from bakufu.infrastructure.persistence.sqlite.base import (
+    Base,
+    MaskedText,
+    UTCDateTime,
+    UUIDStr,
+)
+
+
+class ExternalReviewAuditEntryRow(Base):
+    """ORM mapping for the ``external_review_audit_entries`` table."""
+
+    __tablename__ = "external_review_audit_entries"
+
+    # id: taken directly from AuditEntry.id (domain UUID, NOT regenerated).
+    id: Mapped[UUID] = mapped_column(UUIDStr, primary_key=True)
+    gate_id: Mapped[UUID] = mapped_column(
+        UUIDStr,
+        ForeignKey("external_review_gates.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    # actor_id: intentionally NO FK onto owners/agents — Owner Aggregate not
+    # yet implemented (§設計決定 ERGR-001). GateService validates existence.
+    actor_id: Mapped[UUID] = mapped_column(UUIDStr, nullable=False)
+    action: Mapped[str] = mapped_column(String(32), nullable=False)
+    # comment: MaskedText — CEO-authored text in approve/reject/cancel/view
+    # input path; can carry webhook URLs / API keys (§確定 R1-E). NOT NULL:
+    # AuditEntry.comment defaults to "" on VIEWED entries.
+    comment: Mapped[str] = mapped_column(MaskedText, nullable=False)
+    occurred_at: Mapped[datetime] = mapped_column(UTCDateTime, nullable=False)
+
+
+__all__ = ["ExternalReviewAuditEntryRow"]

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/tables/external_review_gate_attachments.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/tables/external_review_gate_attachments.py
@@ -1,0 +1,58 @@
+"""``external_review_gate_attachments`` table — snapshot Attachment child rows.
+
+Stores per-attachment metadata for the ``deliverable_snapshot`` inline copy
+inside each :class:`ExternalReviewGate`. Physical file bytes are out of scope
+for this feature (``feature/attachment-storage``).
+
+``gate_id`` carries an ``ON DELETE CASCADE`` foreign key onto
+``external_review_gates.id`` — when a Gate is removed, its snapshot
+attachment rows go with it.
+
+``id`` is a **save-internal** primary key regenerated via ``uuid4()`` on
+every :meth:`SqliteExternalReviewGateRepository.save` call (DELETE-then-INSERT
+pattern). External code must not reference this PK; the business key is
+``UNIQUE(gate_id, sha256)``.
+
+**masking 対象カラム**: なし (全カラム masking 対象外)。Attachment metadata
+(sha256 / filename / mime_type / size_bytes) carries no Schneier #6 secret
+semantics; the content hash identifies a file but reveals nothing about its
+contents.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import ForeignKey, Integer, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from bakufu.infrastructure.persistence.sqlite.base import Base, UUIDStr
+
+
+class ExternalReviewGateAttachmentRow(Base):
+    """ORM mapping for the ``external_review_gate_attachments`` table."""
+
+    __tablename__ = "external_review_gate_attachments"
+
+    # id: internal PK regenerated on each save(); external code must use
+    # UNIQUE(gate_id, sha256) as the business key (§確定 R1-B).
+    id: Mapped[UUID] = mapped_column(UUIDStr, primary_key=True)
+    gate_id: Mapped[UUID] = mapped_column(
+        UUIDStr,
+        ForeignKey("external_review_gates.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    # sha256: 64-char lowercase hex; validated by Attachment VO.
+    sha256: Mapped[str] = mapped_column(String(64), nullable=False)
+    filename: Mapped[str] = mapped_column(String(255), nullable=False)
+    mime_type: Mapped[str] = mapped_column(String(128), nullable=False)
+    size_bytes: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    __table_args__ = (
+        # UNIQUE(gate_id, sha256): prevents duplicate content within one Gate;
+        # sha256 provides deterministic ORDER BY anchor (§確定 R1-H).
+        UniqueConstraint("gate_id", "sha256", name="uq_erg_attachments_gate_sha256"),
+    )
+
+
+__all__ = ["ExternalReviewGateAttachmentRow"]

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/tables/external_review_gates.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/tables/external_review_gates.py
@@ -1,0 +1,112 @@
+"""``external_review_gates`` table — ExternalReviewGate Aggregate root row.
+
+Holds all twelve scalar columns of the ExternalReviewGate aggregate root,
+including the inline ``deliverable_snapshot`` copy (four columns prefixed
+``snapshot_``). Child collections (attachments / audit entries) live in
+companion modules so the root row width stays bounded and CASCADE targets
+are obvious.
+
+``task_id`` carries an ``ON DELETE CASCADE`` foreign key onto ``tasks.id`` —
+when a Task is removed, its associated Gates go with it.
+
+``stage_id`` and ``reviewer_id`` and ``snapshot_committed_by`` intentionally
+have **no FK** (§設計決定 ERGR-001):
+- ``stage_id``: Workflow Aggregate boundary; Gate must not depend on
+  workflow_stages directly.
+- ``reviewer_id``: Owner Aggregate not yet implemented (M2 scope).
+- ``snapshot_committed_by``: Agent deletion with CASCADE would destroy the
+  audit-frozen snapshot (task-repository §設計決定 TR-001 同論理).
+
+Two masking columns (§設計決定 ERGR-002, §確定 R1-E, 3-column CI defense):
+
+* ``feedback_text`` — MaskedText: CEO-authored review comment; ``approve`` /
+  ``reject`` / ``cancel`` input paths can carry webhook URLs / API keys.
+* ``snapshot_body_markdown`` — MaskedText: Agent-authored deliverable body;
+  LLM output may contain API keys / auth tokens embedded in code blocks.
+
+Three indexes (§確定 R1-K):
+
+* ``ix_external_review_gates_task_id_created`` — composite ``(task_id,
+  created_at)`` for ``find_by_task_id`` WHERE + ORDER BY in one B-tree scan.
+* ``ix_external_review_gates_reviewer_decision`` — composite
+  ``(reviewer_id, decision)`` for ``find_pending_by_reviewer`` WHERE
+  reviewer_id + decision = 'PENDING' filter.
+* ``ix_external_review_gates_decision`` — single-column ``(decision)`` for
+  ``count_by_decision`` WHERE filter (prefix coverage of the composite index
+  above is insufficient for a full COUNT(*) scan).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import ForeignKey, Index, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from bakufu.infrastructure.persistence.sqlite.base import (
+    Base,
+    MaskedText,
+    UTCDateTime,
+    UUIDStr,
+)
+
+
+class ExternalReviewGateRow(Base):
+    """ORM mapping for the ``external_review_gates`` table."""
+
+    __tablename__ = "external_review_gates"
+
+    id: Mapped[UUID] = mapped_column(UUIDStr, primary_key=True)
+    task_id: Mapped[UUID] = mapped_column(
+        UUIDStr,
+        ForeignKey("tasks.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    # stage_id: intentionally NO FK onto workflow_stages.id —
+    # Aggregate boundary (§設計決定 ERGR-001). GateService validates existence.
+    stage_id: Mapped[UUID] = mapped_column(UUIDStr, nullable=False)
+    # reviewer_id: intentionally NO FK — Owner Aggregate not yet implemented
+    # (§設計決定 ERGR-001). MVP: CEO = single system owner with fixed UUID.
+    reviewer_id: Mapped[UUID] = mapped_column(UUIDStr, nullable=False)
+    decision: Mapped[str] = mapped_column(String(32), nullable=False)
+    # feedback_text: MaskedText — CEO review comment; approve / reject / cancel
+    # input paths can carry webhook URLs / API keys (§設計決定 ERGR-002,
+    # §確定 R1-E). MaskedText.process_bind_param redacts secrets before SQLite
+    # storage. NOT NULL: domain Gate.feedback_text defaults to "" on PENDING.
+    feedback_text: Mapped[str] = mapped_column(MaskedText, nullable=False)
+    # ---- inline deliverable_snapshot copy (§確定 R1-C) ---------------------
+    # snapshot_stage_id: NO FK onto workflow_stages.id — same rationale as
+    # stage_id above (Aggregate boundary).
+    snapshot_stage_id: Mapped[UUID] = mapped_column(UUIDStr, nullable=False)
+    # snapshot_body_markdown: MaskedText — Agent-authored deliverable body;
+    # LLM output may contain secrets embedded in code blocks (§確定 R1-E).
+    snapshot_body_markdown: Mapped[str] = mapped_column(MaskedText, nullable=False)
+    # snapshot_committed_by: intentionally NO FK onto agents.id —
+    # Agent deletion with CASCADE would destroy audit-frozen snapshot
+    # (§設計決定 ERGR-001, TR-001 同論理).
+    snapshot_committed_by: Mapped[UUID] = mapped_column(UUIDStr, nullable=False)
+    snapshot_committed_at: Mapped[datetime] = mapped_column(UTCDateTime, nullable=False)
+    # ---- lifecycle timestamps -----------------------------------------------
+    created_at: Mapped[datetime] = mapped_column(UTCDateTime, nullable=False)
+    # decided_at: NULL iff decision == PENDING (domain invariant).
+    decided_at: Mapped[datetime | None] = mapped_column(UTCDateTime, nullable=True)
+
+    __table_args__ = (
+        # §確定 R1-K: composite (task_id, created_at) index for find_by_task_id.
+        # WHERE task_id + ORDER BY created_at ASC covered by one B-tree scan.
+        Index("ix_external_review_gates_task_id_created", "task_id", "created_at"),
+        # §確定 R1-K: composite (reviewer_id, decision) for find_pending_by_reviewer.
+        # WHERE reviewer_id + decision = 'PENDING' covered without full-table scan.
+        Index(
+            "ix_external_review_gates_reviewer_decision",
+            "reviewer_id",
+            "decision",
+        ),
+        # §確定 R1-K: single-column (decision) for count_by_decision.
+        # The composite above does not cover COUNT(*) over all reviewers.
+        Index("ix_external_review_gates_decision", "decision"),
+    )
+
+
+__all__ = ["ExternalReviewGateRow"]

--- a/backend/tests/architecture/test_masking_columns.py
+++ b/backend/tests/architecture/test_masking_columns.py
@@ -46,6 +46,9 @@ from bakufu.infrastructure.persistence.sqlite.tables import (
     empire_agent_refs,  # noqa: F401  # pyright: ignore[reportUnusedImport]
     empire_room_refs,  # noqa: F401  # pyright: ignore[reportUnusedImport]
     empires,  # noqa: F401  # pyright: ignore[reportUnusedImport]
+    external_review_audit_entries,  # noqa: F401  # pyright: ignore[reportUnusedImport]
+    external_review_gate_attachments,  # noqa: F401  # pyright: ignore[reportUnusedImport]
+    external_review_gates,  # noqa: F401  # pyright: ignore[reportUnusedImport]
     outbox,  # noqa: F401  # pyright: ignore[reportUnusedImport]
     pid_registry,  # noqa: F401  # pyright: ignore[reportUnusedImport]
     room_members,  # noqa: F401  # pyright: ignore[reportUnusedImport]
@@ -82,6 +85,16 @@ _MASKING_CONTRACT: list[tuple[str, str, type]] = [
     # conversation_messages.body_markdown は §BUG-TR-002 凍結済みのため除外。
     # deliverables.body_markdown — Agent 出力に secret 混入の可能性.
     ("deliverables", "body_markdown", MaskedText),
+    # ExternalReviewGate Repository (PR #36, detailed-design.md §確定 R1-E,
+    # §設計決定 ERGR-002):
+    # external_review_gates.snapshot_body_markdown — Agent 出力に secret 混入.
+    ("external_review_gates", "snapshot_body_markdown", MaskedText),
+    # external_review_gates.feedback_text — CEO review comment; approve /
+    # reject / cancel input paths can carry webhook URLs / API keys.
+    ("external_review_gates", "feedback_text", MaskedText),
+    # external_review_audit_entries.comment — CEO-authored free-form text;
+    # same secret-bearing input path as feedback_text.
+    ("external_review_audit_entries", "comment", MaskedText),
 ]
 
 # No-mask contract: §逆引き表「Empire 関連カラム: masking 対象なし」 +
@@ -112,6 +125,11 @@ _NO_MASK_TABLES: list[str] = [
     # §BUG-TR-002 凍結済みのため除外。
     "task_assigned_agents",
     "deliverable_attachments",
+    # ExternalReviewGate Repository (PR #36, detailed-design.md §確定 R1-E):
+    # external_review_gate_attachments carries no secret semantics — file
+    # metadata (sha256 / filename / mime_type / size_bytes) carries no
+    # Schneier #6 secret categories.
+    "external_review_gate_attachments",
 ]
 
 # Partial-mask contract: tables that have **exactly one** masked
@@ -145,6 +163,27 @@ _PARTIAL_MASK_TABLES: list[tuple[str, str]] = [
     # id / task_id / stage_id / committed_by / committed_at carry no secret
     # semantics.
     ("deliverables", "body_markdown"),
+    # ExternalReviewGate Repository (PR #36, detailed-design.md §確定 R1-E):
+    # external_review_audit_entries.comment is the only masked column;
+    # id / gate_id / actor_id / action / occurred_at carry no secret semantics.
+    ("external_review_audit_entries", "comment"),
+]
+
+# Dual-mask contract: tables that have **exactly two** masked columns.
+# Used to catch both under-masking (a required masked column was removed)
+# and over-masking (a non-secret column was accidentally masked).
+#
+# ExternalReviewGate Repository (PR #36, detailed-design.md §確定 R1-E +
+# §設計決定 ERGR-002): external_review_gates requires exactly two masked
+# columns (snapshot_body_markdown for Agent-authored content and
+# feedback_text for CEO-authored review comments).
+#
+# Format: ``(table_name, frozenset_of_allowed_column_names)``.
+_DUAL_MASK_TABLES: list[tuple[str, frozenset[str]]] = [
+    (
+        "external_review_gates",
+        frozenset({"snapshot_body_markdown", "feedback_text"}),
+    ),
 ]
 
 
@@ -259,4 +298,47 @@ class TestPartialMaskContract:
             f"Next: only '{allowed_column}' is registered as masked in "
             f"docs/architecture/domain-model/storage.md §逆引き表; either "
             f"revert the extra Masked* type or update the §逆引き表 entry first."
+        )
+
+
+class TestDualMaskContract:
+    """Tables registered as 'dual mask' must mask exactly two named columns.
+
+    ExternalReviewGate Repository (PR #36) introduces the 'dual mask'
+    pattern: ``external_review_gates`` has two secret-bearing columns
+    (``snapshot_body_markdown`` for Agent output and ``feedback_text`` for
+    CEO review comments). Both are required; neither may be removed or
+    supplemented with a third masked column without updating §逆引き表.
+
+    A future PR that masks an additional column or removes one must update
+    §逆引き表 first; otherwise this assertion fires.
+    """
+
+    @pytest.mark.parametrize(
+        ("table_name", "allowed_columns"),
+        _DUAL_MASK_TABLES,
+        ids=[tbl for tbl, _ in _DUAL_MASK_TABLES],
+    )
+    def test_table_has_only_allowed_masked_columns(
+        self,
+        table_name: str,
+        allowed_columns: frozenset[str],
+    ) -> None:
+        """Assert exactly the allowed masked columns, no more, no less."""
+        table = Base.metadata.tables.get(table_name)
+        assert table is not None, (
+            f"table {table_name!r} missing from Base.metadata; "
+            f"check that tables/{table_name}.py is imported in tables/__init__.py"
+        )
+        masked_columns = sorted(
+            col.name
+            for col in table.columns
+            if isinstance(col.type, MaskedJSONEncoded | MaskedText)
+        )
+        assert masked_columns == sorted(allowed_columns), (
+            f"[FAIL] {table_name} masking surface should be exactly "
+            f"{sorted(allowed_columns)}, got {masked_columns}.\n"
+            f"Next: only {sorted(allowed_columns)} are registered as masked in "
+            f"docs/architecture/domain-model/storage.md §逆引き表; either "
+            f"revert extra Masked* types or update the §逆引き表 entry first."
         )

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_external_review_gate_repository/conftest.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_external_review_gate_repository/conftest.py
@@ -1,0 +1,147 @@
+"""Pytest fixtures shared across external-review-gate-repository integration tests.
+
+ExternalReviewGate has one mandatory FK:
+  - ``external_review_gates.task_id REFERENCES tasks.id ON DELETE CASCADE``
+
+Task itself requires:
+  - ``tasks.room_id REFERENCES rooms.id ON DELETE CASCADE``
+  - ``tasks.directive_id REFERENCES directives.id ON DELETE CASCADE``
+
+Full dependency graph:
+  empires
+    └── workflows
+          └── rooms  ← tasks.room_id FK / directives.target_room_id FK
+                └── directives  ← tasks.directive_id FK
+                      └── tasks  ← external_review_gates.task_id FK
+                            └── external_review_gates  ← test body saves these
+
+``seeded_gate_context`` seeds this hierarchy and returns ``(task_id, stage_id, reviewer_id)``
+so Gate tests can call ``make_gate(task_id=..., stage_id=..., reviewer_id=...)`` and save
+without hitting IntegrityError.
+
+``stage_id`` and ``reviewer_id`` have no FK (§設計決定 ERGR-001: Aggregate boundary);
+they are generated as uuid4() constants for predictable test values.
+
+Per ``docs/features/external-review-gate-repository/test-design.md`` §conftest.py 設計.
+Issue #36 — M2 0008.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID, uuid4
+
+import pytest
+import pytest_asyncio
+from bakufu.infrastructure.persistence.sqlite.repositories.directive_repository import (
+    SqliteDirectiveRepository,
+)
+from bakufu.infrastructure.persistence.sqlite.repositories.empire_repository import (
+    SqliteEmpireRepository,
+)
+from bakufu.infrastructure.persistence.sqlite.repositories.room_repository import (
+    SqliteRoomRepository,
+)
+from bakufu.infrastructure.persistence.sqlite.repositories.task_repository import (
+    SqliteTaskRepository,
+)
+from bakufu.infrastructure.persistence.sqlite.repositories.workflow_repository import (
+    SqliteWorkflowRepository,
+)
+
+from tests.factories.directive import make_directive
+from tests.factories.empire import make_empire
+from tests.factories.room import make_room
+from tests.factories.task import make_task
+from tests.factories.workflow import make_workflow
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+
+@pytest.fixture(autouse=True)
+def _bakufu_data_dir(monkeypatch: pytest.MonkeyPatch) -> None:  # pyright: ignore[reportUnusedFunction]
+    """Set ``BAKUFU_DATA_DIR`` for every test in this package."""
+    monkeypatch.setenv("BAKUFU_DATA_DIR", "/tmp/bakufu-test-root")
+
+
+@pytest_asyncio.fixture
+async def seeded_gate_context(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> tuple[UUID, UUID, UUID]:
+    """Seed empire → workflow → room → directive → task and return (task_id, stage_id, reviewer_id).
+
+    Dependency graph:
+        empires (INSERT via save)
+          └── workflows (INSERT via save)
+                └── rooms (INSERT via save)  ← tasks.room_id FK
+                      └── directives (INSERT via save)  ← tasks.directive_id FK
+                            └── tasks (INSERT via save)  ← external_review_gates.task_id FK
+                                  └── external_review_gates  ← test body saves these
+
+    stage_id and reviewer_id are uuid4() constants — they have no FK constraint
+    (§設計決定 ERGR-001: Aggregate boundary). GateService validates these at the
+    application layer.
+
+    Returns:
+        tuple[UUID, UUID, UUID]: (task.id, stage_id, reviewer_id)
+    """
+    empire = make_empire()
+    workflow = make_workflow()
+    room = make_room(workflow_id=workflow.id)
+    directive = make_directive(target_room_id=room.id)
+    task = make_task(room_id=room.id, directive_id=directive.id)
+
+    async with session_factory() as session, session.begin():
+        await SqliteEmpireRepository(session).save(empire)
+    async with session_factory() as session, session.begin():
+        await SqliteWorkflowRepository(session).save(workflow)
+    async with session_factory() as session, session.begin():
+        await SqliteRoomRepository(session).save(room, empire.id)
+    async with session_factory() as session, session.begin():
+        await SqliteDirectiveRepository(session).save(directive)
+    async with session_factory() as session, session.begin():
+        await SqliteTaskRepository(session).save(task)
+
+    stage_id = uuid4()
+    reviewer_id = uuid4()
+    return task.id, stage_id, reviewer_id
+
+
+async def seed_gate_context(
+    session_factory: async_sessionmaker[AsyncSession],
+    task_id: UUID | None = None,
+    reviewer_id: UUID | None = None,
+) -> tuple[UUID, UUID, UUID]:
+    """Persist empire → workflow → room → directive → task.
+
+    Returns (task_id, stage_id, reviewer_id).
+
+    For tests that need multiple independent gate contexts (e.g. count_by_decision
+    isolation, cross-task isolation). Each call creates fresh rows so contexts are
+    fully independent.
+
+    Returns:
+        tuple[UUID, UUID, UUID]: (task.id, stage_id, reviewer_id)
+    """
+    empire = make_empire(empire_id=uuid4())
+    workflow = make_workflow(workflow_id=uuid4())
+    room = make_room(room_id=uuid4(), workflow_id=workflow.id)
+    directive = make_directive(directive_id=uuid4(), target_room_id=room.id)
+    actual_task_id = task_id if task_id is not None else uuid4()
+    task = make_task(task_id=actual_task_id, room_id=room.id, directive_id=directive.id)
+
+    async with session_factory() as session, session.begin():
+        await SqliteEmpireRepository(session).save(empire)
+    async with session_factory() as session, session.begin():
+        await SqliteWorkflowRepository(session).save(workflow)
+    async with session_factory() as session, session.begin():
+        await SqliteRoomRepository(session).save(room, empire.id)
+    async with session_factory() as session, session.begin():
+        await SqliteDirectiveRepository(session).save(directive)
+    async with session_factory() as session, session.begin():
+        await SqliteTaskRepository(session).save(task)
+
+    stage_id = uuid4()
+    actual_reviewer_id = reviewer_id if reviewer_id is not None else uuid4()
+    return actual_task_id, stage_id, actual_reviewer_id

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_external_review_gate_repository/test_count_by_decision.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_external_review_gate_repository/test_count_by_decision.py
@@ -1,0 +1,167 @@
+"""ExternalReviewGate Repository: count_by_decision SQL guarantee.
+
+TC-UT-ERGR-008 — §確定 R1-D count_by_decision.
+
+Verifies:
+* count_by_decision(PENDING) returns correct count.
+* SQL log contains WHERE decision = filter (not a full-table-scan aggregate).
+* All decision values (PENDING / APPROVED / REJECTED / CANCELLED) isolated.
+
+Per ``docs/features/external-review-gate-repository/test-design.md`` TC-UT-ERGR-008.
+Issue #36 — M2 0008.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+import pytest
+from bakufu.domain.value_objects import ReviewDecision
+from bakufu.infrastructure.persistence.sqlite.repositories.external_review_gate_repository import (
+    SqliteExternalReviewGateRepository,
+)
+from sqlalchemy import event
+
+from tests.factories.external_review_gate import (
+    make_approved_gate,
+    make_gate,
+    make_rejected_gate,
+)
+from tests.infrastructure.persistence.sqlite.repositories.test_external_review_gate_repository.conftest import (  # noqa: E501
+    seed_gate_context,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-ERGR-008: count_by_decision SQL COUNT(*) WHERE decision =
+# ---------------------------------------------------------------------------
+class TestCountByDecision:
+    """TC-UT-ERGR-008: count_by_decision issues COUNT(*) WHERE decision = :decision."""
+
+    async def test_count_by_decision_pending(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_gate_context: tuple[UUID, UUID, UUID],
+    ) -> None:
+        """TC-UT-ERGR-008: count_by_decision(PENDING) = 2 with 2 PENDING gates saved."""
+        task_id, stage_id, reviewer_id = seeded_gate_context
+
+        gate1 = make_gate(task_id=task_id, stage_id=stage_id, reviewer_id=reviewer_id)
+        gate2 = make_gate(task_id=task_id, stage_id=stage_id, reviewer_id=reviewer_id)
+        gate_approved = make_approved_gate(
+            task_id=task_id, stage_id=stage_id, reviewer_id=reviewer_id
+        )
+        gate_rejected = make_rejected_gate(
+            task_id=task_id, stage_id=stage_id, reviewer_id=reviewer_id
+        )
+
+        async with session_factory() as session, session.begin():
+            repo = SqliteExternalReviewGateRepository(session)
+            await repo.save(gate1)
+            await repo.save(gate2)
+            await repo.save(gate_approved)
+            await repo.save(gate_rejected)
+
+        async with session_factory() as session:
+            result = await SqliteExternalReviewGateRepository(session).count_by_decision(
+                ReviewDecision.PENDING
+            )
+
+        assert result == 2, f"[FAIL] Expected count 2 for PENDING, got {result}"
+
+    async def test_count_by_decision_all_values_isolated(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_gate_context: tuple[UUID, UUID, UUID],
+    ) -> None:
+        """TC-UT-ERGR-008: APPROVED=1 / REJECTED=1 / CANCELLED=0 correctly isolated."""
+        task_id, stage_id, reviewer_id = seeded_gate_context
+
+        gate_pending = make_gate(task_id=task_id, stage_id=stage_id, reviewer_id=reviewer_id)
+        gate_approved = make_approved_gate(
+            task_id=task_id, stage_id=stage_id, reviewer_id=reviewer_id
+        )
+        gate_rejected = make_rejected_gate(
+            task_id=task_id, stage_id=stage_id, reviewer_id=reviewer_id
+        )
+
+        async with session_factory() as session, session.begin():
+            repo = SqliteExternalReviewGateRepository(session)
+            await repo.save(gate_pending)
+            await repo.save(gate_approved)
+            await repo.save(gate_rejected)
+
+        async with session_factory() as session:
+            repo = SqliteExternalReviewGateRepository(session)
+            count_pending = await repo.count_by_decision(ReviewDecision.PENDING)
+            count_approved = await repo.count_by_decision(ReviewDecision.APPROVED)
+            count_rejected = await repo.count_by_decision(ReviewDecision.REJECTED)
+            count_cancelled = await repo.count_by_decision(ReviewDecision.CANCELLED)
+
+        assert count_pending == 1, f"[FAIL] PENDING={count_pending}, expected 1"
+        assert count_approved == 1, f"[FAIL] APPROVED={count_approved}, expected 1"
+        assert count_rejected == 1, f"[FAIL] REJECTED={count_rejected}, expected 1"
+        assert count_cancelled == 0, f"[FAIL] CANCELLED={count_cancelled}, expected 0"
+
+    async def test_count_by_decision_sql_contains_where_decision(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_gate_context: tuple[UUID, UUID, UUID],
+    ) -> None:
+        """TC-UT-ERGR-008: SQL log confirms COUNT(*) WHERE decision = filter."""
+        task_id, stage_id, reviewer_id = seeded_gate_context
+        gate = make_gate(task_id=task_id, stage_id=stage_id, reviewer_id=reviewer_id)
+
+        async with session_factory() as session, session.begin():
+            await SqliteExternalReviewGateRepository(session).save(gate)
+
+        sql_log: list[str] = []
+
+        async with session_factory() as session:
+            sync_engine = session.get_bind()
+            if hasattr(sync_engine, "sync_engine"):
+                sync_engine = sync_engine.sync_engine  # type: ignore[union-attr]
+
+            @event.listens_for(sync_engine, "before_cursor_execute")
+            def _capture(conn, cursor, statement, params, context, executemany):  # type: ignore[no-untyped-def]
+                sql_log.append(statement.upper())
+
+            await SqliteExternalReviewGateRepository(session).count_by_decision(
+                ReviewDecision.PENDING
+            )
+
+        combined = " ".join(sql_log)
+        assert "COUNT" in combined, f"[FAIL] COUNT missing from SQL.\nSQL: {sql_log}"
+        assert "WHERE" in combined, f"[FAIL] WHERE clause missing from SQL.\nSQL: {sql_log}"
+        assert "DECISION" in combined, f"[FAIL] decision filter missing from SQL.\nSQL: {sql_log}"
+
+    async def test_count_by_decision_cross_context_isolation(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """TC-UT-ERGR-008: count_by_decision aggregates across all tasks (not task-scoped)."""
+        ctx1 = await seed_gate_context(session_factory)
+        ctx2 = await seed_gate_context(session_factory)
+
+        gate1 = make_gate(task_id=ctx1[0], stage_id=ctx1[1], reviewer_id=ctx1[2])
+        gate2 = make_gate(task_id=ctx2[0], stage_id=ctx2[1], reviewer_id=ctx2[2])
+
+        async with session_factory() as session, session.begin():
+            repo = SqliteExternalReviewGateRepository(session)
+            await repo.save(gate1)
+            await repo.save(gate2)
+
+        async with session_factory() as session:
+            total_pending = await SqliteExternalReviewGateRepository(session).count_by_decision(
+                ReviewDecision.PENDING
+            )
+
+        assert total_pending == 2, (
+            f"[FAIL] count_by_decision should aggregate across all tasks, got {total_pending}"
+        )

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_external_review_gate_repository/test_count_by_decision.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_external_review_gate_repository/test_count_by_decision.py
@@ -129,7 +129,7 @@ class TestCountByDecision:
                 sync_engine = sync_engine.sync_engine  # type: ignore[union-attr]
 
             @event.listens_for(sync_engine, "before_cursor_execute")
-            def _capture(conn, cursor, statement, params, context, executemany):  # type: ignore[no-untyped-def]
+            def _capture(conn, cursor, statement: str, params, context, executemany):  # type: ignore[no-untyped-def]
                 sql_log.append(statement.upper())
 
             await SqliteExternalReviewGateRepository(session).count_by_decision(

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_external_review_gate_repository/test_find_methods.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_external_review_gate_repository/test_find_methods.py
@@ -132,7 +132,7 @@ class TestFindPendingByReviewerSqlLog:
                 sync_engine = sync_engine.sync_engine  # type: ignore[union-attr]
 
             @event.listens_for(sync_engine, "before_cursor_execute")
-            def _capture(conn, cursor, statement, params, context, executemany):  # type: ignore[no-untyped-def]
+            def _capture(conn, cursor, statement: str, params, context, executemany):  # type: ignore[no-untyped-def]
                 sql_log.append(statement.upper())
 
             await SqliteExternalReviewGateRepository(session).find_pending_by_reviewer(reviewer_id)

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_external_review_gate_repository/test_find_methods.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_external_review_gate_repository/test_find_methods.py
@@ -1,0 +1,298 @@
+"""ExternalReviewGate Repository: find_pending_by_reviewer / find_by_task_id.
+
+TC-UT-ERGR-006/006b/006c/006d/007/007b/007c — §確定 R1-D / §確定 R1-H ORDER BY.
+
+Tests ORDER BY determinism (BUG-EMR-001 準拠) for both query methods:
+* find_pending_by_reviewer: created_at DESC, id DESC tiebreaker
+* find_by_task_id: created_at ASC, id ASC (chronological review history)
+
+Per ``docs/features/external-review-gate-repository/test-design.md``
+TC-UT-ERGR-006〜007c.
+Issue #36 — M2 0008.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+import pytest
+from bakufu.domain.value_objects import ReviewDecision
+from bakufu.infrastructure.persistence.sqlite.repositories.external_review_gate_repository import (
+    SqliteExternalReviewGateRepository,
+)
+from sqlalchemy import event
+
+from tests.factories.external_review_gate import (
+    make_approved_gate,
+    make_gate,
+    make_rejected_gate,
+)
+from tests.infrastructure.persistence.sqlite.repositories.test_external_review_gate_repository.conftest import (  # noqa: E501
+    seed_gate_context,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-ERGR-006: find_pending_by_reviewer returns PENDING only
+# ---------------------------------------------------------------------------
+class TestFindPendingByReviewer:
+    """TC-UT-ERGR-006: find_pending_by_reviewer returns only PENDING Gates."""
+
+    async def test_returns_only_pending_gates(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_gate_context: tuple[UUID, UUID, UUID],
+    ) -> None:
+        """TC-UT-ERGR-006: PENDING Gates for reviewer returned; APPROVED excluded."""
+        task_id, stage_id, reviewer_id = seeded_gate_context
+
+        gate_pending1 = make_gate(task_id=task_id, stage_id=stage_id, reviewer_id=reviewer_id)
+        gate_pending2 = make_gate(task_id=task_id, stage_id=stage_id, reviewer_id=reviewer_id)
+        gate_approved = make_approved_gate(
+            task_id=task_id, stage_id=stage_id, reviewer_id=reviewer_id
+        )
+
+        async with session_factory() as session, session.begin():
+            repo = SqliteExternalReviewGateRepository(session)
+            await repo.save(gate_pending1)
+            await repo.save(gate_pending2)
+            await repo.save(gate_approved)
+
+        async with session_factory() as session:
+            results = await SqliteExternalReviewGateRepository(session).find_pending_by_reviewer(
+                reviewer_id
+            )
+
+        assert len(results) == 2, f"[FAIL] Expected 2 PENDING, got {len(results)}"
+        for g in results:
+            assert g.decision == ReviewDecision.PENDING, "[FAIL] Non-PENDING gate in results"
+        ids = {g.id for g in results}
+        assert gate_approved.id not in ids, "[FAIL] APPROVED gate appeared in PENDING results"
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-ERGR-006b: find_pending_by_reviewer returns [] when no PENDING gates
+# ---------------------------------------------------------------------------
+class TestFindPendingByReviewerEmpty:
+    """TC-UT-ERGR-006b: Returns [] (not None) when no PENDING gates exist."""
+
+    async def test_returns_empty_list_when_no_pending(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_gate_context: tuple[UUID, UUID, UUID],
+    ) -> None:
+        """TC-UT-ERGR-006b: No PENDING gates → [] not None."""
+        task_id, stage_id, reviewer_id = seeded_gate_context
+        approved = make_approved_gate(task_id=task_id, stage_id=stage_id, reviewer_id=reviewer_id)
+        rejected = make_rejected_gate(task_id=task_id, stage_id=stage_id, reviewer_id=reviewer_id)
+
+        async with session_factory() as session, session.begin():
+            repo = SqliteExternalReviewGateRepository(session)
+            await repo.save(approved)
+            await repo.save(rejected)
+
+        async with session_factory() as session:
+            results = await SqliteExternalReviewGateRepository(session).find_pending_by_reviewer(
+                reviewer_id
+            )
+
+        assert results == [], f"[FAIL] Expected [] but got {results!r}"
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-ERGR-006c: SQL ログに ORDER BY created_at + reviewer_id filter 含まれる
+# ---------------------------------------------------------------------------
+class TestFindPendingByReviewerSqlLog:
+    """TC-UT-ERGR-006c: SQL log confirms WHERE reviewer_id + decision + ORDER BY."""
+
+    async def test_sql_contains_reviewer_and_decision_filters(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_gate_context: tuple[UUID, UUID, UUID],
+    ) -> None:
+        """TC-UT-ERGR-006c: Raw SQL includes reviewer_id filter + ORDER BY created_at."""
+        task_id, stage_id, reviewer_id = seeded_gate_context
+        gate = make_gate(task_id=task_id, stage_id=stage_id, reviewer_id=reviewer_id)
+
+        async with session_factory() as session, session.begin():
+            await SqliteExternalReviewGateRepository(session).save(gate)
+
+        sql_log: list[str] = []
+
+        async with session_factory() as session:
+            sync_engine = session.get_bind()
+            if hasattr(sync_engine, "sync_engine"):
+                sync_engine = sync_engine.sync_engine  # type: ignore[union-attr]
+
+            @event.listens_for(sync_engine, "before_cursor_execute")
+            def _capture(conn, cursor, statement, params, context, executemany):  # type: ignore[no-untyped-def]
+                sql_log.append(statement.upper())
+
+            await SqliteExternalReviewGateRepository(session).find_pending_by_reviewer(reviewer_id)
+
+        combined = " ".join(sql_log)
+        assert "ORDER BY" in combined, f"[FAIL] ORDER BY missing.\nSQL: {sql_log}"
+        assert "CREATED_AT" in combined, f"[FAIL] created_at ORDER BY missing.\nSQL: {sql_log}"
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-ERGR-006d: id DESC tiebreaker (BUG-EMR-001 準拠)
+# ---------------------------------------------------------------------------
+class TestFindPendingByReviewerTiebreaker:
+    """TC-UT-ERGR-006d: id DESC tiebreaker for same-timestamp PENDING gates."""
+
+    async def test_same_timestamp_ordered_by_id_desc(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_gate_context: tuple[UUID, UUID, UUID],
+    ) -> None:
+        """TC-UT-ERGR-006d: Gates with identical created_at ordered by id DESC."""
+        task_id, stage_id, reviewer_id = seeded_gate_context
+        fixed_time = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+        gate_a = make_gate(
+            task_id=task_id, stage_id=stage_id, reviewer_id=reviewer_id, created_at=fixed_time
+        )
+        gate_b = make_gate(
+            task_id=task_id, stage_id=stage_id, reviewer_id=reviewer_id, created_at=fixed_time
+        )
+        gate_c = make_gate(
+            task_id=task_id, stage_id=stage_id, reviewer_id=reviewer_id, created_at=fixed_time
+        )
+
+        async with session_factory() as session, session.begin():
+            repo = SqliteExternalReviewGateRepository(session)
+            for g in [gate_a, gate_b, gate_c]:
+                await repo.save(g)
+
+        async with session_factory() as session:
+            results = await SqliteExternalReviewGateRepository(session).find_pending_by_reviewer(
+                reviewer_id
+            )
+
+        assert len(results) == 3
+        result_ids = [g.id for g in results]
+        expected_ids = sorted([gate_a.id, gate_b.id, gate_c.id], key=lambda u: u.hex, reverse=True)
+        assert result_ids == expected_ids, (
+            f"[FAIL] id DESC tiebreaker not applied.\nExpected: {expected_ids}\nGot: {result_ids}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-ERGR-007: find_by_task_id returns all Gates for a task
+# ---------------------------------------------------------------------------
+class TestFindByTaskId:
+    """TC-UT-ERGR-007: find_by_task_id returns all Gates for the given task."""
+
+    async def test_returns_all_gates_for_task(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_gate_context: tuple[UUID, UUID, UUID],
+    ) -> None:
+        """TC-UT-ERGR-007: Both PENDING + REJECTED gates for same task returned."""
+        task_id, stage_id, reviewer_id = seeded_gate_context
+        gate_pending = make_gate(task_id=task_id, stage_id=stage_id, reviewer_id=reviewer_id)
+        gate_rejected = make_rejected_gate(
+            task_id=task_id, stage_id=stage_id, reviewer_id=reviewer_id
+        )
+
+        async with session_factory() as session, session.begin():
+            repo = SqliteExternalReviewGateRepository(session)
+            await repo.save(gate_pending)
+            await repo.save(gate_rejected)
+
+        async with session_factory() as session:
+            results = await SqliteExternalReviewGateRepository(session).find_by_task_id(task_id)
+
+        assert len(results) == 2
+        ids = {g.id for g in results}
+        assert gate_pending.id in ids
+        assert gate_rejected.id in ids
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-ERGR-007b: created_at ASC ordering for multi-round review history
+# ---------------------------------------------------------------------------
+class TestFindByTaskIdChronologicalOrder:
+    """TC-UT-ERGR-007b: find_by_task_id returns gates in created_at ASC order."""
+
+    async def test_multiple_rounds_returned_in_chronological_order(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_gate_context: tuple[UUID, UUID, UUID],
+    ) -> None:
+        """TC-UT-ERGR-007b: REJECTED → PENDING → PENDING returned oldest-first."""
+        task_id, stage_id, reviewer_id = seeded_gate_context
+        base = datetime(2026, 1, 1, 10, 0, 0, tzinfo=UTC)
+
+        gate_round1 = make_rejected_gate(
+            task_id=task_id,
+            stage_id=stage_id,
+            reviewer_id=reviewer_id,
+            decided_at=base + timedelta(hours=1),
+            created_at=base,
+        )
+        gate_round2 = make_gate(
+            task_id=task_id,
+            stage_id=stage_id,
+            reviewer_id=reviewer_id,
+            created_at=base + timedelta(hours=2),
+        )
+        gate_round3 = make_gate(
+            task_id=task_id,
+            stage_id=stage_id,
+            reviewer_id=reviewer_id,
+            created_at=base + timedelta(hours=4),
+        )
+
+        async with session_factory() as session, session.begin():
+            repo = SqliteExternalReviewGateRepository(session)
+            for g in [gate_round1, gate_round2, gate_round3]:
+                await repo.save(g)
+
+        async with session_factory() as session:
+            results = await SqliteExternalReviewGateRepository(session).find_by_task_id(task_id)
+
+        assert len(results) == 3
+        assert results[0].id == gate_round1.id, "[FAIL] Oldest gate not first (ASC)."
+        assert results[-1].id == gate_round3.id, "[FAIL] Newest gate not last (ASC)."
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-ERGR-007c: find_by_task_id does not return other task's gates
+# ---------------------------------------------------------------------------
+class TestFindByTaskIdIsolation:
+    """TC-UT-ERGR-007c: Cross-task isolation — gates of task_B excluded."""
+
+    async def test_cross_task_isolation(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_gate_context: tuple[UUID, UUID, UUID],
+    ) -> None:
+        """TC-UT-ERGR-007c: find_by_task_id(task_a) does not include task_b gates."""
+        task_id_a, stage_id_a, reviewer_id_a = seeded_gate_context
+        task_id_b, stage_id_b, reviewer_id_b = await seed_gate_context(session_factory)
+
+        gate_a1 = make_gate(task_id=task_id_a, stage_id=stage_id_a, reviewer_id=reviewer_id_a)
+        gate_a2 = make_gate(task_id=task_id_a, stage_id=stage_id_a, reviewer_id=reviewer_id_a)
+        gate_b = make_gate(task_id=task_id_b, stage_id=stage_id_b, reviewer_id=reviewer_id_b)
+
+        async with session_factory() as session, session.begin():
+            repo = SqliteExternalReviewGateRepository(session)
+            await repo.save(gate_a1)
+            await repo.save(gate_a2)
+            await repo.save(gate_b)
+
+        async with session_factory() as session:
+            results_a = await SqliteExternalReviewGateRepository(session).find_by_task_id(task_id_a)
+
+        assert len(results_a) == 2
+        ids = {g.id for g in results_a}
+        assert gate_b.id not in ids, "[FAIL] task_B gate appeared in task_A results."

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_external_review_gate_repository/test_masking_fields.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_external_review_gate_repository/test_masking_fields.py
@@ -1,0 +1,487 @@
+"""ExternalReviewGate Repository: MaskedText wiring on 3 columns (TC-IT-ERGR-020-masking-*).
+
+RQ-ERGR-006 / §確定 R1-E — 3 MaskedText columns physical verification:
+  * external_review_gates.snapshot_body_markdown
+  * external_review_gates.feedback_text
+  * external_review_audit_entries.comment
+
+Each column is verified via **raw SQL SELECT** so the observation bypasses
+``MaskedText.process_result_value`` and confirms the literal bytes on disk.
+
+9 test cases:
+  snapshot_body_markdown: masked / plain / roundtrip (3 cases)
+  feedback_text: masked / plain / roundtrip (3 cases)
+  comment: masked / plain (2 cases)
+  3-column simultaneous: 1 case
+
+Per ``docs/features/external-review-gate-repository/test-design.md``
+TC-IT-ERGR-020-masking-*.
+Issue #36 — M2 0008.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+import pytest
+from bakufu.domain.value_objects import AuditAction
+from bakufu.infrastructure.persistence.sqlite.repositories.external_review_gate_repository import (
+    SqliteExternalReviewGateRepository,
+)
+from sqlalchemy import text
+
+from tests.factories.external_review_gate import (
+    make_approved_gate,
+    make_audit_entry,
+    make_gate,
+    make_rejected_gate,
+)
+from tests.factories.task import make_deliverable
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Secret token constants (real-shape, constructed to avoid push-protection)
+# ---------------------------------------------------------------------------
+
+# Discord Bot Token — [MN][A-Za-z\d]{23,}\.[\w-]{6}\.[\w-]{27,}
+_DISCORD_TOKEN = "MTk4NjIyNDgz" + "NDcxOTI1MjQ4.ClFDg_." + "A" * 27
+_DISCORD_SENTINEL = "<REDACTED:DISCORD_TOKEN>"
+
+# GitHub PAT — (?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36,}
+_GITHUB_TOKEN = "ghp_" + "X" * 40
+_GITHUB_SENTINEL = "<REDACTED:GITHUB_PAT>"
+
+# Slack Bot Token — xoxb-[0-9]{10,13}-[0-9]{10,13}-[a-zA-Z0-9]{24}
+_SLACK_TOKEN = "xoxb-" + "1" * 11 + "-" + "2" * 11 + "-" + "A" * 24
+_SLACK_SENTINEL = "<REDACTED:SLACK_TOKEN>"
+
+
+# ---------------------------------------------------------------------------
+# Raw-SQL helpers (bypass TypeDecorator.process_result_value)
+# ---------------------------------------------------------------------------
+async def _read_persisted_snapshot_body(
+    session_factory: async_sessionmaker[AsyncSession],
+    gate_id: UUID,
+) -> str:
+    """Fetch external_review_gates.snapshot_body_markdown literal bytes."""
+    async with session_factory() as session:
+        row = (
+            await session.execute(
+                text("SELECT snapshot_body_markdown FROM external_review_gates WHERE id = :id"),
+                {"id": gate_id.hex},
+            )
+        ).first()
+    if row is None:
+        raise AssertionError(f"external_review_gates row not found for id={gate_id}")
+    return row[0]
+
+
+async def _read_persisted_feedback_text(
+    session_factory: async_sessionmaker[AsyncSession],
+    gate_id: UUID,
+) -> str:
+    """Fetch external_review_gates.feedback_text literal bytes."""
+    async with session_factory() as session:
+        row = (
+            await session.execute(
+                text("SELECT feedback_text FROM external_review_gates WHERE id = :id"),
+                {"id": gate_id.hex},
+            )
+        ).first()
+    if row is None:
+        raise AssertionError(f"external_review_gates row not found for id={gate_id}")
+    return row[0]
+
+
+async def _read_persisted_audit_comment(
+    session_factory: async_sessionmaker[AsyncSession],
+    gate_id: UUID,
+) -> str:
+    """Fetch external_review_audit_entries.comment literal bytes (first entry)."""
+    async with session_factory() as session:
+        row = (
+            await session.execute(
+                text(
+                    "SELECT comment FROM external_review_audit_entries"
+                    " WHERE gate_id = :gate_id LIMIT 1"
+                ),
+                {"gate_id": gate_id.hex},
+            )
+        ).first()
+    if row is None:
+        raise AssertionError(f"external_review_audit_entries row not found for gate_id={gate_id}")
+    return row[0]
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-ERGR-020-masking-snapshot-masked
+# ---------------------------------------------------------------------------
+class TestSnapshotBodyMarkdownDiscordTokenMasked:
+    """TC-IT-ERGR-020-masking-snapshot-masked: Discord token in snapshot_body_markdown redacted."""
+
+    async def test_discord_token_in_snapshot_body_redacted_on_disk(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_gate_context: tuple[UUID, UUID, UUID],
+    ) -> None:
+        """Raw-SQL SELECT shows <REDACTED:DISCORD_TOKEN>; raw token absent from disk."""
+        task_id, stage_id, reviewer_id = seeded_gate_context
+        body = (
+            f"# 設計書\nDiscord webhook: https://discord.com/api/webhooks/123/{_DISCORD_TOKEN}\n"
+            f"このURLでレビュー通知を送信します。"
+        )
+        snapshot = make_deliverable(body_markdown=body)
+        gate = make_gate(
+            task_id=task_id,
+            stage_id=stage_id,
+            reviewer_id=reviewer_id,
+            deliverable_snapshot=snapshot,
+        )
+
+        async with session_factory() as session, session.begin():
+            await SqliteExternalReviewGateRepository(session).save(gate)
+
+        persisted = await _read_persisted_snapshot_body(session_factory, gate.id)
+
+        assert _DISCORD_SENTINEL in persisted, (
+            f"[FAIL] snapshot_body_markdown missing Discord sentinel.\nPersisted: {persisted!r}"
+        )
+        assert _DISCORD_TOKEN not in persisted, (
+            f"[FAIL] Raw Discord token leaked into snapshot_body_markdown.\n"
+            f"Violates §確定 R1-E §不可逆性. Persisted: {persisted!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-ERGR-020-masking-snapshot-plain
+# ---------------------------------------------------------------------------
+class TestSnapshotBodyMarkdownPlainPassthrough:
+    """TC-IT-ERGR-020-masking-snapshot-plain: plain text stored unchanged."""
+
+    async def test_plain_snapshot_body_is_passthrough(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_gate_context: tuple[UUID, UUID, UUID],
+    ) -> None:
+        """snapshot_body_markdown without secrets stored byte-identical."""
+        task_id, stage_id, reviewer_id = seeded_gate_context
+        plain_body = "タスク設計が完成した。レビューをお願いします。"
+        snapshot = make_deliverable(body_markdown=plain_body)
+        gate = make_gate(
+            task_id=task_id,
+            stage_id=stage_id,
+            reviewer_id=reviewer_id,
+            deliverable_snapshot=snapshot,
+        )
+
+        async with session_factory() as session, session.begin():
+            await SqliteExternalReviewGateRepository(session).save(gate)
+
+        persisted = await _read_persisted_snapshot_body(session_factory, gate.id)
+        assert persisted == plain_body, (
+            f"[FAIL] Plain snapshot_body_markdown was modified.\n"
+            f"Expected: {plain_body!r}\nGot: {persisted!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-ERGR-020-masking-snapshot-roundtrip
+# ---------------------------------------------------------------------------
+class TestSnapshotBodyMarkdownRoundtripIrreversible:
+    """TC-IT-ERGR-020-masking-snapshot-roundtrip: find_by_id returns masked body."""
+
+    async def test_find_by_id_returns_masked_snapshot_body(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_gate_context: tuple[UUID, UUID, UUID],
+    ) -> None:
+        """Save raw Discord token in snapshot_body_markdown → find_by_id → body == masked."""
+        task_id, stage_id, reviewer_id = seeded_gate_context
+        body = f"設計書: auth={_DISCORD_TOKEN} for Discord integration"
+        snapshot = make_deliverable(body_markdown=body)
+        gate = make_gate(
+            task_id=task_id,
+            stage_id=stage_id,
+            reviewer_id=reviewer_id,
+            deliverable_snapshot=snapshot,
+        )
+
+        async with session_factory() as session, session.begin():
+            await SqliteExternalReviewGateRepository(session).save(gate)
+
+        async with session_factory() as session:
+            restored = await SqliteExternalReviewGateRepository(session).find_by_id(gate.id)
+
+        assert restored is not None
+        restored_body = restored.deliverable_snapshot.body_markdown
+        assert _DISCORD_SENTINEL in restored_body, (
+            f"[FAIL] find_by_id returned unmasked snapshot_body_markdown.\n"
+            f"Restored: {restored_body!r}"
+        )
+        assert _DISCORD_TOKEN not in restored_body, (
+            f"[FAIL] §確定 R1-E §不可逆性 violated: raw Discord token recovered.\n"
+            f"Restored: {restored_body!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-ERGR-020-masking-feedback-masked
+# ---------------------------------------------------------------------------
+class TestFeedbackTextSlackTokenMasked:
+    """TC-IT-ERGR-020-masking-feedback-masked: Slack token in feedback_text redacted."""
+
+    async def test_slack_token_in_feedback_text_redacted_on_disk(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_gate_context: tuple[UUID, UUID, UUID],
+    ) -> None:
+        """Raw-SQL SELECT shows <REDACTED:SLACK_TOKEN>; raw token absent from disk."""
+        task_id, stage_id, reviewer_id = seeded_gate_context
+        feedback = f"レビュー承認。Slack通知: token={_SLACK_TOKEN}"
+        decided_at = datetime.now(UTC)
+        gate = make_rejected_gate(
+            task_id=task_id,
+            stage_id=stage_id,
+            reviewer_id=reviewer_id,
+            feedback_text=feedback,
+            decided_at=decided_at,
+        )
+
+        async with session_factory() as session, session.begin():
+            await SqliteExternalReviewGateRepository(session).save(gate)
+
+        persisted = await _read_persisted_feedback_text(session_factory, gate.id)
+
+        assert _SLACK_SENTINEL in persisted, (
+            f"[FAIL] feedback_text missing Slack sentinel.\nPersisted: {persisted!r}"
+        )
+        assert _SLACK_TOKEN not in persisted, (
+            f"[FAIL] Raw Slack token leaked into feedback_text.\n"
+            f"Violates §確定 R1-E (§設計決定 ERGR-002). Persisted: {persisted!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-ERGR-020-masking-feedback-plain
+# ---------------------------------------------------------------------------
+class TestFeedbackTextPlainPassthrough:
+    """TC-IT-ERGR-020-masking-feedback-plain: plain feedback text stored unchanged."""
+
+    async def test_plain_feedback_text_is_passthrough(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_gate_context: tuple[UUID, UUID, UUID],
+    ) -> None:
+        """feedback_text without secrets stored byte-identical."""
+        task_id, stage_id, reviewer_id = seeded_gate_context
+        plain_feedback = "設計品質が基準を満たしていない。再提出を求める。"
+        decided_at = datetime.now(UTC)
+        gate = make_rejected_gate(
+            task_id=task_id,
+            stage_id=stage_id,
+            reviewer_id=reviewer_id,
+            feedback_text=plain_feedback,
+            decided_at=decided_at,
+        )
+
+        async with session_factory() as session, session.begin():
+            await SqliteExternalReviewGateRepository(session).save(gate)
+
+        persisted = await _read_persisted_feedback_text(session_factory, gate.id)
+        assert persisted == plain_feedback, (
+            f"[FAIL] plain feedback_text was modified.\n"
+            f"Expected: {plain_feedback!r}\nGot: {persisted!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-ERGR-020-masking-feedback-roundtrip
+# ---------------------------------------------------------------------------
+class TestFeedbackTextRoundtripIrreversible:
+    """TC-IT-ERGR-020-masking-feedback-roundtrip: find_by_id returns masked feedback."""
+
+    async def test_find_by_id_returns_masked_feedback_text(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_gate_context: tuple[UUID, UUID, UUID],
+    ) -> None:
+        """Save Slack token in feedback_text → find_by_id → feedback_text == masked."""
+        task_id, stage_id, reviewer_id = seeded_gate_context
+        feedback = f"Slack auth: {_SLACK_TOKEN} で通知を送る"
+        decided_at = datetime.now(UTC)
+        gate = make_approved_gate(
+            task_id=task_id,
+            stage_id=stage_id,
+            reviewer_id=reviewer_id,
+            feedback_text=feedback,
+            decided_at=decided_at,
+        )
+
+        async with session_factory() as session, session.begin():
+            await SqliteExternalReviewGateRepository(session).save(gate)
+
+        async with session_factory() as session:
+            restored = await SqliteExternalReviewGateRepository(session).find_by_id(gate.id)
+
+        assert restored is not None
+        assert _SLACK_SENTINEL in restored.feedback_text, (
+            f"[FAIL] find_by_id returned unmasked feedback_text.\n"
+            f"Restored: {restored.feedback_text!r}"
+        )
+        assert _SLACK_TOKEN not in restored.feedback_text, (
+            f"[FAIL] §確定 R1-E §不可逆性 violated: raw Slack token recovered.\n"
+            f"Restored: {restored.feedback_text!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-ERGR-020-masking-comment-masked
+# ---------------------------------------------------------------------------
+class TestAuditCommentGithubPatMasked:
+    """TC-IT-ERGR-020-masking-comment-masked: GitHub PAT in audit comment redacted."""
+
+    async def test_github_pat_in_audit_comment_redacted_on_disk(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_gate_context: tuple[UUID, UUID, UUID],
+    ) -> None:
+        """Raw-SQL SELECT shows <REDACTED:GITHUB_PAT>; raw PAT absent from disk."""
+        task_id, stage_id, reviewer_id = seeded_gate_context
+        comment = f"承認します。GitHub PAT: {_GITHUB_TOKEN} で変更を確認。"
+        decided_at = datetime.now(UTC)
+        audit_entry = make_audit_entry(
+            action=AuditAction.APPROVED,
+            comment=comment,
+            occurred_at=decided_at,
+        )
+        gate = make_approved_gate(
+            task_id=task_id,
+            stage_id=stage_id,
+            reviewer_id=reviewer_id,
+            audit_trail=[audit_entry],
+            decided_at=decided_at,
+        )
+
+        async with session_factory() as session, session.begin():
+            await SqliteExternalReviewGateRepository(session).save(gate)
+
+        persisted = await _read_persisted_audit_comment(session_factory, gate.id)
+
+        assert _GITHUB_SENTINEL in persisted, (
+            f"[FAIL] audit comment missing GitHub PAT sentinel.\nPersisted: {persisted!r}"
+        )
+        assert _GITHUB_TOKEN not in persisted, (
+            f"[FAIL] Raw GitHub PAT leaked into audit_entries.comment.\n"
+            f"Violates §確定 R1-E. Persisted: {persisted!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-ERGR-020-masking-comment-plain
+# ---------------------------------------------------------------------------
+class TestAuditCommentPlainPassthrough:
+    """TC-IT-ERGR-020-masking-comment-plain: plain comment stored unchanged."""
+
+    async def test_plain_audit_comment_is_passthrough(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_gate_context: tuple[UUID, UUID, UUID],
+    ) -> None:
+        """audit_entries.comment without secrets stored byte-identical."""
+        task_id, stage_id, reviewer_id = seeded_gate_context
+        plain_comment = "設計品質が基準を満たしている。承認する。"
+        decided_at = datetime.now(UTC)
+        audit_entry = make_audit_entry(
+            action=AuditAction.APPROVED,
+            comment=plain_comment,
+            occurred_at=decided_at,
+        )
+        gate = make_approved_gate(
+            task_id=task_id,
+            stage_id=stage_id,
+            reviewer_id=reviewer_id,
+            audit_trail=[audit_entry],
+            decided_at=decided_at,
+        )
+
+        async with session_factory() as session, session.begin():
+            await SqliteExternalReviewGateRepository(session).save(gate)
+
+        persisted = await _read_persisted_audit_comment(session_factory, gate.id)
+        assert persisted == plain_comment, (
+            f"[FAIL] plain audit comment was modified.\n"
+            f"Expected: {plain_comment!r}\nGot: {persisted!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-ERGR-020-masking-3columns: 3 columns simultaneous masking
+# ---------------------------------------------------------------------------
+class TestThreeColumnSimultaneousMasking:
+    """TC-IT-ERGR-020-masking-3columns: All 3 MaskedText columns redacted in one save."""
+
+    async def test_three_masked_text_columns_redacted_simultaneously(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_gate_context: tuple[UUID, UUID, UUID],
+    ) -> None:
+        """Discord + Slack + GitHub all redacted across 3 separate MaskedText columns."""
+        task_id, stage_id, reviewer_id = seeded_gate_context
+
+        # snapshot_body_markdown: Discord token
+        body = f"# 設計書\nDiscord token={_DISCORD_TOKEN} for webhook"
+        snapshot = make_deliverable(body_markdown=body)
+
+        # feedback_text: Slack token
+        feedback = f"レビュー拒否。Slack: {_SLACK_TOKEN}"
+
+        # audit comment: GitHub PAT
+        comment = f"却下理由: GitHub PAT {_GITHUB_TOKEN} が混入していた"
+        decided_at = datetime.now(UTC)
+        audit_entry = make_audit_entry(
+            action=AuditAction.REJECTED,
+            comment=comment,
+            occurred_at=decided_at,
+        )
+
+        gate = make_rejected_gate(
+            task_id=task_id,
+            stage_id=stage_id,
+            reviewer_id=reviewer_id,
+            deliverable_snapshot=snapshot,
+            feedback_text=feedback,
+            audit_trail=[audit_entry],
+            decided_at=decided_at,
+        )
+
+        async with session_factory() as session, session.begin():
+            await SqliteExternalReviewGateRepository(session).save(gate)
+
+        persisted_snapshot = await _read_persisted_snapshot_body(session_factory, gate.id)
+        persisted_feedback = await _read_persisted_feedback_text(session_factory, gate.id)
+        persisted_comment = await _read_persisted_audit_comment(session_factory, gate.id)
+
+        # snapshot_body_markdown — Discord
+        assert _DISCORD_SENTINEL in persisted_snapshot, (
+            "[FAIL] snapshot_body_markdown missing Discord sentinel in 3-column test."
+        )
+        assert _DISCORD_TOKEN not in persisted_snapshot
+
+        # feedback_text — Slack
+        assert _SLACK_SENTINEL in persisted_feedback, (
+            "[FAIL] feedback_text missing Slack sentinel in 3-column test."
+        )
+        assert _SLACK_TOKEN not in persisted_feedback
+
+        # audit comment — GitHub
+        assert _GITHUB_SENTINEL in persisted_comment, (
+            "[FAIL] audit_entries.comment missing GitHub PAT sentinel in 3-column test."
+        )
+        assert _GITHUB_TOKEN not in persisted_comment

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_external_review_gate_repository/test_protocol_crud.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_external_review_gate_repository/test_protocol_crud.py
@@ -286,7 +286,7 @@ class TestCount:
                 sync_engine = sync_engine.sync_engine  # type: ignore[union-attr]
 
             @event.listens_for(sync_engine, "before_cursor_execute")
-            def _capture(conn, cursor, statement, params, context, executemany):  # type: ignore[no-untyped-def]
+            def _capture(conn, cursor, statement: str, params, context, executemany):  # type: ignore[no-untyped-def]
                 sql_log.append(statement.upper())
 
             await SqliteExternalReviewGateRepository(session).count()

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_external_review_gate_repository/test_protocol_crud.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_external_review_gate_repository/test_protocol_crud.py
@@ -1,0 +1,425 @@
+"""ExternalReviewGate Repository: Protocol surface + basic CRUD + Lifecycle.
+
+TC-UT-ERGR-001〜004/009 + TC-IT-ERGR-LIFECYCLE.
+
+RQ-ERGR-001 / RQ-ERGR-002 — 6-method Protocol (§確定 R1-A / §確定 R1-D) +
+CRUD (find_by_id / count / save / Tx boundary) + Lifecycle.
+
+save() 5-step child-table semantics (TC-UT-ERGR-005/005b/005c) live in
+``test_save_child_tables.py``.  find_pending_by_reviewer + find_by_task_id
+(TC-UT-ERGR-006/007) live in ``test_find_methods.py``.
+count_by_decision (TC-UT-ERGR-008) lives in ``test_count_by_decision.py``.
+masking (TC-IT-ERGR-020-masking-*) lives in ``test_masking_fields.py``.
+
+Per ``docs/features/external-review-gate-repository/test-design.md``.
+Issue #36 — M2 0008.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from uuid import UUID, uuid4
+
+import pytest
+from bakufu.application.ports.external_review_gate_repository import (
+    ExternalReviewGateRepository,
+)
+from bakufu.domain.value_objects import (
+    Attachment,
+    AuditAction,
+    Deliverable,
+    ReviewDecision,
+)
+from bakufu.infrastructure.persistence.sqlite.repositories.external_review_gate_repository import (
+    SqliteExternalReviewGateRepository,
+)
+from sqlalchemy import event
+
+from tests.factories.external_review_gate import (
+    make_approved_gate,
+    make_audit_entry,
+    make_gate,
+)
+from tests.factories.task import make_deliverable
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-ERGR-001: Protocol definition + 6-method surface (§確定 R1-A / §確定 R1-D)
+# ---------------------------------------------------------------------------
+class TestExternalReviewGateRepositoryProtocol:
+    """TC-UT-ERGR-001: Protocol declares 6 async methods."""
+
+    async def test_protocol_declares_six_async_methods(self) -> None:
+        """TC-UT-ERGR-001: ExternalReviewGateRepository has all 6 required methods."""
+        for method_name in (
+            "find_by_id",
+            "count",
+            "save",
+            "find_pending_by_reviewer",
+            "find_by_task_id",
+            "count_by_decision",
+        ):
+            assert hasattr(ExternalReviewGateRepository, method_name), (
+                f"[FAIL] ExternalReviewGateRepository.{method_name} missing.\n"
+                f"Protocol requires 6 methods per §確定 R1-D."
+            )
+
+    async def test_protocol_does_not_have_yagni_methods(self) -> None:
+        """TC-UT-ERGR-001: YAGNI methods absent from Protocol.
+
+        §確定 R1-D YAGNI 拒否済み: find_all_pending / find_by_id_all_including_decided.
+        """
+        for banned_method in ("find_all_pending", "find_by_id_all_including_decided"):
+            assert not hasattr(ExternalReviewGateRepository, banned_method), (
+                f"[FAIL] ExternalReviewGateRepository.{banned_method} must not exist (YAGNI).\n"
+                f"Update §確定 R1-D YAGNI 拒否 before adding."
+            )
+
+    async def test_sqlite_repository_satisfies_protocol(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """TC-UT-ERGR-001: SqliteExternalReviewGateRepository satisfies Protocol."""
+        async with session_factory() as session:
+            repo: ExternalReviewGateRepository = SqliteExternalReviewGateRepository(session)
+            for method_name in (
+                "find_by_id",
+                "count",
+                "save",
+                "find_pending_by_reviewer",
+                "find_by_task_id",
+                "count_by_decision",
+            ):
+                assert hasattr(repo, method_name)
+
+    async def test_sqlite_repository_duck_typing_6_methods(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """TC-UT-ERGR-001: duck-typing confirms all 6 methods present on impl."""
+        async with session_factory() as session:
+            repo = SqliteExternalReviewGateRepository(session)
+            for method_name in (
+                "find_by_id",
+                "count",
+                "save",
+                "find_pending_by_reviewer",
+                "find_by_task_id",
+                "count_by_decision",
+            ):
+                assert hasattr(repo, method_name), (
+                    f"SqliteExternalReviewGateRepository missing method: {method_name}"
+                )
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-ERGR-002: find_by_id 存在 / 不在
+# ---------------------------------------------------------------------------
+class TestFindById:
+    """TC-UT-ERGR-002: find_by_id returns Gate or None correctly."""
+
+    async def test_find_by_id_returns_saved_gate(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_gate_context: tuple[UUID, UUID, UUID],
+    ) -> None:
+        """TC-UT-ERGR-002: find_by_id returns the Gate after save."""
+        task_id, stage_id, reviewer_id = seeded_gate_context
+        gate = make_gate(task_id=task_id, stage_id=stage_id, reviewer_id=reviewer_id)
+
+        async with session_factory() as session, session.begin():
+            await SqliteExternalReviewGateRepository(session).save(gate)
+
+        async with session_factory() as session:
+            result = await SqliteExternalReviewGateRepository(session).find_by_id(gate.id)
+
+        assert result is not None
+        assert result.id == gate.id
+
+    async def test_find_by_id_returns_none_for_missing_gate(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """TC-UT-ERGR-002: find_by_id returns None for a non-existent id."""
+        async with session_factory() as session:
+            result = await SqliteExternalReviewGateRepository(session).find_by_id(uuid4())
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-ERGR-003: save → find_by_id round-trip 全属性 (§確定 R1-C)
+# ---------------------------------------------------------------------------
+class TestSaveRoundTrip:
+    """TC-UT-ERGR-003: Full attribute round-trip including child tables."""
+
+    async def test_roundtrip_all_scalar_fields(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_gate_context: tuple[UUID, UUID, UUID],
+    ) -> None:
+        """TC-UT-ERGR-003: save + find_by_id restores all Gate scalar fields."""
+        task_id, stage_id, reviewer_id = seeded_gate_context
+        snapshot_stage_id = uuid4()
+        committed_by = uuid4()
+        now = datetime.now(UTC)
+        snapshot = Deliverable(
+            stage_id=snapshot_stage_id,
+            body_markdown="# 設計書完成\n詳細は別途。",
+            attachments=[],
+            committed_by=committed_by,
+            committed_at=now,
+        )
+        gate = make_gate(
+            task_id=task_id,
+            stage_id=stage_id,
+            reviewer_id=reviewer_id,
+            deliverable_snapshot=snapshot,
+            feedback_text="",
+            created_at=now,
+        )
+
+        async with session_factory() as session, session.begin():
+            await SqliteExternalReviewGateRepository(session).save(gate)
+
+        async with session_factory() as session:
+            restored = await SqliteExternalReviewGateRepository(session).find_by_id(gate.id)
+
+        assert restored is not None
+        assert restored.id == gate.id
+        assert restored.task_id == task_id
+        assert restored.stage_id == stage_id
+        assert restored.reviewer_id == reviewer_id
+        assert restored.decision == ReviewDecision.PENDING
+        assert restored.feedback_text == ""
+        assert restored.decided_at is None
+        assert restored.deliverable_snapshot.stage_id == snapshot_stage_id
+        assert restored.deliverable_snapshot.committed_by == committed_by
+        assert restored.created_at.tzinfo is not None  # UTC tz-aware
+
+    async def test_roundtrip_with_attachments_and_audit_trail(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_gate_context: tuple[UUID, UUID, UUID],
+    ) -> None:
+        """TC-UT-ERGR-003: Attachment + AuditEntry child tables survive round-trip."""
+        task_id, stage_id, reviewer_id = seeded_gate_context
+        sha256 = "a" * 64
+        attachment = Attachment(
+            sha256=sha256,
+            filename="spec.pdf",
+            mime_type="application/pdf",
+            size_bytes=1024,
+        )
+        snapshot = make_deliverable(attachments=[attachment])
+        audit = make_audit_entry(action=AuditAction.VIEWED)
+        gate = make_gate(
+            task_id=task_id,
+            stage_id=stage_id,
+            reviewer_id=reviewer_id,
+            deliverable_snapshot=snapshot,
+            audit_trail=[audit],
+        )
+
+        async with session_factory() as session, session.begin():
+            await SqliteExternalReviewGateRepository(session).save(gate)
+
+        async with session_factory() as session:
+            restored = await SqliteExternalReviewGateRepository(session).find_by_id(gate.id)
+
+        assert restored is not None
+        assert len(restored.deliverable_snapshot.attachments) == 1
+        assert restored.deliverable_snapshot.attachments[0].sha256 == sha256
+        assert len(restored.audit_trail) == 1
+        assert restored.audit_trail[0].action == AuditAction.VIEWED
+        assert restored.audit_trail[0].id == audit.id
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-ERGR-004: count() SQL COUNT(*) 契約
+# ---------------------------------------------------------------------------
+class TestCount:
+    """TC-UT-ERGR-004: count() issues SELECT COUNT(*) without full-row load."""
+
+    async def test_count_returns_correct_total(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_gate_context: tuple[UUID, UUID, UUID],
+    ) -> None:
+        """TC-UT-ERGR-004: count() returns the total number of gates."""
+        task_id, stage_id, reviewer_id = seeded_gate_context
+        gate1 = make_gate(task_id=task_id, stage_id=stage_id, reviewer_id=reviewer_id)
+        gate2 = make_gate(task_id=task_id, stage_id=stage_id, reviewer_id=reviewer_id)
+
+        async with session_factory() as session, session.begin():
+            repo = SqliteExternalReviewGateRepository(session)
+            await repo.save(gate1)
+            await repo.save(gate2)
+
+        async with session_factory() as session:
+            total = await SqliteExternalReviewGateRepository(session).count()
+
+        assert total == 2
+
+    async def test_count_issues_sql_count_star(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_gate_context: tuple[UUID, UUID, UUID],
+    ) -> None:
+        """TC-UT-ERGR-004: count() SQL ログに COUNT(*) が含まれ全行ロードパスなし."""
+        task_id, stage_id, reviewer_id = seeded_gate_context
+        gate = make_gate(task_id=task_id, stage_id=stage_id, reviewer_id=reviewer_id)
+
+        async with session_factory() as session, session.begin():
+            await SqliteExternalReviewGateRepository(session).save(gate)
+
+        sql_log: list[str] = []
+
+        async with session_factory() as session:
+            sync_engine = session.get_bind()
+            if hasattr(sync_engine, "sync_engine"):
+                sync_engine = sync_engine.sync_engine  # type: ignore[union-attr]
+
+            @event.listens_for(sync_engine, "before_cursor_execute")
+            def _capture(conn, cursor, statement, params, context, executemany):  # type: ignore[no-untyped-def]
+                sql_log.append(statement.upper())
+
+            await SqliteExternalReviewGateRepository(session).count()
+
+        assert any("COUNT" in s for s in sql_log), (
+            f"[FAIL] count() did not issue COUNT(*) SQL.\nCaptured SQL: {sql_log}"
+        )
+        # No SELECT * or full-row load
+        assert not any("SELECT external_review_gate" in s.lower() for s in sql_log), (
+            f"[FAIL] count() triggered full-row load.\nCaptured SQL: {sql_log}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-ERGR-009: Tx 境界の責務分離 (empire §確定 B 踏襲)
+# ---------------------------------------------------------------------------
+class TestTransactionBoundary:
+    """TC-UT-ERGR-009: Repository never commits; caller-side UoW owns the boundary."""
+
+    async def test_save_within_begin_is_committed(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_gate_context: tuple[UUID, UUID, UUID],
+    ) -> None:
+        """TC-UT-ERGR-009: save inside session.begin() is visible across sessions."""
+        task_id, stage_id, reviewer_id = seeded_gate_context
+        gate = make_gate(task_id=task_id, stage_id=stage_id, reviewer_id=reviewer_id)
+
+        async with session_factory() as session, session.begin():
+            await SqliteExternalReviewGateRepository(session).save(gate)
+
+        async with session_factory() as session:
+            restored = await SqliteExternalReviewGateRepository(session).find_by_id(gate.id)
+
+        assert restored is not None, "[FAIL] Gate not found after commit."
+
+    async def test_save_without_begin_is_not_committed(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_gate_context: tuple[UUID, UUID, UUID],
+    ) -> None:
+        """TC-UT-ERGR-009: save without session.begin() → not persisted (no auto-commit)."""
+        task_id, stage_id, reviewer_id = seeded_gate_context
+        gate = make_gate(task_id=task_id, stage_id=stage_id, reviewer_id=reviewer_id)
+
+        async with session_factory() as session:
+            # No session.begin() — no explicit transaction context
+            await SqliteExternalReviewGateRepository(session).save(gate)
+            # Session closed without commit
+
+        async with session_factory() as session:
+            restored = await SqliteExternalReviewGateRepository(session).find_by_id(gate.id)
+
+        assert restored is None, (
+            "[FAIL] Gate visible without explicit transaction begin — auto-commit active?."
+        )
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-ERGR-LIFECYCLE: 6 method 全経路連携
+# ---------------------------------------------------------------------------
+class TestLifecycle:
+    """TC-IT-ERGR-LIFECYCLE: All 6 Protocol methods interact correctly end-to-end."""
+
+    async def test_full_lifecycle_six_methods(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_gate_context: tuple[UUID, UUID, UUID],
+    ) -> None:
+        """TC-IT-ERGR-LIFECYCLE: save → find_pending → find_by_task_id → find_by_id
+        → count_by_decision → approve → re-save → verify counts updated."""
+        from tests.infrastructure.persistence.sqlite.repositories.test_external_review_gate_repository.conftest import (  # noqa: E501
+            seed_gate_context,
+        )
+
+        task_id, stage_id, reviewer_id = seeded_gate_context
+        # Second task for isolation
+        task_id2, stage_id2, reviewer_id2 = await seed_gate_context(session_factory)
+
+        gate1 = make_gate(task_id=task_id, stage_id=stage_id, reviewer_id=reviewer_id)
+        gate2 = make_gate(task_id=task_id2, stage_id=stage_id2, reviewer_id=reviewer_id2)
+
+        # (1) save both gates
+        async with session_factory() as session, session.begin():
+            repo = SqliteExternalReviewGateRepository(session)
+            await repo.save(gate1)
+            await repo.save(gate2)
+
+        # (2) find_pending_by_reviewer: only gate1 for reviewer
+        async with session_factory() as session:
+            pending = await SqliteExternalReviewGateRepository(session).find_pending_by_reviewer(
+                reviewer_id
+            )
+        assert len(pending) == 1
+        assert pending[0].id == gate1.id
+
+        # (3) find_by_task_id
+        async with session_factory() as session:
+            by_task = await SqliteExternalReviewGateRepository(session).find_by_task_id(task_id)
+        assert len(by_task) == 1
+        assert by_task[0].id == gate1.id
+
+        # (4) find_by_id
+        async with session_factory() as session:
+            single = await SqliteExternalReviewGateRepository(session).find_by_id(gate1.id)
+        assert single is not None
+        assert single.id == gate1.id
+
+        # (5) count_by_decision: 2 PENDING total
+        async with session_factory() as session:
+            pending_count = await SqliteExternalReviewGateRepository(session).count_by_decision(
+                ReviewDecision.PENDING
+            )
+        assert pending_count == 2
+
+        # (6) approve gate1 → re-save
+        approved_gate1 = make_approved_gate(
+            gate_id=gate1.id,
+            task_id=task_id,
+            stage_id=stage_id,
+            reviewer_id=reviewer_id,
+            decided_at=datetime.now(UTC),
+        )
+        async with session_factory() as session, session.begin():
+            await SqliteExternalReviewGateRepository(session).save(approved_gate1)
+
+        # (7) counts updated
+        async with session_factory() as session:
+            repo = SqliteExternalReviewGateRepository(session)
+            pending_count_after = await repo.count_by_decision(ReviewDecision.PENDING)
+            approved_count = await repo.count_by_decision(ReviewDecision.APPROVED)
+            pending_list = await repo.find_pending_by_reviewer(reviewer_id)
+
+        assert pending_count_after == 1, "[FAIL] PENDING count should drop to 1 after approve."
+        assert approved_count == 1, "[FAIL] APPROVED count should be 1."
+        assert pending_list == [], "[FAIL] find_pending_by_reviewer should return [] after approve."

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_external_review_gate_repository/test_save_child_tables.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_external_review_gate_repository/test_save_child_tables.py
@@ -1,0 +1,261 @@
+"""ExternalReviewGate Repository: 5-step save() physical verification.
+
+TC-UT-ERGR-005 / 005b / 005c — §確定 R1-B save() 5段階の物理確認.
+
+Tests that:
+* DELETE child tables (steps 1+2) prevent duplicate rows on re-save.
+* UPSERT gate (step 3) + INSERT attachments (step 4) + INSERT audit_entries (step 5).
+* UNIQUE(gate_id, sha256) constraint satisfied on every re-save cycle.
+* Empty gate upgraded to full gate (all 5 steps exercised).
+
+Per ``docs/features/external-review-gate-repository/test-design.md``
+TC-UT-ERGR-005/005b/005c.
+Issue #36 — M2 0008.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+import pytest
+from bakufu.domain.value_objects import Attachment, AuditAction, ReviewDecision
+from bakufu.infrastructure.persistence.sqlite.repositories.external_review_gate_repository import (
+    SqliteExternalReviewGateRepository,
+)
+from sqlalchemy import text
+
+from tests.factories.external_review_gate import (
+    make_approved_gate,
+    make_audit_entry,
+    make_gate,
+)
+from tests.factories.task import make_deliverable
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _count_attachments(
+    session_factory: async_sessionmaker[AsyncSession],
+    gate_id: UUID,
+) -> int:
+    """Count external_review_gate_attachments rows for gate_id via raw SQL."""
+    async with session_factory() as session:
+        row = (
+            await session.execute(
+                text(
+                    "SELECT COUNT(*) FROM external_review_gate_attachments WHERE gate_id = :gate_id"
+                ),
+                {"gate_id": gate_id.hex},
+            )
+        ).first()
+    return row[0] if row else 0
+
+
+async def _count_audit_entries(
+    session_factory: async_sessionmaker[AsyncSession],
+    gate_id: UUID,
+) -> int:
+    """Count external_review_audit_entries rows for gate_id via raw SQL."""
+    async with session_factory() as session:
+        row = (
+            await session.execute(
+                text("SELECT COUNT(*) FROM external_review_audit_entries WHERE gate_id = :gate_id"),
+                {"gate_id": gate_id.hex},
+            )
+        ).first()
+    return row[0] if row else 0
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-ERGR-005: audit_entries DELETE + re-INSERT on re-save
+# ---------------------------------------------------------------------------
+class TestSaveChildTableSemantics:
+    """TC-UT-ERGR-005: §確定 R1-B DELETE → UPSERT → INSERT 5-step order."""
+
+    async def test_resave_updates_decision_and_replaces_audit_entries(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_gate_context: tuple[UUID, UUID, UUID],
+    ) -> None:
+        """TC-UT-ERGR-005: re-save after approve replaces audit_entries (DELETE + re-INSERT)."""
+        task_id, stage_id, reviewer_id = seeded_gate_context
+
+        # First save: PENDING gate, no audit entries
+        gate = make_gate(task_id=task_id, stage_id=stage_id, reviewer_id=reviewer_id)
+        async with session_factory() as session, session.begin():
+            await SqliteExternalReviewGateRepository(session).save(gate)
+
+        count_before = await _count_audit_entries(session_factory, gate.id)
+        assert count_before == 0
+
+        # Re-save as APPROVED with 1 audit entry
+        decided_at = datetime.now(UTC)
+        approved = make_approved_gate(
+            gate_id=gate.id,
+            task_id=task_id,
+            stage_id=stage_id,
+            reviewer_id=reviewer_id,
+            decided_at=decided_at,
+        )
+        async with session_factory() as session, session.begin():
+            await SqliteExternalReviewGateRepository(session).save(approved)
+
+        count_after = await _count_audit_entries(session_factory, gate.id)
+        assert count_after == 1, f"[FAIL] expected 1 audit entry after re-save, got {count_after}"
+
+        # Decision updated via UPSERT
+        async with session_factory() as session:
+            restored = await SqliteExternalReviewGateRepository(session).find_by_id(gate.id)
+
+        assert restored is not None
+        assert restored.decision == ReviewDecision.APPROVED
+        assert len(restored.audit_trail) == 1
+        assert restored.audit_trail[0].action == AuditAction.APPROVED
+
+    async def test_resave_does_not_duplicate_gate_rows(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_gate_context: tuple[UUID, UUID, UUID],
+    ) -> None:
+        """TC-UT-ERGR-005: UPSERT ensures only 1 row in external_review_gates per id."""
+        task_id, stage_id, reviewer_id = seeded_gate_context
+        gate = make_gate(task_id=task_id, stage_id=stage_id, reviewer_id=reviewer_id)
+
+        async with session_factory() as session, session.begin():
+            await SqliteExternalReviewGateRepository(session).save(gate)
+        async with session_factory() as session, session.begin():
+            await SqliteExternalReviewGateRepository(session).save(gate)
+
+        async with session_factory() as session:
+            row = (
+                await session.execute(
+                    text("SELECT COUNT(*) FROM external_review_gates WHERE id = :id"),
+                    {"id": gate.id.hex},
+                )
+            ).first()
+        assert row[0] == 1, f"[FAIL] UPSERT produced {row[0]} rows, expected 1."
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-ERGR-005b: UNIQUE(gate_id, sha256) no duplicate on re-save
+# ---------------------------------------------------------------------------
+class TestAttachmentUniqueConstraintOnReSave:
+    """TC-UT-ERGR-005b: Step 1 DELETE prevents UNIQUE(gate_id, sha256) violation."""
+
+    async def test_resave_with_same_attachments_no_unique_violation(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_gate_context: tuple[UUID, UUID, UUID],
+    ) -> None:
+        """TC-UT-ERGR-005b: re-save with same sha256 attachment does not raise IntegrityError."""
+        task_id, stage_id, reviewer_id = seeded_gate_context
+        sha256 = "b" * 64
+        attachment = Attachment(
+            sha256=sha256,
+            filename="report.pdf",
+            mime_type="application/pdf",
+            size_bytes=2048,
+        )
+        snapshot = make_deliverable(attachments=[attachment])
+        gate = make_gate(
+            task_id=task_id,
+            stage_id=stage_id,
+            reviewer_id=reviewer_id,
+            deliverable_snapshot=snapshot,
+        )
+
+        # First save
+        async with session_factory() as session, session.begin():
+            await SqliteExternalReviewGateRepository(session).save(gate)
+        count_after_first = await _count_attachments(session_factory, gate.id)
+        assert count_after_first == 1
+
+        # Re-save (step 1 DELETE + step 4 INSERT — must not fail)
+        async with session_factory() as session, session.begin():
+            await SqliteExternalReviewGateRepository(session).save(gate)
+        count_after_second = await _count_attachments(session_factory, gate.id)
+
+        assert count_after_second == 1, (
+            f"[FAIL] Expected 1 attachment after re-save, got {count_after_second}. "
+            f"Duplicate row created — step 1 DELETE not working."
+        )
+
+    async def test_resave_with_two_attachments_count_is_correct(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_gate_context: tuple[UUID, UUID, UUID],
+    ) -> None:
+        """TC-UT-ERGR-005b: re-save with 2 attachments yields exactly 2 rows."""
+        task_id, stage_id, reviewer_id = seeded_gate_context
+        att1 = Attachment(
+            sha256="c" * 64, filename="a.pdf", mime_type="application/pdf", size_bytes=100
+        )
+        att2 = Attachment(
+            sha256="d" * 64, filename="b.pdf", mime_type="application/pdf", size_bytes=200
+        )
+        snapshot = make_deliverable(attachments=[att1, att2])
+        gate = make_gate(
+            task_id=task_id,
+            stage_id=stage_id,
+            reviewer_id=reviewer_id,
+            deliverable_snapshot=snapshot,
+        )
+
+        async with session_factory() as session, session.begin():
+            await SqliteExternalReviewGateRepository(session).save(gate)
+        async with session_factory() as session, session.begin():
+            await SqliteExternalReviewGateRepository(session).save(gate)
+
+        count = await _count_attachments(session_factory, gate.id)
+        assert count == 2, f"[FAIL] Expected 2 attachments, got {count}."
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-ERGR-005c: Empty gate → full gate update (all 5 steps)
+# ---------------------------------------------------------------------------
+class TestEmptyToFullGateUpdate:
+    """TC-UT-ERGR-005c: Empty gate (no children) → gate with audit_trail (steps 3-5)."""
+
+    async def test_resave_empty_to_full_gate_all_child_tables(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_gate_context: tuple[UUID, UUID, UUID],
+    ) -> None:
+        """TC-UT-ERGR-005c: Empty gate upgraded to APPROVED gate with audit entries."""
+        task_id, stage_id, reviewer_id = seeded_gate_context
+
+        # Save empty gate (PENDING, no audit_trail)
+        gate = make_gate(task_id=task_id, stage_id=stage_id, reviewer_id=reviewer_id)
+        async with session_factory() as session, session.begin():
+            await SqliteExternalReviewGateRepository(session).save(gate)
+
+        assert await _count_audit_entries(session_factory, gate.id) == 0
+
+        # Re-save as APPROVED with 1 entry
+        decided = datetime.now(UTC)
+        audit_entry = make_audit_entry(action=AuditAction.APPROVED, occurred_at=decided)
+        approved = make_approved_gate(
+            gate_id=gate.id,
+            task_id=task_id,
+            stage_id=stage_id,
+            reviewer_id=reviewer_id,
+            audit_trail=[audit_entry],
+            decided_at=decided,
+        )
+        async with session_factory() as session, session.begin():
+            await SqliteExternalReviewGateRepository(session).save(approved)
+
+        assert await _count_audit_entries(session_factory, gate.id) == 1
+
+        async with session_factory() as session:
+            restored = await SqliteExternalReviewGateRepository(session).find_by_id(gate.id)
+
+        assert restored is not None
+        assert restored.decision == ReviewDecision.APPROVED
+        assert len(restored.audit_trail) == 1
+        assert restored.audit_trail[0].action == AuditAction.APPROVED

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_external_review_gate_repository/test_save_child_tables.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_external_review_gate_repository/test_save_child_tables.py
@@ -138,7 +138,9 @@ class TestSaveChildTableSemantics:
                     {"id": gate.id.hex},
                 )
             ).first()
-        assert row[0] == 1, f"[FAIL] UPSERT produced {row[0]} rows, expected 1."
+        assert row is not None and row[0] == 1, (
+            f"[FAIL] UPSERT produced {row[0] if row else 'None'} rows, expected 1."
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/infrastructure/persistence/sqlite/test_alembic_external_review_gate.py
+++ b/backend/tests/infrastructure/persistence/sqlite/test_alembic_external_review_gate.py
@@ -1,0 +1,400 @@
+"""Alembic 8th revision tests — ExternalReviewGate aggregate (TC-IT-ERGR-001〜008).
+
+RQ-ERGR-007 / §確定 R1-B / §確定 R1-K / §設計決定 ERGR-001.
+
+Real Alembic upgrade/downgrade against a real SQLite file plus chain
+integrity check that makes sure 0001→…→0008 chain stays linear.
+
+Also verifies:
+* 3 tables created: external_review_gates / external_review_gate_attachments /
+  external_review_audit_entries.
+* 3 indexes: ix_external_review_gates_task_id_created /
+  ix_external_review_gates_reviewer_decision /
+  ix_external_review_gates_decision.
+* FK: external_review_gates.task_id → tasks.id ON DELETE CASCADE.
+* §設計決定 ERGR-001: reviewer_id / snapshot_committed_by have NO FK.
+* 0008.down_revision == "0007_task_aggregate".
+* upgrade → downgrade → upgrade is idempotent.
+* Task CASCADE: deleting task removes associated Gates.
+
+Per ``docs/features/external-review-gate-repository/test-design.md``
+TC-IT-ERGR-001〜008.
+Issue #36 — M2 0008.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+from bakufu.infrastructure.persistence.sqlite import engine as engine_mod
+from bakufu.infrastructure.persistence.sqlite.migrations import run_upgrade_head
+from sqlalchemy import text
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncEngine
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+@pytest_asyncio.fixture
+async def empty_engine(tmp_path: Path) -> AsyncIterator[AsyncEngine]:
+    """Fresh app engine with no migrations applied."""
+    url = f"sqlite+aiosqlite:///{tmp_path / 'bakufu.db'}"
+    engine = engine_mod.create_engine(url)
+    try:
+        yield engine
+    finally:
+        await engine.dispose()
+
+
+def _alembic_config() -> Config:
+    """Resolve bakufu Alembic config for ScriptDirectory inspection."""
+    backend_root = Path(__file__).resolve().parents[4]
+    cfg = Config(str(backend_root / "alembic.ini"))
+    cfg.set_main_option("script_location", str(backend_root / "alembic"))
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-ERGR-001: 0008 creates 3 ExternalReviewGate tables (受入基準 6)
+# ---------------------------------------------------------------------------
+class TestEighthRevisionThreeTablesPresent:
+    """TC-IT-ERGR-001: alembic upgrade head adds the 3 ExternalReviewGate tables."""
+
+    async def test_three_erg_tables_present_after_upgrade(
+        self,
+        empty_engine: AsyncEngine,
+    ) -> None:
+        """TC-IT-ERGR-001: 3 ERG tables exist after upgrade head."""
+        await run_upgrade_head(empty_engine)
+        async with empty_engine.connect() as conn:
+            result = await conn.execute(text("SELECT name FROM sqlite_master WHERE type='table'"))
+            tables = {row[0] for row in result}
+
+        expected = {
+            "external_review_gates",
+            "external_review_gate_attachments",
+            "external_review_audit_entries",
+        }
+        assert expected.issubset(tables), (
+            f"[FAIL] Missing ExternalReviewGate tables after upgrade head.\n"
+            f"Missing: {expected - tables}\n"
+            f"Tables found: {tables}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-ERGR-002: 3 INDEXes on external_review_gates (§確定 R1-K)
+# ---------------------------------------------------------------------------
+class TestExternalReviewGateIndexesPresent:
+    """TC-IT-ERGR-002: All 3 required INDEXes exist on external_review_gates."""
+
+    async def test_three_indexes_present(
+        self,
+        empty_engine: AsyncEngine,
+    ) -> None:
+        """TC-IT-ERGR-002: ix_task_id_created / ix_reviewer_decision / ix_decision exist."""
+        await run_upgrade_head(empty_engine)
+        async with empty_engine.connect() as conn:
+            result = await conn.execute(
+                text(
+                    "SELECT name FROM sqlite_master"
+                    " WHERE type='index' AND tbl_name='external_review_gates'"
+                )
+            )
+            index_names = {row[0] for row in result}
+
+        expected_indexes = {
+            "ix_external_review_gates_task_id_created",
+            "ix_external_review_gates_reviewer_decision",
+            "ix_external_review_gates_decision",
+        }
+        assert expected_indexes.issubset(index_names), (
+            f"[FAIL] Missing INDEXes on external_review_gates.\n"
+            f"Missing: {expected_indexes - index_names}\n"
+            f"Indexes found: {index_names}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-ERGR-003: FK external_review_gates.task_id → tasks.id CASCADE
+# ---------------------------------------------------------------------------
+class TestExternalReviewGateForeignKey:
+    """TC-IT-ERGR-003: external_review_gates.task_id → tasks.id ON DELETE CASCADE."""
+
+    async def test_task_id_fk_to_tasks_cascade(
+        self,
+        empty_engine: AsyncEngine,
+    ) -> None:
+        """TC-IT-ERGR-003: PRAGMA foreign_key_list confirms tasks CASCADE FK."""
+        await run_upgrade_head(empty_engine)
+        async with empty_engine.connect() as conn:
+            result = await conn.execute(text("PRAGMA foreign_key_list('external_review_gates')"))
+            fk_list = [dict(row._mapping) for row in result]
+
+        tasks_fks = [fk for fk in fk_list if fk.get("table") == "tasks"]
+        assert len(tasks_fks) >= 1, (
+            f"[FAIL] No FK from external_review_gates to tasks found.\nFK list: {fk_list}"
+        )
+        cascade_fk = next(
+            (fk for fk in tasks_fks if fk.get("on_delete", "").upper() == "CASCADE"),
+            None,
+        )
+        assert cascade_fk is not None, (
+            f"[FAIL] tasks FK missing ON DELETE CASCADE.\ntasks FKs: {tasks_fks}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-ERGR-004: Alembic chain 0001→...→0008 is a single head
+# ---------------------------------------------------------------------------
+class TestAlembicChainSingleHead:
+    """TC-IT-ERGR-004: ScriptDirectory has exactly 1 head (no branch divergence)."""
+
+    def test_alembic_chain_has_single_head(self) -> None:
+        """TC-IT-ERGR-004: len(heads) == 1 — chain is linear 0001→...→0008."""
+        cfg = _alembic_config()
+        script_dir = ScriptDirectory.from_config(cfg)
+        heads = script_dir.get_heads()
+        assert len(heads) == 1, (
+            f"[FAIL] Alembic chain has {len(heads)} heads (expected 1).\n"
+            f"Heads: {heads}\n"
+            f"Branching means two revisions both point to the same down_revision."
+        )
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-ERGR-005: upgrade → downgrade → upgrade is idempotent (受入基準 6)
+# ---------------------------------------------------------------------------
+class TestUpgradeDowngradeIdempotent:
+    """TC-IT-ERGR-005: upgrade head → downgrade base → upgrade head restores 3 tables."""
+
+    async def test_upgrade_downgrade_upgrade_idempotent(
+        self,
+        empty_engine: AsyncEngine,
+    ) -> None:
+        """TC-IT-ERGR-005: Double migration cycle — final state has 3 ERG tables."""
+        import asyncio
+
+        from alembic import command as alembic_command
+
+        await run_upgrade_head(empty_engine)
+
+        # Downgrade to base via alembic command (runs in a thread to avoid event-loop deadlock)
+        cfg = _alembic_config()
+        cfg.set_main_option("sqlalchemy.url", str(empty_engine.url))
+
+        def _do_downgrade() -> None:
+            alembic_command.downgrade(cfg, "base")
+
+        await asyncio.to_thread(_do_downgrade)
+
+        # Verify ERG tables are gone after downgrade
+        async with empty_engine.connect() as conn:
+            result = await conn.execute(text("SELECT name FROM sqlite_master WHERE type='table'"))
+            tables_after_down = {row[0] for row in result}
+        assert "external_review_gates" not in tables_after_down, (
+            f"[FAIL] external_review_gates still present after downgrade to base.\n"
+            f"Tables: {tables_after_down}"
+        )
+
+        # Re-upgrade
+        await run_upgrade_head(empty_engine)
+
+        async with empty_engine.connect() as conn:
+            result = await conn.execute(text("SELECT name FROM sqlite_master WHERE type='table'"))
+            tables = {row[0] for row in result}
+
+        expected = {
+            "external_review_gates",
+            "external_review_gate_attachments",
+            "external_review_audit_entries",
+        }
+        assert expected.issubset(tables), (
+            f"[FAIL] ERG tables missing after re-upgrade.\nMissing: {expected - tables}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-ERGR-006: 0008.down_revision == "0007_task_aggregate"
+# ---------------------------------------------------------------------------
+class TestDownRevisionChain:
+    """TC-IT-ERGR-006: 0008 down_revision points to 0007_task_aggregate."""
+
+    def test_0008_down_revision_is_0007(self) -> None:
+        """TC-IT-ERGR-006: Chain is 0007_task_aggregate → 0008_external_review_gate_aggregate."""
+        cfg = _alembic_config()
+        script_dir = ScriptDirectory.from_config(cfg)
+        rev = script_dir.get_revision("0008_external_review_gate_aggregate")
+        assert rev is not None, "[FAIL] Revision 0008_external_review_gate_aggregate not found."
+        assert rev.down_revision == "0007_task_aggregate", (
+            f"[FAIL] 0008.down_revision = {rev.down_revision!r}, expected '0007_task_aggregate'.\n"
+            f"Chain 0007→0008 is broken."
+        )
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-ERGR-007: Task CASCADE FK deletes Gates (受入基準 7)
+# ---------------------------------------------------------------------------
+class TestTaskCascadeDeletesGate:
+    """TC-IT-ERGR-007: DELETE FROM tasks cascades to external_review_gates."""
+
+    async def test_delete_task_cascades_to_external_review_gates(
+        self,
+        empty_engine: AsyncEngine,
+    ) -> None:
+        """TC-IT-ERGR-007: Deleting a Task row removes its associated Gate rows."""
+        await run_upgrade_head(empty_engine)
+
+        empire_id = uuid4().hex
+        workflow_id = uuid4().hex
+        room_id = uuid4().hex
+        directive_id = uuid4().hex
+        task_id = uuid4().hex
+        gate_id = uuid4().hex
+        stage_id = uuid4().hex
+        reviewer_id = uuid4().hex
+        committed_by = uuid4().hex
+        now_str = "2026-01-01T00:00:00+00:00"
+
+        async with empty_engine.begin() as conn:
+            await conn.execute(text("PRAGMA foreign_keys = ON"))
+
+            await conn.execute(
+                text("INSERT INTO empires (id, name) VALUES (:id, 'test_empire')"),
+                {"id": empire_id},
+            )
+            await conn.execute(
+                text(
+                    "INSERT INTO workflows (id, name, entry_stage_id)"
+                    " VALUES (:id, 'test_workflow', :sid)"
+                ),
+                {"id": workflow_id, "sid": stage_id},
+            )
+            await conn.execute(
+                text(
+                    "INSERT INTO rooms (id, empire_id, workflow_id, name)"
+                    " VALUES (:id, :eid, :wid, 'test_room')"
+                ),
+                {"id": room_id, "eid": empire_id, "wid": workflow_id},
+            )
+            await conn.execute(
+                text(
+                    "INSERT INTO directives (id, text, target_room_id, created_at)"
+                    " VALUES (:id, 'テスト指令', :rid, :n)"
+                ),
+                {"id": directive_id, "rid": room_id, "n": now_str},
+            )
+            await conn.execute(
+                text(
+                    "INSERT INTO tasks"
+                    " (id, room_id, directive_id, current_stage_id, status,"
+                    "  created_at, updated_at)"
+                    " VALUES (:id, :rid, :did, :sid, 'PENDING', :n, :n)"
+                ),
+                {
+                    "id": task_id,
+                    "rid": room_id,
+                    "did": directive_id,
+                    "sid": stage_id,
+                    "n": now_str,
+                },
+            )
+            await conn.execute(
+                text(
+                    "INSERT INTO external_review_gates"
+                    " (id, task_id, stage_id, reviewer_id, decision, feedback_text,"
+                    "  snapshot_stage_id, snapshot_body_markdown, snapshot_committed_by,"
+                    "  snapshot_committed_at, created_at, decided_at)"
+                    " VALUES (:id, :tid, :sid, :rid, 'PENDING', '',"
+                    "  :ssid, 'body', :scby, :n, :n, NULL)"
+                ),
+                {
+                    "id": gate_id,
+                    "tid": task_id,
+                    "sid": stage_id,
+                    "rid": reviewer_id,
+                    "ssid": stage_id,
+                    "scby": committed_by,
+                    "n": now_str,
+                },
+            )
+
+        # Verify gate exists before delete
+        async with empty_engine.connect() as conn:
+            row = (
+                await conn.execute(
+                    text("SELECT COUNT(*) FROM external_review_gates WHERE id = :id"),
+                    {"id": gate_id},
+                )
+            ).first()
+        assert row[0] == 1, "[FAIL] Gate row not inserted."
+
+        # Delete task — CASCADE should remove gate
+        async with empty_engine.begin() as conn:
+            await conn.execute(text("PRAGMA foreign_keys = ON"))
+            await conn.execute(text("DELETE FROM tasks WHERE id = :id"), {"id": task_id})
+
+        # Gate must be gone
+        async with empty_engine.connect() as conn:
+            row = (
+                await conn.execute(
+                    text("SELECT COUNT(*) FROM external_review_gates WHERE id = :id"),
+                    {"id": gate_id},
+                )
+            ).first()
+        assert row[0] == 0, "[FAIL] Gate row still exists after CASCADE DELETE of parent Task."
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-ERGR-008: §設計決定 ERGR-001 — reviewer_id / snapshot_committed_by have NO FK
+# ---------------------------------------------------------------------------
+class TestAggregrateBoundaryNoForeignKeys:
+    """TC-IT-ERGR-008: reviewer_id / snapshot_committed_by have no FK (§設計決定 ERGR-001)."""
+
+    async def test_reviewer_id_has_no_fk(
+        self,
+        empty_engine: AsyncEngine,
+    ) -> None:
+        """TC-IT-ERGR-008: PRAGMA foreign_key_list — no FK to owners/agents for reviewer_id."""
+        await run_upgrade_head(empty_engine)
+        async with empty_engine.connect() as conn:
+            result = await conn.execute(text("PRAGMA foreign_key_list('external_review_gates')"))
+            fk_list = [dict(row._mapping) for row in result]
+
+        referenced_tables = {fk.get("table") for fk in fk_list}
+        # The only FK must be tasks (CASCADE). Owner / Agent Aggregate tables must not appear.
+        forbidden = {"owners", "agents", "users", "members"}
+        leaked = referenced_tables & forbidden
+        assert not leaked, (
+            f"[FAIL] §設計決定 ERGR-001 violated: external_review_gates has FK to {leaked}.\n"
+            f"reviewer_id / snapshot_committed_by must have NO FK (Aggregate boundary).\n"
+            f"All referenced tables: {referenced_tables}"
+        )
+
+    async def test_only_tasks_fk_present(
+        self,
+        empty_engine: AsyncEngine,
+    ) -> None:
+        """TC-IT-ERGR-008: The only FK from external_review_gates is to tasks."""
+        await run_upgrade_head(empty_engine)
+        async with empty_engine.connect() as conn:
+            result = await conn.execute(text("PRAGMA foreign_key_list('external_review_gates')"))
+            fk_list = [dict(row._mapping) for row in result]
+
+        referenced_tables = {fk.get("table") for fk in fk_list}
+        assert referenced_tables == {"tasks"}, (
+            f"[FAIL] external_review_gates FKs expected: {{tasks}}, got: {referenced_tables}.\n"
+            f"§設計決定 ERGR-001: Only task_id carries an FK (ON DELETE CASCADE).\n"
+            f"All FK entries: {fk_list}"
+        )

--- a/backend/tests/infrastructure/persistence/sqlite/test_alembic_external_review_gate.py
+++ b/backend/tests/infrastructure/persistence/sqlite/test_alembic_external_review_gate.py
@@ -140,7 +140,7 @@ class TestExternalReviewGateForeignKey:
         await run_upgrade_head(empty_engine)
         async with empty_engine.connect() as conn:
             result = await conn.execute(text("PRAGMA foreign_key_list('external_review_gates')"))
-            fk_list = [dict(row._mapping) for row in result]
+            fk_list = [dict(row) for row in result.mappings()]
 
         tasks_fks = [fk for fk in fk_list if fk.get("table") == "tasks"]
         assert len(tasks_fks) >= 1, (
@@ -338,7 +338,7 @@ class TestTaskCascadeDeletesGate:
                     {"id": gate_id},
                 )
             ).first()
-        assert row[0] == 1, "[FAIL] Gate row not inserted."
+        assert row is not None and row[0] == 1, "[FAIL] Gate row not inserted."
 
         # Delete task — CASCADE should remove gate
         async with empty_engine.begin() as conn:
@@ -353,7 +353,9 @@ class TestTaskCascadeDeletesGate:
                     {"id": gate_id},
                 )
             ).first()
-        assert row[0] == 0, "[FAIL] Gate row still exists after CASCADE DELETE of parent Task."
+        assert row is not None and row[0] == 0, (
+            "[FAIL] Gate row still exists after CASCADE DELETE of parent Task."
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -370,7 +372,7 @@ class TestAggregrateBoundaryNoForeignKeys:
         await run_upgrade_head(empty_engine)
         async with empty_engine.connect() as conn:
             result = await conn.execute(text("PRAGMA foreign_key_list('external_review_gates')"))
-            fk_list = [dict(row._mapping) for row in result]
+            fk_list = [dict(row) for row in result.mappings()]
 
         referenced_tables = {fk.get("table") for fk in fk_list}
         # The only FK must be tasks (CASCADE). Owner / Agent Aggregate tables must not appear.
@@ -390,7 +392,7 @@ class TestAggregrateBoundaryNoForeignKeys:
         await run_upgrade_head(empty_engine)
         async with empty_engine.connect() as conn:
             result = await conn.execute(text("PRAGMA foreign_key_list('external_review_gates')"))
-            fk_list = [dict(row._mapping) for row in result]
+            fk_list = [dict(row) for row in result.mappings()]
 
         referenced_tables = {fk.get("table") for fk in fk_list}
         assert referenced_tables == {"tasks"}, (

--- a/scripts/ci/check_masking_columns.sh
+++ b/scripts/ci/check_masking_columns.sh
@@ -100,6 +100,14 @@ readonly NO_MASK_FILES=(
     # 凍結済みのため除外。
     "${TABLES_DIR}/task_assigned_agents.py"
     "${TABLES_DIR}/deliverable_attachments.py"
+    # ExternalReviewGate Repository (PR #36, detailed-design.md §確定 R1-E):
+    # external_review_gate_attachments carries no secret semantics — file
+    # metadata (sha256 / filename / mime_type / size_bytes) is content-
+    # addressing with no Schneier #6 secret category.
+    # external_review_gates / external_review_audit_entries are registered in
+    # PARTIAL_MASK_FILES (masked columns: snapshot_body_markdown + feedback_text
+    # and comment respectively).
+    "${TABLES_DIR}/external_review_gate_attachments.py"
 )
 
 for file in "${NO_MASK_FILES[@]}"; do
@@ -120,18 +128,25 @@ done
 
 # Layer 1-C: 過剰マスキング防止 ─ partially-masked テーブルで指定の
 # カラム以外に Masked* が混入していないこと。各ファイルに対し
-# 「許可カラムが期待型で 1 つ宣言されている」+「他カラムに Masked* が
+# 「許可カラムが期待型でそれぞれ宣言されている」+「他カラムに Masked* が
 # 一切登場しない」の両方を assert する。
+#
+# 1 ファイルに複数の許可カラムを登録できる（ExternalReviewGate #36 から導入）。
+# ループが同一ファイルの全エントリを集約してから照合するため、
+# 許可カラムが 1 本でも 2 本以上でも正しく動作する。
 #
 # 登録されている partial-mask テーブル:
 #   * Workflow Repository (PR #31, detailed-design.md §確定 E):
-#     workflow_stages.notify_channels_json だけが MaskedJSONEncoded、
-#     他カラムは JSONEncoded / String / Text に閉じる。
+#     workflow_stages.notify_channels_json だけが MaskedJSONEncoded。
 #   * Agent Repository (PR #32, detailed-design.md §確定 E):
-#     agents.prompt_body だけが MaskedText、他カラムは String / Boolean
-#     に閉じる。Schneier 申し送り #3 实適用の grep 物理保証層。
+#     agents.prompt_body だけが MaskedText。Schneier 申し送り #3 实適用。
+#   * ExternalReviewGate Repository (PR #36, detailed-design.md §確定 R1-E):
+#     external_review_gates は snapshot_body_markdown + feedback_text の 2 本が
+#     MaskedText（§設計決定 ERGR-002 対応で feedback_text を追加）。
+#     external_review_audit_entries.comment だけが MaskedText。
 #
 # フォーマット: "<file>:<allowed_column>:<expected_type>"
+# 同一 <file> に複数エントリを追加することで許可カラムセットを拡張できる。
 readonly PARTIAL_MASK_FILES=(
     "${TABLES_DIR}/workflow_stages.py:notify_channels_json:MaskedJSONEncoded"
     "${TABLES_DIR}/agents.py:prompt_body:MaskedText"
@@ -152,39 +167,80 @@ readonly PARTIAL_MASK_FILES=(
     # deliverables.body_markdown だけが MaskedText（Agent 出力に secret 混入）、
     # 他カラムは UUIDStr / UTCDateTime に閉じる。
     "${TABLES_DIR}/deliverables.py:body_markdown:MaskedText"
+    # ExternalReviewGate Repository (PR #36, detailed-design.md §確定 R1-E,
+    # §設計決定 ERGR-002): external_review_gates は 2 本の MaskedText カラムを持つ。
+    # snapshot_body_markdown — Agent 出力に secret 混入の可能性。
+    "${TABLES_DIR}/external_review_gates.py:snapshot_body_markdown:MaskedText"
+    # feedback_text — CEO review comment; approve/reject/cancel 入力経路が
+    # webhook URL / API key を含む可能性（§設計決定 ERGR-002）。
+    "${TABLES_DIR}/external_review_gates.py:feedback_text:MaskedText"
+    # external_review_audit_entries.comment だけが MaskedText（CEO 入力経路）、
+    # 他カラムは UUIDStr / String / UTCDateTime に閉じる。
+    "${TABLES_DIR}/external_review_audit_entries.py:comment:MaskedText"
 )
 
-for entry in "${PARTIAL_MASK_FILES[@]}"; do
-    IFS=':' read -r file allowed expected_type <<< "$entry"
+# Collect unique file paths from PARTIAL_MASK_FILES.
+_partial_files=()
+for _entry in "${PARTIAL_MASK_FILES[@]}"; do
+    IFS=':' read -r _f _col _typ <<< "$_entry"
+    _already_seen=false
+    for _seen in "${_partial_files[@]}"; do
+        [[ "$_seen" == "$_f" ]] && _already_seen=true && break
+    done
+    [[ "$_already_seen" == false ]] && _partial_files+=("$_f")
+done
 
-    if [[ ! -f "$file" ]]; then
+for _file in "${_partial_files[@]}"; do
+    if [[ ! -f "$_file" ]]; then
+        # ファイル未作成（後続 PR が追加予定）。スキップ。
         continue
     fi
 
-    # All Masked* column declarations on this file. The allowed
-    # column must appear exactly once with the expected type and
-    # nothing else may carry a Masked* TypeDecorator.
-    masked_decls=$(grep -nE "^\s*[A-Za-z_][A-Za-z0-9_]*\s*:\s*Mapped.*Masked(JSONEncoded|Text)" \
-        "$file" || true)
+    # Build allowed (col:type) pairs for this file from all entries.
+    _allowed_pairs=()
+    for _entry in "${PARTIAL_MASK_FILES[@]}"; do
+        IFS=':' read -r _entry_file _col _typ <<< "$_entry"
+        [[ "$_entry_file" == "$_file" ]] && _allowed_pairs+=("${_col}:${_typ}")
+    done
 
-    if [[ -z "$masked_decls" ]]; then
-        echo "[FAIL] partial-mask table file is missing the expected" >&2
-        echo "       ${expected_type} column declaration: $file" >&2
-        echo "       Next: declare ${allowed} with ${expected_type} per" >&2
+    # Get all Masked* column declarations in this file.
+    _masked_decls=$(grep -nE "^\s*[A-Za-z_][A-Za-z0-9_]*\s*:\s*Mapped.*Masked(JSONEncoded|Text)" \
+        "$_file" || true)
+
+    if [[ -z "$_masked_decls" ]]; then
+        echo "[FAIL] partial-mask table file is missing all expected Masked* declarations: $_file" >&2
+        for _pair in "${_allowed_pairs[@]}"; do
+            _col="${_pair%%:*}"
+            _typ="${_pair##*:}"
+            echo "       Next: declare ${_col} with ${_typ} per" >&2
+        done
         echo "       docs/architecture/domain-model/storage.md §逆引き表." >&2
         violations=$((violations + 1))
         continue
     fi
 
-    while IFS= read -r line; do
-        [[ -z "$line" ]] && continue
+    # Check that each masked declaration is for an allowed column.
+    while IFS= read -r _line; do
+        [[ -z "$_line" ]] && continue
 
-        # Reject masking on a column other than the allowed one.
-        if [[ "$line" != *"${allowed}"* ]]; then
-            echo "[FAIL] partial-mask table file declares Masked* on a" >&2
-            echo "       column other than '${allowed}': $file" >&2
-            echo "       ${line}" >&2
-            echo "       Next: only '${allowed}' is registered as masked in" >&2
+        _matched_pair=""
+        for _pair in "${_allowed_pairs[@]}"; do
+            _col="${_pair%%:*}"
+            if [[ "$_line" == *"${_col}"* ]]; then
+                _matched_pair="$_pair"
+                break
+            fi
+        done
+
+        if [[ -z "$_matched_pair" ]]; then
+            _allowed_names=""
+            for _pair in "${_allowed_pairs[@]}"; do
+                _allowed_names+="'${_pair%%:*}' "
+            done
+            echo "[FAIL] partial-mask table file declares Masked* on an" >&2
+            echo "       unexpected column: $_file" >&2
+            echo "       ${_line}" >&2
+            echo "       Next: only ${_allowed_names}registered as masked in" >&2
             echo "       docs/architecture/domain-model/storage.md §逆引き表;" >&2
             echo "       move the masking to the correct column or update §逆引き表." >&2
             violations=$((violations + 1))
@@ -192,15 +248,30 @@ for entry in "${PARTIAL_MASK_FILES[@]}"; do
         fi
 
         # Allowed column must use the expected TypeDecorator.
-        if [[ "$line" != *"$expected_type"* ]]; then
-            echo "[FAIL] partial-mask column '${allowed}' uses the wrong Masked*" >&2
-            echo "       TypeDecorator (expected ${expected_type}): $file" >&2
-            echo "       ${line}" >&2
-            echo "       Next: switch ${allowed} to mapped_column(${expected_type}, ...) per" >&2
+        _col="${_matched_pair%%:*}"
+        _expected_type="${_matched_pair##*:}"
+        if [[ "$_line" != *"$_expected_type"* ]]; then
+            echo "[FAIL] partial-mask column '${_col}' uses the wrong Masked*" >&2
+            echo "       TypeDecorator (expected ${_expected_type}): $_file" >&2
+            echo "       ${_line}" >&2
+            echo "       Next: switch ${_col} to mapped_column(${_expected_type}, ...) per" >&2
             echo "       docs/architecture/domain-model/storage.md §逆引き表." >&2
             violations=$((violations + 1))
         fi
-    done <<< "$masked_decls"
+    done <<< "$_masked_decls"
+
+    # Check that all required allowed columns are present in the file.
+    for _pair in "${_allowed_pairs[@]}"; do
+        _col="${_pair%%:*}"
+        _expected_type="${_pair##*:}"
+        if ! grep -qE "^\s*${_col}\s*:\s*Mapped.*${_expected_type}" "$_file"; then
+            echo "[FAIL] partial-mask required column '${_col}' with ${_expected_type}" >&2
+            echo "       missing from: $_file" >&2
+            echo "       Next: declare ${_col} with mapped_column(${_expected_type}, ...) per" >&2
+            echo "       docs/architecture/domain-model/storage.md §逆引き表." >&2
+            violations=$((violations + 1))
+        fi
+    done
 done
 
 if [[ "$violations" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

- `ExternalReviewGateRepository` Protocol (6 methods: find_by_id / count / save / find_pending_by_reviewer / find_by_task_id / count_by_decision)
- `SqliteExternalReviewGateRepository` with §確定 R1-B 5-step save, `_hydrate_row` helper for N+1-safe child fetching, TypeDecorator-trust throughout
- 3 new ORM tables: `external_review_gates` (MaskedText: feedback_text + snapshot_body_markdown), `external_review_gate_attachments` (no masking), `external_review_audit_entries` (MaskedText: comment)
- Alembic migration `0008_external_review_gate_aggregate` (down_revision=0007_task_aggregate)
- CI三層防衛: Layer 1 (check_masking_columns.sh redesigned to support multi-column partial-mask files) + Layer 2 (test_masking_columns.py: 33 tests including new TestDualMaskContract for 2-column masking pattern)

## Key design decisions applied

- **§設計決定 ERGR-001**: reviewer_id / snapshot_committed_by / stage_id / actor_id have NO FK (Aggregate boundary + Owner Aggregate M2 scope)
- **§設計決定 ERGR-002**: feedback_text elevated to MaskedText (CEO input path → webhook URL risk)
- **§確定 R1-A**: TypeDecorator-trust — no manual MaskingGateway.mask() calls, no UUID() defensive wrapping
- **§確定 R1-B**: Strict 5-step order (DELETE attach → DELETE audit → UPSERT gate → INSERT attach → INSERT audit)
- **§確定 R1-C**: Deliverable snapshot reconstructed from gate_row scalars + attach_rows; audit_trail from audit_rows ordered occurred_at ASC, id ASC
- **check_masking_columns.sh Layer 1-C redesign**: Previous script assumed exactly 1 masked column per file (single-entry PARTIAL_MASK_FILES). external_review_gates has 2 masked columns. Redesigned to group entries by file and check all allowed columns together — backward-compatible with existing single-column entries

## Test points for テスト担当

- `SqliteExternalReviewGateRepository.save()` 5-step DELETE→INSERT — verify UPSERT updates decision/feedback_text/decided_at but NOT task_id/stage_id/reviewer_id/created_at/snapshot_*
- Round-trip `find_by_id` after `save`: MaskedText columns (feedback_text, snapshot_body_markdown, comment) return masked form; UUID fields return UUID instances; decided_at is None for PENDING, datetime for decided states
- `find_pending_by_reviewer`: ORDER BY created_at DESC, id DESC tiebreaker; skips APPROVED/REJECTED/CANCELLED
- `find_by_task_id`: ORDER BY created_at ASC, id ASC; returns all decisions
- `count_by_decision`: correct count per ReviewDecision value
- Alembic migration: `alembic upgrade 0008` creates 3 tables + 3 indexes; `alembic downgrade 0007` drops all cleanly
- `test_masking_columns.py` new TestDualMaskContract: external_review_gates has exactly {feedback_text, snapshot_body_markdown} masked

🤖 Generated with [Claude Code](https://claude.com/claude-code)