### PR TITLE
docs(room/http-api): Room + Agent assignment HTTP API 設計書 (Issue #57)

### DIFF
--- a/docs/features/room/feature-spec.md
+++ b/docs/features/room/feature-spec.md
@@ -1,15 +1,15 @@
 # 業務仕様書（feature-spec）— Room
 
 > feature: `room`（業務概念単位）
-> sub-features: [`domain/`](domain/) | [`repository/`](repository/) | http-api（将来）| ui（将来）
-> 関連 Issue: [#18 feat(room): Room Aggregate Root (M1)](https://github.com/bakufu-dev/bakufu/issues/18) / [#33 feat(room-repository): Room SQLite Repository (M2)](https://github.com/bakufu-dev/bakufu/issues/33)
+> sub-features: [`domain/`](domain/) | [`repository/`](repository/) | [`http-api/`](http-api/) | ui（将来）
+> 関連 Issue: [#18 feat(room): Room Aggregate Root (M1)](https://github.com/bakufu-dev/bakufu/issues/18) / [#33 feat(room-repository): Room SQLite Repository (M2)](https://github.com/bakufu-dev/bakufu/issues/33) / [#57 feat(room-http-api): Room + Agent assignment HTTP API (M3)](https://github.com/bakufu-dev/bakufu/issues/57)
 > 凍結済み設計: [`docs/design/domain-model/aggregates.md`](../../design/domain-model/aggregates.md) §Room / [`docs/design/domain-model/value-objects.md`](../../design/domain-model/value-objects.md) §AgentMembership
 
 ## 本書の役割
 
 本書は **Room という業務概念全体の業務仕様** を凍結する。bakufu 全体の要求分析（[`docs/analysis/`](../../analysis/)）を Room という業務概念で具体化し、ペルソナ（個人開発者 CEO）から見て **観察可能な業務ふるまい** を実装レイヤー（domain / repository / http-api / ui）に依存せず定義する。Vモデル正規工程では **要件定義（業務）** 相当（システムテスト ↔ [`system-test-design.md`](system-test-design.md)）。
 
-各 sub-feature（[`domain/`](domain/) / [`repository/`](repository/) / 将来の http-api / ui）は本書を **業務根拠の真実源** として参照する。各 sub-feature は本書の業務ルール R1-X を実装方針 §確定 A〜Z として展開し、本書には逆流させない（本書の更新は別 PR で先行する）。
+各 sub-feature（[`domain/`](domain/) / [`repository/`](repository/) / [`http-api/`](http-api/) / 将来の ui）は本書を **業務根拠の真実源** として参照する。各 sub-feature は本書の業務ルール R1-X を実装方針 §確定 A〜Z として展開し、本書には逆流させない（本書の更新は別 PR で先行する）。
 
 **書くこと**:
 - ペルソナ（CEO）が Room という業務概念で達成できるようになる行為（ユースケース）
@@ -33,7 +33,7 @@ Room の業務的なライフサイクルは複数の実装レイヤーを跨ぐ
 |---|---|---|
 | domain | [`domain/`](domain/) | Room の構造的整合性（不変条件・メンバー一意・容量・PromptKit 規約・archived terminal）を Aggregate 内で保証 |
 | repository | [`repository/`](repository/) | Room の状態を再起動跨ぎで保持（永続化）、PromptKit.prefix_markdown の secret マスキングを担保 |
-| http-api | (将来) | UI / 外部クライアントから Room を操作・取得する経路 |
+| http-api | [`http-api/`](http-api/) | 外部クライアントから Room を操作・取得する経路（7 エンドポイント：CRUD + Agent 割り当て/解除）|
 | ui | (将来) | CEO が Room を直感的に編成する画面 |
 
 本書はこれら全レイヤーを貫く **業務概念単位の凍結文書** であり、各 sub-feature は本書を引用して実装契約を凍結する。
@@ -48,6 +48,10 @@ Room の業務的なライフサイクルは複数の実装レイヤーを跨ぐ
 >
 > bakufu MVP（v0.1.0）M2「SQLite 永続化」の後続 Repository PR（empire-repository #25 のテンプレート責務継承）。**Room Aggregate** の SQLite 永続化を実装する。**`PromptKit.prefix_markdown` の Repository マスキング実適用**（room §確定 G 踏襲）が本 PR の核心。
 
+> Issue #57（M3 http-api）:
+>
+> bakufu MVP（v0.1.0）M3「HTTP API」の Room エンドポイント群を実装する。Room CRUD（作成 / 一覧 / 単件取得 / 更新 / アーカイブ）および Agent の Room 割り当て / 解除の 7 エンドポイントを提供し、外部クライアント（将来の UI / CLI / テスト）が HTTP 経由で Room を操作できるようにする。
+
 ## 3. 背景・痛点
 
 ### 現状の痛点
@@ -57,6 +61,7 @@ Room の業務的なライフサイクルは複数の実装レイヤーを跨ぐ
 3. UI の MVP は「Room 一覧 → Room 詳細」を中核ナビゲーションに据える設計で、Room の attribute / 不変条件が決まっていないと UI 側の画面・API も着手できない
 4. CEO が Room を編成しても再起動で状態が消えるなら業務として成立しない（Room 設立は持続的な組織概念）
 5. **room §確定 G 申し送り**: `PromptKit.prefix_markdown` に API key / GitHub PAT が混入した場合、Repository 経由での DB 永続化時に raw 流出する経路が残っている
+6. domain / repository が完成しても **HTTP API がなければ UI / テストが Room を操作できない**。curl / SDK / 将来の UI すべてが HTTP API 経由で Room CRUD を行う
 
 ### 解決されれば変わること
 
@@ -64,6 +69,7 @@ Room の業務的なライフサイクルは複数の実装レイヤーを跨ぐ
 - `directive` / `task` Issue が Room 参照を前提に実装可能になる
 - Room の状態がアプリ再起動を跨いで保持される
 - `PromptKit.prefix_markdown` に CEO が誤って API key / webhook URL を貼り付けても DB には `<REDACTED:*>` で永続化（**room §確定 G 実適用完了**）
+- HTTP API 経由で Room の CRUD と Agent 編成が外部クライアントから操作可能になる
 
 ### ビジネス価値
 
@@ -74,7 +80,7 @@ Room の業務的なライフサイクルは複数の実装レイヤーを跨ぐ
 
 | ペルソナ名 | 役割 | 観察主体 | 達成したいゴール |
 |-----------|------|---------|---------------|
-| 個人開発者 CEO | bakufu インスタンスのオーナー | 直接（将来の UI 経由）/ 間接（domain・repository sub-feature では application 層経由） | Room を設立し、Workflow / Agent / PromptKit を設定してチームに組み込み、再起動跨ぎで状態が保持される |
+| 個人開発者 CEO | bakufu インスタンスのオーナー | 直接（将来の UI 経由）/ 間接（domain・repository sub-feature では application 層経由）/ HTTP API（M3） | Room を設立し、Workflow / Agent / PromptKit を設定してチームに組み込み、再起動跨ぎで状態が保持される |
 
 bakufu システム全体ペルソナは [`docs/analysis/personas.md`](../../analysis/personas.md) を参照。
 
@@ -89,24 +95,31 @@ bakufu システム全体ペルソナは [`docs/analysis/personas.md`](../../ana
 | UC-RM-005 | CEO | Room をアーカイブできる（物理削除なし、terminal 状態） | 必須 | domain |
 | UC-RM-006 | CEO | 設立した Room の状態がアプリ再起動を跨いで保持される（永続化を意識しない） | 必須 | repository |
 | UC-RM-007 | CEO | 同 Empire 内で Room 名は一意でなければならない（重複設立は拒否される） | 必須 | repository（find_by_name 提供）+ application 層（強制） |
+| UC-RM-008 | CEO | HTTP API 経由で Room を作成できる（POST /api/empires/{empire_id}/rooms）| 必須 | http-api |
+| UC-RM-009 | CEO | HTTP API 経由で Empire 内の Room 一覧を取得できる（GET /api/empires/{empire_id}/rooms）| 必須 | http-api |
+| UC-RM-010 | CEO | HTTP API 経由で Room を単件取得できる（GET /api/rooms/{room_id}）| 必須 | http-api |
+| UC-RM-011 | CEO | HTTP API 経由で Room を更新できる（name / description / prompt_kit の部分更新、PATCH /api/rooms/{room_id}）| 必須 | http-api |
+| UC-RM-012 | CEO | HTTP API 経由で Room をアーカイブできる（DELETE /api/rooms/{room_id}、論理削除）| 必須 | http-api |
+| UC-RM-013 | CEO | HTTP API 経由で Room に Agent を割り当てられる（POST /api/rooms/{room_id}/agents）| 必須 | http-api |
+| UC-RM-014 | CEO | HTTP API 経由で Room の Agent 割り当てを解除できる（DELETE /api/rooms/{room_id}/agents/{agent_id}）| 必須 | http-api |
 
 ## 6. スコープ
 
 ### In Scope
 
-- Room 業務概念全体で観察可能な業務ふるまい（UC-RM-001〜007）
+- Room 業務概念全体で観察可能な業務ふるまい（UC-RM-001〜014）
 - ふるまいの呼び出し失敗時に観察される拒否シグナル（業務ルール違反）
+- HTTP API 経由の Room CRUD + Agent 割り当て/解除（UC-RM-008〜014）
 - 業務概念単位の E2E 検証戦略 → [`system-test-design.md`](system-test-design.md)
 
 ### Out of Scope（参照）
 
-- Room の HTTP API → 将来の `room/http-api/` sub-feature
 - Room の管理 UI → 将来の `room/ui/` sub-feature
 - Room の管理 CLI → 別 feature `feature/admin-cli`（横断的）
 - Directive / Task との結合（target_room_id 等） → `feature/directive` / `feature/task`
 - 永続化基盤の汎用責務（WAL / マイグレーション / masking gateway） → [`feature/persistence-foundation`](../persistence-foundation/)
 - LLM Adapter（Room の PromptKit を LLM に送信する経路） → 将来の `feature/llm-adapter`
-- 「Empire 内 name 一意」の application 層強制 → 将来の `feature/empire-application`（domain と repository の合間に位置）
+- 「Empire 内 name 一意」の application 層強制 → `RoomService.create` で担保（本 http-api sub-feature スコープ内）
 - leader 必須性（Workflow が要求する場合）の application 層強制 → 将来の `feature/room-application`
 
 ## 7. 業務ルールの確定（要求としての凍結）
@@ -141,11 +154,15 @@ bakufu システム全体ペルソナは [`docs/analysis/personas.md`](../../ana
 
 ### 確定 R1-8: 同 Empire 内の Room 名は一意
 
-**理由**: CEO が「部屋の重複」に気付かず設立すると、業務上の役割分担が曖昧になる。この不変条件は **Aggregate 外部の集合知識**（同 Empire 内の他 Room との比較を要する）のため、application 層 `EmpireService.establish_room()` が `RoomRepository.find_by_name(empire_id, name)` 経由で判定する。Aggregate 自身は自分の name の一意性を知らない設計。
+**理由**: CEO が「部屋の重複」に気付かず設立すると、業務上の役割分担が曖昧になる。この不変条件は **Aggregate 外部の集合知識**（同 Empire 内の他 Room との比較を要する）のため、application 層 `RoomService.create()` が `RoomRepository.find_by_name(empire_id, name)` 経由で判定する。Aggregate 自身は自分の name の一意性を知らない設計。
 
 ### 確定 R1-9: `PromptKit.prefix_markdown` は永続化前にシークレットマスキングを適用する
 
 **理由**: CEO が PromptKit 設計時に `prefix_markdown` に Discord webhook URL / API key を誤って含めた場合、DB 直読み / バックアップ / 監査ログ経路への raw token 流出を防ぐ（**room §確定 G 実適用**）。domain 層は raw 文字列を保持し、Repository 層の `MaskedText` TypeDecorator 経由で INSERT/UPDATE 前にマスキングを適用する。
+
+### 確定 R1-10: HTTP API の path parameter は FastAPI に型検証を委ねる
+
+**理由**: `empire_id` / `room_id` / `agent_id` はすべて UUID 型で受け取り、不正形式（非 UUID 文字列）には `RequestValidationError` → 422 を返す（500 ではない）。empire-http-api BUG-EM-SEC-001 解消方針に準拠。
 
 ## 8. 制約・前提
 
@@ -155,7 +172,7 @@ bakufu システム全体ペルソナは [`docs/analysis/personas.md`](../../ana
 | ライセンス | MIT |
 | 対象 OS | Windows 10 21H2+ / macOS 12+ / Linux glibc 2.35+ |
 | ネットワーク | 該当なし — Room 業務概念は外部通信を持たない（永続化はローカル SQLite） |
-| 依存 feature | M1 開始時点: empire / workflow / agent の M1 マージ済み / M2 開始時点: M1 `room/domain` + [`feature/persistence-foundation`](../persistence-foundation/) + empire-repo / workflow-repo / agent-repo マージ済み |
+| 依存 feature | M3 開始時点: M1 `room/domain` + M2 `room/repository` + `http-api-foundation`（Issue #55 マージ済み）+ `empire/http-api` マージ済み |
 
 実装技術スタック（Python 3.12 / Pydantic v2 / SQLAlchemy 2.x async / Alembic / pyright strict / pytest）は各 sub-feature の `basic-design.md §依存関係` に集約する。
 
@@ -176,12 +193,25 @@ bakufu システム全体ペルソナは [`docs/analysis/personas.md`](../../ana
 | 11 | `archive()` で `archived = True` の新 Room が返る | UC-RM-005 | TC-UT-RM-011 |
 | 12 | `archived == True` の Room への `archive()` も新インスタンスを返す（冪等、業務ルール R1-5） | UC-RM-005 | TC-UT-RM-012 |
 | 13 | `archived == True` の Room への `add_member` / `remove_member` / `update_prompt_kit` は拒否される（業務ルール R1-5） | UC-RM-001〜004 | TC-UT-RM-013 |
-| 14 | 業務ルール違反のエラーメッセージに Discord webhook URL が含まれていた場合、`<REDACTED:DISCORD_WEBHOOK>` として伏字化される（domain 層での多層防御、受入基準 18 の repository 層マスキングとは独立） | UC-RM-001 | TC-UT-RM-014 |
+| 14 | 業務ルール違反のエラーメッセージに Discord webhook URL が含まれていた場合、`<REDACTED:DISCORD_WEBHOOK>` として伏字化される（domain 層での多層防御） | UC-RM-001 | TC-UT-RM-014 |
 | 16 | 設立した Room の状態がアプリ再起動跨ぎで保持される（業務ルール R1-7） | UC-RM-006 | TC-E2E-RM-001（[`system-test-design.md`](system-test-design.md)） |
 | 17 | 同 Empire 内で同名 Room を設立しようとすると拒否される（業務ルール R1-8） | UC-RM-007 | TC-E2E-RM-002 |
 | 18 | `PromptKit.prefix_markdown` に webhook URL を含めて永続化すると DB には `<REDACTED:*>` で保存される（業務ルール R1-9） | UC-RM-006 | TC-IT-RR-008-masking（[`repository/test-design.md`](repository/test-design.md)） |
+| 19 | HTTP API 経由で Room を作成できる（POST /api/empires/{empire_id}/rooms → 201 + RoomResponse）| UC-RM-008 | TC-IT-RM-HTTP-001（[`http-api/test-design.md`](http-api/test-design.md)） |
+| 20 | 同 Empire 内で同名 Room を HTTP API 経由で作成しようとすると 409 が返る（業務ルール R1-8）| UC-RM-008 | TC-IT-RM-HTTP-002 |
+| 21 | 存在しない Empire への Room 作成（POST /api/empires/{empire_id}/rooms）は 404 が返る | UC-RM-008 | TC-IT-RM-HTTP-003 |
+| 22 | HTTP API 経由で Empire 内 Room 一覧を取得できる（GET /api/empires/{empire_id}/rooms → 200 + RoomListResponse）| UC-RM-009 | TC-IT-RM-HTTP-004 |
+| 23 | HTTP API 経由で Room を単件取得できる（GET /api/rooms/{room_id} → 200 + RoomResponse）| UC-RM-010 | TC-IT-RM-HTTP-005 |
+| 24 | 不在 Room への GET は 404 が返る | UC-RM-010 | TC-IT-RM-HTTP-006 |
+| 25 | HTTP API 経由で Room を部分更新できる（PATCH /api/rooms/{room_id} → 200 + RoomResponse）| UC-RM-011 | TC-IT-RM-HTTP-007 |
+| 26 | アーカイブ済み Room への PATCH は 409 が返る（業務ルール R1-5）| UC-RM-011 | TC-IT-RM-HTTP-008 |
+| 27 | HTTP API 経由で Room をアーカイブできる（DELETE /api/rooms/{room_id} → 204）| UC-RM-012 | TC-IT-RM-HTTP-009 |
+| 28 | HTTP API 経由で Agent を Room に割り当てられる（POST /api/rooms/{room_id}/agents → 201 + RoomResponse）| UC-RM-013 | TC-IT-RM-HTTP-010 |
+| 29 | アーカイブ済み Room への Agent 割り当ては 409 が返る（業務ルール R1-5）| UC-RM-013 | TC-IT-RM-HTTP-011 |
+| 30 | HTTP API 経由で Agent 割り当てを解除できる（DELETE /api/rooms/{room_id}/agents/{agent_id}?role={role} → 204）| UC-RM-014 | TC-IT-RM-HTTP-012 |
+| 31 | 不正な UUID パスパラメータ（empire_id / room_id / agent_id）は 422 が返る（業務ルール R1-10）| UC-RM-008〜014 | TC-IT-RM-HTTP-013 |
 
-E2E（受入基準 16, 17）は [`system-test-design.md`](system-test-design.md) で詳細凍結。受入基準 1〜14 は domain sub-feature の IT / UT で検証（[`domain/test-design.md`](domain/test-design.md)）。受入基準 18 は repository IT（TC-IT-RR-008）と E2E（TC-E2E-RM-003）の両方で検証。
+E2E（受入基準 16, 17）は [`system-test-design.md`](system-test-design.md) で詳細凍結。受入基準 1〜14 は domain sub-feature の IT / UT で検証（[`domain/test-design.md`](domain/test-design.md)）。受入基準 18 は repository IT（TC-IT-RR-008）と E2E（TC-E2E-RM-003）の両方で検証。受入基準 19〜31 は http-api sub-feature の IT で検証（[`http-api/test-design.md`](http-api/test-design.md)）。
 
 ## 10. 開発者品質基準（CI 担保、業務要求ではない）
 
@@ -191,7 +221,7 @@ E2E（受入基準 16, 17）は [`system-test-design.md`](system-test-design.md)
 
 ## 11. 開放論点 (Open Questions)
 
-凍結時点で未確定の論点はなし — R1 レビューで全件凍結済み。確定 R1-1〜9 として §7 に集約。
+凍結時点で未確定の論点はなし — R1 レビューで全件凍結済み。確定 R1-1〜10 として §7 に集約。
 
 ## 12. sub-feature 一覧とマイルストーン整理
 
@@ -214,4 +244,4 @@ E2E（受入基準 16, 17）は [`system-test-design.md`](system-test-design.md)
 | パフォーマンス | 業務ふるまい呼び出しの応答が CEO 視点で「即時」（数 ms 以内）と感じられること。MVP 想定規模（members ≤ 50）で domain 層 1ms 未満、永続化層 50ms 未満を目標 |
 | 可用性 | 永続化層の WAL モード + crash safety（[`feature/persistence-foundation`](../persistence-foundation/) 担保）により、書き込み中のクラッシュでも Room 状態が破損しない |
 | 可搬性 | 純 Python のみ。OS / ファイルシステム依存なし（SQLite はクロスプラットフォーム） |
-| セキュリティ | 業務ルール違反は早期に拒否される（Fail Fast）。`PromptKit.prefix_markdown` の Discord webhook URL / API key は `MaskedText` で永続化前マスキング（業務ルール R1-9、room §確定 G 実適用）。`RoomInvariantViolation` の例外経路での webhook URL 漏洩は webhook auto-mask で防御（多層防御） |
+| セキュリティ | 業務ルール違反は早期に拒否される（Fail Fast）。`PromptKit.prefix_markdown` の Discord webhook URL / API key は `MaskedText` で永続化前マスキング（業務ルール R1-9、room §確定 G 実適用）。`RoomInvariantViolation` の例外経路での webhook URL 漏洩は webhook auto-mask で防御（多層防御）。HTTP path parameter は FastAPI UUID 型検証で不正値 → 422（業務ルール R1-10）|

--- a/docs/features/room/http-api/basic-design.md
+++ b/docs/features/room/http-api/basic-design.md
@@ -1,0 +1,399 @@
+# 基本設計書
+
+> feature: `room` / sub-feature: `http-api`
+> 関連 Issue: [#57 feat(room-http-api): Room + Agent assignment HTTP API (M3)](https://github.com/bakufu-dev/bakufu/issues/57)
+> 関連: [`../feature-spec.md`](../feature-spec.md) / [`../domain/basic-design.md`](../domain/basic-design.md) / [`../repository/basic-design.md`](../repository/basic-design.md) / [`../../http-api-foundation/http-api/basic-design.md`](../../http-api-foundation/http-api/basic-design.md)
+> 凍結済み設計参照: [`docs/design/architecture.md §interfaces レイヤー詳細`](../../../design/architecture.md) / [`docs/design/threat-model.md`](../../../design/threat-model.md)
+
+## 記述ルール（必ず守ること）
+
+基本設計に**疑似コード・サンプル実装（python/ts/sh/yaml 等の言語コードブロック）を書かない**。
+ソースコードと二重管理になりメンテナンスコストしか生まない。
+必要なのは構造契約（クラス・モジュール・データの関係）であり、実装の細部は [detailed-design.md](detailed-design.md) で凍結する。
+
+## モジュール構成
+
+本 sub-feature で追加・変更するモジュール一覧。
+
+| 機能 ID | モジュール | ディレクトリ | 責務 |
+|--------|----------|------------|------|
+| REQ-RM-HTTP-001〜007 | `room_router` | `backend/src/bakufu/interfaces/http/routers/rooms.py` | Room CRUD + Agent 割り当て/解除 エンドポイント（7 本）|
+| REQ-RM-HTTP-001〜007 | `RoomService` | `backend/src/bakufu/application/services/room_service.py` | http-api-foundation で骨格確定済み。本 sub-feature で全メソッドを肉付け |
+| REQ-RM-HTTP-001〜007 | `RoomSchemas` | `backend/src/bakufu/interfaces/http/schemas/room.py` | Pydantic v2 リクエスト / レスポンスモデル（新規ファイル）|
+| 横断 | `room 例外ハンドラ群` | `backend/src/bakufu/interfaces/http/error_handlers.py`（既存追記）| `RoomInvariantViolation` / `RoomNotFoundError` / `RoomNameAlreadyExistsError` / `RoomArchivedError` / `WorkflowNotFoundError` / `AgentNotFoundError` → `ErrorResponse` 変換 |
+| REQ-RM-HTTP-002 | `RoomRepository.find_all_by_empire` 拡張 | `backend/src/bakufu/application/ports/room_repository.py`（既存追記）| `find_all_by_empire(empire_id) → list[Room]` メソッド追加（一覧取得 UC-RM-009 のため）|
+| REQ-RM-HTTP-002 | `SqliteRoomRepository.find_all_by_empire` 実装 | `backend/src/bakufu/infrastructure/persistence/sqlite/repositories/room_repository.py`（既存追記）| `SELECT * FROM rooms WHERE empire_id=?` で Empire スコープ全件取得 |
+
+```
+本 sub-feature で追加・変更されるファイル:
+
+backend/
+└── src/bakufu/
+    ├── application/
+    │   ├── ports/
+    │   │   └── room_repository.py              # 既存追記: find_all_by_empire() 追加
+    │   ├── exceptions/
+    │   │   └── room_exceptions.py              # 新規: RoomNotFoundError / RoomNameAlreadyExistsError / RoomArchivedError / WorkflowNotFoundError / AgentNotFoundError
+    │   └── services/
+    │       └── room_service.py                 # 既存追記: create / find_all_by_empire / find_by_id / update / archive / assign_agent / unassign_agent
+    ├── infrastructure/persistence/sqlite/repositories/
+    │   └── room_repository.py                  # 既存追記: find_all_by_empire() 実装
+    └── interfaces/http/
+        ├── error_handlers.py                   # 既存追記: room 例外ハンドラ群
+        ├── routers/
+        │   └── rooms.py                        # 新規: 7 エンドポイント
+        └── schemas/
+            └── room.py                         # 新規: RoomCreate / RoomUpdate / AgentAssignRequest / RoomResponse / RoomListResponse
+```
+
+## モジュール契約（機能要件）
+
+本 sub-feature が提供するモジュールの入出力契約を凍結する。各 REQ-RM-HTTP-NNN は親 [`../feature-spec.md §5`](../feature-spec.md) ユースケース UC-RM-NNN と 1:1 または N:1 で対応する（孤児要件を作らない）。
+
+### REQ-RM-HTTP-001: Room 作成（POST /api/empires/{empire_id}/rooms）
+
+| 項目 | 内容 |
+|---|---|
+| 入力 | パスパラメータ `empire_id: UUID` / リクエスト Body `RoomCreate(name: str, description: str, workflow_id: UUID, prompt_kit_prefix_markdown: str)`（description・prompt_kit_prefix_markdown は空文字デフォルト）|
+| 処理 | `RoomService.create(empire_id, name, description, workflow_id, prompt_kit_prefix_markdown)` → 1) Empire 存在確認（不在 → `EmpireNotFoundError` 404）2) Workflow 存在確認（不在 → `WorkflowNotFoundError` 404）3) 同 Empire 内 name 重複確認（`find_by_name`、重複 → `RoomNameAlreadyExistsError` 409）4) `Room(...)` 構築（R1-1/R1-2/R1-3/R1-4 検査）→ 5) `RoomRepository.save(room, empire_id)` |
+| 出力 | HTTP 201, `RoomResponse`（id / name / description / workflow_id / members / prompt_kit_prefix_markdown / archived）|
+| エラー時 | Empire 不在 → 404 / Workflow 不在 → 404 / name 重複 → 409 (MSG-RM-HTTP-001) / name 範囲違反 → 422 / 不正 UUID → 422 |
+
+### REQ-RM-HTTP-002: Room 一覧取得（GET /api/empires/{empire_id}/rooms）
+
+| 項目 | 内容 |
+|---|---|
+| 入力 | パスパラメータ `empire_id: UUID` |
+| 処理 | `RoomService.find_all_by_empire(empire_id)` → Empire 存在確認 → `RoomRepository.find_all_by_empire(empire_id)` で Empire スコープ全件取得 |
+| 出力 | HTTP 200, `RoomListResponse(items: list[RoomResponse], total: int)`（空リストも 200 で返す）|
+| エラー時 | Empire 不在 → 404 / 不正 UUID → 422 |
+
+### REQ-RM-HTTP-003: Room 単件取得（GET /api/rooms/{room_id}）
+
+| 項目 | 内容 |
+|---|---|
+| 入力 | パスパラメータ `room_id: UUID` |
+| 処理 | `RoomService.find_by_id(room_id)` → `RoomRepository.find_by_id(room_id)` → 不在 → `RoomNotFoundError` |
+| 出力 | HTTP 200, `RoomResponse` |
+| エラー時 | 不在 → 404 (MSG-RM-HTTP-002) / 不正 UUID → 422 |
+
+### REQ-RM-HTTP-004: Room 更新（PATCH /api/rooms/{room_id}）
+
+| 項目 | 内容 |
+|---|---|
+| 入力 | パスパラメータ `room_id: UUID` + `RoomUpdate(name: str \| None, description: str \| None, prompt_kit_prefix_markdown: str \| None)`（None は変更なし）|
+| 処理 | `RoomService.update(room_id, name, description, prompt_kit_prefix_markdown)` → 1) `find_by_id` → 不在 → 404 / archived → 409 2) 変更フィールドのみ差し替えた `Room(...)` 再構築（pre-validate）3) `RoomRepository.save(updated_room, empire_id)` |
+| 出力 | HTTP 200, 更新済み `RoomResponse` |
+| エラー時 | 不在 → 404 / アーカイブ済み → 409 (MSG-RM-HTTP-003) / name 範囲違反 → 422 / 不正 UUID → 422 |
+
+### REQ-RM-HTTP-005: Room アーカイブ（DELETE /api/rooms/{room_id}）
+
+| 項目 | 内容 |
+|---|---|
+| 入力 | パスパラメータ `room_id: UUID` |
+| 処理 | `RoomService.archive(room_id)` → `find_by_id` → `room.archive()` → `RoomRepository.save(archived_room, empire_id)` |
+| 出力 | HTTP 204 No Content |
+| エラー時 | 不在 → 404 (MSG-RM-HTTP-002) / 不正 UUID → 422 |
+
+### REQ-RM-HTTP-006: Agent 割り当て（POST /api/rooms/{room_id}/agents）
+
+| 項目 | 内容 |
+|---|---|
+| 入力 | パスパラメータ `room_id: UUID` + リクエスト Body `AgentAssignRequest(agent_id: UUID, role: str)` |
+| 処理 | `RoomService.assign_agent(room_id, agent_id, role)` → 1) Room 存在確認・archived 確認 2) Agent 存在確認（不在 → `AgentNotFoundError` 404）3) `room.add_member(agent_id, role, joined_at=now())` （`(agent_id, role)` 重複 → `RoomInvariantViolation` 422 / capacity 超過 → 422）4) `RoomRepository.save(updated_room, empire_id)` |
+| 出力 | HTTP 201, 更新済み `RoomResponse` |
+| エラー時 | Room 不在 → 404 / Room アーカイブ済み → 409 (MSG-RM-HTTP-003) / Agent 不在 → 404 (MSG-RM-HTTP-004) / `(agent_id, role)` 重複 → 422 / capacity 超過 → 422 / 不正 UUID → 422 |
+
+### REQ-RM-HTTP-007: Agent 割り当て解除（DELETE /api/rooms/{room_id}/agents/{agent_id}）
+
+| 項目 | 内容 |
+|---|---|
+| 入力 | パスパラメータ `room_id: UUID` / `agent_id: UUID` + クエリパラメータ `role: str`（必須。同一 agent_id の複数 role を区別するため）|
+| 処理 | `RoomService.unassign_agent(room_id, agent_id, role)` → 1) Room 存在確認・archived 確認 2) `room.remove_member(agent_id, role)` （不在 → `RoomInvariantViolation(kind='member_not_found')` 404）3) `RoomRepository.save(updated_room, empire_id)` |
+| 出力 | HTTP 204 No Content |
+| エラー時 | Room 不在 → 404 (MSG-RM-HTTP-002) / Room アーカイブ済み → 409 (MSG-RM-HTTP-003) / membership 不在 → 404 (MSG-RM-HTTP-005) / 不正 UUID → 422 |
+
+## ユーザー向けメッセージ一覧
+
+確定文言は [`detailed-design.md §MSG 確定文言表`](detailed-design.md) で凍結する。
+
+| ID | 種別 | 条件 | HTTP ステータス |
+|---|---|---|---|
+| MSG-RM-HTTP-001 | エラー（競合）| 同 Empire 内で同名 Room が既に存在する（R1-8 違反）| 409 |
+| MSG-RM-HTTP-002 | エラー（不在）| Room が見つからない | 404 |
+| MSG-RM-HTTP-003 | エラー（競合）| アーカイブ済み Room への更新 / Agent 操作（R1-5 違反）| 409 |
+| MSG-RM-HTTP-004 | エラー（不在）| Agent が見つからない | 404 |
+| MSG-RM-HTTP-005 | エラー（不在）| 指定した membership が Room に存在しない | 404 |
+| MSG-RM-HTTP-006 | エラー（競合）| Workflow が見つからない | 404 |
+| MSG-RM-HTTP-007 | エラー（検証）| `RoomInvariantViolation` の業務ルール違反本文 | 422 |
+
+## 依存関係
+
+| 区分 | 依存 | バージョン方針 | 備考 |
+|---|---|---|---|
+| ランタイム | Python 3.12+ | pyproject.toml | 既存 |
+| HTTP フレームワーク | FastAPI / Pydantic v2 / httpx | pyproject.toml | http-api-foundation で確定済み |
+| DI パターン | `get_session()` / `get_room_service()` | http-api-foundation 確定E | `dependencies.py` に `get_room_repository()` / `get_room_service()` を追記 |
+| application 例外 | `RoomNotFoundError` / `RoomNameAlreadyExistsError` / `RoomArchivedError` / `WorkflowNotFoundError` / `AgentNotFoundError` | 本 PR で新規定義 | `application/exceptions/room_exceptions.py` |
+| domain | `Room` / `RoomId` / `RoomInvariantViolation` / `AgentMembership` / `PromptKit` | M1 確定 | room domain sub-feature（Issue #18）|
+| repository | `RoomRepository` Protocol / `SqliteRoomRepository` | M2 確定 + 本 PR で `find_all_by_empire` 追記 | room repository sub-feature（Issue #33）|
+| 基盤 | http-api-foundation（ErrorResponse / lifespan / CSRF / CORS）| M3-A 確定（Issue #55）| 全 error handler / app.state.session_factory を引き継ぐ |
+| empire 参照 | `EmpireRepository.find_by_id`（Empire 存在確認）/ `EmpireNotFoundError` | empire http-api（Issue #56）確定 | Empire 不在時 404 を返すため |
+
+## クラス設計（概要）
+
+```mermaid
+classDiagram
+    class RoomRouter {
+        <<FastAPI APIRouter>>
+        +POST /api/empires/{empire_id}/rooms
+        +GET /api/empires/{empire_id}/rooms
+        +GET /api/rooms/{room_id}
+        +PATCH /api/rooms/{room_id}
+        +DELETE /api/rooms/{room_id}
+        +POST /api/rooms/{room_id}/agents
+        +DELETE /api/rooms/{room_id}/agents/{agent_id}
+    }
+    class RoomService {
+        -_room_repo: RoomRepository
+        -_empire_repo: EmpireRepository
+        -_workflow_repo: WorkflowRepository
+        -_agent_repo: AgentRepository
+        +__init__(room_repo, empire_repo, workflow_repo, agent_repo)
+        +create(empire_id, name, description, workflow_id, prompt_kit_prefix_markdown) Room
+        +find_all_by_empire(empire_id) list~Room~
+        +find_by_id(room_id) Room
+        +update(room_id, name, description, prompt_kit_prefix_markdown) Room
+        +archive(room_id) None
+        +assign_agent(room_id, agent_id, role) Room
+        +unassign_agent(room_id, agent_id, role) None
+    }
+    class RoomRepository {
+        <<Protocol>>
+        +find_by_id(room_id) Room | None
+        +find_by_name(empire_id, name) Room | None
+        +find_all_by_empire(empire_id) list~Room~
+        +count() int
+        +save(room, empire_id) None
+    }
+    class RoomCreate {
+        <<Pydantic BaseModel>>
+        +name: str
+        +description: str
+        +workflow_id: UUID
+        +prompt_kit_prefix_markdown: str
+    }
+    class RoomUpdate {
+        <<Pydantic BaseModel>>
+        +name: str | None
+        +description: str | None
+        +prompt_kit_prefix_markdown: str | None
+    }
+    class AgentAssignRequest {
+        <<Pydantic BaseModel>>
+        +agent_id: UUID
+        +role: str
+    }
+    class RoomResponse {
+        <<Pydantic BaseModel>>
+        +id: str
+        +name: str
+        +description: str
+        +workflow_id: str
+        +members: list~MemberResponse~
+        +prompt_kit_prefix_markdown: str
+        +archived: bool
+    }
+    class RoomListResponse {
+        <<Pydantic BaseModel>>
+        +items: list~RoomResponse~
+        +total: int
+    }
+    class MemberResponse {
+        <<Pydantic BaseModel>>
+        +agent_id: str
+        +role: str
+        +joined_at: str
+    }
+
+    RoomRouter --> RoomService : uses (DI)
+    RoomService --> RoomRepository : uses (Port)
+    RoomRouter ..> RoomCreate : deserializes
+    RoomRouter ..> RoomUpdate : deserializes
+    RoomRouter ..> AgentAssignRequest : deserializes
+    RoomRouter ..> RoomResponse : serializes
+    RoomRouter ..> RoomListResponse : serializes
+```
+
+## 処理フロー
+
+### ユースケース 1: Room 作成（POST /api/empires/{empire_id}/rooms）
+
+1. Router が `empire_id: UUID` をパスパラメータとして受け取る（不正形式 → 422、業務ルール R1-10）
+2. Router が `RoomCreate` を Pydantic でデシリアライズ（422 on 失敗）
+3. `get_room_service()` DI で `RoomService` を取得
+4. `RoomService.create(empire_id, name, description, workflow_id, prompt_kit_prefix_markdown)` 呼び出し
+5. Empire 存在確認（`EmpireRepository.find_by_id` → None → `EmpireNotFoundError` → 404）
+6. Workflow 存在確認（`WorkflowRepository.find_by_id` → None → `WorkflowNotFoundError` → 404）
+7. Empire スコープ name 重複確認（`RoomRepository.find_by_name(empire_id, name)` → 存在 → `RoomNameAlreadyExistsError` → 409）
+8. `Room(id=uuid4(), name=name, ...)` 構築（R1-1〜R1-4 失敗時 `RoomInvariantViolation` → 422）
+9. `async with session.begin()`: `RoomRepository.save(room, empire_id)` → `MaskedText` で prefix_markdown マスキング適用（業務ルール R1-9）
+10. HTTP 201, `RoomResponse` を返す
+
+### ユースケース 2: Room 一覧取得（GET /api/empires/{empire_id}/rooms）
+
+1. `empire_id: UUID` パスパラメータ取得（不正形式 → 422）
+2. Empire 存在確認（不在 → 404）
+3. `RoomService.find_all_by_empire(empire_id)` → `RoomRepository.find_all_by_empire(empire_id)`
+4. `list[Room]` を `list[RoomResponse]` にマップ
+5. `RoomListResponse(items=..., total=len(...))` で HTTP 200
+
+### ユースケース 3: Room 単件取得（GET /api/rooms/{room_id}）
+
+1. `room_id: UUID` 取得（不正形式 → 422）
+2. `RoomService.find_by_id(room_id)` → None → 404
+3. `RoomResponse` で HTTP 200
+
+### ユースケース 4: Room 更新（PATCH /api/rooms/{room_id}）
+
+1. `room_id: UUID` + `RoomUpdate` 取得
+2. `RoomService.update(room_id, ...)` → `find_by_id` → None → 404 / archived → 409
+3. 変更フィールドのみ差し替えた `Room(...)` 再構築（pre-validate、R1-1/R1-2 検査）
+4. `async with session.begin()`: `RoomRepository.save(updated_room, empire_id)`
+5. `RoomResponse` で HTTP 200
+
+### ユースケース 5: Room アーカイブ（DELETE /api/rooms/{room_id}）
+
+1. `room_id: UUID` 取得（不正形式 → 422）
+2. `RoomService.archive(room_id)` → `find_by_id` → None → 404
+3. `room.archive()` → `archived=True` の新 Room（冪等）
+4. `async with session.begin()`: `RoomRepository.save(archived_room, empire_id)`
+5. HTTP 204 No Content
+
+### ユースケース 6: Agent 割り当て（POST /api/rooms/{room_id}/agents）
+
+1. `room_id: UUID` + `AgentAssignRequest` 取得（不正形式 → 422）
+2. `RoomService.assign_agent(room_id, agent_id, role)` 呼び出し
+3. Room 存在確認（不在 → 404）/ archived 確認（archived → 409）
+4. Agent 存在確認（`AgentRepository.find_by_id` → None → `AgentNotFoundError` → 404）
+5. `room.add_member(agent_id, role, joined_at=now())` → `RoomInvariantViolation` 発生時 → 422
+6. `async with session.begin()`: `RoomRepository.save(updated_room, empire_id)`
+7. HTTP 201, 更新済み `RoomResponse`
+
+### ユースケース 7: Agent 割り当て解除（DELETE /api/rooms/{room_id}/agents/{agent_id}）
+
+1. `room_id: UUID` / `agent_id: UUID` + クエリパラメータ `role: str` 取得（不正形式 → 422）
+2. `RoomService.unassign_agent(room_id, agent_id, role)` 呼び出し
+3. Room 存在確認（不在 → 404）/ archived 確認（archived → 409）
+4. `room.remove_member(agent_id, role)` → `RoomInvariantViolation(kind='member_not_found')` → 404
+5. `async with session.begin()`: `RoomRepository.save(updated_room, empire_id)`
+6. HTTP 204 No Content
+
+## シーケンス図
+
+```mermaid
+sequenceDiagram
+    participant Client as HTTP Client
+    participant Router as room_router
+    participant Service as RoomService
+    participant EmpRepo as EmpireRepository
+    participant WfRepo as WorkflowRepository
+    participant RoomRepo as RoomRepository
+    participant Domain as Room (domain)
+    participant DB as SQLite
+
+    Client->>Router: POST /api/empires/{empire_id}/rooms
+    Router->>Service: create(empire_id, name, description, workflow_id, ...)
+    Service->>EmpRepo: find_by_id(empire_id)
+    EmpRepo->>DB: SELECT FROM empires WHERE id=?
+    DB-->>EmpRepo: empire_row
+    EmpRepo-->>Service: Empire
+    Service->>WfRepo: find_by_id(workflow_id)
+    WfRepo-->>Service: Workflow
+    Service->>RoomRepo: find_by_name(empire_id, name)
+    RoomRepo->>DB: SELECT FROM rooms WHERE empire_id=? AND name=?
+    DB-->>RoomRepo: None
+    RoomRepo-->>Service: None（重複なし）
+    Service->>Domain: Room(id=uuid4(), name=name, ...)
+    Domain-->>Service: room（pre-validate 通過）
+    Service->>RoomRepo: save(room, empire_id)
+    RoomRepo->>DB: UPSERT rooms + DELETE/INSERT room_members
+    DB-->>RoomRepo: ok
+    RoomRepo-->>Service: None
+    Service-->>Router: room
+    Router-->>Client: 201 RoomResponse
+```
+
+## アーキテクチャへの影響
+
+- **`docs/design/architecture.md`**: 変更なし（http-api-foundation で routers/ の配置はすでに明示済み）
+- **`docs/design/tech-stack.md`**: 変更なし
+- **`room/repository/basic-design.md`**: `find_all_by_empire()` メソッド追加（本 PR で実施、既存 `room_repository.md` の Protocol に追記）。room_repository.py の `REQ-RR-001` 定義に `find_all_by_empire` メソッドを加える
+- 既存 feature への波及: `error_handlers.py` に room 専用ハンドラを追記するが、既存ハンドラ（HTTPException / ValidationError / generic / empire 専用）は変更しない
+
+## 外部連携
+
+| 連携先 | 目的 | プロトコル | 認証 | タイムアウト / リトライ |
+|-------|------|----------|-----|---------------------|
+| 該当なし | — | — | — | — |
+
+外部連携なし — 理由: Room HTTP API は SQLite ローカル永続化のみで完結し、外部 API 呼び出しを行わない。
+
+## UX 設計
+
+| シナリオ | 期待される挙動 |
+|---------|------------|
+| Empire に Room がゼロで GET /api/empires/{empire_id}/rooms | `{"items": [], "total": 0}` で 200（エラーではない）|
+| 同名 Room を同 Empire に POST | 409 `{"error": {"code": "conflict", "message": "Room name already exists in this empire."}}` |
+| アーカイブ済み Room に PATCH | 409 `{"error": {"code": "conflict", "message": "Room is archived and cannot be modified."}}` |
+| 不正 UUID でパスパラメータ | 422 FastAPI validation_error |
+| 存在しない Agent を割り当て | 404 `{"error": {"code": "not_found", "message": "Agent not found."}}` |
+| 同一 (agent_id, role) を二重割り当て | 422 `RoomInvariantViolation` の業務ルール違反本文 |
+
+**アクセシビリティ方針**: 該当なし（HTTP API のため）。
+
+## セキュリティ設計
+
+### 脅威モデル
+
+| 想定攻撃者 | 攻撃経路 | 保護資産 | 対策 |
+|-----------|---------|---------|------|
+| **T1: CSRF 経由での Room 改ざん** | ブラウザ経由の不正 POST / PATCH / DELETE | Room の状態整合性 | http-api-foundation 確定D: CSRF Origin 検証ミドルウェア（Origin ヘッダ不一致なら 403）|
+| **T2: スタックトレース露出** | 500 エラーレスポンスへのスタックトレース混入 | 内部実装情報 | http-api-foundation 確定A: generic_exception_handler が `internal_error` のみを返す |
+| **T3: 不正 UUID によるパスインジェクション** | `empire_id` / `room_id` / `agent_id` に不正値を注入 | DB 整合性 | FastAPI `UUID` 型強制（422 on 不正形式、業務ルール R1-10）+ SQLAlchemy ORM |
+| **T4: PromptKit 経由の secret 流出** | POST / PATCH で `prompt_kit_prefix_markdown` に webhook URL を含めて永続化 | Discord webhook token / API key | `MaskedText` TypeDecorator（room §確定 G 実適用済み）で永続化前マスキング。レスポンス返却時は masked 文字列のまま |
+
+### OWASP Top 10 対応
+
+| # | カテゴリ | 対応状況 |
+|---|---------|---------|
+| A01 | Broken Access Control | loopback バインド（`127.0.0.1:8000`）+ CSRF Origin 検証（http-api-foundation 確定D）|
+| A02 | Cryptographic Failures | **該当**: `prompt_kit_prefix_markdown` は `MaskedText` 経由で永続化前マスキング（T4 対策）|
+| A03 | Injection | SQLAlchemy ORM 経由（raw SQL 不使用）|
+| A04 | Insecure Design | domain の pre-validate + frozen Room で不整合状態を物理的に防止 |
+| A05 | Security Misconfiguration | http-api-foundation の lifespan / CORS 設定を引き継ぐ |
+| A06 | Vulnerable Components | 依存 CVE は CI `pip-audit` で監視 |
+| A07 | Auth Failures | MVP 設計上 意図的な認証なし（loopback バインドで代替）|
+| A08 | Data Integrity Failures | delete-then-insert + UoW（repository sub-feature 確定済み）|
+| A09 | Logging Failures | 内部エラーは application 層でログ、スタックトレースはレスポンスに含めない |
+| A10 | SSRF | 該当なし（外部 URL fetch なし）|
+
+## ER 図
+
+本 sub-feature は DB スキーマを変更しない。ER は [`../repository/basic-design.md §ER 図`](../repository/basic-design.md) を参照。
+
+## エラーハンドリング方針
+
+| 例外種別 | 発生箇所 | 処理方針 | HTTP ステータス |
+|---------|---------|---------|---------------|
+| `RoomNotFoundError` | `RoomService.find_by_id`（None 時）| `error_handlers.py` 専用ハンドラ → HTTP 404 | 404 |
+| `RoomNameAlreadyExistsError` | `RoomService.create`（name 重複時）| 専用ハンドラ → HTTP 409 (MSG-RM-HTTP-001) | 409 |
+| `RoomArchivedError` | `RoomService.update` / `assign_agent` / `unassign_agent`（archived 時）| 専用ハンドラ → HTTP 409 (MSG-RM-HTTP-003) | 409 |
+| `WorkflowNotFoundError` | `RoomService.create`（Workflow 不在時）| 専用ハンドラ → HTTP 404 (MSG-RM-HTTP-006) | 404 |
+| `AgentNotFoundError` | `RoomService.assign_agent`（Agent 不在時）| 専用ハンドラ → HTTP 404 (MSG-RM-HTTP-004) | 404 |
+| `RoomInvariantViolation(kind='member_not_found')` | `room.remove_member`（不在 membership）| 専用ハンドラで `kind` を判定 → HTTP 404 (MSG-RM-HTTP-005) | 404 |
+| `RoomInvariantViolation`（その他）| domain Room（名前範囲 / 重複 / 容量違反）| 専用ハンドラ → HTTP 422 (MSG-RM-HTTP-007) | 422 |
+| `RequestValidationError` | FastAPI Pydantic（入力形式不正）| http-api-foundation の既存ハンドラ | 422 |
+| その他例外 | どこでも | http-api-foundation generic_exception_handler | 500（スタックトレース非露出）|
+
+Router 内に `try/except` は書かない（http-api-foundation architecture 規律）。

--- a/docs/features/room/http-api/detailed-design.md
+++ b/docs/features/room/http-api/detailed-design.md
@@ -1,0 +1,218 @@
+# 詳細設計書
+
+> feature: `room` / sub-feature: `http-api`
+> 関連 Issue: [#57 feat(room-http-api): Room + Agent assignment HTTP API (M3)](https://github.com/bakufu-dev/bakufu/issues/57)
+> 関連: [`basic-design.md §モジュール契約`](basic-design.md) / [`../feature-spec.md`](../feature-spec.md) / [`../../http-api-foundation/http-api/detailed-design.md`](../../http-api-foundation/http-api/detailed-design.md)
+
+## 本書の役割
+
+**実装者が本書だけを読んで迷わず実装できる粒度** で構造契約を凍結する。`basic-design.md §モジュール契約` の各 REQ-RM-HTTP-NNN を、Pydantic スキーマ定義・例外マッピング・確定文言として展開する。
+
+**書くこと**:
+- Pydantic スキーマ（フィールド名・型・バリデーション制約）
+- 例外マッピングテーブル（domain / application 例外 → HTTP ステータス + ErrorCode + MSG ID）
+- MSG 確定文言（エラーレスポンスの `message` フィールド文字列）
+- `dependencies.py` 追記内容（`get_room_repository` / `get_room_service`）
+- `error_handlers.py` 追記内容（room 専用例外ハンドラ群）
+- `RoomService` メソッド一覧と raises 定義
+
+**書かないこと**:
+- 疑似コード / サンプル実装 → 設計書とソースコードの二重管理になる
+- テストケース → `test-design.md`
+
+## 確定 A: Pydantic スキーマ定義（`interfaces/http/schemas/room.py`）
+
+http-api-foundation 確定A の `ErrorResponse` / `ErrorDetail` と同一ファイル分割方針に従い、room 専用スキーマを `schemas/room.py` に配置する。`model_config = ConfigDict(extra="forbid")` を全スキーマに適用する（余分なフィールドを拒否、Q-3 物理保証）。
+
+### リクエストスキーマ
+
+| スキーマ名 | フィールド | 型 | 制約 | 用途 |
+|---|---|---|---|---|
+| `RoomCreate` | `name` | `str` | `min_length=1`, `max_length=80`（業務ルール R1-1）| POST /api/empires/{empire_id}/rooms Body |
+| | `description` | `str` | `max_length=500`（業務ルール R1-2）, default `""` | 同上 |
+| | `workflow_id` | `UUID` | 必須 | 同上 |
+| | `prompt_kit_prefix_markdown` | `str` | `max_length=10000`, default `""` | 同上 |
+| `RoomUpdate` | `name` | `str \| None` | `min_length=1`, `max_length=80`（適用時のみ）| PATCH /api/rooms/{room_id} Body |
+| | `description` | `str \| None` | `max_length=500`（適用時のみ）| 同上 |
+| | `prompt_kit_prefix_markdown` | `str \| None` | `max_length=10000`（適用時のみ）| 同上 |
+| `AgentAssignRequest` | `agent_id` | `UUID` | 必須 | POST /api/rooms/{room_id}/agents Body |
+| | `role` | `str` | `min_length=1`, `max_length=50` | 同上 |
+
+`RoomUpdate` の全フィールドが `None` の場合は変更なし（部分更新 PATCH パターン）。
+
+### レスポンスサブスキーマ
+
+| スキーマ名 | フィールド | 型 | 備考 |
+|---|---|---|---|
+| `MemberResponse` | `agent_id` | `str` | UUID 文字列 |
+| | `role` | `str` | Role enum の値 |
+| | `joined_at` | `str` | ISO 8601 UTC 文字列（`datetime.isoformat()`）|
+
+### レスポンススキーマ
+
+| スキーマ名 | フィールド | 型 | 備考 |
+|---|---|---|---|
+| `RoomResponse` | `id` | `str` | Room.id（UUID 文字列）|
+| | `name` | `str` | Room.name |
+| | `description` | `str` | Room.description |
+| | `workflow_id` | `str` | Room.workflow_id（UUID 文字列）|
+| | `members` | `list[MemberResponse]` | Room.members のマップ |
+| | `prompt_kit_prefix_markdown` | `str` | Room.prompt_kit.prefix_markdown（masked 文字列のまま返却、不可逆性）|
+| | `archived` | `bool` | Room.archived |
+| `RoomListResponse` | `items` | `list[RoomResponse]` | 0 件以上 |
+| | `total` | `int` | `len(items)` |
+
+`RoomResponse` は `model_config = ConfigDict(from_attributes=True)` を適用。domain `Room` からの変換時は `str(room.id)` / `str(room.workflow_id)` で UUID → 文字列変換する点に注意（`RoomId` は UUID wrapper のため）。
+
+## 確定 B: 例外マッピングテーブル
+
+room http-api に関わるすべての例外と HTTP レスポンスの対応を凍結する。Router 内では `try/except` を書かない（http-api-foundation architecture 規律）。
+
+| 例外クラス | 発生箇所 | HTTP ステータス | ErrorCode | MSG ID |
+|---|---|---|---|---|
+| `RoomNotFoundError` | `RoomService.find_by_id`（None 時）/ archive（None 時）/ unassign_agent（Room 不在時）| 404 | `not_found` | MSG-RM-HTTP-002 |
+| `RoomNameAlreadyExistsError` | `RoomService.create`（name 重複時）| 409 | `conflict` | MSG-RM-HTTP-001 |
+| `RoomArchivedError` | `RoomService.update` / `assign_agent` / `unassign_agent`（archived=True 時）| 409 | `conflict` | MSG-RM-HTTP-003 |
+| `WorkflowNotFoundError` | `RoomService.create`（Workflow 不在時）| 404 | `not_found` | MSG-RM-HTTP-006 |
+| `AgentNotFoundError` | `RoomService.assign_agent`（Agent 不在時）| 404 | `not_found` | MSG-RM-HTTP-004 |
+| `EmpireNotFoundError` | `RoomService.create` / `find_all_by_empire`（Empire 不在時）| 404 | `not_found` | empire MSG-EM-HTTP-002（既存ハンドラが処理）|
+| `RoomInvariantViolation(kind='member_not_found')` | `room.remove_member`（不在 membership 時）| 404 | `not_found` | MSG-RM-HTTP-005 |
+| `RoomInvariantViolation`（その他 kind）| domain Room（name_range / description_too_long / member_duplicate / capacity_exceeded / room_archived）| 422 | `validation_error` | MSG-RM-HTTP-007（str(exc) を前処理して使用）|
+| `RequestValidationError` | FastAPI Pydantic デシリアライズ失敗 | 422 | `validation_error` | http-api-foundation MSG-HAF-002（既存ハンドラが処理）|
+| `HTTPException` | CSRF ミドルウェア（`Origin` 不一致）| 403 | `forbidden` | http-api-foundation MSG-HAF-004（既存ハンドラが処理）|
+| `Exception`（その他）| どこでも | 500 | `internal_error` | http-api-foundation MSG-HAF-003（既存ハンドラが処理）|
+
+## 確定 C: 例外ハンドラ実装（`error_handlers.py` 追記）
+
+http-api-foundation の `error_handlers.py` に以下のハンドラ関数を追記し、`app.py` の `_register_exception_handlers` で登録する。
+
+| ハンドラ関数名 | 処理例外 | 返却する ErrorResponse |
+|---|---|---|
+| `room_not_found_handler` | `RoomNotFoundError` | `ErrorResponse(code="not_found", message=MSG-RM-HTTP-002)` + HTTP 404 |
+| `room_name_already_exists_handler` | `RoomNameAlreadyExistsError` | `ErrorResponse(code="conflict", message=MSG-RM-HTTP-001)` + HTTP 409 |
+| `room_archived_handler` | `RoomArchivedError` | `ErrorResponse(code="conflict", message=MSG-RM-HTTP-003)` + HTTP 409 |
+| `workflow_not_found_handler` | `WorkflowNotFoundError` | `ErrorResponse(code="not_found", message=MSG-RM-HTTP-006)` + HTTP 404 |
+| `agent_not_found_handler` | `AgentNotFoundError` | `ErrorResponse(code="not_found", message=MSG-RM-HTTP-004)` + HTTP 404 |
+| `room_invariant_violation_handler` | `RoomInvariantViolation` | `kind='member_not_found'` → HTTP 404 (MSG-RM-HTTP-005) / その他 → HTTP 422 (MSG-RM-HTTP-007 前処理済み本文)|
+
+登録順は既存の `HTTPException` / `RequestValidationError` / `Exception` ハンドラより**前**（empire ハンドラ群の直後）に登録する。
+
+**`room_invariant_violation_handler` の処理ルール（凍結）**:
+
+1. `exc.kind == 'member_not_found'` の場合 → HTTP 404, `ErrorResponse(code="not_found", message=MSG-RM-HTTP-005)`
+2. それ以外の場合 → HTTP 422, `ErrorResponse(code="validation_error", message=<前処理済みメッセージ>)`
+
+前処理ルール（empire http-api §確定C と同一パターン）:
+1. `[FAIL] ` プレフィックスを除去: `re.sub(r"^\[FAIL\]\s*", "", str(exc))`
+2. `\nNext:` 以降を除去: `.split("\nNext:")[0].strip()`
+
+これにより domain 内部の AI エージェント向けフォーマットが HTTP クライアントに露出しない。
+
+## 確定 D: `dependencies.py` 追記（DI ファクトリ）
+
+http-api-foundation の `dependencies.py` に以下を追記する。
+
+| 関数名 | 型シグネチャ | 依存 |
+|---|---|---|
+| `get_room_repository` | `(session: AsyncSession = Depends(get_session)) → RoomRepository` | `get_session()` |
+| `get_room_service` | `(room_repo: RoomRepository = Depends(get_room_repository), empire_repo: EmpireRepository = Depends(get_empire_repository), workflow_repo: WorkflowRepository = Depends(get_workflow_repository), agent_repo: AgentRepository = Depends(get_agent_repository)) → RoomService` | 複数 repo を受け取り `RoomService` を構築 |
+
+`get_room_service` は `Annotated[RoomService, Depends(get_room_service)]` 型エイリアスを定義し、各エンドポイントで簡潔に使えるようにする。
+
+`get_workflow_repository` / `get_agent_repository` は workflow / agent http-api PR でそれぞれ追加予定。本 PR 時点で未定義の場合は、本 PR で先行して追記する。
+
+## 確定 E: エンドポイント定義（`routers/rooms.py`）
+
+| メソッド | パス | パスパラメータ | クエリパラメータ | リクエスト Body | レスポンス | ステータスコード |
+|---|---|---|---|---|---|---|
+| POST | `/api/empires/{empire_id}/rooms` | `empire_id: UUID` | なし | `RoomCreate` | `RoomResponse` | 201 |
+| GET | `/api/empires/{empire_id}/rooms` | `empire_id: UUID` | なし | なし | `RoomListResponse` | 200 |
+| GET | `/api/rooms/{room_id}` | `room_id: UUID` | なし | なし | `RoomResponse` | 200 |
+| PATCH | `/api/rooms/{room_id}` | `room_id: UUID` | なし | `RoomUpdate` | `RoomResponse` | 200 |
+| DELETE | `/api/rooms/{room_id}` | `room_id: UUID` | なし | なし | なし（No Content）| 204 |
+| POST | `/api/rooms/{room_id}/agents` | `room_id: UUID` | なし | `AgentAssignRequest` | `RoomResponse` | 201 |
+| DELETE | `/api/rooms/{room_id}/agents/{agent_id}` | `room_id: UUID`, `agent_id: UUID` | `role: str`（必須）| なし | なし（No Content）| 204 |
+
+パスパラメータはすべて `UUID` 型で宣言し、FastAPI の path validation で不正形式を 422 に変換する（業務ルール R1-10、empire http-api BUG-EM-SEC-001 解消方針に準拠）。
+
+Router は 2 つの `prefix` で構成する:
+- `empire_rooms_router`: `prefix="/api/empires"`, `tags=["room"]`（empire_id スコープのエンドポイント）
+- `rooms_router`: `prefix="/api/rooms"`, `tags=["room"]`（room_id スコープのエンドポイント）
+
+`http-api-foundation` の `app.py` に両 router を `app.include_router(...)` で追記する。
+
+## 確定 F: application 例外定義（`application/exceptions/room_exceptions.py`）
+
+| 例外クラス名 | 基底クラス | `__init__` 引数 | 用途 |
+|---|---|---|---|
+| `RoomNotFoundError` | `Exception` | `room_id: str` | find_by_id / archive / unassign_agent で Room 不在 |
+| `RoomNameAlreadyExistsError` | `Exception` | `name: str, empire_id: str` | create で同 Empire 内 name 重複（R1-8）|
+| `RoomArchivedError` | `Exception` | `room_id: str` | update / assign_agent / unassign_agent で archived=True（R1-5）|
+| `WorkflowNotFoundError` | `Exception` | `workflow_id: str` | create で Workflow 不在。workflow_exceptions.py で定義済みの場合はそこから import |
+| `AgentNotFoundError` | `Exception` | `agent_id: str` | assign_agent で Agent 不在。agent_exceptions.py で定義済みの場合はそこから import |
+
+`WorkflowNotFoundError` / `AgentNotFoundError` は workflow / agent http-api PR（将来 Issue）で既に定義される場合、その定義を import して使う。本 PR 時点で未定義の場合は `room_exceptions.py` に暫定定義し、将来 PR で統合先に移動する（開放論点 Q-OPEN-1 参照）。
+
+これらは application 層の例外であり、domain 例外（`RoomInvariantViolation`）とは独立する。
+
+## 確定 G: `RoomService` メソッド一覧
+
+http-api-foundation 確定F で骨格が確定済み（`RoomService.__init__(repo: RoomRepository)`）。本 PR で以下のシグネチャに変更し、メソッドを全て肉付けする。
+
+コンストラクタ変更: `__init__(self, room_repo, empire_repo, workflow_repo, agent_repo)` に拡張（複数 Repo を受け取る形に変更）。
+
+| メソッド名 | 引数 | 戻り値 | raises |
+|---|---|---|---|
+| `create` | `empire_id: RoomId, name: str, description: str, workflow_id: WorkflowId, prompt_kit_prefix_markdown: str` | `Room` | `EmpireNotFoundError` / `WorkflowNotFoundError` / `RoomNameAlreadyExistsError` / `RoomInvariantViolation` |
+| `find_all_by_empire` | `empire_id: RoomId` | `list[Room]` | `EmpireNotFoundError` |
+| `find_by_id` | `room_id: RoomId` | `Room` | `RoomNotFoundError` |
+| `update` | `room_id: RoomId, name: str \| None, description: str \| None, prompt_kit_prefix_markdown: str \| None` | `Room` | `RoomNotFoundError` / `RoomArchivedError` / `RoomInvariantViolation` |
+| `archive` | `room_id: RoomId` | `None` | `RoomNotFoundError` |
+| `assign_agent` | `room_id: RoomId, agent_id: AgentId, role: str` | `Room` | `RoomNotFoundError` / `RoomArchivedError` / `AgentNotFoundError` / `RoomInvariantViolation` |
+| `unassign_agent` | `room_id: RoomId, agent_id: AgentId, role: str` | `None` | `RoomNotFoundError` / `RoomArchivedError` / `RoomInvariantViolation(kind='member_not_found')` |
+
+`create` / `update` / `archive` / `assign_agent` / `unassign_agent` は `async with session.begin()` を service 内で開く（UoW 責務は service 層が持つ）。
+
+**`update` の部分更新ルール（凍結）**: 引数が `None` のフィールドは変更しない。既存 `Room` の値をそのまま引き継いで `Room(...)` 再構築する。全フィールドが `None` の場合は変更なし（save せず既存 Room を返す）。
+
+**`unassign_agent` の membership 不在処理**: `room.remove_member(agent_id, role)` が `RoomInvariantViolation(kind='member_not_found')` を raise した場合、`RoomService.unassign_agent` はそのまま上位に伝播させる（service 層での catch なし）。`room_invariant_violation_handler` が `kind` で分岐して 404 を返す（確定C 参照）。
+
+## 確定 H: `RoomRepository` Protocol 拡張（`application/ports/room_repository.py`）
+
+| メソッド名 | 型シグネチャ | 用途 |
+|---|---|---|
+| `find_all_by_empire` | `async def find_all_by_empire(empire_id: RoomId) → list[Room]` | Empire スコープの Room 全件取得（UC-RM-009）|
+
+本 PR で既存 Protocol に追記する。`SqliteRoomRepository.find_all_by_empire` は `SELECT * FROM rooms WHERE empire_id = :empire_id ORDER BY name ASC` + `find_by_id` の内部実装に委譲（詳細は実装担当者判断）。
+
+## MSG 確定文言表
+
+| MSG ID | `code` | `message`（確定文言）| HTTP ステータス |
+|---|---|---|---|
+| MSG-RM-HTTP-001 | `conflict` | `"Room name already exists in this empire."` | 409 |
+| MSG-RM-HTTP-002 | `not_found` | `"Room not found."` | 404 |
+| MSG-RM-HTTP-003 | `conflict` | `"Room is archived and cannot be modified."` | 409 |
+| MSG-RM-HTTP-004 | `not_found` | `"Agent not found."` | 404 |
+| MSG-RM-HTTP-005 | `not_found` | `"Agent membership not found in this room."` | 404 |
+| MSG-RM-HTTP-006 | `not_found` | `"Workflow not found."` | 404 |
+| MSG-RM-HTTP-007 | `validation_error` | `RoomInvariantViolation.message` から `[FAIL]` プレフィックスと `\nNext:.*` を除去した本文のみ（例: `"Room name は 1〜80 文字でなければなりません。"`）| 422 |
+
+MSG-RM-HTTP-007 は domain 層の `RoomInvariantViolation.message` を **前処理したうえで** HTTP レスポンスに使用する（前処理ルールは §確定C 末尾に凍結）。
+
+## 参照設計との整合確認
+
+| http-api-foundation 確定事項 | room http-api での適用 |
+|---|---|
+| 確定A: ErrorCode 定数（`not_found` / `validation_error` / `internal_error` / `forbidden`）| `conflict` を empire と共通で使用（`error_handlers.py` の `ErrorCode` 定数は empire PR で追記済み）|
+| 確定B: `app.state.session_factory` / `engine` | `get_session()` DI 経由で `AsyncSession` を取得（変更なし）|
+| 確定D: CSRF Origin 検証（MVP: Origin なし通過 / 不一致 403）| POST / PATCH / DELETE は CSRF ミドルウェアが適用される（追加設定不要）|
+| 確定E: `get_session()` DI | `get_room_repository(session=Depends(get_session))` で利用（変更なし）|
+| 確定F: Service `__init__(repo)` 骨格 | `RoomService.__init__` の引数を 4 repo に拡張（http-api-foundation の単一 repo 骨格から変更）|
+
+## 開放論点
+
+| # | 論点 | 起票先 |
+|---|---|---|
+| Q-OPEN-1 | `WorkflowNotFoundError` / `AgentNotFoundError` の定義先（本 PR で暫定定義 → workflow / agent http-api PR で統合）| 将来 Issue（workflow-http-api / agent-http-api）|
+| Q-OPEN-2 | `find_all_by_empire` の返却順（name 昇順 / 作成日降順 / ID 順）。本 PR では name ASC を暫定とし、将来の UI 要件で変更可 | 将来 Issue（room-ui）|
+| Q-OPEN-3 | アーカイブ済み Room への `DELETE /api/rooms/{room_id}` の冪等性。本 PR では `archive()` が冪等（domain 設計）なので 204 を返す（実質 no-op）。ユーザーへの告知が必要か | 将来 Issue（UX review）|

--- a/docs/features/room/http-api/test-design.md
+++ b/docs/features/room/http-api/test-design.md
@@ -1,0 +1,156 @@
+# テスト設計書
+
+> feature: `room` / sub-feature: `http-api`
+> 関連 Issue: [#57 feat(room-http-api): Room + Agent assignment HTTP API (M3)](https://github.com/bakufu-dev/bakufu/issues/57)
+> 関連: [`basic-design.md §モジュール契約`](basic-design.md) / [`detailed-design.md`](detailed-design.md) / [`../feature-spec.md`](../feature-spec.md) / [`../system-test-design.md`](../system-test-design.md)
+
+## 本書の役割
+
+本書は **テストケースで検証可能な単位までトレーサビリティを担保する**。`basic-design.md §モジュール契約` の REQ-RM-HTTP-NNN / `detailed-design.md §MSG 確定文言表` の MSG-RM-HTTP-NNN / 親 `feature-spec.md §9 受入基準` #19〜31 / 脅威 T1〜T4 を、それぞれ最低 1 件のテストケースで検証する。
+
+**書くこと**:
+- REQ-RM-HTTP-NNN / MSG-RM-HTTP-NNN / 受入基準 # / 脅威を実テストケース（TC-IT / TC-UT）に紐付けるマトリクス
+- 外部 I/O 依存マップ（factory / raw fixture の characterization 状態を含む）
+- 各レベルのテストケース定義（前提条件 / 操作 / 期待結果）
+- モック方針
+- カバレッジ基準
+
+**書かないこと**:
+- E2E テスト（TC-E2E-RM-001〜003）→ 親 [`../system-test-design.md`](../system-test-design.md) が扱う
+- 受入テスト → [`docs/acceptance-tests/scenarios/`](../../../acceptance-tests/scenarios/)
+
+## テストケース ID 採番規則
+
+本 sub-feature のテスト ID 体系:
+
+| 番号帯 | 用途 |
+|---|---|
+| TC-IT-RM-HTTP-001〜016 | 結合テスト（HTTP リクエスト / DI / 例外ハンドラ）|
+| TC-IT-RM-HTTP-017〜 | 予約番号帯（将来の room 拡張 API で利用）|
+| TC-UT-RM-HTTP-001〜006 | ユニットテスト（スキーマ / 例外ハンドラ / サービス）|
+| TC-UT-RM-HTTP-010〜 | 静的解析系テスト専用帯（依存方向 / import 解析）|
+
+## テストマトリクス
+
+| 要件 ID | 実装アーティファクト | テストケース ID | テストレベル | 種別 | 受入基準 |
+|---|---|---|---|---|---|
+| REQ-RM-HTTP-001 | `rooms_router` POST + `RoomService.create` | TC-IT-RM-HTTP-001 | 結合 | 正常系 | feature-spec.md §9 #19 |
+| REQ-RM-HTTP-001（name 重複）| `rooms_router` POST + `RoomNameAlreadyExistsError` | TC-IT-RM-HTTP-002 | 結合 | 異常系 | feature-spec.md §9 #20 |
+| REQ-RM-HTTP-001（Empire 不在）| `rooms_router` POST + `EmpireNotFoundError` | TC-IT-RM-HTTP-003 | 結合 | 異常系 | feature-spec.md §9 #21 |
+| REQ-RM-HTTP-001（Workflow 不在）| `rooms_router` POST + `WorkflowNotFoundError` | TC-IT-RM-HTTP-014 | 結合 | 異常系 | Q-3 |
+| REQ-RM-HTTP-002 | `rooms_router` GET list + `RoomService.find_all_by_empire` | TC-IT-RM-HTTP-004 | 結合 | 正常系 | feature-spec.md §9 #22 |
+| REQ-RM-HTTP-002（Empire 不在）| `rooms_router` GET list + `EmpireNotFoundError` | TC-IT-RM-HTTP-003（b）| 結合 | 異常系 | Q-3 |
+| REQ-RM-HTTP-003 | `rooms_router` GET by id + `RoomService.find_by_id` | TC-IT-RM-HTTP-005 | 結合 | 正常系 | feature-spec.md §9 #23 |
+| REQ-RM-HTTP-003（不在）| `rooms_router` GET by id + `RoomNotFoundError` | TC-IT-RM-HTTP-006 | 結合 | 異常系 | feature-spec.md §9 #24 |
+| REQ-RM-HTTP-004 | `rooms_router` PATCH + `RoomService.update` | TC-IT-RM-HTTP-007 | 結合 | 正常系 | feature-spec.md §9 #25 |
+| REQ-RM-HTTP-004（archived）| `rooms_router` PATCH + `RoomArchivedError` | TC-IT-RM-HTTP-008 | 結合 | 異常系 | feature-spec.md §9 #26 |
+| REQ-RM-HTTP-004（不在）| `rooms_router` PATCH + `RoomNotFoundError` | TC-IT-RM-HTTP-007（b）| 結合 | 異常系 | Q-3 |
+| REQ-RM-HTTP-005 | `rooms_router` DELETE + `RoomService.archive` | TC-IT-RM-HTTP-009 | 結合 | 正常系 | feature-spec.md §9 #27 |
+| REQ-RM-HTTP-005（不在）| `rooms_router` DELETE + `RoomNotFoundError` | TC-IT-RM-HTTP-009（b）| 結合 | 異常系 | Q-3 |
+| REQ-RM-HTTP-006 | `rooms_router` POST agents + `RoomService.assign_agent` | TC-IT-RM-HTTP-010 | 結合 | 正常系 | feature-spec.md §9 #28 |
+| REQ-RM-HTTP-006（Room archived）| `rooms_router` POST agents + `RoomArchivedError` | TC-IT-RM-HTTP-011 | 結合 | 異常系 | feature-spec.md §9 #29 |
+| REQ-RM-HTTP-006（Agent 不在）| `rooms_router` POST agents + `AgentNotFoundError` | TC-IT-RM-HTTP-015 | 結合 | 異常系 | Q-3 |
+| REQ-RM-HTTP-007 | `rooms_router` DELETE agents + `RoomService.unassign_agent` | TC-IT-RM-HTTP-012 | 結合 | 正常系 | feature-spec.md §9 #30 |
+| REQ-RM-HTTP-007（membership 不在）| `rooms_router` DELETE agents + `RoomInvariantViolation(kind='member_not_found')` | TC-IT-RM-HTTP-016 | 結合 | 異常系 | Q-3 |
+| REQ-RM-HTTP-007（Room archived）| `rooms_router` DELETE agents + `RoomArchivedError` | TC-IT-RM-HTTP-011（b）| 結合 | 異常系 | Q-3 |
+| R1-10（不正 UUID）| FastAPI UUID パス検証 → 422 | TC-IT-RM-HTTP-013 | 結合 | 異常系 | feature-spec.md §9 #31 |
+| MSG-RM-HTTP-001 | `room_name_already_exists_handler` | TC-IT-RM-HTTP-002 | 結合 | 異常系 | Q-3 |
+| MSG-RM-HTTP-002 | `room_not_found_handler` | TC-IT-RM-HTTP-006 | 結合 | 異常系 | Q-3 |
+| MSG-RM-HTTP-003 | `room_archived_handler` | TC-IT-RM-HTTP-008 | 結合 | 異常系 | Q-3 |
+| MSG-RM-HTTP-004 | `agent_not_found_handler` | TC-IT-RM-HTTP-015 | 結合 | 異常系 | Q-3 |
+| MSG-RM-HTTP-005 | `room_invariant_violation_handler`（kind='member_not_found'）| TC-IT-RM-HTTP-016 | 結合 | 異常系 | Q-3 |
+| MSG-RM-HTTP-006 | `workflow_not_found_handler` | TC-IT-RM-HTTP-014 | 結合 | 異常系 | Q-3 |
+| MSG-RM-HTTP-007 | `room_invariant_violation_handler`（前処理ルール + kind 分岐）| TC-UT-RM-HTTP-005 | ユニット | 異常系 | Q-3 |
+| `RoomCreate` スキーマ | `schemas/room.py` | TC-UT-RM-HTTP-001 | ユニット | 正常系 / 異常系 | Q-3 |
+| `RoomUpdate` スキーマ | `schemas/room.py` | TC-UT-RM-HTTP-002 | ユニット | 正常系 / 異常系 | Q-3 |
+| `AgentAssignRequest` スキーマ | `schemas/room.py` | TC-UT-RM-HTTP-003 | ユニット | 正常系 / 異常系 | Q-3 |
+| `RoomResponse` / `MemberResponse` / `RoomListResponse` スキーマ | `schemas/room.py` | TC-UT-RM-HTTP-004 | ユニット | 正常系 | Q-3 |
+| `RoomService.__init__`（4 repo）| `application/services/room_service.py` | TC-UT-RM-HTTP-006 | ユニット | 正常系 | Q-3 |
+| T1（CSRF）| CSRF ミドルウェア → POST /api/empires/{empire_id}/rooms | TC-IT-RM-HTTP-001（CSRF バリアント）| 結合 | 異常系 | Q-3 |
+| T3（不正 UUID パスインジェクション）| FastAPI UUID 型強制（basic-design.md §セキュリティ設計）| TC-IT-RM-HTTP-013 | 結合 | 異常系 | Q-3 |
+| T4（PromptKit マスキング）| MaskedText TypeDecorator（repository layer）| TC-IT-RR-008-masking（[`../repository/test-design.md`](../repository/test-design.md)）| — | — | feature-spec.md §9 #18 |
+| 依存方向（interfaces → domain 直参照禁止）| 全 `interfaces/http/` モジュール | TC-UT-RM-HTTP-010 | ユニット（静的解析）| 異常系 | Q-3 |
+| Q-1 | pyright / ruff | CI ジョブ | — | — | Q-1 |
+| Q-2 | pytest --cov | CI ジョブ | — | — | Q-2 |
+
+**マトリクス充足の証拠**:
+- REQ-RM-HTTP-001〜007 すべてに最低 1 件の正常系テストケース（TC-IT-RM-HTTP-001/004/005/007/009/010/012）
+- REQ-RM-HTTP-001〜007 の主要な異常系（name 重複 / 不在 / archived / 不正 UUID / Agent 不在 / membership 不在 / Workflow 不在）が各 TC-IT で網羅
+- MSG-RM-HTTP-001〜007 の全件が `response.json()["error"]["code"]` / `"message"` の静的照合テストで確認
+- 親受入基準 #19〜31 のすべてが TC-IT-RM-HTTP-001〜013 で対応（1:1 または sub-case で網羅）
+- T1（CSRF）/ T3（不正 UUID）脅威への対策が最低 1 件で有効性確認
+- T4（PromptKit マスキング）は repository layer の責務のため repository test-design.md 参照（孤児ではない）
+- 孤児要件なし
+
+## 外部 I/O 依存マップ
+
+| 外部 I/O | 用途 | raw fixture / factory | characterization 状態 |
+|---|---|---|---|
+| SQLite（テスト用 DB）| `get_session()` DI / lifespan 経由の Session / RoomRepository / EmpireRepository | `tests/factories/db.py`（http-api-foundation で定義済み）+ `tmp_path` tempfile | **済** |
+| FastAPI ASGI | HTTP リクエスト送信（AsyncClient）| `httpx.AsyncClient(ASGITransport(app=app), base_url="http://test")`（`room_app_client` fixture — empire と同パターン）| **済**（conftest.py に追記要）|
+| Workflow SQLite レコード | `RoomService.create` の Workflow 存在確認（TC-IT-RM-HTTP-001 / 014）| `tests/factories/workflow.py`（未作成）— WorkflowRow を tempdb に直接 INSERT | **要起票** |
+| Agent SQLite レコード | `RoomService.assign_agent` の Agent 存在確認（TC-IT-RM-HTTP-010 / 015）| `tests/factories/agent.py`（未作成）— AgentRow を tempdb に直接 INSERT | **要起票** |
+
+> **重要**: Workflow factory および Agent factory（上表「**要起票**」）が完成するまで
+> TC-IT-RM-HTTP-001（POST happy path）および TC-IT-RM-HTTP-010（assign_agent happy path）のテスト実装に着手してはならない。
+> `tests/factories/workflow.py` / `tests/factories/agent.py` を先行 task として起票すること。
+> Workflow / Agent factory が未定義のまま実装に入ったテストは assumed mock（禁止）とみなしレビューで却下する。
+
+## モック方針
+
+| 対象 | テストレベル | モック戦略 |
+|---|---|---|
+| SQLite DB | IT（結合）| モックなし — `tmp_path` 配下 tempfile を使用する実 SQLite。8 PRAGMA + WAL を production と同一設定で起動 |
+| SQLite DB | UT（ユニット）| `MagicMock()` でリポジトリをモック（DB アクセスなし）|
+| FastAPI ASGI | IT | `httpx.AsyncClient(ASGITransport(app=app, raise_app_exceptions=False), base_url="http://test")` |
+| Workflow / Agent（happy path）| IT | 上表 factory で tempdb に直接 INSERT した実データを参照（assumed mock 禁止）|
+| Workflow / Agent | UT | `MagicMock()` で代替 |
+| EmpireRepository / RoomRepository 等 | UT | `MagicMock()` で代替（TC-UT-RM-HTTP-006 等）|
+
+## 結合テストケース
+
+| テスト ID | 対象モジュール連携 | 使用 raw fixture | 前提条件 | 操作 | 期待結果 |
+|---|---|---|---|---|---|
+| TC-IT-RM-HTTP-001 | `rooms_router` → `RoomService.create` → `SqliteRoomRepository.save` | 実 SQLite tempdb + Workflow factory | Empire 存在 / Workflow 存在 | `POST /api/empires/{empire_id}/rooms` `{"name": "Vモデル開発室", "workflow_id": <wf_id>, "description": "", "prompt_kit_prefix_markdown": ""}` | HTTP 201, `{"id": <uuid>, "name": "Vモデル開発室", "description": "", "workflow_id": <wf_id_str>, "members": [], "prompt_kit_prefix_markdown": "", "archived": false}` |
+| TC-IT-RM-HTTP-002 | `rooms_router` → `RoomService.create` → `RoomNameAlreadyExistsError` → `room_name_already_exists_handler` | 実 SQLite tempdb | Empire 存在 / Workflow 存在 / 同名 Room 存在（事前 POST 済）| `POST /api/empires/{empire_id}/rooms` `{"name": "Vモデル開発室", "workflow_id": <wf_id>, ...}` | HTTP 409, `{"error": {"code": "conflict", "message": "Room name already exists in this empire."}}` |
+| TC-IT-RM-HTTP-003 | `rooms_router` → `RoomService.create` / `find_all_by_empire` → `EmpireNotFoundError` → empire_not_found_handler（既存）| 実 SQLite tempdb | Empire 不存在（ランダム UUID）| (a) `POST /api/empires/{random_uuid}/rooms` `{"name": "X", "workflow_id": <uuid>, ...}` (b) `GET /api/empires/{random_uuid}/rooms` | (a)(b) 共に HTTP 404, `{"error": {"code": "not_found", "message": "Empire not found."}}` |
+| TC-IT-RM-HTTP-004 | `rooms_router` → `RoomService.find_all_by_empire` → `SqliteRoomRepository.find_all_by_empire` | 実 SQLite tempdb | (a) Empire 存在 / Room 0 件 (b) Empire 存在 / Room 2 件（事前 POST 済）| (a)(b) `GET /api/empires/{empire_id}/rooms` | (a) HTTP 200, `{"items": [], "total": 0}` (b) HTTP 200, `{"items": [<RoomResponse>, <RoomResponse>], "total": 2}`（items の name 一致確認）|
+| TC-IT-RM-HTTP-005 | `rooms_router` → `RoomService.find_by_id` → `SqliteRoomRepository.find_by_id` | 実 SQLite tempdb | Room 存在（事前 POST 済）| `GET /api/rooms/{room_id}` | HTTP 200, `RoomResponse`（name 一致 / archived=false 確認）|
+| TC-IT-RM-HTTP-006 | `rooms_router` → `RoomService.find_by_id` → `RoomNotFoundError` → `room_not_found_handler` | 実 SQLite tempdb | Room 不存在（ランダム UUID）| `GET /api/rooms/{random_uuid}` | HTTP 404, `{"error": {"code": "not_found", "message": "Room not found."}}` |
+| TC-IT-RM-HTTP-007 | `rooms_router` → `RoomService.update` → `SqliteRoomRepository.save` | 実 SQLite tempdb | (a) Room 存在（archived=false）(b) Room 不存在（ランダム UUID）| (a) `PATCH /api/rooms/{room_id}` `{"name": "新Vモデル開発室"}` (b) `PATCH /api/rooms/{random_uuid}` `{"name": "変更試み"}` | (a) HTTP 200, `RoomResponse`（name="新Vモデル開発室"）(b) HTTP 404, `{"error": {"code": "not_found", "message": "Room not found."}}` |
+| TC-IT-RM-HTTP-008 | `rooms_router` → `RoomService.update` → `RoomArchivedError` → `room_archived_handler` | 実 SQLite tempdb | Room 存在（archived=true: DELETE 済み）| `PATCH /api/rooms/{room_id}` `{"name": "変更試み"}` | HTTP 409, `{"error": {"code": "conflict", "message": "Room is archived and cannot be modified."}}` |
+| TC-IT-RM-HTTP-009 | `rooms_router` → `RoomService.archive` → `SqliteRoomRepository.save` | 実 SQLite tempdb | (a) Room 存在（archived=false）(b) Room 不存在（ランダム UUID）| (a) `DELETE /api/rooms/{room_id}` → `GET /api/rooms/{room_id}` (b) `DELETE /api/rooms/{random_uuid}` | (a) DELETE → HTTP 204 No Content, GET → `{"archived": true}` (b) HTTP 404, `{"error": {"code": "not_found", "message": "Room not found."}}` |
+| TC-IT-RM-HTTP-010 | `rooms_router` → `RoomService.assign_agent` → `SqliteRoomRepository.save` | 実 SQLite tempdb + Agent factory | Room 存在（archived=false）/ Agent 存在 | `POST /api/rooms/{room_id}/agents` `{"agent_id": <agent_id>, "role": "leader"}` | HTTP 201, `RoomResponse`（members に `{"agent_id": <agent_id_str>, "role": "leader", "joined_at": <iso8601>}` 含む）|
+| TC-IT-RM-HTTP-011 | `rooms_router` → `RoomService.assign_agent` / `unassign_agent` → `RoomArchivedError` → `room_archived_handler` | 実 SQLite tempdb | Room 存在（archived=true）| (a) `POST /api/rooms/{room_id}/agents` `{"agent_id": <uuid>, "role": "leader"}` (b) `DELETE /api/rooms/{room_id}/agents/{agent_id}?role=leader` | (a)(b) 共に HTTP 409, `{"error": {"code": "conflict", "message": "Room is archived and cannot be modified."}}` |
+| TC-IT-RM-HTTP-012 | `rooms_router` → `RoomService.unassign_agent` → `SqliteRoomRepository.save` | 実 SQLite tempdb | Room 存在（archived=false）/ Agent membership 存在（assign 済み: TC-IT-RM-HTTP-010 の状態を再利用または事前 POST）| `DELETE /api/rooms/{room_id}/agents/{agent_id}?role=leader` | HTTP 204 No Content / 後続 `GET /api/rooms/{room_id}` で members が空（membership 削除確認）|
+| TC-IT-RM-HTTP-013 | FastAPI UUID パス検証 → `RequestValidationError` | 実 SQLite tempdb | — | (a) `GET /api/rooms/not-a-uuid` (b) `PATCH /api/rooms/not-a-uuid` `{"name": "X"}` (c) `DELETE /api/rooms/not-a-uuid` (d) `GET /api/empires/not-a-uuid/rooms` (e) `POST /api/empires/not-a-uuid/rooms` `{...}` (f) `DELETE /api/rooms/{room_id}/agents/not-a-uuid?role=leader` | (a)〜(f) すべて HTTP 422（500 ではないことを確認 — 業務ルール R1-10 / BUG-EM-SEC-001 準拠）|
+| TC-IT-RM-HTTP-014 | `rooms_router` → `RoomService.create` → `WorkflowNotFoundError` → `workflow_not_found_handler` | 実 SQLite tempdb | Empire 存在 / Workflow 不存在（ランダム UUID）| `POST /api/empires/{empire_id}/rooms` `{"name": "X", "workflow_id": <random_uuid>, "description": "", "prompt_kit_prefix_markdown": ""}` | HTTP 404, `{"error": {"code": "not_found", "message": "Workflow not found."}}` |
+| TC-IT-RM-HTTP-015 | `rooms_router` → `RoomService.assign_agent` → `AgentNotFoundError` → `agent_not_found_handler` | 実 SQLite tempdb | Room 存在（archived=false）/ Agent 不存在（ランダム UUID）| `POST /api/rooms/{room_id}/agents` `{"agent_id": <random_uuid>, "role": "reviewer"}` | HTTP 404, `{"error": {"code": "not_found", "message": "Agent not found."}}` |
+| TC-IT-RM-HTTP-016 | `rooms_router` → `RoomService.unassign_agent` → `RoomInvariantViolation(kind='member_not_found')` → `room_invariant_violation_handler` | 実 SQLite tempdb | Room 存在（archived=false）/ 指定 membership 不存在（未割り当て agent）| `DELETE /api/rooms/{room_id}/agents/{agent_id}?role=leader`（agent_id は DB に存在しない UUID）| HTTP 404, `{"error": {"code": "not_found", "message": "Agent membership not found in this room."}}` |
+
+**CSRF 結合テスト補足**: TC-IT-RM-HTTP-001 の異常系バリアントとして、`Origin: http://evil.example.com` ヘッダ付きの `POST /api/empires/{empire_id}/rooms` が HTTP 403 を返すことを確認する（T1: CSRF 保護、http-api-foundation TC-IT-HAF-008 と同一パターン。room_router でも CSRF ミドルウェアが適用されることの物理保証）。
+
+**部分更新検証補足（TC-IT-RM-HTTP-007 拡張）**: PATCH で `name=None`（省略）の場合に既存 name が保持されること（RoomUpdate 全 None ケース）を TC-IT-RM-HTTP-007 のサブケースとして追加することを推奨する（`detailed-design.md §確定G` 部分更新ルール凍結の検証）。
+
+## ユニットテストケース
+
+| テスト ID | 対象 | 種別 | 入力（factory / mock）| 期待結果 |
+|---|---|---|---|---|
+| TC-UT-RM-HTTP-001 | `RoomCreate` スキーマ | 正常系 / 異常系 | (a) `name="Vモデル開発室", workflow_id=uuid4()` (b) `name=""` (c) `name="x"*81` (d) `description="x"*501` (e) `prompt_kit_prefix_markdown="x"*10001` (f) `extra_field="z"` | (a) バリデーション通過 / (b) min_length 違反 → ValidationError / (c) max_length 違反 → ValidationError / (d) description max_length 違反 → ValidationError / (e) prompt_kit max_length 違反 → ValidationError / (f) extra 禁止 → ValidationError |
+| TC-UT-RM-HTTP-002 | `RoomUpdate` スキーマ | 正常系 / 異常系 | (a) `name="新名前"` (b) `name=None` (c) `name=""` (d) `description=None` (e) 全フィールド `None` (f) `extra_field="z"` | (a) 通過 / (b) `name=None` で通過（変更なし）/ (c) min_length 違反 → ValidationError / (d) 通過（None は変更なし）/ (e) 全 None で通過 / (f) extra 禁止 → ValidationError |
+| TC-UT-RM-HTTP-003 | `AgentAssignRequest` スキーマ | 正常系 / 異常系 | (a) `agent_id=uuid4(), role="leader"` (b) `role=""` (c) `role="x"*51` (d) `extra_field="z"` | (a) 通過 / (b) min_length 違反 → ValidationError / (c) max_length 違反 → ValidationError / (d) extra 禁止 → ValidationError |
+| TC-UT-RM-HTTP-004 | `RoomResponse` / `MemberResponse` / `RoomListResponse` スキーマ | 正常系 | Room ドメインオブジェクト（id / name / description / workflow_id / members / prompt_kit_prefix_markdown / archived）| `id` が str（UUID 文字列）/ `workflow_id` が str / `members` が `list[MemberResponse]`（各 `agent_id` str / `role` str / `joined_at` ISO 8601 str）/ `archived` が bool / `RoomListResponse.total` が `len(items)` と一致 |
+| TC-UT-RM-HTTP-005 | `room_invariant_violation_handler`（`detailed-design.md §確定C` 前処理ルール）| 異常系 | (a) `kind="name_range"`, message=`"[FAIL] Room name は 1〜80 文字でなければなりません。\nNext: 1〜80 文字の名前を指定してください。"` (b) `kind="member_not_found"`, message=任意 | (a) HTTP 422, `{"error": {"code": "validation_error", "message": "Room name は 1〜80 文字でなければなりません。"}}` — `[FAIL]` プレフィックスと `\nNext:.*` が除去されていること / (b) HTTP 404, `{"error": {"code": "not_found", "message": "Agent membership not found in this room."}}` — kind='member_not_found' 分岐（MSG-RM-HTTP-005）確認 |
+| TC-UT-RM-HTTP-006 | `RoomService.__init__`（4 repo 構造 — `detailed-design.md §確定G`）| 正常系 | `room_repo=MagicMock()` / `empire_repo=MagicMock()` / `workflow_repo=MagicMock()` / `agent_repo=MagicMock()` | インスタンス生成成功 / `_room_repo` / `_empire_repo` / `_workflow_repo` / `_agent_repo` に各 mock が格納される（http-api-foundation の単一 repo 骨格からの拡張を検証）|
+| TC-UT-RM-HTTP-010 | 依存方向（静的解析: `ast` モジュール）| 異常系 | `ast.parse()` で `interfaces/http/` 配下の全 `.py` を解析し、Module.body トップレベルの `import` / `from ... import` 文を抽出 | `bakufu.domain` / `bakufu.infrastructure` への直接トップレベル import が存在しないことを `assert` で確認（TC-UT-HAF-010 / TC-UT-EM-HTTP-010 と同一検証パターン。room スキーマ / routers 追加後も依存方向が維持されることを物理保証）|
+
+## カバレッジ基準
+
+| 対象 | 方針 |
+|---|---|
+| `interfaces/http/routers/rooms.py` | TC-IT-RM-HTTP-001〜016 で全 7 エンドポイントを網羅。branch coverage 90% 以上 |
+| `interfaces/http/schemas/room.py` | TC-UT-RM-HTTP-001〜004 で全スキーマの全フィールド / 全 validation ルールを検証 |
+| `interfaces/http/error_handlers.py`（room 追記分）| TC-IT-RM-HTTP-002/006/008/011/014/015/016 と TC-UT-RM-HTTP-005 で全ハンドラ（`room_not_found_handler` / `room_name_already_exists_handler` / `room_archived_handler` / `workflow_not_found_handler` / `agent_not_found_handler` / `room_invariant_violation_handler`）を網羅。`kind='member_not_found'` 分岐を TC-UT-RM-HTTP-005(b) で単独検証 |
+| `application/services/room_service.py` | TC-IT-RM-HTTP-001〜016 の結合テストで全メソッド（create / find_all_by_empire / find_by_id / update / archive / assign_agent / unassign_agent）を起動。TC-UT-RM-HTTP-006 でインスタンス化・4 repo 格納を確認 |
+| `application/exceptions/room_exceptions.py` | TC-IT-RM-HTTP-002/006/008/011/014/015/016 の結合テストで全例外クラス（`RoomNotFoundError` / `RoomNameAlreadyExistsError` / `RoomArchivedError` / `WorkflowNotFoundError` / `AgentNotFoundError`）が発火 → ハンドラを経由することを確認 |
+| 孤児要件なし | REQ-RM-HTTP-001〜007・MSG-RM-HTTP-001〜007・受入基準 #19〜31 の全件がテストマトリクスに紐付けられている（上表 §テストマトリクス で確認）|

--- a/docs/features/room/http-api/test-design.md
+++ b/docs/features/room/http-api/test-design.md
@@ -25,8 +25,8 @@
 
 | 番号帯 | 用途 |
 |---|---|
-| TC-IT-RM-HTTP-001〜016 | 結合テスト（HTTP リクエスト / DI / 例外ハンドラ）|
-| TC-IT-RM-HTTP-017〜 | 予約番号帯（将来の room 拡張 API で利用）|
+| TC-IT-RM-HTTP-001〜020 | 結合テスト（HTTP リクエスト / DI / 例外ハンドラ）|
+| TC-IT-RM-HTTP-021〜 | 予約番号帯（将来の room 拡張 API で利用）|
 | TC-UT-RM-HTTP-001〜006 | ユニットテスト（スキーマ / 例外ハンドラ / サービス）|
 | TC-UT-RM-HTTP-010〜 | 静的解析系テスト専用帯（依存方向 / import 解析）|
 
@@ -39,20 +39,20 @@
 | REQ-RM-HTTP-001（Empire 不在）| `rooms_router` POST + `EmpireNotFoundError` | TC-IT-RM-HTTP-003 | 結合 | 異常系 | feature-spec.md §9 #21 |
 | REQ-RM-HTTP-001（Workflow 不在）| `rooms_router` POST + `WorkflowNotFoundError` | TC-IT-RM-HTTP-014 | 結合 | 異常系 | Q-3 |
 | REQ-RM-HTTP-002 | `rooms_router` GET list + `RoomService.find_all_by_empire` | TC-IT-RM-HTTP-004 | 結合 | 正常系 | feature-spec.md §9 #22 |
-| REQ-RM-HTTP-002（Empire 不在）| `rooms_router` GET list + `EmpireNotFoundError` | TC-IT-RM-HTTP-003（b）| 結合 | 異常系 | Q-3 |
+| REQ-RM-HTTP-002（Empire 不在）| `rooms_router` GET list + `EmpireNotFoundError` | TC-IT-RM-HTTP-017 | 結合 | 異常系 | Q-3 |
 | REQ-RM-HTTP-003 | `rooms_router` GET by id + `RoomService.find_by_id` | TC-IT-RM-HTTP-005 | 結合 | 正常系 | feature-spec.md §9 #23 |
 | REQ-RM-HTTP-003（不在）| `rooms_router` GET by id + `RoomNotFoundError` | TC-IT-RM-HTTP-006 | 結合 | 異常系 | feature-spec.md §9 #24 |
 | REQ-RM-HTTP-004 | `rooms_router` PATCH + `RoomService.update` | TC-IT-RM-HTTP-007 | 結合 | 正常系 | feature-spec.md §9 #25 |
 | REQ-RM-HTTP-004（archived）| `rooms_router` PATCH + `RoomArchivedError` | TC-IT-RM-HTTP-008 | 結合 | 異常系 | feature-spec.md §9 #26 |
-| REQ-RM-HTTP-004（不在）| `rooms_router` PATCH + `RoomNotFoundError` | TC-IT-RM-HTTP-007（b）| 結合 | 異常系 | Q-3 |
+| REQ-RM-HTTP-004（不在）| `rooms_router` PATCH + `RoomNotFoundError` | TC-IT-RM-HTTP-018 | 結合 | 異常系 | Q-3 |
 | REQ-RM-HTTP-005 | `rooms_router` DELETE + `RoomService.archive` | TC-IT-RM-HTTP-009 | 結合 | 正常系 | feature-spec.md §9 #27 |
-| REQ-RM-HTTP-005（不在）| `rooms_router` DELETE + `RoomNotFoundError` | TC-IT-RM-HTTP-009（b）| 結合 | 異常系 | Q-3 |
+| REQ-RM-HTTP-005（不在）| `rooms_router` DELETE + `RoomNotFoundError` | TC-IT-RM-HTTP-019 | 結合 | 異常系 | Q-3 |
 | REQ-RM-HTTP-006 | `rooms_router` POST agents + `RoomService.assign_agent` | TC-IT-RM-HTTP-010 | 結合 | 正常系 | feature-spec.md §9 #28 |
 | REQ-RM-HTTP-006（Room archived）| `rooms_router` POST agents + `RoomArchivedError` | TC-IT-RM-HTTP-011 | 結合 | 異常系 | feature-spec.md §9 #29 |
 | REQ-RM-HTTP-006（Agent 不在）| `rooms_router` POST agents + `AgentNotFoundError` | TC-IT-RM-HTTP-015 | 結合 | 異常系 | Q-3 |
-| REQ-RM-HTTP-007 | `rooms_router` DELETE agents + `RoomService.unassign_agent` | TC-IT-RM-HTTP-012 | 結合 | 正常系 | feature-spec.md §9 #30 |
+| REQ-RM-HTTP-007 | `rooms_router` DELETE agents/{agent_id}/roles/{role} + `RoomService.unassign_agent` | TC-IT-RM-HTTP-012 | 結合 | 正常系 | feature-spec.md §9 #30 |
 | REQ-RM-HTTP-007（membership 不在）| `rooms_router` DELETE agents + `RoomInvariantViolation(kind='member_not_found')` | TC-IT-RM-HTTP-016 | 結合 | 異常系 | Q-3 |
-| REQ-RM-HTTP-007（Room archived）| `rooms_router` DELETE agents + `RoomArchivedError` | TC-IT-RM-HTTP-011（b）| 結合 | 異常系 | Q-3 |
+| REQ-RM-HTTP-007（Room archived）| `rooms_router` DELETE agents + `RoomArchivedError` | TC-IT-RM-HTTP-020 | 結合 | 異常系 | Q-3 |
 | R1-10（不正 UUID）| FastAPI UUID パス検証 → 422 | TC-IT-RM-HTTP-013 | 結合 | 異常系 | feature-spec.md §9 #31 |
 | MSG-RM-HTTP-001 | `room_name_already_exists_handler` | TC-IT-RM-HTTP-002 | 結合 | 異常系 | Q-3 |
 | MSG-RM-HTTP-002 | `room_not_found_handler` | TC-IT-RM-HTTP-006 | 結合 | 異常系 | Q-3 |
@@ -69,15 +69,15 @@
 | T1（CSRF）| CSRF ミドルウェア → POST /api/empires/{empire_id}/rooms | TC-IT-RM-HTTP-001（CSRF バリアント）| 結合 | 異常系 | Q-3 |
 | T3（不正 UUID パスインジェクション）| FastAPI UUID 型強制（basic-design.md §セキュリティ設計）| TC-IT-RM-HTTP-013 | 結合 | 異常系 | Q-3 |
 | T4（PromptKit マスキング）| MaskedText TypeDecorator（repository layer）| TC-IT-RR-008-masking（[`../repository/test-design.md`](../repository/test-design.md)）| — | — | feature-spec.md §9 #18 |
-| 依存方向（interfaces → domain 直参照禁止）| 全 `interfaces/http/` モジュール | TC-UT-RM-HTTP-010 | ユニット（静的解析）| 異常系 | Q-3 |
+| 依存方向（interfaces → domain 直参照禁止）| `interfaces/http/routers/` + `interfaces/http/schemas/`（スコープ限定）| TC-UT-RM-HTTP-010 | ユニット（静的解析）| 異常系 | Q-3 |
 | Q-1 | pyright / ruff | CI ジョブ | — | — | Q-1 |
 | Q-2 | pytest --cov | CI ジョブ | — | — | Q-2 |
 
 **マトリクス充足の証拠**:
 - REQ-RM-HTTP-001〜007 すべてに最低 1 件の正常系テストケース（TC-IT-RM-HTTP-001/004/005/007/009/010/012）
-- REQ-RM-HTTP-001〜007 の主要な異常系（name 重複 / 不在 / archived / 不正 UUID / Agent 不在 / membership 不在 / Workflow 不在）が各 TC-IT で網羅
+- REQ-RM-HTTP-001〜007 の主要な異常系（name 重複 / 不在 / archived / 不正 UUID / Agent 不在 / membership 不在 / Workflow 不在）が各 TC-IT で網羅（001〜020）
 - MSG-RM-HTTP-001〜007 の全件が `response.json()["error"]["code"]` / `"message"` の静的照合テストで確認
-- 親受入基準 #19〜31 のすべてが TC-IT-RM-HTTP-001〜013 で対応（1:1 または sub-case で網羅）
+- 親受入基準 #19〜31 のすべてが TC-IT-RM-HTTP-001〜013 で対応（1:1 網羅）
 - T1（CSRF）/ T3（不正 UUID）脅威への対策が最低 1 件で有効性確認
 - T4（PromptKit マスキング）は repository layer の責務のため repository test-design.md 参照（孤児ではない）
 - 孤児要件なし
@@ -113,24 +113,28 @@
 |---|---|---|---|---|---|
 | TC-IT-RM-HTTP-001 | `rooms_router` → `RoomService.create` → `SqliteRoomRepository.save` | 実 SQLite tempdb + Workflow factory | Empire 存在 / Workflow 存在 | `POST /api/empires/{empire_id}/rooms` `{"name": "Vモデル開発室", "workflow_id": <wf_id>, "description": "", "prompt_kit_prefix_markdown": ""}` | HTTP 201, `{"id": <uuid>, "name": "Vモデル開発室", "description": "", "workflow_id": <wf_id_str>, "members": [], "prompt_kit_prefix_markdown": "", "archived": false}` |
 | TC-IT-RM-HTTP-002 | `rooms_router` → `RoomService.create` → `RoomNameAlreadyExistsError` → `room_name_already_exists_handler` | 実 SQLite tempdb | Empire 存在 / Workflow 存在 / 同名 Room 存在（事前 POST 済）| `POST /api/empires/{empire_id}/rooms` `{"name": "Vモデル開発室", "workflow_id": <wf_id>, ...}` | HTTP 409, `{"error": {"code": "conflict", "message": "Room name already exists in this empire."}}` |
-| TC-IT-RM-HTTP-003 | `rooms_router` → `RoomService.create` / `find_all_by_empire` → `EmpireNotFoundError` → empire_not_found_handler（既存）| 実 SQLite tempdb | Empire 不存在（ランダム UUID）| (a) `POST /api/empires/{random_uuid}/rooms` `{"name": "X", "workflow_id": <uuid>, ...}` (b) `GET /api/empires/{random_uuid}/rooms` | (a)(b) 共に HTTP 404, `{"error": {"code": "not_found", "message": "Empire not found."}}` |
+| TC-IT-RM-HTTP-003 | `rooms_router` → `RoomService.create` → `EmpireNotFoundError` → empire_not_found_handler（既存）| 実 SQLite tempdb | Empire 不存在（ランダム UUID）| `POST /api/empires/{random_uuid}/rooms` `{"name": "X", "workflow_id": <uuid>, ...}` | HTTP 404, `{"error": {"code": "not_found", "message": "Empire not found."}}` |
 | TC-IT-RM-HTTP-004 | `rooms_router` → `RoomService.find_all_by_empire` → `SqliteRoomRepository.find_all_by_empire` | 実 SQLite tempdb | (a) Empire 存在 / Room 0 件 (b) Empire 存在 / Room 2 件（事前 POST 済）| (a)(b) `GET /api/empires/{empire_id}/rooms` | (a) HTTP 200, `{"items": [], "total": 0}` (b) HTTP 200, `{"items": [<RoomResponse>, <RoomResponse>], "total": 2}`（items の name 一致確認）|
 | TC-IT-RM-HTTP-005 | `rooms_router` → `RoomService.find_by_id` → `SqliteRoomRepository.find_by_id` | 実 SQLite tempdb | Room 存在（事前 POST 済）| `GET /api/rooms/{room_id}` | HTTP 200, `RoomResponse`（name 一致 / archived=false 確認）|
 | TC-IT-RM-HTTP-006 | `rooms_router` → `RoomService.find_by_id` → `RoomNotFoundError` → `room_not_found_handler` | 実 SQLite tempdb | Room 不存在（ランダム UUID）| `GET /api/rooms/{random_uuid}` | HTTP 404, `{"error": {"code": "not_found", "message": "Room not found."}}` |
-| TC-IT-RM-HTTP-007 | `rooms_router` → `RoomService.update` → `SqliteRoomRepository.save` | 実 SQLite tempdb | (a) Room 存在（archived=false）(b) Room 不存在（ランダム UUID）| (a) `PATCH /api/rooms/{room_id}` `{"name": "新Vモデル開発室"}` (b) `PATCH /api/rooms/{random_uuid}` `{"name": "変更試み"}` | (a) HTTP 200, `RoomResponse`（name="新Vモデル開発室"）(b) HTTP 404, `{"error": {"code": "not_found", "message": "Room not found."}}` |
-| TC-IT-RM-HTTP-008 | `rooms_router` → `RoomService.update` → `RoomArchivedError` → `room_archived_handler` | 実 SQLite tempdb | Room 存在（archived=true: DELETE 済み）| `PATCH /api/rooms/{room_id}` `{"name": "変更試み"}` | HTTP 409, `{"error": {"code": "conflict", "message": "Room is archived and cannot be modified."}}` |
-| TC-IT-RM-HTTP-009 | `rooms_router` → `RoomService.archive` → `SqliteRoomRepository.save` | 実 SQLite tempdb | (a) Room 存在（archived=false）(b) Room 不存在（ランダム UUID）| (a) `DELETE /api/rooms/{room_id}` → `GET /api/rooms/{room_id}` (b) `DELETE /api/rooms/{random_uuid}` | (a) DELETE → HTTP 204 No Content, GET → `{"archived": true}` (b) HTTP 404, `{"error": {"code": "not_found", "message": "Room not found."}}` |
+| TC-IT-RM-HTTP-007 | `rooms_router` → `RoomService.update` → `SqliteRoomRepository.save` | 実 SQLite tempdb | Room 存在（archived=false）| `PATCH /api/rooms/{room_id}` `{"name": "新Vモデル開発室"}` | HTTP 200, `RoomResponse`（name="新Vモデル開発室"）|
+| TC-IT-RM-HTTP-008 | `rooms_router` → `RoomService.update` → `RoomArchivedError` → `room_archived_handler` | 実 SQLite tempdb | Room 存在（archived=true）| `PATCH /api/rooms/{room_id}` `{"name": "変更試み"}` | HTTP 409, `{"error": {"code": "conflict", "message": "Room is archived and cannot be modified."}}` |
+| TC-IT-RM-HTTP-009 | `rooms_router` → `RoomService.archive` → `SqliteRoomRepository.save` | 実 SQLite tempdb | Room 存在（archived=false）| `DELETE /api/rooms/{room_id}` → 後続 `GET /api/rooms/{room_id}` | HTTP 204 No Content / GET → `RoomResponse`（archived=true）|
 | TC-IT-RM-HTTP-010 | `rooms_router` → `RoomService.assign_agent` → `SqliteRoomRepository.save` | 実 SQLite tempdb + Agent factory | Room 存在（archived=false）/ Agent 存在 | `POST /api/rooms/{room_id}/agents` `{"agent_id": <agent_id>, "role": "leader"}` | HTTP 201, `RoomResponse`（members に `{"agent_id": <agent_id_str>, "role": "leader", "joined_at": <iso8601>}` 含む）|
-| TC-IT-RM-HTTP-011 | `rooms_router` → `RoomService.assign_agent` / `unassign_agent` → `RoomArchivedError` → `room_archived_handler` | 実 SQLite tempdb | Room 存在（archived=true）| (a) `POST /api/rooms/{room_id}/agents` `{"agent_id": <uuid>, "role": "leader"}` (b) `DELETE /api/rooms/{room_id}/agents/{agent_id}?role=leader` | (a)(b) 共に HTTP 409, `{"error": {"code": "conflict", "message": "Room is archived and cannot be modified."}}` |
-| TC-IT-RM-HTTP-012 | `rooms_router` → `RoomService.unassign_agent` → `SqliteRoomRepository.save` | 実 SQLite tempdb | Room 存在（archived=false）/ Agent membership 存在（assign 済み: TC-IT-RM-HTTP-010 の状態を再利用または事前 POST）| `DELETE /api/rooms/{room_id}/agents/{agent_id}?role=leader` | HTTP 204 No Content / 後続 `GET /api/rooms/{room_id}` で members が空（membership 削除確認）|
-| TC-IT-RM-HTTP-013 | FastAPI UUID パス検証 → `RequestValidationError` | 実 SQLite tempdb | — | (a) `GET /api/rooms/not-a-uuid` (b) `PATCH /api/rooms/not-a-uuid` `{"name": "X"}` (c) `DELETE /api/rooms/not-a-uuid` (d) `GET /api/empires/not-a-uuid/rooms` (e) `POST /api/empires/not-a-uuid/rooms` `{...}` (f) `DELETE /api/rooms/{room_id}/agents/not-a-uuid?role=leader` | (a)〜(f) すべて HTTP 422（500 ではないことを確認 — 業務ルール R1-10 / BUG-EM-SEC-001 準拠）|
+| TC-IT-RM-HTTP-011 | `rooms_router` → `RoomService.assign_agent` → `RoomArchivedError` → `room_archived_handler` | 実 SQLite tempdb | Room 存在（archived=true）| `POST /api/rooms/{room_id}/agents` `{"agent_id": <uuid>, "role": "leader"}` | HTTP 409, `{"error": {"code": "conflict", "message": "Room is archived and cannot be modified."}}` |
+| TC-IT-RM-HTTP-012 | `rooms_router` → `RoomService.unassign_agent` → `SqliteRoomRepository.save` | 実 SQLite tempdb | Room 存在（archived=false）/ Agent membership 存在（事前 POST 済）| `DELETE /api/rooms/{room_id}/agents/{agent_id}/roles/leader` | HTTP 204 No Content / 後続 `GET /api/rooms/{room_id}` で members が空（membership 削除確認）|
+| TC-IT-RM-HTTP-013 | FastAPI UUID パス検証 → `RequestValidationError` | 実 SQLite tempdb | — | (a) `GET /api/rooms/not-a-uuid` (b) `PATCH /api/rooms/not-a-uuid` (c) `DELETE /api/rooms/not-a-uuid` (d) `GET /api/empires/not-a-uuid/rooms` (e) `POST /api/empires/not-a-uuid/rooms` (f) `DELETE /api/rooms/{room_id}/agents/not-a-uuid/roles/leader` | (a)〜(f) すべて HTTP 422（500 ではないことを確認 — 業務ルール R1-10 / BUG-EM-SEC-001 準拠）|
 | TC-IT-RM-HTTP-014 | `rooms_router` → `RoomService.create` → `WorkflowNotFoundError` → `workflow_not_found_handler` | 実 SQLite tempdb | Empire 存在 / Workflow 不存在（ランダム UUID）| `POST /api/empires/{empire_id}/rooms` `{"name": "X", "workflow_id": <random_uuid>, "description": "", "prompt_kit_prefix_markdown": ""}` | HTTP 404, `{"error": {"code": "not_found", "message": "Workflow not found."}}` |
 | TC-IT-RM-HTTP-015 | `rooms_router` → `RoomService.assign_agent` → `AgentNotFoundError` → `agent_not_found_handler` | 実 SQLite tempdb | Room 存在（archived=false）/ Agent 不存在（ランダム UUID）| `POST /api/rooms/{room_id}/agents` `{"agent_id": <random_uuid>, "role": "reviewer"}` | HTTP 404, `{"error": {"code": "not_found", "message": "Agent not found."}}` |
-| TC-IT-RM-HTTP-016 | `rooms_router` → `RoomService.unassign_agent` → `RoomInvariantViolation(kind='member_not_found')` → `room_invariant_violation_handler` | 実 SQLite tempdb | Room 存在（archived=false）/ 指定 membership 不存在（未割り当て agent）| `DELETE /api/rooms/{room_id}/agents/{agent_id}?role=leader`（agent_id は DB に存在しない UUID）| HTTP 404, `{"error": {"code": "not_found", "message": "Agent membership not found in this room."}}` |
+| TC-IT-RM-HTTP-016 | `rooms_router` → `RoomService.unassign_agent` → `RoomInvariantViolation(kind='member_not_found')` → `room_invariant_violation_handler` | 実 SQLite tempdb | Room 存在（archived=false）/ 指定 membership 不存在（未割り当て）| `DELETE /api/rooms/{room_id}/agents/{agent_id}/roles/leader`（agent_id は未割り当て）| HTTP 404, `{"error": {"code": "not_found", "message": "Agent membership not found in this room."}}` |
+| TC-IT-RM-HTTP-017 | `rooms_router` → `RoomService.find_all_by_empire` → `EmpireNotFoundError` → empire_not_found_handler（既存）| 実 SQLite tempdb | Empire 不存在（ランダム UUID）| `GET /api/empires/{random_uuid}/rooms` | HTTP 404, `{"error": {"code": "not_found", "message": "Empire not found."}}` |
+| TC-IT-RM-HTTP-018 | `rooms_router` → `RoomService.update` → `RoomNotFoundError` → `room_not_found_handler` | 実 SQLite tempdb | Room 不存在（ランダム UUID）| `PATCH /api/rooms/{random_uuid}` `{"name": "変更試み"}` | HTTP 404, `{"error": {"code": "not_found", "message": "Room not found."}}` |
+| TC-IT-RM-HTTP-019 | `rooms_router` → `RoomService.archive` → `RoomNotFoundError` → `room_not_found_handler` | 実 SQLite tempdb | Room 不存在（ランダム UUID）| `DELETE /api/rooms/{random_uuid}` | HTTP 404, `{"error": {"code": "not_found", "message": "Room not found."}}` |
+| TC-IT-RM-HTTP-020 | `rooms_router` → `RoomService.unassign_agent` → `RoomArchivedError` → `room_archived_handler` | 実 SQLite tempdb | Room 存在（archived=true）| `DELETE /api/rooms/{room_id}/agents/{agent_id}/roles/leader` | HTTP 409, `{"error": {"code": "conflict", "message": "Room is archived and cannot be modified."}}` |
 
 **CSRF 結合テスト補足**: TC-IT-RM-HTTP-001 の異常系バリアントとして、`Origin: http://evil.example.com` ヘッダ付きの `POST /api/empires/{empire_id}/rooms` が HTTP 403 を返すことを確認する（T1: CSRF 保護、http-api-foundation TC-IT-HAF-008 と同一パターン。room_router でも CSRF ミドルウェアが適用されることの物理保証）。
 
-**部分更新検証補足（TC-IT-RM-HTTP-007 拡張）**: PATCH で `name=None`（省略）の場合に既存 name が保持されること（RoomUpdate 全 None ケース）を TC-IT-RM-HTTP-007 のサブケースとして追加することを推奨する（`detailed-design.md §確定G` 部分更新ルール凍結の検証）。
+**部分更新検証補足**: PATCH で全フィールド `None`（省略）の場合に既存値が保持されることを TC-IT-RM-HTTP-021（予約番号帯）として追加することを推奨する（`detailed-design.md §確定G` 部分更新ルール凍結の検証）。
 
 ## ユニットテストケース
 
@@ -142,15 +146,15 @@
 | TC-UT-RM-HTTP-004 | `RoomResponse` / `MemberResponse` / `RoomListResponse` スキーマ | 正常系 | Room ドメインオブジェクト（id / name / description / workflow_id / members / prompt_kit_prefix_markdown / archived）| `id` が str（UUID 文字列）/ `workflow_id` が str / `members` が `list[MemberResponse]`（各 `agent_id` str / `role` str / `joined_at` ISO 8601 str）/ `archived` が bool / `RoomListResponse.total` が `len(items)` と一致 |
 | TC-UT-RM-HTTP-005 | `room_invariant_violation_handler`（`detailed-design.md §確定C` 前処理ルール）| 異常系 | (a) `kind="name_range"`, message=`"[FAIL] Room name は 1〜80 文字でなければなりません。\nNext: 1〜80 文字の名前を指定してください。"` (b) `kind="member_not_found"`, message=任意 | (a) HTTP 422, `{"error": {"code": "validation_error", "message": "Room name は 1〜80 文字でなければなりません。"}}` — `[FAIL]` プレフィックスと `\nNext:.*` が除去されていること / (b) HTTP 404, `{"error": {"code": "not_found", "message": "Agent membership not found in this room."}}` — kind='member_not_found' 分岐（MSG-RM-HTTP-005）確認 |
 | TC-UT-RM-HTTP-006 | `RoomService.__init__`（4 repo 構造 — `detailed-design.md §確定G`）| 正常系 | `room_repo=MagicMock()` / `empire_repo=MagicMock()` / `workflow_repo=MagicMock()` / `agent_repo=MagicMock()` | インスタンス生成成功 / `_room_repo` / `_empire_repo` / `_workflow_repo` / `_agent_repo` に各 mock が格納される（http-api-foundation の単一 repo 骨格からの拡張を検証）|
-| TC-UT-RM-HTTP-010 | 依存方向（静的解析: `ast` モジュール）| 異常系 | `ast.parse()` で `interfaces/http/` 配下の全 `.py` を解析し、Module.body トップレベルの `import` / `from ... import` 文を抽出 | `bakufu.domain` / `bakufu.infrastructure` への直接トップレベル import が存在しないことを `assert` で確認（TC-UT-HAF-010 / TC-UT-EM-HTTP-010 と同一検証パターン。room スキーマ / routers 追加後も依存方向が維持されることを物理保証）|
+| TC-UT-RM-HTTP-010 | 依存方向（静的解析: `ast.walk()` 全ノード走査 — スコープ: `routers/` + `schemas/`）| 異常系 | `ast.walk(ast.parse(src))` で `interfaces/http/routers/` + `interfaces/http/schemas/` 配下の全 `.py` を全ノード（関数内・クラス内・メソッド内含む）走査する（`app.py` / `dependencies.py` / `error_handlers.py` は除外 — これらは基盤層でドメイン参照を持ち得るため別途管理）| `bakufu.domain` / `bakufu.infrastructure` への import ノード（`ImportFrom` / `Import` の全出現、トップレベル限定でない）が存在しないことを `assert` で確認。**`tree.body` のみの走査では関数内遅延 import（例: `def f(): from bakufu.domain import X`）を見逃す。`ast.walk()` による全ノード走査が必須**（TC-UT-EM-HTTP-010 の同一 `ast.walk()` 走査方式に準拠。旧 `tree.body` パターンへの退行を禁止する）|
 
 ## カバレッジ基準
 
 | 対象 | 方針 |
 |---|---|
-| `interfaces/http/routers/rooms.py` | TC-IT-RM-HTTP-001〜016 で全 7 エンドポイントを網羅。branch coverage 90% 以上 |
+| `interfaces/http/routers/rooms.py` | TC-IT-RM-HTTP-001〜020 で全 7 エンドポイントを網羅。branch coverage 90% 以上 |
 | `interfaces/http/schemas/room.py` | TC-UT-RM-HTTP-001〜004 で全スキーマの全フィールド / 全 validation ルールを検証 |
-| `interfaces/http/error_handlers.py`（room 追記分）| TC-IT-RM-HTTP-002/006/008/011/014/015/016 と TC-UT-RM-HTTP-005 で全ハンドラ（`room_not_found_handler` / `room_name_already_exists_handler` / `room_archived_handler` / `workflow_not_found_handler` / `agent_not_found_handler` / `room_invariant_violation_handler`）を網羅。`kind='member_not_found'` 分岐を TC-UT-RM-HTTP-005(b) で単独検証 |
-| `application/services/room_service.py` | TC-IT-RM-HTTP-001〜016 の結合テストで全メソッド（create / find_all_by_empire / find_by_id / update / archive / assign_agent / unassign_agent）を起動。TC-UT-RM-HTTP-006 でインスタンス化・4 repo 格納を確認 |
-| `application/exceptions/room_exceptions.py` | TC-IT-RM-HTTP-002/006/008/011/014/015/016 の結合テストで全例外クラス（`RoomNotFoundError` / `RoomNameAlreadyExistsError` / `RoomArchivedError` / `WorkflowNotFoundError` / `AgentNotFoundError`）が発火 → ハンドラを経由することを確認 |
+| `interfaces/http/error_handlers.py`（room 追記分）| TC-IT-RM-HTTP-002/006/008/011/014/015/016/020 と TC-UT-RM-HTTP-005 で全ハンドラ（`room_not_found_handler` / `room_name_already_exists_handler` / `room_archived_handler` / `workflow_not_found_handler` / `agent_not_found_handler` / `room_invariant_violation_handler`）を網羅。`kind='member_not_found'` 分岐を TC-UT-RM-HTTP-005(b) で単独検証 |
+| `application/services/room_service.py` | TC-IT-RM-HTTP-001〜020 の結合テストで全メソッド（create / find_all_by_empire / find_by_id / update / archive / assign_agent / unassign_agent）を起動。TC-UT-RM-HTTP-006 でインスタンス化・4 repo 格納を確認 |
+| `application/exceptions/room_exceptions.py` | TC-IT-RM-HTTP-002/006/008/011/014/015/016/019/020 の結合テストで全例外クラス（`RoomNotFoundError` / `RoomNameAlreadyExistsError` / `RoomArchivedError` / `WorkflowNotFoundError` / `AgentNotFoundError`）が発火 → ハンドラを経由することを確認 |
 | 孤児要件なし | REQ-RM-HTTP-001〜007・MSG-RM-HTTP-001〜007・受入基準 #19〜31 の全件がテストマトリクスに紐付けられている（上表 §テストマトリクス で確認）|


### PR DESCRIPTION
## Summary

- `docs/features/room/feature-spec.md` — UC-RM-008〜014（HTTP API 経由の Room CRUD + Agent 割り当て/解除）・業務ルール R1-10（UUID path parameter 検証）を追記。http-api sub-feature への参照リンクを凍結
- `docs/features/room/http-api/basic-design.md` — **新規作成**。7 エンドポイントのモジュール契約（REQ-RM-HTTP-001〜007）・クラス設計・シーケンス図・セキュリティ設計を凍結
- `docs/features/room/http-api/detailed-design.md` — **新規作成**。Pydantic スキーマ定義・例外マッピングテーブル・MSG 確定文言・`dependencies.py` 追記内容・`RoomService` メソッド一覧を凍結

## 設計の要点

- empire/http-api パターンを厳密に踏襲（疑似コードなし・Router 内 try/except なし・UUID path param → FastAPI 検証 → 422）
- `DELETE /api/rooms/{room_id}/agents/{agent_id}?role={role}` — 同一 agent_id に複数 role が存在し得る（R1-3）ため role をクエリパラメータで区別
- `RoomInvariantViolation(kind='member_not_found')` → 404 / その他 → 422 の分岐を handler 側で担う（domain 例外を HTTP 層でのみ解釈）
- `prompt_kit_prefix_markdown` は masked 文字列のままレスポンス返却（不可逆性を維持）

## 依存 sub-feature

| sub-feature | 状態 |
|---|---|
| room/domain | ✅ マージ済み（Issue #18）|
| room/repository | ✅ マージ済み（Issue #33）|
| http-api-foundation | ✅ マージ済み（Issue #55）|
| empire/http-api | ✅ マージ済み（Issue #56）|

## Test plan

- [ ] `basic-design.md` のモジュール契約・クラス設計が empire/http-api パターンと整合しているか確認
- [ ] `detailed-design.md` の例外マッピングが全エンドポイントを網羅しているか確認
- [ ] `feature-spec.md` の受入基準 #19〜31 が UC-RM-008〜014 と 1:1 で対応しているか確認
- [ ] `test-design.md` はヤン・ルカン担当（本 PR 完了後に作成）

Closes #57（設計書部分のみ、実装 PR は別途）

🤖 Generated with [Claude Code](https://claude.com/claude-code)