### PR TITLE
chore(backend): 全コメント・docstring・ログ/例外メッセージを日本語化 (Closes #102)

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,17 +1,17 @@
-"""Alembic environment for the bakufu Backend.
+"""bakufu Backend の Alembic 環境。
 
-Two modes:
+2 つの実行モードを持つ:
 
-* **Programmatic** — Bootstrap stage 3 calls ``command.upgrade`` from
-  inside an active asyncio loop. The migrations runner pre-establishes
-  a sync :class:`Connection` and stuffs it into ``config.attributes``;
-  this module reuses it instead of opening a new asyncio loop.
-* **CLI standalone** — ``alembic upgrade head`` from a shell. There is
-  no asyncio loop yet, so we open the engine ourselves and ``asyncio.run``
-  the upgrade.
+* **プログラム経由** — Bootstrap stage 3 がアクティブな asyncio ループ内から
+  ``command.upgrade`` を呼び出す。マイグレーションランナーが事前に同期版の
+  :class:`Connection` を確立し ``config.attributes`` に格納する。本モジュールは
+  新しい asyncio ループを開く代わりにそれを再利用する。
+* **CLI 単独** — シェルから ``alembic upgrade head`` を実行する場合。まだ
+  asyncio ループが存在しないため、エンジンを自前で開き ``asyncio.run`` で
+  アップグレードを実行する。
 
-Both paths share the same ``target_metadata`` so autogenerate sees
-every cross-cutting table.
+両経路とも同じ ``target_metadata`` を共有し、autogenerate がすべての横断テーブルを
+認識できるようにしている。
 """
 
 from __future__ import annotations
@@ -23,8 +23,8 @@ from pathlib import Path
 from alembic import context
 from bakufu.infrastructure.persistence.sqlite.base import Base
 
-# Importing the table modules registers the ORM mappings + listeners
-# with the metadata, so autogenerate sees them.
+# テーブルモジュールを import することで ORM マッピング・リスナーが metadata に
+# 登録され、autogenerate から参照できるようにする。
 from bakufu.infrastructure.persistence.sqlite.tables import (  # noqa: F401
     audit_log,
     outbox,
@@ -33,28 +33,26 @@ from bakufu.infrastructure.persistence.sqlite.tables import (  # noqa: F401
 from sqlalchemy.engine import Connection
 from sqlalchemy.ext.asyncio import AsyncEngine, async_engine_from_config
 
-# BUG-PF-002 fix: do **not** invoke ``logging.config.fileConfig`` here.
-# Alembic's default ``env.py`` template loads logger configuration
-# from ``alembic.ini``, which (a) silences every previously-configured
-# bakufu logger via ``disable_existing_loggers=True`` and (b) raises
-# the root logger to ``WARN``. Either side effect makes the Bootstrap
-# stages 4〜8 INFO/WARN telemetry disappear from production logs once
-# stage 3 completes. Bakufu configures logging up-front via
-# ``logging.basicConfig`` (production) or pytest's caplog (tests);
-# Alembic's own ``alembic.runtime.migration`` logger inherits from
-# root, so migrations still emit their progress lines.
+# BUG-PF-002 修正: ここで ``logging.config.fileConfig`` を**呼ばない**こと。
+# Alembic 既定の ``env.py`` テンプレートは ``alembic.ini`` からロガー設定を読み込むが、
+# (a) ``disable_existing_loggers=True`` により設定済みの bakufu ロガーを全て無効化し、
+# (b) ルートロガーを ``WARN`` に引き上げてしまう。いずれの副作用も、stage 3 完了後に
+# Bootstrap stages 4〜8 の INFO/WARN テレメトリが本番ログから失われる原因となる。
+# bakufu はロギングを先に ``logging.basicConfig``（本番）または pytest の caplog
+# （テスト）で構成する。Alembic 自身の ``alembic.runtime.migration`` ロガーは root を
+# 継承するため、マイグレーションの進捗行は引き続き出力される。
 config = context.config
 
 target_metadata = Base.metadata
 
 
 def _resolve_url() -> str:
-    """Pick the SQLAlchemy URL.
+    """SQLAlchemy URL を選択する。
 
-    Priority:
-    1. ``BAKUFU_ALEMBIC_URL`` env var (test rigs / CI override).
-    2. ``BAKUFU_DATA_DIR`` env var → ``<dir>/bakufu.db``.
-    3. ``alembic.ini`` ``sqlalchemy.url`` value (CLI fallback).
+    優先順位:
+    1. ``BAKUFU_ALEMBIC_URL`` 環境変数（テスト環境 / CI でのオーバーライド）。
+    2. ``BAKUFU_DATA_DIR`` 環境変数 → ``<dir>/bakufu.db``。
+    3. ``alembic.ini`` の ``sqlalchemy.url`` 値（CLI フォールバック）。
     """
     override = os.environ.get("BAKUFU_ALEMBIC_URL")
     if override:
@@ -72,7 +70,7 @@ def _resolve_url() -> str:
 
 
 def run_migrations_offline() -> None:
-    """Render SQL without opening a connection."""
+    """接続を開かずに SQL をレンダリングする。"""
     context.configure(
         url=_resolve_url(),
         target_metadata=target_metadata,
@@ -90,7 +88,7 @@ def _do_run_migrations(connection: Connection) -> None:
 
 
 async def _run_async_migrations() -> None:
-    """CLI-standalone path: build an engine and run the upgrade."""
+    """CLI 単独経路: エンジンを構築してアップグレードを実行する。"""
     connectable: AsyncEngine = async_engine_from_config(
         {"sqlalchemy.url": _resolve_url()},
         prefix="sqlalchemy.",
@@ -101,14 +99,13 @@ async def _run_async_migrations() -> None:
 
 
 def run_migrations_online() -> None:
-    # Programmatic path (Bootstrap stage 3): caller has already opened
-    # a sync Connection inside ``connection.run_sync`` and stuffed it
-    # into ``config.attributes['connection']``.
+    # プログラム経由（Bootstrap stage 3）: 呼び出し側が既に ``connection.run_sync``
+    # 内で同期 Connection を開き、``config.attributes['connection']`` に格納している。
     injected = config.attributes.get("connection", None)
     if isinstance(injected, Connection):
         _do_run_migrations(injected)
         return
-    # CLI standalone: spin up our own engine and asyncio loop.
+    # CLI 単独: エンジンと asyncio ループを自前で立ち上げる。
     asyncio.run(_run_async_migrations())
 
 

--- a/backend/alembic/versions/0001_init_audit_pid_outbox.py
+++ b/backend/alembic/versions/0001_init_audit_pid_outbox.py
@@ -1,9 +1,9 @@
-"""Initial revision: audit_log + bakufu_pid_registry + domain_event_outbox.
+"""初期 revision: audit_log + bakufu_pid_registry + domain_event_outbox。
 
-Creates the three cross-cutting tables shared across every Aggregate,
-the polling-optimized index on the Outbox, and the two SQLite triggers
-that enforce ``audit_log`` immutability at the database layer
-(Confirmation C — see ``docs/features/persistence-foundation/detailed-design/triggers.md``).
+すべての Aggregate にまたがる横断的な 3 テーブル、Outbox 上のポーリング最適化用
+インデックス、および ``audit_log`` の不変性をデータベース層で強制する 2 種類の
+SQLite トリガーを作成する
+（確定 C — ``docs/features/persistence-foundation/detailed-design/triggers.md`` 参照）。
 
 Revision ID: 0001_init
 Revises:
@@ -71,7 +71,7 @@ def upgrade() -> None:
         ["status", "next_attempt_at"],
     )
 
-    # Trigger 1: forbid DELETE on audit_log (append-only).
+    # トリガー 1: audit_log への DELETE を禁止する（追記専用）。
     op.execute(
         "CREATE TRIGGER audit_log_no_delete "
         "BEFORE DELETE ON audit_log "
@@ -80,7 +80,7 @@ def upgrade() -> None:
         "END"
     )
 
-    # Trigger 2: forbid UPDATE once `result` has been set.
+    # トリガー 2: `result` が設定済みの行に対する UPDATE を禁止する。
     op.execute(
         "CREATE TRIGGER audit_log_update_restricted "
         "BEFORE UPDATE ON audit_log "

--- a/backend/alembic/versions/0002_empire_aggregate.py
+++ b/backend/alembic/versions/0002_empire_aggregate.py
@@ -1,15 +1,15 @@
-"""Empire Aggregate tables: empires + empire_room_refs + empire_agent_refs.
+"""Empire Aggregate テーブル群: empires + empire_room_refs + empire_agent_refs。
 
-Adds the three tables that back :class:`SqliteEmpireRepository`:
+:class:`SqliteEmpireRepository` を支える 3 つのテーブルを追加する:
 
-* ``empires`` (id PK + name)
-* ``empire_room_refs`` (FK CASCADE on empire_id, UNIQUE pair)
-* ``empire_agent_refs`` (FK CASCADE on empire_id, UNIQUE pair)
+* ``empires``（id PK + name）
+* ``empire_room_refs``（empire_id に FK CASCADE、組で UNIQUE）
+* ``empire_agent_refs``（empire_id に FK CASCADE、組で UNIQUE）
 
-Per ``docs/features/empire-repository/detailed-design.md`` §確定 F,
-each subsequent ``feature/{aggregate}-repository`` PR appends its own
-revision (``0003_workflow_aggregate``, ``0004_agent_aggregate``, …)
-on top of this one so the Alembic chain stays linear.
+``docs/features/empire-repository/detailed-design.md`` §確定 F に従い、
+後続の ``feature/{aggregate}-repository`` PR はそれぞれの revision
+（``0003_workflow_aggregate``、``0004_agent_aggregate``、…）を本 revision の
+上に積み重ね、Alembic チェーンを線形に保つ。
 
 Revision ID: 0002_empire_aggregate
 Revises: 0001_init
@@ -81,8 +81,7 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    # Drop child tables first so the FK CASCADE doesn't trigger work
-    # against an already-deleted parent.
+    # 削除済みの親に対して FK CASCADE が発火しないよう、子テーブルから先に削除する。
     op.drop_table("empire_agent_refs")
     op.drop_table("empire_room_refs")
     op.drop_table("empires")

--- a/backend/alembic/versions/0003_workflow_aggregate.py
+++ b/backend/alembic/versions/0003_workflow_aggregate.py
@@ -1,22 +1,21 @@
-"""Workflow Aggregate tables: workflows + workflow_stages + workflow_transitions.
+"""Workflow Aggregate テーブル群: workflows + workflow_stages + workflow_transitions。
 
-Adds the three tables that back :class:`SqliteWorkflowRepository`:
+:class:`SqliteWorkflowRepository` を支える 3 つのテーブルを追加する:
 
-* ``workflows`` (id PK + name + entry_stage_id, **no FK** on entry_stage_id
-  per ``docs/features/workflow-repository/detailed-design.md`` §確定 J).
-* ``workflow_stages`` (FK CASCADE on workflow_id, UNIQUE pair) — the
-  ``notify_channels_json`` column carries Discord webhook URLs and is
-  declared with the :class:`MaskedJSONEncoded` TypeDecorator at the ORM
-  level (Alembic stores it as ``TEXT`` here; the masking gate lives on
-  the Python side).
-* ``workflow_transitions`` (FK CASCADE on workflow_id, UNIQUE pair).
+* ``workflows``（id PK + name + entry_stage_id。entry_stage_id には
+  ``docs/features/workflow-repository/detailed-design.md`` §確定 J に従い
+  **FK を付けない**）。
+* ``workflow_stages``（workflow_id に FK CASCADE、組で UNIQUE）—
+  ``notify_channels_json`` カラムは Discord の Webhook URL を保持し、ORM 層では
+  :class:`MaskedJSONEncoded` TypeDecorator として宣言される（Alembic 側では
+  ``TEXT`` として保存し、マスキングゲートは Python 側に置く）。
+* ``workflow_transitions``（workflow_id に FK CASCADE、組で UNIQUE）。
 
-Per ``docs/features/empire-repository/detailed-design.md`` §確定 F, each
-subsequent ``feature/{aggregate}-repository`` PR appends its own
-revision (``0004_agent_aggregate``, …) on top of this one so the
-Alembic chain stays linear; this revision pins ``down_revision =
-"0002_empire_aggregate"`` strictly so the chain check enforces a single
-head.
+``docs/features/empire-repository/detailed-design.md`` §確定 F に従い、後続の
+``feature/{aggregate}-repository`` PR は本 revision の上にそれぞれの revision
+（``0004_agent_aggregate``、…）を積み重ね、Alembic チェーンを線形に保つ。本 revision は
+``down_revision = "0002_empire_aggregate"`` を厳密に固定し、チェーン検査が単一 head
+を強制するようにする。
 
 Revision ID: 0003_workflow_aggregate
 Revises: 0002_empire_aggregate
@@ -41,9 +40,8 @@ def upgrade() -> None:
         "workflows",
         sa.Column("id", sa.CHAR(32), primary_key=True, nullable=False),
         sa.Column("name", sa.String(80), nullable=False),
-        # entry_stage_id intentionally has NO FK constraint — see
-        # detailed-design §確定 J. The Aggregate invariant
-        # ``_validate_entry_in_stages`` guards reference integrity.
+        # entry_stage_id には意図的に FK 制約を付けない — detailed-design §確定 J 参照。
+        # 参照整合性は Aggregate 不変条件 ``_validate_entry_in_stages`` で守る。
         sa.Column("entry_stage_id", sa.CHAR(32), nullable=False),
     )
 
@@ -66,9 +64,9 @@ def upgrade() -> None:
             nullable=False,
             server_default=sa.text("''"),
         ),
-        # JSONEncoded / MaskedJSONEncoded TypeDecorators serialize as
-        # TEXT in SQLite. The Python-side decorator does the masking
-        # gate (see infrastructure/persistence/sqlite/base.py).
+        # JSONEncoded / MaskedJSONEncoded TypeDecorator は SQLite では TEXT として
+        # 直列化される。マスキングゲートは Python 側のデコレータで行う
+        # （infrastructure/persistence/sqlite/base.py 参照）。
         sa.Column("completion_policy_json", sa.Text(), nullable=False),
         sa.Column(
             "notify_channels_json",
@@ -93,9 +91,9 @@ def upgrade() -> None:
             nullable=False,
         ),
         sa.Column("transition_id", sa.CHAR(32), primary_key=True, nullable=False),
-        # from_stage_id / to_stage_id intentionally have NO FK
-        # constraint — same circular-reference rationale as
-        # workflows.entry_stage_id (detailed-design §確定 J).
+        # from_stage_id / to_stage_id には意図的に FK 制約を付けない —
+        # workflows.entry_stage_id と同じ循環参照回避の理由による
+        # （detailed-design §確定 J）。
         sa.Column("from_stage_id", sa.CHAR(32), nullable=False),
         sa.Column("to_stage_id", sa.CHAR(32), nullable=False),
         sa.Column("condition", sa.String(32), nullable=False),
@@ -114,8 +112,7 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    # Drop child tables first so the FK CASCADE doesn't trigger work
-    # against an already-deleted parent.
+    # 削除済みの親に対して FK CASCADE が発火しないよう、子テーブルから先に削除する。
     op.drop_table("workflow_transitions")
     op.drop_table("workflow_stages")
     op.drop_table("workflows")

--- a/backend/alembic/versions/0004_agent_aggregate.py
+++ b/backend/alembic/versions/0004_agent_aggregate.py
@@ -1,26 +1,24 @@
-"""Agent Aggregate tables: agents + agent_providers + agent_skills.
+"""Agent Aggregate テーブル群: agents + agent_providers + agent_skills。
 
-Adds the three tables that back :class:`SqliteAgentRepository`:
+:class:`SqliteAgentRepository` を支える 3 つのテーブルを追加する:
 
-* ``agents`` (id PK + empire_id FK CASCADE + Persona scalars). The
-  ``prompt_body`` column is declared with the
-  :class:`MaskedText` TypeDecorator at the ORM level (Alembic stores
-  it as ``TEXT`` here; the masking gate lives on the Python side).
-* ``agent_providers`` (FK CASCADE on agent_id, UNIQUE(agent_id,
-  provider_kind)) **plus a partial unique index** on ``agent_id``
-  scoped by ``WHERE is_default = 1``. The partial index is the §確定 G
-  Defense-in-Depth floor for "exactly one default provider per Agent"
-  — even if a future PR introduces a corrupted SQL path, the DB still
-  refuses two ``is_default=1`` rows on the same Agent.
-* ``agent_skills`` (FK CASCADE on agent_id, UNIQUE(agent_id,
-  skill_id)). The ``path`` column is bounded to 500 characters per
-  the agent feature §確定 H pipeline; H1〜H10 traversal defense lives
-  on the VO side.
+* ``agents``（id PK + empire_id FK CASCADE + Persona スカラー群）。
+  ``prompt_body`` カラムは ORM 層で :class:`MaskedText` TypeDecorator として
+  宣言される（Alembic 側では ``TEXT`` として保存し、マスキングゲートは Python 側に置く）。
+* ``agent_providers``（agent_id に FK CASCADE、UNIQUE(agent_id, provider_kind)）
+  **に加えて**、``WHERE is_default = 1`` でスコープした ``agent_id`` の部分 UNIQUE
+  インデックスを持つ。この部分インデックスは「Agent ごとにデフォルトプロバイダは
+  ちょうど 1 つ」の §確定 G Defense-in-Depth 最終防衛線である — 将来の PR で
+  破損した SQL 経路が混入しても、DB は同一 Agent に対して ``is_default=1`` の行が
+  2 件入ることを拒否する。
+* ``agent_skills``（agent_id に FK CASCADE、UNIQUE(agent_id, skill_id)）。
+  ``path`` カラムは agent feature §確定 H パイプラインに従い 500 文字に制限する。
+  H1〜H10 のトラバーサル防御は VO 側で実装する。
 
-Per ``docs/features/empire-repository/detailed-design.md`` §確定 F
-each subsequent ``feature/{aggregate}-repository`` PR appends its own
-revision; this revision pins ``down_revision = "0003_workflow_aggregate"``
-strictly so the chain check enforces a single head.
+``docs/features/empire-repository/detailed-design.md`` §確定 F に従い、後続の
+``feature/{aggregate}-repository`` PR はそれぞれの revision を積み重ねる。本 revision は
+``down_revision = "0003_workflow_aggregate"`` を厳密に固定し、チェーン検査が単一 head
+を強制するようにする。
 
 Revision ID: 0004_agent_aggregate
 Revises: 0003_workflow_aggregate
@@ -59,9 +57,9 @@ def upgrade() -> None:
             nullable=False,
             server_default=sa.text("''"),
         ),
-        # MaskedText TypeDecorator serializes as TEXT in SQLite. The
-        # Python-side decorator does the masking gate (see
-        # infrastructure/persistence/sqlite/base.py).
+        # MaskedText TypeDecorator は SQLite では TEXT として直列化される。
+        # マスキングゲートは Python 側のデコレータで行う
+        # （infrastructure/persistence/sqlite/base.py 参照）。
         sa.Column(
             "prompt_body",
             sa.Text(),
@@ -104,10 +102,10 @@ def upgrade() -> None:
             name="uq_agent_providers_pair",
         ),
     )
-    # detailed-design §確定 G: partial unique index for the
-    # "at most one default provider per agent" Defense-in-Depth floor.
-    # SQLite ships partial indexes natively; the same syntax ports to
-    # PostgreSQL when the M5+ migration lands.
+    # detailed-design §確定 G: 「Agent ごとにデフォルトプロバイダは高々 1 つ」を
+    # 担保する Defense-in-Depth 最終防衛線としての部分 UNIQUE インデックス。
+    # SQLite は部分インデックスをネイティブにサポートしており、同じ構文は
+    # M5 以降の PostgreSQL マイグレーションにそのまま移植できる。
     op.create_index(
         "uq_agent_providers_default",
         "agent_providers",
@@ -137,8 +135,7 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    # Drop child tables first so the FK CASCADE doesn't trigger work
-    # against an already-deleted parent.
+    # 削除済みの親に対して FK CASCADE が発火しないよう、子テーブルから先に削除する。
     op.drop_table("agent_skills")
     op.drop_index("uq_agent_providers_default", table_name="agent_providers")
     op.drop_table("agent_providers")

--- a/backend/alembic/versions/0005_room_aggregate.py
+++ b/backend/alembic/versions/0005_room_aggregate.py
@@ -1,27 +1,26 @@
-"""Room Aggregate tables: rooms + room_members; empire_room_refs FK closure.
+"""Room Aggregate テーブル群: rooms + room_members、加えて empire_room_refs の FK クロージャ。
 
-Adds the two tables that back :class:`SqliteRoomRepository`:
+:class:`SqliteRoomRepository` を支える 2 つのテーブルを追加する:
 
-* ``rooms`` (id PK + empire_id FK CASCADE + workflow_id FK RESTRICT +
-  5 scalar columns). The ``prompt_kit_prefix_markdown`` column is stored as
-  ``TEXT`` here (Alembic does not know about ``MaskedText``); the masking
-  gate lives on the Python side via the TypeDecorator.
-* ``room_members`` (composite PK(room_id, agent_id, role) + FK CASCADE on
-  room_id + UNIQUE(room_id, agent_id, role) for §確定 R1-D Defense-in-Depth
-  + no FK on agent_id per room §確定).
+* ``rooms``（id PK + empire_id FK CASCADE + workflow_id FK RESTRICT +
+  スカラー 5 カラム）。``prompt_kit_prefix_markdown`` カラムは Alembic 側では
+  ``TEXT`` として保存される（Alembic は ``MaskedText`` を知らない）。マスキング
+  ゲートは TypeDecorator により Python 側で行う。
+* ``room_members``（複合 PK(room_id, agent_id, role) + room_id に FK CASCADE +
+  §確定 R1-D Defense-in-Depth のための UNIQUE(room_id, agent_id, role) +
+  room §確定 に従い agent_id には FK を付けない）。
 
-Also closes BUG-EMR-001 FK closure:
+加えて BUG-EMR-001 の FK クロージャを完了する:
 
-* ``empire_room_refs.room_id → rooms.id`` FK (ON DELETE CASCADE) is added
-  via ``op.batch_alter_table('empire_room_refs', recreate='always')`` because
-  SQLite does not support ``ALTER TABLE ... ADD CONSTRAINT FOREIGN KEY``
-  directly. The batch operation rebuilds the table internally so all existing
-  rows are preserved.
+* ``empire_room_refs.room_id → rooms.id`` FK（ON DELETE CASCADE）を
+  ``op.batch_alter_table('empire_room_refs', recreate='always')`` 経由で追加する。
+  SQLite は ``ALTER TABLE ... ADD CONSTRAINT FOREIGN KEY`` を直接サポートしないため
+  である。バッチ操作はテーブルを内部的に再構築するため、既存行はすべて保持される。
 
-Per ``docs/features/empire-repository/detailed-design.md`` §確定 F each
-subsequent ``feature/{aggregate}-repository`` PR appends its own revision;
-this revision pins ``down_revision = "0004_agent_aggregate"`` strictly so the
-chain check enforces a single head.
+``docs/features/empire-repository/detailed-design.md`` §確定 F に従い、後続の
+``feature/{aggregate}-repository`` PR はそれぞれの revision を積み重ねる。
+本 revision は ``down_revision = "0004_agent_aggregate"`` を厳密に固定し、
+チェーン検査が単一 head を強制するようにする。
 
 Revision ID: 0005_room_aggregate
 Revises: 0004_agent_aggregate
@@ -42,7 +41,7 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-    # Step 1: rooms table (empire_id FK CASCADE + workflow_id FK RESTRICT).
+    # Step 1: rooms テーブル（empire_id FK CASCADE + workflow_id FK RESTRICT）。
     op.create_table(
         "rooms",
         sa.Column("id", sa.CHAR(32), primary_key=True, nullable=False),
@@ -65,8 +64,8 @@ def upgrade() -> None:
             nullable=False,
             server_default=sa.text("''"),
         ),
-        # MaskedText TypeDecorator serializes as TEXT in SQLite. The
-        # Python-side decorator does the masking gate (base.py MaskedText).
+        # MaskedText TypeDecorator は SQLite では TEXT として直列化される。
+        # マスキングゲートは Python 側のデコレータで行う（base.py の MaskedText）。
         sa.Column(
             "prompt_kit_prefix_markdown",
             sa.Text(),
@@ -81,9 +80,9 @@ def upgrade() -> None:
         ),
     )
 
-    # §確定 R1-F: non-UNIQUE composite index for Empire-scoped find_by_name.
-    # Left-prefix optimises both ``WHERE empire_id = ?`` and
-    # ``WHERE empire_id = ? AND name = ?`` queries.
+    # §確定 R1-F: Empire スコープの find_by_name 用の非 UNIQUE 複合インデックス。
+    # 左端プレフィックスにより ``WHERE empire_id = ?`` と
+    # ``WHERE empire_id = ? AND name = ?`` の両方のクエリを最適化する。
     op.create_index(
         "ix_rooms_empire_id_name",
         "rooms",
@@ -91,7 +90,7 @@ def upgrade() -> None:
         unique=False,
     )
 
-    # Step 2: room_members table (composite PK + FK CASCADE + UNIQUE §確定 R1-D).
+    # Step 2: room_members テーブル（複合 PK + FK CASCADE + §確定 R1-D の UNIQUE）。
     op.create_table(
         "room_members",
         sa.Column(
@@ -106,8 +105,8 @@ def upgrade() -> None:
             sa.CHAR(32),
             primary_key=True,
             nullable=False,
-            # Intentionally no FK onto agents.id — application-layer
-            # responsibility (room §確定, see detailed-design §設計判断補足).
+            # agents.id への FK を意図的に付けない — アプリケーション層の責務
+            # （room §確定、detailed-design §設計判断補足 を参照）。
         ),
         sa.Column(
             "role",
@@ -120,9 +119,9 @@ def upgrade() -> None:
             sa.DateTime(timezone=True),
             nullable=False,
         ),
-        # §確定 R1-D: explicit UniqueConstraint in addition to composite PK so
-        # CI Layer 2 arch test can assert constraint existence via
-        # ``__table_args__`` scanning (agent_providers pattern).
+        # §確定 R1-D: 複合 PK に加え明示的に UniqueConstraint を宣言する。
+        # これにより CI の Layer 2 アーキテクチャテストが ``__table_args__``
+        # スキャンによって制約の存在を検証できる（agent_providers と同パターン）。
         sa.UniqueConstraint(
             "room_id",
             "agent_id",
@@ -131,12 +130,11 @@ def upgrade() -> None:
         ),
     )
 
-    # Step 3: empire_room_refs FK closure (BUG-EMR-001 close).
-    # SQLite does not support ``ALTER TABLE ... ADD CONSTRAINT FOREIGN KEY``
-    # directly. Alembic's ``batch_alter_table(recreate='always')`` rebuilds
-    # the table internally, copying existing rows, then renames. The
-    # ``recreate='always'`` flag forces the rebuild even when no column
-    # changes are detected — necessary for FK addition in SQLite.
+    # Step 3: empire_room_refs の FK クロージャ（BUG-EMR-001 のクローズ）。
+    # SQLite は ``ALTER TABLE ... ADD CONSTRAINT FOREIGN KEY`` を直接サポートしない。
+    # Alembic の ``batch_alter_table(recreate='always')`` はテーブルを内部的に再構築し、
+    # 既存行をコピーした上で rename する。``recreate='always'`` フラグはカラム変更が
+    # 検出されない場合でも再構築を強制する — SQLite で FK を追加するために必要。
     with op.batch_alter_table("empire_room_refs", recreate="always") as batch_op:
         batch_op.create_foreign_key(
             "fk_empire_room_refs_room_id",
@@ -148,11 +146,11 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    # Reverse order: FK closure → index → child table → root table.
+    # 逆順: FK クロージャ → インデックス → 子テーブル → 親テーブル。
     with op.batch_alter_table("empire_room_refs", recreate="always") as batch_op:
         batch_op.drop_constraint("fk_empire_room_refs_room_id", type_="foreignkey")
 
     op.drop_index("ix_rooms_empire_id_name", table_name="rooms")
-    # Drop child table first (room_members.room_id FK CASCADE onto rooms.id).
+    # 子テーブルから先に削除する（room_members.room_id は rooms.id への FK CASCADE）。
     op.drop_table("room_members")
     op.drop_table("rooms")

--- a/backend/alembic/versions/0006_directive_aggregate.py
+++ b/backend/alembic/versions/0006_directive_aggregate.py
@@ -1,25 +1,24 @@
-"""Directive Aggregate table: directives.
+"""Directive Aggregate テーブル: directives。
 
-Adds the table that backs :class:`SqliteDirectiveRepository`:
+:class:`SqliteDirectiveRepository` を支えるテーブルを追加する:
 
-* ``directives`` (id PK + text MaskedText NOT NULL + target_room_id FK CASCADE
-  onto rooms.id + created_at DateTime NOT NULL + task_id nullable CHAR(32)
-  with NO FK at this level — see §BUG-DRR-001 申し送り below).
-* ``INDEX(target_room_id, created_at)`` composite index for Room-scoped
-  ``find_by_room`` queries.
+* ``directives``（id PK + text MaskedText NOT NULL + target_room_id は rooms.id
+  への FK CASCADE + created_at DateTime NOT NULL + task_id は nullable CHAR(32)
+  でこの段階では FK を付けない — 下記 §BUG-DRR-001 申し送り 参照）。
+* Room スコープの ``find_by_room`` クエリ用の
+  ``INDEX(target_room_id, created_at)`` 複合インデックス。
 
 §BUG-DRR-001 FK申し送り:
-``directives.task_id`` is declared as a nullable CHAR(32) at this revision.
-The ``tasks.id`` FK will be closed in the task-repository PR via
-``op.batch_alter_table('directives', recreate='always')`` (same pattern as
-BUG-EMR-001 closure in 0005_room_aggregate, empire-repository PR #33).
+``directives.task_id`` は本 revision では nullable CHAR(32) として宣言する。
+``tasks.id`` への FK は task-repository PR で
+``op.batch_alter_table('directives', recreate='always')`` 経由でクローズする
+（0005_room_aggregate での BUG-EMR-001 クローズと同パターン、empire-repository PR #33）。
 
-ON DELETE RESTRICT is recommended for the deferred FK: a Directive is the
-audit trail of an instruction; Task deletion should be blocked if a
-Directive still references it.
+延期する FK には ON DELETE RESTRICT を推奨する: Directive は指示の監査証跡であり、
+Directive がまだ参照している Task の削除はブロックすべきである。
 
-Per ``docs/features/directive-repository/detailed-design.md`` §確定 R1-B
-and §確定 R1-C.
+``docs/features/directive-repository/detailed-design.md`` §確定 R1-B
+および §確定 R1-C に従う。
 
 Revision ID: 0006_directive_aggregate
 Revises: 0005_room_aggregate
@@ -40,12 +39,12 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-    # directives table: flat 5-column aggregate (no child tables).
+    # directives テーブル: 5 カラムのフラットな Aggregate（子テーブルなし）。
     op.create_table(
         "directives",
         sa.Column("id", sa.CHAR(32), primary_key=True, nullable=False),
-        # MaskedText TypeDecorator serializes as TEXT in SQLite. The Python-side
-        # decorator does the masking gate (base.py MaskedText). §確定 R1-E.
+        # MaskedText TypeDecorator は SQLite では TEXT として直列化される。
+        # マスキングゲートは Python 側のデコレータで行う（base.py の MaskedText）。§確定 R1-E。
         sa.Column("text", sa.Text(), nullable=False),
         sa.Column(
             "target_room_id",

--- a/backend/alembic/versions/0006_directive_aggregate.py
+++ b/backend/alembic/versions/0006_directive_aggregate.py
@@ -52,18 +52,18 @@ def upgrade() -> None:
             sa.ForeignKey("rooms.id", ondelete="CASCADE"),
             nullable=False,
         ),
-        # created_at uses Text storage (UTCDateTime TypeDecorator stores
-        # ISO-8601 string). Always UTC-aware at the Python layer.
+        # created_at は Text 形式で保存する（UTCDateTime TypeDecorator が
+        # ISO-8601 文字列を格納する）。Python 側では常に UTC-aware。
         sa.Column("created_at", sa.Text(), nullable=False),
-        # task_id: nullable CHAR(32) with NO FK at this level — see §BUG-DRR-001.
-        # The FK closure (fk_directives_task_id → tasks.id RESTRICT) is deferred
-        # to the task-repository PR.
+        # task_id: このレベルでは FK 無しの nullable CHAR(32) — §BUG-DRR-001 を参照。
+        # FK クロージャ（fk_directives_task_id → tasks.id RESTRICT）は
+        # task-repository PR に延期される。
         sa.Column("task_id", sa.CHAR(32), nullable=True),
     )
 
-    # §確定 R1-D: composite index for Room-scoped find_by_room query.
-    # Left-prefix covers ``WHERE target_room_id = ?`` and
-    # ``WHERE target_room_id = ? ORDER BY created_at DESC``.
+    # §確定 R1-D: Room スコープの find_by_room クエリ用の複合インデックス。
+    # 左プレフィックスが ``WHERE target_room_id = ?`` と
+    # ``WHERE target_room_id = ? ORDER BY created_at DESC`` をカバーする。
     op.create_index(
         "ix_directives_target_room_id_created_at",
         "directives",
@@ -73,6 +73,6 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    # Reverse order: index first, then table.
+    # 逆順: まずインデックス、次にテーブル。
     op.drop_index("ix_directives_target_room_id_created_at", table_name="directives")
     op.drop_table("directives")

--- a/backend/alembic/versions/0007_task_aggregate.py
+++ b/backend/alembic/versions/0007_task_aggregate.py
@@ -1,46 +1,45 @@
-"""Task Aggregate tables: tasks + 3 child tables; BUG-DRR-001 FK closure.
+"""Task Aggregate テーブル群: tasks + 3 子テーブル、BUG-DRR-001 FK クロージャ。
 
-Adds the four tables that back :class:`SqliteTaskRepository`:
+:class:`SqliteTaskRepository` を支える 4 つのテーブルを追加する:
 
-* ``tasks`` (id PK + room_id FK CASCADE + directive_id FK CASCADE +
-  current_stage_id NOT NULL (no FK, Aggregate boundary §確定 R1-G) +
+* ``tasks``（id PK + room_id FK CASCADE + directive_id FK CASCADE +
+  current_stage_id NOT NULL（FK 無し、Aggregate 境界 §確定 R1-G） +
   status String(32) NOT NULL + last_error MaskedText NULL +
-  created_at / updated_at UTCDateTime NOT NULL).
-  Two indexes: ``ix_tasks_room_id`` (single-column) and
-  ``ix_tasks_status_updated_id`` (composite, §確定 R1-K).
-* ``task_assigned_agents`` (composite PK (task_id, agent_id) + FK CASCADE on
-  task_id + NO FK on agent_id per §設計決定 TR-001 + UNIQUE(task_id, agent_id)
-  Defense-in-Depth).
-* ``deliverables`` (id PK + task_id FK CASCADE + stage_id NOT NULL (no FK,
-  Aggregate boundary) + body_markdown MaskedText NOT NULL + committed_by
-  NOT NULL (no FK) + committed_at UTCDateTime NOT NULL +
-  UNIQUE(task_id, stage_id)).
-* ``deliverable_attachments`` (id PK + deliverable_id FK CASCADE + sha256
+  created_at / updated_at UTCDateTime NOT NULL）。
+  インデックス 2 つ: ``ix_tasks_room_id``（単一カラム）と
+  ``ix_tasks_status_updated_id``（複合、§確定 R1-K）。
+* ``task_assigned_agents``（複合 PK (task_id, agent_id) + task_id への FK CASCADE
+  + §設計決定 TR-001 により agent_id への FK 無し + UNIQUE(task_id, agent_id) の
+  多層防御）。
+* ``deliverables``（id PK + task_id FK CASCADE + stage_id NOT NULL（FK 無し、
+  Aggregate 境界） + body_markdown MaskedText NOT NULL + committed_by NOT NULL
+  （FK 無し） + committed_at UTCDateTime NOT NULL + UNIQUE(task_id, stage_id)）。
+* ``deliverable_attachments``（id PK + deliverable_id FK CASCADE + sha256
   String(64) NOT NULL + filename String(255) NOT NULL + mime_type
   String(128) NOT NULL + size_bytes Integer NOT NULL +
-  UNIQUE(deliverable_id, sha256)).
+  UNIQUE(deliverable_id, sha256)）。
 
-``conversations`` / ``conversation_messages`` tables are excluded (§BUG-TR-002
-凍結済み): Task Aggregate currently has no ``conversations`` attribute. These
-tables will be added in the future migration that wires up
-``Task.conversations: list[Conversation]``.
+``conversations`` / ``conversation_messages`` テーブルは除外（§BUG-TR-002
+凍結済み）: Task Aggregate には現状 ``conversations`` 属性が無い。これらの
+テーブルは ``Task.conversations: list[Conversation]`` を配線する将来の
+マイグレーションで追加される。
 
-Also closes BUG-DRR-001 FK申し送り:
+加えて BUG-DRR-001 FK 申し送りを完了する:
 
-* ``directives.task_id → tasks.id`` FK (ON DELETE RESTRICT) is added via
-  ``op.batch_alter_table('directives', recreate='always')`` because SQLite
-  does not support ``ALTER TABLE ... ADD CONSTRAINT FOREIGN KEY`` directly.
-  The batch operation rebuilds the table internally, copying existing rows,
-  then renames. This is the same pattern as BUG-EMR-001 closure in
-  0005_room_aggregate (empire-repository PR #47).
+* ``directives.task_id → tasks.id`` FK（ON DELETE RESTRICT）を
+  ``op.batch_alter_table('directives', recreate='always')`` 経由で追加する。
+  SQLite は ``ALTER TABLE ... ADD CONSTRAINT FOREIGN KEY`` を直接サポートしない
+  ため。バッチ操作は内部でテーブルを再構築し、既存行をコピーして名前を変更する。
+  0005_room_aggregate の BUG-EMR-001 クロージャ（empire-repository PR #47）と
+  同じパターン。
 
-ON DELETE RESTRICT rationale: a Directive that references a Task must not
-silently lose that reference when the Task is deleted. The application layer
-must call ``directive.unlink_task()`` + ``save()`` before deleting a Task
-(Fail Fast §確定 R1-C).
+ON DELETE RESTRICT の根拠: Task を参照する Directive は、Task が削除された際に
+サイレントに参照を失ってはならない。アプリケーション層は Task 削除前に
+``directive.unlink_task()`` + ``save()`` を呼ばなければならない
+（Fail Fast §確定 R1-C）。
 
-Per ``docs/features/task-repository/detailed-design.md`` §確定 R1-B,
-§確定 R1-C, §確定 R1-K.
+``docs/features/task-repository/detailed-design.md`` §確定 R1-B、§確定 R1-C、
+§確定 R1-K に従う。
 
 Revision ID: 0007_task_aggregate
 Revises: 0006_directive_aggregate
@@ -61,7 +60,7 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-    # ---- tasks table -------------------------------------------------------
+    # ---- tasks テーブル ----------------------------------------------------
     op.create_table(
         "tasks",
         sa.Column("id", sa.CHAR(32), primary_key=True, nullable=False),
@@ -77,24 +76,26 @@ def upgrade() -> None:
             sa.ForeignKey("directives.id", ondelete="CASCADE"),
             nullable=False,
         ),
-        # current_stage_id: intentionally NO FK onto workflow_stages.id —
-        # Aggregate boundary (§確定 R1-G). TaskService validates existence.
+        # current_stage_id: workflow_stages.id への FK は意図的に持たない —
+        # Aggregate 境界（§確定 R1-G）。TaskService が存在性を検証する。
         sa.Column("current_stage_id", sa.CHAR(32), nullable=False),
         sa.Column("status", sa.String(32), nullable=False),
-        # last_error: MaskedText serialises as TEXT. The Python-side TypeDecorator
-        # does the masking gate (base.py MaskedText). NULL = not BLOCKED.
+        # last_error: MaskedText は TEXT としてシリアライズされる。Python 側の
+        # TypeDecorator がマスキング ゲートを実行する（base.py MaskedText）。
+        # NULL = BLOCKED ではない。
         sa.Column("last_error", sa.Text(), nullable=True),
-        # UTCDateTime TypeDecorator stores ISO-8601 text; always tz-aware at Python.
+        # UTCDateTime TypeDecorator は ISO-8601 テキストを格納し、Python 側では
+        # 常に tz-aware。
         sa.Column("created_at", sa.Text(), nullable=False),
         sa.Column("updated_at", sa.Text(), nullable=False),
     )
 
-    # §確定 R1-K: single-column index for count_by_room WHERE filter.
+    # §確定 R1-K: count_by_room WHERE フィルタ用の単一カラム インデックス。
     op.create_index("ix_tasks_room_id", "tasks", ["room_id"], unique=False)
 
-    # §確定 R1-K: composite (status, updated_at, id) index.
-    # Covers find_blocked WHERE status = 'BLOCKED' ORDER BY updated_at DESC, id DESC
-    # and count_by_status WHERE status = ? in one B-tree scan.
+    # §確定 R1-K: 複合 (status, updated_at, id) インデックス。
+    # find_blocked の WHERE status = 'BLOCKED' ORDER BY updated_at DESC, id DESC
+    # と count_by_status の WHERE status = ? を 1 回の B-tree スキャンでカバーする。
     op.create_index(
         "ix_tasks_status_updated_id",
         "tasks",
@@ -102,7 +103,7 @@ def upgrade() -> None:
         unique=False,
     )
 
-    # ---- task_assigned_agents table ----------------------------------------
+    # ---- task_assigned_agents テーブル ------------------------------------
     op.create_table(
         "task_assigned_agents",
         sa.Column(
@@ -112,16 +113,16 @@ def upgrade() -> None:
             primary_key=True,
             nullable=False,
         ),
-        # agent_id: intentionally NO FK onto agents.id — Aggregate boundary
-        # (§設計決定 TR-001, room_members.agent_id 前例同方針).
+        # agent_id: agents.id への FK は意図的に持たない — Aggregate 境界
+        # （§設計決定 TR-001、room_members.agent_id 先例と同方針）。
         sa.Column("agent_id", sa.CHAR(32), primary_key=True, nullable=False),
         sa.Column("order_index", sa.Integer(), nullable=False),
-        # Defense-in-Depth: explicit UNIQUE mirrors Aggregate invariant
-        # _validate_assigned_agents_unique at the DB level.
+        # 多層防御: 明示的な UNIQUE が Aggregate 不変条件
+        # _validate_assigned_agents_unique を DB レベルでミラーする。
         sa.UniqueConstraint("task_id", "agent_id", name="uq_task_assigned_agents"),
     )
 
-    # ---- deliverables table ------------------------------------------------
+    # ---- deliverables テーブル --------------------------------------------
     op.create_table(
         "deliverables",
         sa.Column("id", sa.CHAR(32), primary_key=True, nullable=False),
@@ -131,22 +132,22 @@ def upgrade() -> None:
             sa.ForeignKey("tasks.id", ondelete="CASCADE"),
             nullable=False,
         ),
-        # stage_id: intentionally NO FK onto workflow_stages.id — Aggregate
-        # boundary (§確定 R1-G, same rationale as tasks.current_stage_id).
+        # stage_id: workflow_stages.id への FK は意図的に持たない — Aggregate
+        # 境界（§確定 R1-G、tasks.current_stage_id と同じ理由）。
         sa.Column("stage_id", sa.CHAR(32), nullable=False),
-        # body_markdown: MaskedText serialises as TEXT (§確定 R1-E).
+        # body_markdown: MaskedText は TEXT としてシリアライズされる（§確定 R1-E）。
         sa.Column("body_markdown", sa.Text(), nullable=False),
-        # committed_by: intentionally NO FK onto agents.id — Aggregate
-        # boundary (§設計決定 TR-001, same as task_assigned_agents.agent_id).
+        # committed_by: agents.id への FK は意図的に持たない — Aggregate 境界
+        # （§設計決定 TR-001、task_assigned_agents.agent_id と同じ）。
         sa.Column("committed_by", sa.CHAR(32), nullable=False),
-        # UTCDateTime TypeDecorator stores ISO-8601 text.
+        # UTCDateTime TypeDecorator は ISO-8601 テキストを格納する。
         sa.Column("committed_at", sa.Text(), nullable=False),
-        # UNIQUE(task_id, stage_id): mirrors Aggregate's dict[StageId, Deliverable]
-        # key-uniqueness invariant at the DB level.
+        # UNIQUE(task_id, stage_id): Aggregate の dict[StageId, Deliverable] キー
+        # 一意性不変条件を DB レベルでミラーする。
         sa.UniqueConstraint("task_id", "stage_id", name="uq_deliverables_task_stage"),
     )
 
-    # ---- deliverable_attachments table -------------------------------------
+    # ---- deliverable_attachments テーブル ---------------------------------
     op.create_table(
         "deliverable_attachments",
         sa.Column("id", sa.CHAR(32), primary_key=True, nullable=False),
@@ -156,13 +157,13 @@ def upgrade() -> None:
             sa.ForeignKey("deliverables.id", ondelete="CASCADE"),
             nullable=False,
         ),
-        # sha256: 64-char lowercase hex; validated by Attachment VO.
+        # sha256: 64 文字の小文字 hex。Attachment VO で検証される。
         sa.Column("sha256", sa.String(64), nullable=False),
         sa.Column("filename", sa.String(255), nullable=False),
         sa.Column("mime_type", sa.String(128), nullable=False),
         sa.Column("size_bytes", sa.Integer(), nullable=False),
-        # UNIQUE(deliverable_id, sha256): prevents duplicate content within
-        # one Deliverable; sha256 provides deterministic ORDER BY anchor.
+        # UNIQUE(deliverable_id, sha256): 単一 Deliverable 内のコンテンツ重複を
+        # 防ぐ。sha256 は決定的な ORDER BY アンカーを提供する。
         sa.UniqueConstraint(
             "deliverable_id",
             "sha256",
@@ -170,14 +171,14 @@ def upgrade() -> None:
         ),
     )
 
-    # ---- BUG-DRR-001 FK closure -------------------------------------------
-    # ``directives.task_id → tasks.id`` FK (ON DELETE RESTRICT).
-    # SQLite does not support ``ALTER TABLE ... ADD CONSTRAINT FOREIGN KEY``
-    # directly. Alembic's ``batch_alter_table(recreate='always')`` rebuilds
-    # the table internally, copying existing rows, then renames.
-    # The ``recreate='always'`` flag forces the rebuild even when no column
-    # changes are detected — necessary for FK addition in SQLite
-    # (same pattern as BUG-EMR-001 closure in 0005_room_aggregate).
+    # ---- BUG-DRR-001 FK クロージャ ----------------------------------------
+    # ``directives.task_id → tasks.id`` FK（ON DELETE RESTRICT）。
+    # SQLite は ``ALTER TABLE ... ADD CONSTRAINT FOREIGN KEY`` を直接
+    # サポートしない。Alembic の ``batch_alter_table(recreate='always')`` が
+    # 内部でテーブルを再構築し、既存行をコピーして名前を変更する。
+    # ``recreate='always'`` フラグはカラム変更が検出されない場合でも再構築を
+    # 強制する — SQLite での FK 追加に必要（0005_room_aggregate での
+    # BUG-EMR-001 クロージャと同じパターン）。
     with op.batch_alter_table("directives", recreate="always") as batch_op:
         batch_op.create_foreign_key(
             "fk_directives_task_id",
@@ -189,21 +190,21 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    # Reverse order:
-    # 1. Drop BUG-DRR-001 FK closure first (directives depends on tasks).
+    # 逆順:
+    # 1. まず BUG-DRR-001 FK クロージャを削除する（directives は tasks に依存）。
     with op.batch_alter_table("directives", recreate="always") as batch_op:
         batch_op.drop_constraint("fk_directives_task_id", type_="foreignkey")
 
-    # 2. Drop child tables (CASCADE dependency order: deepest first).
+    # 2. 子テーブルを削除する（CASCADE 依存順、最深から）。
     op.drop_table("deliverable_attachments")
 
-    # 3. Drop mid-level child tables.
+    # 3. 中間レベルの子テーブルを削除する。
     op.drop_table("deliverables")
     op.drop_table("task_assigned_agents")
 
-    # 4. Drop indexes before dropping root table.
+    # 4. ルート テーブル削除前にインデックスを削除する。
     op.drop_index("ix_tasks_status_updated_id", table_name="tasks")
     op.drop_index("ix_tasks_room_id", table_name="tasks")
 
-    # 5. Drop root table.
+    # 5. ルート テーブルを削除する。
     op.drop_table("tasks")

--- a/backend/alembic/versions/0008_external_review_gate_aggregate.py
+++ b/backend/alembic/versions/0008_external_review_gate_aggregate.py
@@ -1,47 +1,45 @@
-"""ExternalReviewGate Aggregate tables: 3 tables + 3 indexes.
+"""ExternalReviewGate Aggregate テーブル群: 3 テーブル + 3 インデックス。
 
-Adds the three tables that back :class:`SqliteExternalReviewGateRepository`:
+:class:`SqliteExternalReviewGateRepository` を支える 3 つのテーブルを追加する:
 
-* ``external_review_gates`` (id PK + task_id FK CASCADE + stage_id NOT NULL
-  (no FK, Aggregate boundary §設計決定 ERGR-001) + reviewer_id NOT NULL (no FK,
-  Owner Aggregate M2 scope) + decision String(32) NOT NULL + feedback_text
-  MaskedText NOT NULL + snapshot_stage_id NOT NULL (no FK) +
+* ``external_review_gates``（id PK + task_id FK CASCADE + stage_id NOT NULL
+  （FK 無し、Aggregate 境界 §設計決定 ERGR-001） + reviewer_id NOT NULL（FK 無し、
+  Owner Aggregate は M2 範囲） + decision String(32) NOT NULL + feedback_text
+  MaskedText NOT NULL + snapshot_stage_id NOT NULL（FK 無し） +
   snapshot_body_markdown MaskedText NOT NULL + snapshot_committed_by NOT NULL
-  (no FK) + snapshot_committed_at UTCDateTime NOT NULL + created_at UTCDateTime
-  NOT NULL + decided_at UTCDateTime NULL).
-  Three indexes: ``ix_external_review_gates_task_id_created`` (composite),
-  ``ix_external_review_gates_reviewer_decision`` (composite),
-  ``ix_external_review_gates_decision`` (single-column).
+  （FK 無し） + snapshot_committed_at UTCDateTime NOT NULL + created_at
+  UTCDateTime NOT NULL + decided_at UTCDateTime NULL）。
+  インデックス 3 つ: ``ix_external_review_gates_task_id_created``（複合）、
+  ``ix_external_review_gates_reviewer_decision``（複合）、
+  ``ix_external_review_gates_decision``（単一カラム）。
 
-* ``external_review_gate_attachments`` (id PK (save-internal, uuid4() per save)
-  + gate_id FK CASCADE + sha256 String(64) NOT NULL + filename String(255)
-  NOT NULL + mime_type String(128) NOT NULL + size_bytes Integer NOT NULL +
-  UNIQUE(gate_id, sha256)).
+* ``external_review_gate_attachments``（id PK（save 内部、save ごとに uuid4()） +
+  gate_id FK CASCADE + sha256 String(64) NOT NULL + filename String(255) NOT NULL
+  + mime_type String(128) NOT NULL + size_bytes Integer NOT NULL +
+  UNIQUE(gate_id, sha256)）。
 
-* ``external_review_audit_entries`` (id PK (domain AuditEntry.id) + gate_id
-  FK CASCADE + actor_id NOT NULL (no FK, Owner Aggregate boundary) +
-  action String(32) NOT NULL + comment MaskedText NOT NULL + occurred_at
-  UTCDateTime NOT NULL).
+* ``external_review_audit_entries``（id PK（ドメイン AuditEntry.id） + gate_id
+  FK CASCADE + actor_id NOT NULL（FK 無し、Owner Aggregate 境界） + action
+  String(32) NOT NULL + comment MaskedText NOT NULL + occurred_at UTCDateTime
+  NOT NULL）。
 
-``external_review_gates.task_id → tasks.id`` ON DELETE CASCADE: when a Task
-is removed, its associated Gates go with it. This is the only inter-Aggregate
-FK (§設計決定 ERGR-001 — all other UUID references are boundary-crossing and
-intentionally FK-free).
+``external_review_gates.task_id → tasks.id`` ON DELETE CASCADE: Task が削除
+されるとその関連 Gate も一緒に削除される。これは唯一の Aggregate 間 FK
+（§設計決定 ERGR-001 — 他のすべての UUID 参照は境界横断であり意図的に FK 無し）。
 
-``stage_id``, ``reviewer_id``, ``snapshot_stage_id``, ``snapshot_committed_by``,
-and ``actor_id`` intentionally have **no FK** (§設計決定 ERGR-001):
-- Stage / Workflow Aggregate boundary (Gate must not depend on
-  workflow_stages).
-- Owner Aggregate not yet implemented (M2 scope; MVP uses fixed UUID).
-- snapshot_committed_by: Agent deletion with CASCADE would destroy the
-  audit-frozen snapshot (task-repository §設計決定 TR-001 同論理).
-- actor_id: Owner Aggregate same as reviewer_id rationale.
+``stage_id``、``reviewer_id``、``snapshot_stage_id``、``snapshot_committed_by``、
+``actor_id`` は意図的に **FK を持たない**（§設計決定 ERGR-001）:
+- Stage / Workflow Aggregate 境界（Gate は workflow_stages に依存してはならない）。
+- Owner Aggregate は未実装（M2 範囲。MVP は固定 UUID を使う）。
+- snapshot_committed_by: Agent 削除に CASCADE が伴うと監査凍結された
+  スナップショットを破壊してしまう（task-repository §設計決定 TR-001 と同論理）。
+- actor_id: reviewer_id と同じ Owner Aggregate の根拠。
 
-No inter-Aggregate FK申し送り is added: §設計決定 ERGR-001 resolves this as
-a permanent design decision (not a BUG申し送り).
+Aggregate 間 FK 申し送りは追加しない: §設計決定 ERGR-001 がこれを恒久的な
+設計決定として解決する（BUG 申し送りではない）。
 
-Per ``docs/features/external-review-gate-repository/detailed-design.md``
-§確定 R1-B, §設計決定 ERGR-001, §確定 R1-K.
+``docs/features/external-review-gate-repository/detailed-design.md`` §確定 R1-B、
+§設計決定 ERGR-001、§確定 R1-K に従う。
 
 Revision ID: 0008_external_review_gate_aggregate
 Revises: 0007_task_aggregate
@@ -62,7 +60,7 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-    # ---- external_review_gates table ----------------------------------------
+    # ---- external_review_gates テーブル ------------------------------------
     op.create_table(
         "external_review_gates",
         sa.Column("id", sa.CHAR(32), primary_key=True, nullable=False),
@@ -72,33 +70,35 @@ def upgrade() -> None:
             sa.ForeignKey("tasks.id", ondelete="CASCADE"),
             nullable=False,
         ),
-        # stage_id: intentionally NO FK onto workflow_stages.id —
-        # Aggregate boundary (§設計決定 ERGR-001). GateService validates existence.
+        # stage_id: workflow_stages.id への FK は意図的に持たない —
+        # Aggregate 境界（§設計決定 ERGR-001）。GateService が存在性を検証する。
         sa.Column("stage_id", sa.CHAR(32), nullable=False),
-        # reviewer_id: intentionally NO FK — Owner Aggregate not yet implemented
-        # (§設計決定 ERGR-001). MVP: CEO = single system owner with fixed UUID.
+        # reviewer_id: 意図的に FK 無し — Owner Aggregate は未実装
+        # （§設計決定 ERGR-001）。MVP: CEO = 固定 UUID を持つ単一システム所有者。
         sa.Column("reviewer_id", sa.CHAR(32), nullable=False),
         sa.Column("decision", sa.String(32), nullable=False),
-        # feedback_text: MaskedText serialises as TEXT (§設計決定 ERGR-002,
-        # §確定 R1-E). CEO review comment; can carry webhook URLs / API keys.
+        # feedback_text: MaskedText は TEXT としてシリアライズされる
+        # （§設計決定 ERGR-002、§確定 R1-E）。CEO のレビュー コメント。webhook URL
+        # / API キーを持ち得る。
         sa.Column("feedback_text", sa.Text(), nullable=False),
-        # Inline snapshot_* columns — immutable after Gate creation (§確定 D).
-        # snapshot_stage_id: NO FK onto workflow_stages.id — Aggregate boundary.
+        # インライン snapshot_* カラム — Gate 作成後は不変（§確定 D）。
+        # snapshot_stage_id: workflow_stages.id への FK 無し — Aggregate 境界。
         sa.Column("snapshot_stage_id", sa.CHAR(32), nullable=False),
-        # snapshot_body_markdown: MaskedText serialises as TEXT (§確定 R1-E).
-        # Agent-authored deliverable body; LLM output may contain secrets.
+        # snapshot_body_markdown: MaskedText は TEXT としてシリアライズされる
+        # （§確定 R1-E）。Agent が書く成果物本体。LLM 出力はシークレットを含み得る。
         sa.Column("snapshot_body_markdown", sa.Text(), nullable=False),
-        # snapshot_committed_by: NO FK onto agents.id — Agent deletion with
-        # CASCADE would destroy audit-frozen snapshot (§設計決定 ERGR-001).
+        # snapshot_committed_by: agents.id への FK 無し — CASCADE 付きの Agent
+        # 削除は監査凍結されたスナップショットを破壊してしまう（§設計決定 ERGR-001）。
         sa.Column("snapshot_committed_by", sa.CHAR(32), nullable=False),
-        # UTCDateTime TypeDecorator stores ISO-8601 text; always tz-aware at Python.
+        # UTCDateTime TypeDecorator は ISO-8601 テキストを格納し、Python 側では
+        # 常に tz-aware。
         sa.Column("snapshot_committed_at", sa.Text(), nullable=False),
         sa.Column("created_at", sa.Text(), nullable=False),
-        # decided_at: NULL iff decision == PENDING (domain invariant).
+        # decided_at: decision == PENDING のときに限り NULL（ドメイン不変条件）。
         sa.Column("decided_at", sa.Text(), nullable=True),
     )
 
-    # §確定 R1-K: composite (task_id, created_at) index for find_by_task_id.
+    # §確定 R1-K: find_by_task_id 用の複合 (task_id, created_at) インデックス。
     op.create_index(
         "ix_external_review_gates_task_id_created",
         "external_review_gates",
@@ -106,7 +106,7 @@ def upgrade() -> None:
         unique=False,
     )
 
-    # §確定 R1-K: composite (reviewer_id, decision) for find_pending_by_reviewer.
+    # §確定 R1-K: find_pending_by_reviewer 用の複合 (reviewer_id, decision)。
     op.create_index(
         "ix_external_review_gates_reviewer_decision",
         "external_review_gates",
@@ -114,7 +114,7 @@ def upgrade() -> None:
         unique=False,
     )
 
-    # §確定 R1-K: single-column (decision) for count_by_decision.
+    # §確定 R1-K: count_by_decision 用の単一カラム (decision)。
     op.create_index(
         "ix_external_review_gates_decision",
         "external_review_gates",
@@ -122,11 +122,11 @@ def upgrade() -> None:
         unique=False,
     )
 
-    # ---- external_review_gate_attachments table ----------------------------
+    # ---- external_review_gate_attachments テーブル -------------------------
     op.create_table(
         "external_review_gate_attachments",
-        # id: save-internal PK (uuid4() regenerated on each save()).
-        # Business key: UNIQUE(gate_id, sha256).
+        # id: save 内部 PK（save() ごとに uuid4() を再生成）。
+        # ビジネス キー: UNIQUE(gate_id, sha256)。
         sa.Column("id", sa.CHAR(32), primary_key=True, nullable=False),
         sa.Column(
             "gate_id",
@@ -134,13 +134,13 @@ def upgrade() -> None:
             sa.ForeignKey("external_review_gates.id", ondelete="CASCADE"),
             nullable=False,
         ),
-        # sha256: 64-char lowercase hex; validated by Attachment VO.
+        # sha256: 64 文字の小文字 hex。Attachment VO で検証される。
         sa.Column("sha256", sa.String(64), nullable=False),
         sa.Column("filename", sa.String(255), nullable=False),
         sa.Column("mime_type", sa.String(128), nullable=False),
         sa.Column("size_bytes", sa.Integer(), nullable=False),
-        # UNIQUE(gate_id, sha256): prevents duplicate content within one Gate;
-        # sha256 provides deterministic ORDER BY anchor (§確定 R1-H).
+        # UNIQUE(gate_id, sha256): 1 つの Gate 内のコンテンツ重複を防ぐ。
+        # sha256 は決定的な ORDER BY アンカーを提供する（§確定 R1-H）。
         sa.UniqueConstraint(
             "gate_id",
             "sha256",
@@ -148,10 +148,10 @@ def upgrade() -> None:
         ),
     )
 
-    # ---- external_review_audit_entries table -------------------------------
+    # ---- external_review_audit_entries テーブル ---------------------------
     op.create_table(
         "external_review_audit_entries",
-        # id: taken from domain AuditEntry.id (NOT regenerated on save).
+        # id: ドメイン AuditEntry.id から取得（save 時に再生成しない）。
         sa.Column("id", sa.CHAR(32), primary_key=True, nullable=False),
         sa.Column(
             "gate_id",
@@ -159,25 +159,25 @@ def upgrade() -> None:
             sa.ForeignKey("external_review_gates.id", ondelete="CASCADE"),
             nullable=False,
         ),
-        # actor_id: intentionally NO FK — Owner Aggregate not yet implemented
-        # (§設計決定 ERGR-001). Same rationale as reviewer_id above.
+        # actor_id: 意図的に FK 無し — Owner Aggregate は未実装
+        # （§設計決定 ERGR-001）。上の reviewer_id と同じ根拠。
         sa.Column("actor_id", sa.CHAR(32), nullable=False),
         sa.Column("action", sa.String(32), nullable=False),
-        # comment: MaskedText serialises as TEXT (§確定 R1-E).
-        # CEO-authored text; can carry webhook URLs / API keys.
+        # comment: MaskedText は TEXT としてシリアライズされる（§確定 R1-E）。
+        # CEO 著作テキスト。webhook URL / API キーを持ち得る。
         sa.Column("comment", sa.Text(), nullable=False),
-        # UTCDateTime TypeDecorator stores ISO-8601 text.
+        # UTCDateTime TypeDecorator は ISO-8601 テキストを格納する。
         sa.Column("occurred_at", sa.Text(), nullable=False),
     )
 
 
 def downgrade() -> None:
-    # Reverse order: child tables first (CASCADE FK order), then root.
-    # 1. Drop deepest child tables (no dependents within this migration).
+    # 逆順: まず子テーブル（CASCADE FK 順）、次にルート。
+    # 1. 最深の子テーブルを削除する（本マイグレーション内に依存先がない）。
     op.drop_table("external_review_audit_entries")
     op.drop_table("external_review_gate_attachments")
 
-    # 2. Drop indexes before dropping root table.
+    # 2. ルート テーブル削除前にインデックスを削除する。
     op.drop_index(
         "ix_external_review_gates_decision",
         table_name="external_review_gates",
@@ -191,5 +191,5 @@ def downgrade() -> None:
         table_name="external_review_gates",
     )
 
-    # 3. Drop root table.
+    # 3. ルート テーブルを削除する。
     op.drop_table("external_review_gates")

--- a/backend/alembic/versions/0009_empire_archived.py
+++ b/backend/alembic/versions/0009_empire_archived.py
@@ -1,7 +1,7 @@
-"""Add ``archived`` column to ``empires`` table (確定 I).
+"""``empires`` テーブルに ``archived`` カラムを追加（確定 I）。
 
-Adds the logical-delete flag required by UC-EM-010 / REQ-EM-HTTP-005
-(``DELETE /api/empires/{id}`` → soft-delete).
+UC-EM-010 / REQ-EM-HTTP-005（``DELETE /api/empires/{id}`` → 論理削除）が要求する
+論理削除フラグを追加する。
 
 Revision ID: 0009_empire_archived
 Revises: 0008_external_review_gate_aggregate
@@ -34,8 +34,8 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    # SQLite does not support ALTER TABLE ... DROP COLUMN directly via Alembic
-    # without batch mode — use batch_alter_table as specified in 確定 I.
-    # See: https://alembic.sqlalchemy.org/en/latest/batch.html
+    # SQLite は Alembic の通常モードでは ALTER TABLE ... DROP COLUMN を直接
+    # サポートしない — 確定 I で指定された通り batch_alter_table を使う。
+    # 参照: https://alembic.sqlalchemy.org/en/latest/batch.html
     with op.batch_alter_table("empires") as batch_op:
         batch_op.drop_column("archived")

--- a/backend/src/bakufu/__init__.py
+++ b/backend/src/bakufu/__init__.py
@@ -1,3 +1,3 @@
-"""bakufu backend package root."""
+"""bakufu バックエンドのパッケージルート。"""
 
 __version__: str = "0.0.0"

--- a/backend/src/bakufu/application/__init__.py
+++ b/backend/src/bakufu/application/__init__.py
@@ -1,17 +1,15 @@
-"""Application layer.
+"""Application 層。
 
-Sits between :mod:`bakufu.domain` (pure DDD aggregates) and
-:mod:`bakufu.infrastructure` (SQLite / FS / process I/O). The layer
-owns:
+:mod:`bakufu.domain`（純粋な DDD Aggregate）と :mod:`bakufu.infrastructure`
+（SQLite / FS / プロセス I/O）の中間に位置する。本層が保有するのは:
 
-* **Ports** (:mod:`bakufu.application.ports`) — :class:`typing.Protocol`
-  contracts that the infrastructure layer must satisfy. Hexagonal
-  Architecture's "ports and adapters" pattern.
-* **Services** (later PRs) — orchestration / Unit-of-Work coordination
-  / cross-aggregate Tx boundaries.
+* **Ports**（:mod:`bakufu.application.ports`） — infrastructure 層が満たすべき
+  :class:`typing.Protocol` 契約。Hexagonal Architecture の "ports and adapters"
+  パターン。
+* **Services**（後続 PR） — オーケストレーション、Unit-of-Work の協調、
+  Aggregate 横断 Tx 境界。
 
-Dependency direction is **strictly** ``domain ← application ←
-infrastructure``: this package may import from ``domain`` but not from
-``infrastructure``; ``infrastructure`` imports the ports defined here
-to declare adapter classes.
+依存方向は **厳格に** ``domain ← application ← infrastructure``。本パッケージは
+``domain`` を import してよいが ``infrastructure`` を import してはならない。
+``infrastructure`` はここで定義した ports を import して adapter クラスを宣言する。
 """

--- a/backend/src/bakufu/application/exceptions/__init__.py
+++ b/backend/src/bakufu/application/exceptions/__init__.py
@@ -1,1 +1,1 @@
-"""Application layer exceptions."""
+"""Application 層の例外。"""

--- a/backend/src/bakufu/application/exceptions/empire_exceptions.py
+++ b/backend/src/bakufu/application/exceptions/empire_exceptions.py
@@ -1,24 +1,23 @@
-"""Empire application-layer exceptions (確定 F).
+"""Empire アプリケーション層の例外（確定 F）。
 
-These are application-level exceptions, independent of domain-layer
-``EmpireInvariantViolation``. The interfaces layer's exception handlers
-catch these and convert them to HTTP responses.
+これらは、ドメイン層の ``EmpireInvariantViolation`` とは独立したアプリケーション層
+レベルの例外である。interfaces 層の例外ハンドラがこれらを捕捉し、HTTP レスポンス
+へ変換する。
 
-* :class:`EmpireNotFoundError` — target Empire not found (404)
-* :class:`EmpireAlreadyExistsError` — Empire already exists (409, R1-5)
-* :class:`EmpireArchivedError` — update attempted on archived Empire (409, R1-8)
+* :class:`EmpireNotFoundError` — 対象の Empire が存在しない（404）
+* :class:`EmpireAlreadyExistsError` — Empire が既に存在する（409, R1-5）
+* :class:`EmpireArchivedError` — アーカイブ済み Empire への更新試行（409, R1-8）
 """
 
 from __future__ import annotations
 
 
 class EmpireNotFoundError(Exception):
-    """Raised when the requested Empire does not exist.
+    """要求された Empire が存在しないときに送出される。
 
-    Raised by ``EmpireService.find_by_id`` when the repository returns
-    ``None``, and by ``EmpireService.archive`` on the same condition.
-    The interfaces layer converts this to HTTP 404 / ``not_found``
-    (MSG-EM-HTTP-002).
+    ``EmpireService.find_by_id`` がリポジトリから ``None`` を受け取った場合、および
+    ``EmpireService.archive`` で同条件のときに送出される。interfaces 層では
+    HTTP 404 / ``not_found``（MSG-EM-HTTP-002）に変換される。
     """
 
     def __init__(self, empire_id: str) -> None:
@@ -27,11 +26,11 @@ class EmpireNotFoundError(Exception):
 
 
 class EmpireAlreadyExistsError(Exception):
-    """Raised when ``EmpireService.create`` detects an existing Empire (R1-5).
+    """``EmpireService.create`` が既存の Empire を検出したときに送出される（R1-5）。
 
-    Bakufu's Empire is a singleton; ``EmpireRepository.count() > 0``
-    triggers this. The interfaces layer converts it to HTTP 409 /
-    ``conflict`` (MSG-EM-HTTP-001).
+    bakufu の Empire はシングルトンであり、``EmpireRepository.count() > 0`` で
+    本例外がトリガされる。interfaces 層では HTTP 409 / ``conflict``
+    （MSG-EM-HTTP-001）に変換される。
     """
 
     def __init__(self) -> None:
@@ -39,11 +38,10 @@ class EmpireAlreadyExistsError(Exception):
 
 
 class EmpireArchivedError(Exception):
-    """Raised when an update is attempted on an archived Empire (R1-8).
+    """アーカイブ済み Empire に対して更新が試みられたときに送出される（R1-8）。
 
-    Checked in ``EmpireService.update`` before applying any field change.
-    The interfaces layer converts this to HTTP 409 / ``conflict``
-    (MSG-EM-HTTP-003).
+    ``EmpireService.update`` 内で、フィールド変更を適用する前にチェックされる。
+    interfaces 層では HTTP 409 / ``conflict``（MSG-EM-HTTP-003）に変換される。
     """
 
     def __init__(self, empire_id: str) -> None:

--- a/backend/src/bakufu/application/ports/__init__.py
+++ b/backend/src/bakufu/application/ports/__init__.py
@@ -1,15 +1,15 @@
-"""Repository ports (one Protocol per Aggregate).
+"""Repository ports（Aggregate ごとに 1 Protocol）。
 
-Each Aggregate owns its own :class:`typing.Protocol` file under this
-package so:
+各 Aggregate は本パッケージ配下に専用の :class:`typing.Protocol` ファイルを保有する。
+これにより:
 
-1. The contract surface of one Aggregate is searchable in isolation.
-2. Adding a new Repository for a new Aggregate is a single file diff.
-3. The ports stay free of any infrastructure imports — the domain
-   types they reference are the same VOs the Aggregate Roots use.
+1. ある Aggregate の契約面を単独で検索できる。
+2. 新しい Aggregate に対する Repository の追加が単一ファイルの差分で済む。
+3. ports は infrastructure の import から完全に分離される —
+   参照するドメイン型は Aggregate Root が用いる VO と同一。
 
-See ``docs/features/empire-repository/detailed-design.md`` §確定 A
-(イーロン承認済み, "Repository ポート配置 — Aggregate 別ファイル分離")
-for the placement rule. Subsequent ``feature/{aggregate}-repository``
-PRs add their own files following the same pattern.
+配置ルールは ``docs/features/empire-repository/detailed-design.md`` §確定 A
+（イーロン承認済み「Repository ポート配置 — Aggregate 別ファイル分離」）を参照。
+後続の ``feature/{aggregate}-repository`` PR は同じパターンに従って自身のファイルを
+追加する。
 """

--- a/backend/src/bakufu/application/ports/agent_repository.py
+++ b/backend/src/bakufu/application/ports/agent_repository.py
@@ -1,19 +1,18 @@
-"""Agent Repository port.
+"""Agent Repository ポート。
 
-Per ``docs/features/agent-repository/detailed-design.md`` §確定 A
-(empire-repo / workflow-repo テンプレート 100% 継承) plus §確定 F
-(``find_by_name`` 第 4 method 追加 — the **first** Repository in the
-codebase to extend the canonical 3-method surface):
+``docs/features/agent-repository/detailed-design.md`` §確定 A
+（empire-repo / workflow-repo テンプレート 100% 継承）および §確定 F
+（``find_by_name`` を第 4 メソッドとして追加 — 標準 3 メソッド面を拡張する
+コードベース上 **最初** の Repository）に従う:
 
-* Protocol class with **no** ``@runtime_checkable`` decorator —
-  Python 3.12 ``typing.Protocol`` duck typing is enough.
-* Every method declared ``async def`` (async-first contract).
-* Argument and return types come exclusively from
-  :mod:`bakufu.domain` — no SQLAlchemy types leak across the port.
-* ``find_by_name`` takes ``empire_id`` first because the "name unique
-  within an Empire" invariant is Empire-scoped (§確定 F (a)
-  rejected the global-scope alternative). Argument order **scope →
-  identifier** is the natural reading.
+* Protocol クラスに ``@runtime_checkable`` デコレータを **付けない** —
+  Python 3.12 の ``typing.Protocol`` ダックタイピングで十分。
+* すべてのメソッドを ``async def`` で宣言（async-first 契約）。
+* 引数および戻り値の型は :mod:`bakufu.domain` 由来のもののみ —
+  SQLAlchemy 型がポートを越えて漏れることはない。
+* ``find_by_name`` は ``empire_id`` を第 1 引数に取る。「名前は Empire 内で一意」
+  という不変条件が Empire スコープのため（§確定 F (a) でグローバルスコープ案は
+  却下）。引数順は **スコープ → 識別子** が自然な読み方となる。
 """
 
 from __future__ import annotations
@@ -25,61 +24,57 @@ from bakufu.domain.value_objects import AgentId, EmpireId
 
 
 class AgentRepository(Protocol):
-    """Persistence contract for the :class:`Agent` Aggregate Root.
+    """:class:`Agent` Aggregate Root の永続化契約。
 
-    The application layer (``AgentService.hire`` etc., future PR)
-    consumes this Protocol via dependency injection; the SQLite
-    implementation lives in
-    :mod:`bakufu.infrastructure.persistence.sqlite.repositories.agent_repository`.
+    application 層（``AgentService.hire`` 等、将来 PR）が依存性注入により本
+    Protocol を消費する。SQLite 実装は
+    :mod:`bakufu.infrastructure.persistence.sqlite.repositories.agent_repository`
+    に存在する。
     """
 
     async def find_by_id(self, agent_id: AgentId) -> Agent | None:
-        """Hydrate the Agent whose primary key equals ``agent_id``.
+        """主キーが ``agent_id`` の Agent をハイドレートする。
 
-        Returns ``None`` when the row is absent. SQLAlchemy / driver /
-        ``pydantic.ValidationError`` exceptions propagate untouched so
-        the application service's Unit-of-Work boundary can choose
-        between rollback and surfaced error.
+        該当行がない場合は ``None`` を返す。SQLAlchemy / ドライバ /
+        ``pydantic.ValidationError`` 例外はそのまま伝播させ、application service の
+        Unit-of-Work 境界がロールバックとエラー表出のいずれを取るかを判断できるように
+        する。
         """
         ...
 
     async def count(self) -> int:
-        """Return ``SELECT COUNT(*) FROM agents``.
+        """``SELECT COUNT(*) FROM agents`` を返す。
 
-        Application services use this for bulk-introspection
-        (e.g. monitoring dashboards). Deciding what the count means is
-        the application layer's call (§確定 D).
+        application service は本メソッドを一括イントロスペクション
+        （例: 監視ダッシュボード）に用いる。カウントが何を意味するかを判断するのは
+        application 層の役割（§確定 D）。
         """
         ...
 
     async def save(self, agent: Agent) -> None:
-        """Persist ``agent`` via the §確定 B delete-then-insert flow.
+        """§確定 B の delete-then-insert フローで ``agent`` を永続化する。
 
-        The implementation must run the five-step sequence (UPSERT
-        agents → DELETE agent_providers → bulk INSERT providers →
-        DELETE agent_skills → bulk INSERT skills) within the
-        **caller-managed** transaction. Repositories never call
-        ``session.commit()`` / ``session.rollback()``; the application
-        service owns the Unit-of-Work boundary.
+        実装は **呼び出し元が管理する** トランザクション内で 5 段階のシーケンス
+        （UPSERT agents → DELETE agent_providers → bulk INSERT providers →
+        DELETE agent_skills → bulk INSERT skills）を実行しなければならない。
+        Repository は ``session.commit()`` / ``session.rollback()`` を決して
+        呼び出さない。Unit-of-Work 境界の保有は application service の責務である。
         """
         ...
 
     async def find_by_name(self, empire_id: EmpireId, name: str) -> Agent | None:
-        """Hydrate the Agent named ``name`` inside Empire ``empire_id`` (§確定 F).
+        """Empire ``empire_id`` 内で ``name`` という名前の Agent をハイドレートする（§確定 F）。
 
-        The "name unique within an Empire" invariant is Empire-scoped
-        per ``docs/features/agent/detailed-design.md`` so the
-        Repository takes ``empire_id`` first. Implementations must
-        emit ``WHERE empire_id = :empire_id AND name = :name LIMIT 1``
-        rather than fetching all Agents and filtering in Python (the
-        latter is explicitly rejected as a memory / N+1 pitfall in
-        §確定 F (c)).
+        「名前は Empire 内で一意」という不変条件は Empire スコープであり
+        （``docs/features/agent/detailed-design.md`` 参照）、Repository は
+        ``empire_id`` を第 1 引数に取る。実装は全 Agent を取得して Python 側で
+        フィルタするのではなく、必ず ``WHERE empire_id = :empire_id AND name = :name LIMIT 1``
+        を発行しなければならない（後者はメモリ / N+1 落とし穴として §確定 F (c) で
+        明示的に却下されている）。
 
-        Returns ``None`` when no Agent matches. Implementations are
-        expected to delegate the side-table SELECTs to
-        :meth:`find_by_id` once the AgentId is known so the
-        ``_to_row`` / ``_from_row`` conversion logic is not duplicated
-        (§設計判断補足).
+        該当する Agent がない場合は ``None`` を返す。実装は AgentId が判明した時点で
+        サイドテーブルの SELECT を :meth:`find_by_id` に委譲し、``_to_row`` /
+        ``_from_row`` 変換ロジックの重複を避けることが期待される（§設計判断補足）。
         """
         ...
 

--- a/backend/src/bakufu/application/ports/directive_repository.py
+++ b/backend/src/bakufu/application/ports/directive_repository.py
@@ -1,23 +1,22 @@
-"""Directive Repository port.
+"""Directive Repository ポート。
 
-Per ``docs/features/directive-repository/detailed-design.md`` §確定 R1-A
-(empire-repo / workflow-repo / agent-repo / room-repo テンプレート 100% 継承)
-plus §確定 R1-D (``find_by_room`` — Room-scoped Directive lookup, ORDER BY
-``created_at DESC, id DESC`` for deterministic ordering per BUG-EMR-001 規約)
-and §確定 R1-F (``save(directive)`` — standard 1-argument pattern because
-:class:`Directive` Aggregate holds ``target_room_id`` as its own attribute):
+``docs/features/directive-repository/detailed-design.md`` §確定 R1-A
+（empire-repo / workflow-repo / agent-repo / room-repo テンプレート 100% 継承）に加え、
+§確定 R1-D（``find_by_room`` — Room スコープの Directive 検索、BUG-EMR-001 規約に
+基づき決定的な順序とするため ``created_at DESC, id DESC`` で並べる）および §確定 R1-F
+（``save(directive)`` — :class:`Directive` Aggregate が ``target_room_id`` を自身の
+属性として保持するため、標準の 1 引数パターン）に従う:
 
-* Protocol class with **no** ``@runtime_checkable`` decorator (empire-repo
-  §確定 A: Python 3.12 ``typing.Protocol`` duck typing is sufficient).
-* Every method declared ``async def`` (async-first contract).
-* Argument and return types come exclusively from :mod:`bakufu.domain` —
-  no SQLAlchemy types cross the port boundary.
-* ``save`` signature is ``save(directive: Directive) -> None`` (standard
-  1-argument pattern, §確定 R1-F): :class:`Directive` carries
-  ``target_room_id`` as an attribute so the Repository can read it
-  directly — the non-symmetric Room pattern is not needed here.
-* ``find_by_room`` is the 4th method; ``find_by_task_id`` is deferred to
-  the task-repository PR (YAGNI, §確定 R1-D 後続申し送り).
+* Protocol クラスに ``@runtime_checkable`` デコレータを **付けない**
+  （empire-repo §確定 A: Python 3.12 の ``typing.Protocol`` ダックタイピングで十分）。
+* すべてのメソッドを ``async def`` で宣言（async-first 契約）。
+* 引数および戻り値の型は :mod:`bakufu.domain` 由来のもののみ —
+  SQLAlchemy 型がポート境界を越えることはない。
+* ``save`` のシグネチャは ``save(directive: Directive) -> None``（標準 1 引数パターン、
+  §確定 R1-F）。:class:`Directive` は ``target_room_id`` を属性として持つため、
+  Repository が直接読み取れる — Room の非対称パターンはここでは不要。
+* ``find_by_room`` が第 4 メソッド。``find_by_task_id`` は task-repository PR に
+  延期（YAGNI、§確定 R1-D 後続申し送り）。
 """
 
 from __future__ import annotations
@@ -29,58 +28,56 @@ from bakufu.domain.value_objects import DirectiveId, RoomId
 
 
 class DirectiveRepository(Protocol):
-    """Persistence contract for the :class:`Directive` Aggregate Root.
+    """:class:`Directive` Aggregate Root の永続化契約。
 
-    The application layer (``DirectiveService``, future PRs) consumes this
-    Protocol via dependency injection; the SQLite implementation lives in
-    :mod:`bakufu.infrastructure.persistence.sqlite.repositories.directive_repository`.
+    application 層（``DirectiveService``、将来 PR）が依存性注入により本 Protocol を
+    消費する。SQLite 実装は
+    :mod:`bakufu.infrastructure.persistence.sqlite.repositories.directive_repository`
+    に存在する。
     """
 
     async def find_by_id(self, directive_id: DirectiveId) -> Directive | None:
-        """Hydrate the Directive whose primary key equals ``directive_id``.
+        """主キーが ``directive_id`` の Directive をハイドレートする。
 
-        Returns ``None`` when the row is absent. SQLAlchemy / driver /
-        ``pydantic.ValidationError`` exceptions propagate untouched so the
-        application service's Unit-of-Work boundary can choose between
-        rollback and surfaced error.
+        該当行がない場合は ``None`` を返す。SQLAlchemy / ドライバ /
+        ``pydantic.ValidationError`` 例外はそのまま伝播させ、application service の
+        Unit-of-Work 境界がロールバックとエラー表出のいずれを取るかを判断できるように
+        する。
         """
         ...
 
     async def count(self) -> int:
-        """Return ``SELECT COUNT(*) FROM directives``.
+        """``SELECT COUNT(*) FROM directives`` を返す。
 
-        Application services use this for monitoring / bulk introspection.
-        The count is global (§確定 R1-A: SQL ``COUNT(*)`` contract,
-        empire-repo §確定 D 踏襲).
+        application service は本メソッドを監視 / 一括イントロスペクションに用いる。
+        カウントはグローバル（§確定 R1-A: SQL ``COUNT(*)`` 契約、empire-repo
+        §確定 D 踏襲）。
         """
         ...
 
     async def save(self, directive: Directive) -> None:
-        """Persist ``directive`` via a single-table UPSERT (§確定 R1-B).
+        """単一テーブルの UPSERT で ``directive`` を永続化する（§確定 R1-B）。
 
-        Directive has no child tables, so the save flow reduces to one step:
-        ``INSERT INTO directives ... ON CONFLICT (id) DO UPDATE SET ...``.
+        Directive には子テーブルが存在しないため、save フローは 1 ステップに集約される:
+        ``INSERT INTO directives ... ON CONFLICT (id) DO UPDATE SET ...``。
 
-        ``target_room_id`` is read from ``directive.target_room_id`` directly
-        (§確定 R1-F: standard 1-argument pattern). The implementation must
-        not call ``session.commit()`` / ``session.rollback()``; the
-        application service owns the Unit-of-Work boundary (empire-repo
-        §確定 B 踏襲).
+        ``target_room_id`` は ``directive.target_room_id`` から直接読み取る
+        （§確定 R1-F: 標準 1 引数パターン）。実装は ``session.commit()`` /
+        ``session.rollback()`` を呼んではならない。Unit-of-Work 境界の保有は
+        application service の責務である（empire-repo §確定 B 踏襲）。
         """
         ...
 
     async def find_by_room(self, room_id: RoomId) -> list[Directive]:
-        """Return all Directives targeting ``room_id``, newest first.
+        """``room_id`` を対象とする全 Directive を新しい順に返す。
 
-        ORDER BY ``created_at DESC, id DESC`` (BUG-EMR-001 規約: composite
-        key for deterministic ordering — ``created_at`` alone is insufficient
-        when multiple Directives share the same timestamp; ``id`` (PK, UUID)
-        is the tiebreaker that makes the result fully deterministic).
+        ORDER BY ``created_at DESC, id DESC``（BUG-EMR-001 規約: 決定的な順序付けの
+        ための複合キー — 複数の Directive が同一タイムスタンプを持つ場合 ``created_at``
+        単独では不十分。``id``（PK、UUID）が tiebreaker として結果を完全に決定的にする）。
 
-        Returns ``[]`` when no Directives exist for the Room. The empty-list
-        response does not distinguish between "Room exists but has no
-        Directives" and "Room does not exist" — that distinction is the
-        application layer's responsibility.
+        Room に対して Directive が存在しない場合は ``[]`` を返す。空リスト応答は
+        「Room は存在するが Directive がない」と「Room が存在しない」を区別しない —
+        この区別は application 層の責務である。
         """
         ...
 

--- a/backend/src/bakufu/application/ports/empire_repository.py
+++ b/backend/src/bakufu/application/ports/empire_repository.py
@@ -1,16 +1,16 @@
-"""Empire Repository port.
+"""Empire Repository ポート。
 
-Per ``docs/features/empire-repository/detailed-design.md`` §確定 A:
+``docs/features/empire-repository/detailed-design.md`` §確定 A に従う:
 
-* Protocol class with **no** ``@runtime_checkable`` decorator — Python
-  3.12 ``typing.Protocol`` duck typing is enough; the runtime overhead
-  of ``@runtime_checkable`` adds ``isinstance`` paths the application
-  layer never needs.
-* Every method declared ``async def`` (async-first contract) so the
-  application layer can compose Repositories inside an
-  ``async with session.begin():`` Unit-of-Work.
-* Argument and return types come exclusively from
-  :mod:`bakufu.domain` — no SQLAlchemy types leak across the port.
+* Protocol クラスに ``@runtime_checkable`` デコレータを **付けない** —
+  Python 3.12 の ``typing.Protocol`` ダックタイピングで十分。
+  ``@runtime_checkable`` の実行時オーバーヘッドは、application 層が必要としない
+  ``isinstance`` 経路を増やしてしまう。
+* すべてのメソッドを ``async def`` で宣言（async-first 契約）。これにより
+  application 層は ``async with session.begin():`` の Unit-of-Work 内で
+  Repository を組み合わせられる。
+* 引数および戻り値の型は :mod:`bakufu.domain` 由来のもののみ —
+  SQLAlchemy 型がポートを越えて漏れることはない。
 """
 
 from __future__ import annotations
@@ -22,52 +22,50 @@ from bakufu.domain.value_objects import EmpireId
 
 
 class EmpireRepository(Protocol):
-    """Persistence contract for the :class:`Empire` Aggregate Root.
+    """:class:`Empire` Aggregate Root の永続化契約。
 
-    The application layer (``EmpireService``) consumes this Protocol
-    via dependency injection; the SQLite implementation lives in
-    :mod:`bakufu.infrastructure.persistence.sqlite.repositories.empire_repository`.
+    application 層（``EmpireService``）が依存性注入により本 Protocol を消費する。
+    SQLite 実装は
+    :mod:`bakufu.infrastructure.persistence.sqlite.repositories.empire_repository`
+    に存在する。
     """
 
     async def find_by_id(self, empire_id: EmpireId) -> Empire | None:
-        """Hydrate the Empire whose primary key equals ``empire_id``.
+        """主キーが ``empire_id`` の Empire をハイドレートする。
 
-        Returns ``None`` when the row is absent. Implementations
-        propagate SQLAlchemy / driver exceptions unchanged so the
-        Unit-of-Work boundary in the application service can choose
-        between rollback and surfaced error.
+        該当行がない場合は ``None`` を返す。実装は SQLAlchemy / ドライバの例外を
+        そのまま伝播させ、application service の Unit-of-Work 境界がロールバックと
+        エラー表出のいずれを取るかを判断できるようにする。
         """
         ...
 
     async def find_all(self) -> list[Empire]:
-        """Return all Empire rows as a list.
+        """全 Empire 行をリストとして返す。
 
-        Bakufu's Empire is a singleton, so the result is 0 or 1 element.
-        ``EmpireService.find_all()`` uses this to back
-        ``GET /api/empires`` (REQ-EM-HTTP-002).
+        bakufu の Empire はシングルトンであるため、結果は 0 件または 1 件の要素となる。
+        ``EmpireService.find_all()`` がこれを ``GET /api/empires``（REQ-EM-HTTP-002）の
+        裏付けに用いる。
         """
         ...
 
     async def count(self) -> int:
-        """Return ``SELECT COUNT(*) FROM empires``.
+        """``SELECT COUNT(*) FROM empires`` を返す。
 
-        ``EmpireService.create()`` calls this to enforce the Empire
-        singleton invariant. The count itself is the Repository's
-        responsibility; deciding whether ``count == 0`` /
-        ``count == 1`` / ``count >= 2`` triggers a service-level error
-        is the *application* layer's call (§確定 D).
+        ``EmpireService.create()`` は本メソッドを呼び出して Empire シングルトン不変条件を
+        強制する。カウント自体は Repository の責務だが、``count == 0`` /
+        ``count == 1`` / ``count >= 2`` のいずれが service レベルのエラーを起こすかの
+        判断は *application* 層の役割である（§確定 D）。
         """
         ...
 
     async def save(self, empire: Empire) -> None:
-        """Persist ``empire`` via the §確定 B delete-then-insert flow.
+        """§確定 B の delete-then-insert フローで ``empire`` を永続化する。
 
-        The implementation must run the five-step sequence (UPSERT
-        empires → DELETE empire_room_refs → bulk INSERT room_refs →
-        DELETE empire_agent_refs → bulk INSERT agent_refs) within the
-        **caller-managed** transaction. Repositories never call
-        ``session.commit()`` / ``session.rollback()``; the application
-        service owns the Unit-of-Work boundary.
+        実装は **呼び出し元が管理する** トランザクション内で 5 段階のシーケンス
+        （UPSERT empires → DELETE empire_room_refs → bulk INSERT room_refs →
+        DELETE empire_agent_refs → bulk INSERT agent_refs）を実行しなければならない。
+        Repository は ``session.commit()`` / ``session.rollback()`` を決して
+        呼び出さない。Unit-of-Work 境界の保有は application service の責務である。
         """
         ...
 

--- a/backend/src/bakufu/application/ports/external_review_gate_repository.py
+++ b/backend/src/bakufu/application/ports/external_review_gate_repository.py
@@ -1,20 +1,19 @@
-"""ExternalReviewGate Repository port.
+"""ExternalReviewGate Repository ポート。
 
-Per ``docs/features/external-review-gate-repository/detailed-design.md``
-§確定 R1-A (empire-repo / workflow-repo / agent-repo / room-repo /
-directive-repo / task-repo テンプレート 100% 継承) plus Gate-specific
-query methods:
+``docs/features/external-review-gate-repository/detailed-design.md`` §確定 R1-A
+（empire-repo / workflow-repo / agent-repo / room-repo / directive-repo / task-repo
+テンプレート 100% 継承）に加え、Gate 固有のクエリメソッドに従う:
 
-* Protocol class with **no** ``@runtime_checkable`` decorator (empire-repo
-  §確定 A: Python 3.12 ``typing.Protocol`` duck typing is sufficient).
-* Every method declared ``async def`` (async-first contract).
-* Argument and return types come exclusively from :mod:`bakufu.domain` —
-  no SQLAlchemy types cross the port boundary.
-* ``save`` signature is ``save(gate: ExternalReviewGate) -> None`` (standard
-  1-argument pattern): :class:`ExternalReviewGate` carries all own attributes
-  so the Repository reads them directly.
-* Four Gate-specific query methods beyond the empire-repo §確定 B baseline
-  (``find_pending_by_reviewer`` / ``find_by_task_id`` / ``count_by_decision``).
+* Protocol クラスに ``@runtime_checkable`` デコレータを **付けない**
+  （empire-repo §確定 A: Python 3.12 の ``typing.Protocol`` ダックタイピングで十分）。
+* すべてのメソッドを ``async def`` で宣言（async-first 契約）。
+* 引数および戻り値の型は :mod:`bakufu.domain` 由来のもののみ —
+  SQLAlchemy 型がポート境界を越えることはない。
+* ``save`` のシグネチャは ``save(gate: ExternalReviewGate) -> None``
+  （標準 1 引数パターン）。:class:`ExternalReviewGate` がすべての属性を保持するため、
+  Repository が直接読み取る。
+* empire-repo §確定 B のベースラインに加え、Gate 固有のクエリメソッドを 4 つ持つ
+  （``find_pending_by_reviewer`` / ``find_by_task_id`` / ``count_by_decision``）。
 """
 
 from __future__ import annotations
@@ -26,82 +25,81 @@ from bakufu.domain.value_objects import GateId, OwnerId, ReviewDecision, TaskId
 
 
 class ExternalReviewGateRepository(Protocol):
-    """Persistence contract for the :class:`ExternalReviewGate` Aggregate Root.
+    """:class:`ExternalReviewGate` Aggregate Root の永続化契約。
 
-    The application layer (``GateService``, future PRs) consumes this
-    Protocol via dependency injection; the SQLite implementation lives in
-    :mod:`bakufu.infrastructure.persistence.sqlite.repositories.external_review_gate_repository`.
+    application 層（``GateService``、将来 PR）が依存性注入により本 Protocol を
+    消費する。SQLite 実装は
+    :mod:`bakufu.infrastructure.persistence.sqlite.repositories.external_review_gate_repository`
+    に存在する。
     """
 
     async def find_by_id(self, gate_id: GateId) -> ExternalReviewGate | None:
-        """Hydrate the Gate whose primary key equals ``gate_id``.
+        """主キーが ``gate_id`` の Gate をハイドレートする。
 
-        Returns ``None`` when the row is absent. Both child tables
-        (external_review_gate_attachments / external_review_audit_entries)
-        are fetched and included in the hydrated Gate. SQLAlchemy / driver /
-        ``pydantic.ValidationError`` exceptions propagate untouched so the
-        application service's Unit-of-Work boundary can choose between
-        rollback and surfaced error.
+        該当行がない場合は ``None`` を返す。両方の子テーブル
+        （external_review_gate_attachments / external_review_audit_entries）が
+        フェッチされ、ハイドレートされた Gate に含まれる。SQLAlchemy / ドライバ /
+        ``pydantic.ValidationError`` 例外はそのまま伝播させ、application service の
+        Unit-of-Work 境界がロールバックとエラー表出のいずれを取るかを判断できるように
+        する。
         """
         ...
 
     async def count(self) -> int:
-        """Return ``SELECT COUNT(*) FROM external_review_gates``.
+        """``SELECT COUNT(*) FROM external_review_gates`` を返す。
 
-        Global count across all Gates regardless of decision or reviewer.
-        Application services use this for monitoring / bulk introspection
-        (empire-repo §確定 D 踏襲).
+        decision や reviewer に関わらず、全 Gate を横断するグローバルカウント。
+        application service は本メソッドを監視 / 一括イントロスペクションに用いる
+        （empire-repo §確定 D 踏襲）。
         """
         ...
 
     async def save(self, gate: ExternalReviewGate) -> None:
-        """Persist ``gate`` via the §確定 R1-B 5-step delete-then-insert.
+        """§確定 R1-B の 5 段階 delete-then-insert で ``gate`` を永続化する。
 
-        The save flow covers all three tables:
+        save フローは 3 つのテーブルすべてを対象とする:
 
         1. DELETE external_review_gate_attachments WHERE gate_id = :id
         2. DELETE external_review_audit_entries WHERE gate_id = :id
-        3. UPSERT external_review_gates (ON CONFLICT id DO UPDATE mutable fields)
-        4. INSERT external_review_gate_attachments (per Attachment in snapshot)
-        5. INSERT external_review_audit_entries (per AuditEntry in audit_trail)
+        3. UPSERT external_review_gates（ON CONFLICT id DO UPDATE で可変フィールド更新）
+        4. INSERT external_review_gate_attachments（snapshot 内の Attachment ごと）
+        5. INSERT external_review_audit_entries（audit_trail 内の AuditEntry ごと）
 
-        The implementation must not call ``session.commit()`` /
-        ``session.rollback()``; the application service owns the
-        Unit-of-Work boundary (empire-repo §確定 B 踏襲).
+        実装は ``session.commit()`` / ``session.rollback()`` を呼んではならない。
+        Unit-of-Work 境界の保有は application service の責務である
+        （empire-repo §確定 B 踏襲）。
         """
         ...
 
     async def find_pending_by_reviewer(self, reviewer_id: OwnerId) -> list[ExternalReviewGate]:
-        """Return all PENDING Gates for ``reviewer_id`` ordered ``created_at DESC, id DESC``.
+        """``reviewer_id`` の全 PENDING Gate を ``created_at DESC, id DESC`` の順で返す。
 
-        Used by ``GateService`` to surface a reviewer's open review queue.
-        Returns ``[]`` when no PENDING Gates exist for the given reviewer.
+        ``GateService`` が reviewer のオープンなレビューキューを表面化するために用いる。
+        該当 reviewer に PENDING Gate が存在しない場合は ``[]`` を返す。
 
-        ORDER BY ``created_at DESC, id DESC`` (BUG-EMR-001 規約: composite
-        key for deterministic ordering — ``created_at`` alone is
-        insufficient when multiple Gates share the same timestamp; ``id``
-        (PK, UUID) is the tiebreaker that makes the result fully
-        deterministic).
+        ORDER BY ``created_at DESC, id DESC``（BUG-EMR-001 規約: 決定的な順序付けの
+        ための複合キー — 複数の Gate が同一タイムスタンプを持つ場合 ``created_at``
+        単独では不十分。``id``（PK、UUID）が tiebreaker として結果を完全に決定的にする）。
         """
         ...
 
     async def find_by_task_id(self, task_id: TaskId) -> list[ExternalReviewGate]:
-        """Return all Gates for ``task_id`` ordered ``created_at ASC, id ASC``.
+        """``task_id`` の全 Gate を ``created_at ASC, id ASC`` の順で返す。
 
-        Used by ``GateService`` to fetch the full review history for a Task.
-        Returns ``[]`` when no Gates exist for the given Task.
+        ``GateService`` が Task の完全なレビュー履歴を取得するために用いる。
+        該当 Task に Gate が存在しない場合は ``[]`` を返す。
 
-        ORDER BY ``created_at ASC, id ASC`` — chronological ordering matches
-        the "review history" read pattern where older gates appear first.
+        ORDER BY ``created_at ASC, id ASC`` — 古い gate が先に現れる「レビュー履歴」の
+        読み取りパターンに合致する時系列順。
         """
         ...
 
     async def count_by_decision(self, decision: ReviewDecision) -> int:
-        """Return ``SELECT COUNT(*) FROM external_review_gates WHERE decision = :decision``.
+        """``SELECT COUNT(*) FROM external_review_gates WHERE decision = :decision`` を返す。
 
-        Used for dashboard metrics (PENDING backlog size, APPROVED / REJECTED /
-        CANCELLED historical counts).
-        Returns 0 when no Gates exist with the given decision.
+        ダッシュボード指標（PENDING バックログサイズ、APPROVED / REJECTED /
+        CANCELLED の履歴件数）に用いる。
+        該当 decision の Gate が存在しない場合は 0 を返す。
         """
         ...
 

--- a/backend/src/bakufu/application/ports/room_repository.py
+++ b/backend/src/bakufu/application/ports/room_repository.py
@@ -1,23 +1,23 @@
-"""Room Repository port.
+"""Room Repository ポート。
 
-Per ``docs/features/room-repository/detailed-design.md`` §確定 R1-A
-(empire-repo / workflow-repo / agent-repo テンプレート 100% 継承) plus
-§確定 R1-F (``find_by_name`` 第 4 method — Empire-scoped name lookup)
-and §確定 R1-H (``save(room, empire_id)`` — empire_id passed as argument
-because :class:`Room` Aggregate holds no ``empire_id`` attribute):
+``docs/features/room-repository/detailed-design.md`` §確定 R1-A
+（empire-repo / workflow-repo / agent-repo テンプレート 100% 継承）に加え、
+§確定 R1-F（``find_by_name`` を第 4 メソッドとして追加 — Empire スコープでの
+名前検索）および §確定 R1-H（``save(room, empire_id)`` — :class:`Room` Aggregate が
+``empire_id`` 属性を保持しないため、empire_id を引数で渡す）に従う:
 
-* Protocol class with **no** ``@runtime_checkable`` decorator (empire-repo
-  §確定 A: Python 3.12 ``typing.Protocol`` duck typing is sufficient).
-* Every method declared ``async def`` (async-first contract).
-* Argument and return types come exclusively from :mod:`bakufu.domain` —
-  no SQLAlchemy types cross the port boundary.
-* ``save`` signature is ``save(room: Room, empire_id: EmpireId) -> None``
-  because :class:`Room` does not carry ``empire_id`` (ownership is
-  expressed via ``Empire.rooms: list[RoomRef]``); the calling service
-  always has ``empire_id`` at hand and passes it as an argument rather
-  than forcing a domain-model change (§確定 R1-H).
-* ``find_by_name`` takes ``empire_id`` first because Room name uniqueness
-  is Empire-scoped (§確定 R1-F: ``WHERE empire_id = :e AND name = :n``).
+* Protocol クラスに ``@runtime_checkable`` デコレータを **付けない**
+  （empire-repo §確定 A: Python 3.12 の ``typing.Protocol`` ダックタイピングで十分）。
+* すべてのメソッドを ``async def`` で宣言（async-first 契約）。
+* 引数および戻り値の型は :mod:`bakufu.domain` 由来のもののみ —
+  SQLAlchemy 型がポート境界を越えることはない。
+* ``save`` のシグネチャは ``save(room: Room, empire_id: EmpireId) -> None``。
+  :class:`Room` は ``empire_id`` を保持しない（所有関係は
+  ``Empire.rooms: list[RoomRef]`` で表現される）ため、呼び出し元のサービスが常に
+  保持している ``empire_id`` をドメインモデル変更を強制せずに引数として渡す
+  （§確定 R1-H）。
+* ``find_by_name`` は ``empire_id`` を第 1 引数に取る。Room の名前一意性は Empire
+  スコープのため（§確定 R1-F: ``WHERE empire_id = :e AND name = :n``）。
 """
 
 from __future__ import annotations
@@ -29,60 +29,59 @@ from bakufu.domain.value_objects import EmpireId, RoomId
 
 
 class RoomRepository(Protocol):
-    """Persistence contract for the :class:`Room` Aggregate Root.
+    """:class:`Room` Aggregate Root の永続化契約。
 
-    The application layer (``RoomService``, ``EmpireService``, future PRs)
-    consumes this Protocol via dependency injection; the SQLite implementation
-    lives in
-    :mod:`bakufu.infrastructure.persistence.sqlite.repositories.room_repository`.
+    application 層（``RoomService``、``EmpireService``、将来 PR）が依存性注入により
+    本 Protocol を消費する。SQLite 実装は
+    :mod:`bakufu.infrastructure.persistence.sqlite.repositories.room_repository`
+    に存在する。
     """
 
     async def find_by_id(self, room_id: RoomId) -> Room | None:
-        """Hydrate the Room whose primary key equals ``room_id``.
+        """主キーが ``room_id`` の Room をハイドレートする。
 
-        Returns ``None`` when the row is absent. SQLAlchemy / driver /
-        ``pydantic.ValidationError`` exceptions propagate untouched so the
-        application service's Unit-of-Work boundary can choose between
-        rollback and surfaced error.
+        該当行がない場合は ``None`` を返す。SQLAlchemy / ドライバ /
+        ``pydantic.ValidationError`` 例外はそのまま伝播させ、application service の
+        Unit-of-Work 境界がロールバックとエラー表出のいずれを取るかを判断できるように
+        する。
         """
         ...
 
     async def count(self) -> int:
-        """Return ``SELECT COUNT(*) FROM rooms``.
+        """``SELECT COUNT(*) FROM rooms`` を返す。
 
-        Application services use this for monitoring / bulk introspection.
-        The count is empire-global (§確定 R1-D: SQL ``COUNT(*)`` contract,
-        empire-repo §確定 D 踏襲).
+        application service は本メソッドを監視 / 一括イントロスペクションに用いる。
+        カウントは Empire グローバル（§確定 R1-D: SQL ``COUNT(*)`` 契約、empire-repo
+        §確定 D 踏襲）。
         """
         ...
 
     async def save(self, room: Room, empire_id: EmpireId) -> None:
-        """Persist ``room`` via the §確定 R1-B three-step delete-then-insert.
+        """§確定 R1-B の 3 段階 delete-then-insert で ``room`` を永続化する。
 
-        ``empire_id`` is passed as an explicit argument because :class:`Room`
-        does not hold ``empire_id`` as an attribute (room §確定 — ownership is
-        expressed via ``Empire.rooms``). The calling service always has
-        ``empire_id`` in scope and passes it here (§確定 R1-H).
+        ``empire_id`` を明示的な引数として渡す。これは :class:`Room` が ``empire_id``
+        を属性として保持しないため（room §確定 — 所有関係は ``Empire.rooms`` で
+        表現される）。呼び出し元のサービスは常に ``empire_id`` をスコープに持つので
+        ここで渡す（§確定 R1-H）。
 
-        The implementation must run the three-step sequence (UPSERT rooms →
-        DELETE room_members → bulk INSERT room_members) within the
-        **caller-managed** transaction. Repositories never call
-        ``session.commit()`` / ``session.rollback()``; the application service
-        owns the Unit-of-Work boundary (empire-repo §確定 B 踏襲).
+        実装は **呼び出し元が管理する** トランザクション内で 3 段階のシーケンス
+        （UPSERT rooms → DELETE room_members → bulk INSERT room_members）を
+        実行しなければならない。Repository は ``session.commit()`` /
+        ``session.rollback()`` を決して呼び出さない。Unit-of-Work 境界の保有は
+        application service の責務である（empire-repo §確定 B 踏襲）。
         """
         ...
 
     async def find_by_name(self, empire_id: EmpireId, name: str) -> Room | None:
-        """Hydrate the Room named ``name`` inside Empire ``empire_id`` (§確定 R1-F).
+        """Empire ``empire_id`` 内で ``name`` という名前の Room をハイドレートする（§確定 R1-F）。
 
-        Two-stage flow: a lightweight ``SELECT id ... LIMIT 1`` locates the
-        RoomId, then delegation to :meth:`find_by_id` so the child-table
-        SELECTs and ``_from_row`` conversion stay single-sourced (agent §R1-C
-        inheritance pattern).
+        2 段階フロー: 軽量な ``SELECT id ... LIMIT 1`` で RoomId を特定し、
+        :meth:`find_by_id` に委譲することで子テーブルの SELECT と ``_from_row``
+        変換を一元化する（agent §R1-C 継承パターン）。
 
-        Returns ``None`` when no Room matches. The implementation must not
-        fetch all Rooms and filter in Python — that pattern is explicitly
-        rejected as a memory / N+1 pitfall in §確定 R1-F (c).
+        該当 Room がない場合は ``None`` を返す。実装は全 Room を取得して Python 側で
+        フィルタしてはならない — そのパターンはメモリ / N+1 落とし穴として
+        §確定 R1-F (c) で明示的に却下されている。
         """
         ...
 

--- a/backend/src/bakufu/application/ports/task_repository.py
+++ b/backend/src/bakufu/application/ports/task_repository.py
@@ -1,20 +1,19 @@
-"""Task Repository port.
+"""Task Repository ポート。
 
-Per ``docs/features/task-repository/detailed-design.md`` §確定 R1-A
-(empire-repo / workflow-repo / agent-repo / room-repo / directive-repo
-テンプレート 100% 継承) plus §確定 R1-D (additional Task-specific methods):
+``docs/features/task-repository/detailed-design.md`` §確定 R1-A
+（empire-repo / workflow-repo / agent-repo / room-repo / directive-repo
+テンプレート 100% 継承）に加え、§確定 R1-D（Task 固有メソッドの追加）に従う:
 
-* Protocol class with **no** ``@runtime_checkable`` decorator (empire-repo
-  §確定 A: Python 3.12 ``typing.Protocol`` duck typing is sufficient).
-* Every method declared ``async def`` (async-first contract).
-* Argument and return types come exclusively from :mod:`bakufu.domain` —
-  no SQLAlchemy types cross the port boundary.
-* ``save`` signature is ``save(task: Task) -> None`` (standard 1-argument
-  pattern, §確定 R1-F): :class:`Task` carries ``room_id`` and
-  ``directive_id`` as own attributes so the Repository reads them directly.
-* Three Task-specific query methods beyond the empire-repo §確定 B baseline
-  (``count_by_status`` / ``count_by_room`` / ``find_blocked``) are
-  included per §確定 R1-D.
+* Protocol クラスに ``@runtime_checkable`` デコレータを **付けない**
+  （empire-repo §確定 A: Python 3.12 の ``typing.Protocol`` ダックタイピングで十分）。
+* すべてのメソッドを ``async def`` で宣言（async-first 契約）。
+* 引数および戻り値の型は :mod:`bakufu.domain` 由来のもののみ —
+  SQLAlchemy 型がポート境界を越えることはない。
+* ``save`` のシグネチャは ``save(task: Task) -> None``（標準 1 引数パターン、
+  §確定 R1-F）。:class:`Task` が ``room_id`` および ``directive_id`` を自身の属性として
+  保持するため、Repository が直接読み取れる。
+* §確定 R1-D に従い、empire-repo §確定 B のベースラインに加え Task 固有のクエリ
+  メソッドを 3 つ持つ（``count_by_status`` / ``count_by_room`` / ``find_blocked``）。
 """
 
 from __future__ import annotations
@@ -26,84 +25,83 @@ from bakufu.domain.value_objects import RoomId, TaskId, TaskStatus
 
 
 class TaskRepository(Protocol):
-    """Persistence contract for the :class:`Task` Aggregate Root.
+    """:class:`Task` Aggregate Root の永続化契約。
 
-    The application layer (``TaskService``, future PRs) consumes this
-    Protocol via dependency injection; the SQLite implementation lives in
-    :mod:`bakufu.infrastructure.persistence.sqlite.repositories.task_repository`.
+    application 層（``TaskService``、将来 PR）が依存性注入により本 Protocol を
+    消費する。SQLite 実装は
+    :mod:`bakufu.infrastructure.persistence.sqlite.repositories.task_repository`
+    に存在する。
     """
 
     async def find_by_id(self, task_id: TaskId) -> Task | None:
-        """Hydrate the Task whose primary key equals ``task_id``.
+        """主キーが ``task_id`` の Task をハイドレートする。
 
-        Returns ``None`` when the row is absent. All five child tables
-        (task_assigned_agents / conversations / conversation_messages /
-        deliverables / deliverable_attachments) are fetched and included
-        in the hydrated Task. SQLAlchemy / driver / ``pydantic.ValidationError``
-        exceptions propagate untouched so the application service's
-        Unit-of-Work boundary can choose between rollback and surfaced error.
+        該当行がない場合は ``None`` を返す。5 つのすべての子テーブル
+        （task_assigned_agents / conversations / conversation_messages /
+        deliverables / deliverable_attachments）がフェッチされ、ハイドレートされた
+        Task に含まれる。SQLAlchemy / ドライバ / ``pydantic.ValidationError`` 例外は
+        そのまま伝播させ、application service の Unit-of-Work 境界がロールバックと
+        エラー表出のいずれを取るかを判断できるようにする。
         """
         ...
 
     async def count(self) -> int:
-        """Return ``SELECT COUNT(*) FROM tasks``.
+        """``SELECT COUNT(*) FROM tasks`` を返す。
 
-        Global count across all Tasks regardless of status or room.
-        Application services use this for monitoring / bulk introspection
-        (empire-repo §確定 D 踏襲).
+        ステータスや room を問わず、全 Task を横断するグローバルカウント。
+        application service は本メソッドを監視 / 一括イントロスペクションに用いる
+        （empire-repo §確定 D 踏襲）。
         """
         ...
 
     async def save(self, task: Task) -> None:
-        """Persist ``task`` via the §確定 R1-B 9-step delete-then-insert.
+        """§確定 R1-B の 9 段階 delete-then-insert で ``task`` を永続化する。
 
-        The save flow covers all six tables:
-        1. DELETE deliverables (CASCADE removes deliverable_attachments)
-        2. DELETE conversations (CASCADE removes conversation_messages)
+        save フローは 6 つのテーブルすべてを対象とする:
+        1. DELETE deliverables（CASCADE で deliverable_attachments も削除）
+        2. DELETE conversations（CASCADE で conversation_messages も削除）
         3. DELETE task_assigned_agents
-        4. UPSERT tasks (ON CONFLICT id DO UPDATE)
-        5. INSERT task_assigned_agents (per AgentId, with order_index)
-        6. INSERT conversations (per Conversation)
-        7. INSERT conversation_messages (per Message per Conversation)
-        8. INSERT deliverables (per Deliverable)
-        9. INSERT deliverable_attachments (per Attachment per Deliverable)
+        4. UPSERT tasks（ON CONFLICT id DO UPDATE）
+        5. INSERT task_assigned_agents（AgentId ごと、order_index 付き）
+        6. INSERT conversations（Conversation ごと）
+        7. INSERT conversation_messages（Conversation 内の Message ごと）
+        8. INSERT deliverables（Deliverable ごと）
+        9. INSERT deliverable_attachments（Deliverable 内の Attachment ごと）
 
-        The implementation must not call ``session.commit()`` /
-        ``session.rollback()``; the application service owns the
-        Unit-of-Work boundary (empire-repo §確定 B 踏襲).
+        実装は ``session.commit()`` / ``session.rollback()`` を呼んではならない。
+        Unit-of-Work 境界の保有は application service の責務である
+        （empire-repo §確定 B 踏襲）。
         """
         ...
 
     async def count_by_status(self, status: TaskStatus) -> int:
-        """Return ``SELECT COUNT(*) FROM tasks WHERE status = :status``.
+        """``SELECT COUNT(*) FROM tasks WHERE status = :status`` を返す。
 
-        Used for Room dashboard status aggregations and monitoring.
-        Returns 0 when no Tasks exist with the given status.
+        Room ダッシュボードのステータス集計や監視に用いる。
+        該当 status の Task が存在しない場合は 0 を返す。
         """
         ...
 
     async def count_by_room(self, room_id: RoomId) -> int:
-        """Return ``SELECT COUNT(*) FROM tasks WHERE room_id = :room_id``.
+        """``SELECT COUNT(*) FROM tasks WHERE room_id = :room_id`` を返す。
 
-        Used for Room detail page Task count display (after HTTP API PR).
-        Returns 0 when no Tasks exist for the given Room.
+        Room 詳細ページの Task 件数表示（HTTP API PR 後）に用いる。
+        該当 Room に Task が存在しない場合は 0 を返す。
         """
         ...
 
     async def find_blocked(self) -> list[Task]:
-        """Return all BLOCKED Tasks ordered by ``updated_at DESC, id DESC``.
+        """全 BLOCKED Task を ``updated_at DESC, id DESC`` の順で返す。
 
-        Used by ``TaskService.find_blocked_tasks()`` (Issue #38) for
-        障害隔離 — recently blocked Tasks are surfaced first so operators
-        can triage in priority order.
+        ``TaskService.find_blocked_tasks()``（Issue #38）の障害隔離に用いる —
+        最近ブロックされた Task が先に現れることで、運用者が優先順位順にトリアージ
+        できるようにする。
 
-        ORDER BY ``updated_at DESC, id DESC`` (BUG-EMR-001 規約: composite
-        key for deterministic ordering — ``updated_at`` alone is
-        insufficient when multiple Tasks share the same timestamp; ``id``
-        (PK, UUID) is the tiebreaker that makes the result fully
-        deterministic).
+        ORDER BY ``updated_at DESC, id DESC``（BUG-EMR-001 規約: 決定的な順序付けの
+        ための複合キー — 複数の Task が同一タイムスタンプを持つ場合 ``updated_at``
+        単独では不十分。``id``（PK、UUID）が tiebreaker として結果を完全に決定的にする）。
 
-        Returns ``[]`` when no BLOCKED Tasks exist.
+        BLOCKED Task が存在しない場合は ``[]`` を返す。
         """
         ...
 

--- a/backend/src/bakufu/application/ports/workflow_repository.py
+++ b/backend/src/bakufu/application/ports/workflow_repository.py
@@ -1,17 +1,18 @@
-"""Workflow Repository port.
+"""Workflow Repository ポート。
 
-Per ``docs/features/workflow-repository/detailed-design.md`` §確定 A
-(empire-repository テンプレート 100% 継承):
+``docs/features/workflow-repository/detailed-design.md`` §確定 A
+（empire-repository テンプレート 100% 継承）に従う:
 
-* Protocol class with **no** ``@runtime_checkable`` decorator — Python
-  3.12 ``typing.Protocol`` duck typing is enough; the runtime overhead
-  of ``@runtime_checkable`` adds ``isinstance`` paths the application
-  layer never needs (mirrors :mod:`bakufu.application.ports.empire_repository`).
-* Every method declared ``async def`` (async-first contract) so the
-  application layer can compose Repositories inside an
-  ``async with session.begin():`` Unit-of-Work.
-* Argument and return types come exclusively from
-  :mod:`bakufu.domain` — no SQLAlchemy types leak across the port.
+* Protocol クラスに ``@runtime_checkable`` デコレータを **付けない** —
+  Python 3.12 の ``typing.Protocol`` ダックタイピングで十分。
+  ``@runtime_checkable`` の実行時オーバーヘッドは、application 層が必要としない
+  ``isinstance`` 経路を増やしてしまう
+  （:mod:`bakufu.application.ports.empire_repository` をミラーリング）。
+* すべてのメソッドを ``async def`` で宣言（async-first 契約）。これにより
+  application 層は ``async with session.begin():`` の Unit-of-Work 内で
+  Repository を組み合わせられる。
+* 引数および戻り値の型は :mod:`bakufu.domain` 由来のもののみ —
+  SQLAlchemy 型がポートを越えて漏れることはない。
 """
 
 from __future__ import annotations
@@ -23,44 +24,42 @@ from bakufu.domain.workflow import Workflow
 
 
 class WorkflowRepository(Protocol):
-    """Persistence contract for the :class:`Workflow` Aggregate Root.
+    """:class:`Workflow` Aggregate Root の永続化契約。
 
-    The application layer (``WorkflowService``, future PR) consumes
-    this Protocol via dependency injection; the SQLite implementation
-    lives in
-    :mod:`bakufu.infrastructure.persistence.sqlite.repositories.workflow_repository`.
+    application 層（``WorkflowService``、将来 PR）が依存性注入により本 Protocol を
+    消費する。SQLite 実装は
+    :mod:`bakufu.infrastructure.persistence.sqlite.repositories.workflow_repository`
+    に存在する。
     """
 
     async def find_by_id(self, workflow_id: WorkflowId) -> Workflow | None:
-        """Hydrate the Workflow whose primary key equals ``workflow_id``.
+        """主キーが ``workflow_id`` の Workflow をハイドレートする。
 
-        Returns ``None`` when the row is absent. Implementations
-        propagate SQLAlchemy / driver / ``pydantic.ValidationError``
-        exceptions unchanged so the Unit-of-Work boundary in the
-        application service can choose between rollback and surfaced
-        error.
+        該当行がない場合は ``None`` を返す。実装は SQLAlchemy / ドライバ /
+        ``pydantic.ValidationError`` 例外をそのまま伝播させ、application service の
+        Unit-of-Work 境界がロールバックとエラー表出のいずれを取るかを判断できるように
+        する。
         """
         ...
 
     async def count(self) -> int:
-        """Return ``SELECT COUNT(*) FROM workflows``.
+        """``SELECT COUNT(*) FROM workflows`` を返す。
 
-        Application services use this to introspect whether at least
-        one Workflow has been registered (e.g. preset bootstrap
-        check). Deciding what the count means is the *application*
-        layer's call (§確定 D).
+        application service は本メソッドを用いて Workflow が少なくとも 1 件
+        登録されているかを内省する（例: プリセット bootstrap チェック）。
+        カウントが何を意味するかを判断するのは *application* 層の役割である
+        （§確定 D）。
         """
         ...
 
     async def save(self, workflow: Workflow) -> None:
-        """Persist ``workflow`` via the §確定 B delete-then-insert flow.
+        """§確定 B の delete-then-insert フローで ``workflow`` を永続化する。
 
-        The implementation must run the five-step sequence (UPSERT
-        workflows → DELETE workflow_stages → bulk INSERT stages →
-        DELETE workflow_transitions → bulk INSERT transitions) within
-        the **caller-managed** transaction. Repositories never call
-        ``session.commit()`` / ``session.rollback()``; the application
-        service owns the Unit-of-Work boundary.
+        実装は **呼び出し元が管理する** トランザクション内で 5 段階のシーケンス
+        （UPSERT workflows → DELETE workflow_stages → bulk INSERT stages →
+        DELETE workflow_transitions → bulk INSERT transitions）を実行しなければ
+        ならない。Repository は ``session.commit()`` / ``session.rollback()`` を
+        決して呼び出さない。Unit-of-Work 境界の保有は application service の責務である。
         """
         ...
 

--- a/backend/src/bakufu/application/services/empire_service.py
+++ b/backend/src/bakufu/application/services/empire_service.py
@@ -1,9 +1,9 @@
 """EmpireService — Empire Aggregate 操作の application 層サービス。
 
-Implements ``REQ-EM-HTTP-001``〜``REQ-EM-HTTP-005`` per
-``docs/features/empire/http-api/detailed-design.md`` §確定 G.
+``docs/features/empire/http-api/detailed-design.md`` §確定 G に従い、
+``REQ-EM-HTTP-001``〜``REQ-EM-HTTP-005`` を実装する。
 
-Design notes:
+設計メモ:
 
 * **UoW 境界**: write 操作 (``create`` / ``update`` / ``archive``) は read も含め
   単一の ``async with self._session.begin():`` ブロック内で完結させる。
@@ -12,13 +12,12 @@ Design notes:
   が発生するため (BUG-EM-001 修正)。
 * ``find_all`` / ``find_by_id`` は read-only。明示的な ``begin()`` は不要。
   SQLAlchemy が autobegin するため呼び出し元でトランザクションを意識しなくてよい。
-* The service raises application-layer exceptions
+* 本サービスは sentinel 値を返す代わりに application 層の例外
   (:class:`EmpireNotFoundError` / :class:`EmpireAlreadyExistsError` /
-  :class:`EmpireArchivedError`) rather than returning sentinel values,
-  keeping the interfaces layer free of domain-level conditionals.
-* Domain-layer ``EmpireInvariantViolation`` propagates unchanged to the
-  interfaces layer which maps it to HTTP 422 via
-  ``empire_invariant_violation_handler``.
+  :class:`EmpireArchivedError`) を送出することで、interfaces 層をドメインレベルの
+  条件分岐から解放する。
+* ドメイン層の ``EmpireInvariantViolation`` はそのまま interfaces 層へ伝播し、
+  ``empire_invariant_violation_handler`` 経由で HTTP 422 にマップされる。
 """
 
 from __future__ import annotations
@@ -40,10 +39,10 @@ from bakufu.domain.value_objects.identifiers import EmpireId
 class EmpireService:
     """Empire Aggregate 操作の thin CRUD サービス (確定 G)。
 
-    The session is injected alongside the repository so the service can
-    open and commit its own Unit-of-Work transactions for write
-    operations. Read-only operations (``find_all`` / ``find_by_id``)
-    execute directly on the session without an explicit ``begin()``.
+    session は repository とともに注入され、サービスが write 操作向けに自前の
+    Unit-of-Work トランザクションを開いて commit できるようにする。read-only 操作
+    （``find_all`` / ``find_by_id``）は明示的な ``begin()`` なしで session 上で
+    直接実行する。
     """
 
     def __init__(self, repo: EmpireRepository, session: AsyncSession) -> None:
@@ -51,27 +50,27 @@ class EmpireService:
         self._session = session
 
     async def create(self, name: str) -> Empire:
-        """Construct and persist a new Empire (REQ-EM-HTTP-001).
+        """新しい Empire を構築して永続化する（REQ-EM-HTTP-001）。
 
         Args:
-            name: Raw Empire name. Normalized via domain's NFC+strip
-                pipeline; length validated as 1-80 chars (R1-1).
+            name: 生の Empire 名。ドメインの NFC+strip パイプラインで正規化され、
+                長さは 1–80 文字として検証される（R1-1）。
 
         Returns:
-            The freshly persisted Empire.
+            新たに永続化された Empire。
 
         Raises:
-            EmpireAlreadyExistsError: if an Empire already exists (R1-5).
-            EmpireInvariantViolation: if ``name`` fails domain validation.
+            EmpireAlreadyExistsError: Empire が既に存在する場合（R1-5）。
+            EmpireInvariantViolation: ``name`` がドメイン検証に失敗した場合。
         """
-        # BUG-EM-001: count() triggers autobegin. Put ALL operations
-        # (read + write) inside a single begin() to avoid
-        # "InvalidRequestError: A transaction is already begun".
+        # BUG-EM-001: count() が autobegin を起動する。
+        # "InvalidRequestError: A transaction is already begun" を避けるため、
+        # 全操作（read + write）を単一の begin() 内に置く。
         async with self._session.begin():
             count = await self._repo.count()
             if count > 0:
                 raise EmpireAlreadyExistsError()
-            # EmpireId is a type alias for UUID — uuid4() is the correct type.
+            # EmpireId は UUID の型エイリアスのため、uuid4() が正しい型となる。
             empire = Empire(
                 id=uuid4(),
                 name=name,
@@ -81,24 +80,24 @@ class EmpireService:
         return empire
 
     async def find_all(self) -> list[Empire]:
-        """Return all Empire rows (REQ-EM-HTTP-002).
+        """全 Empire 行を返す（REQ-EM-HTTP-002）。
 
         Returns:
-            0 or 1 Empire (singleton). Never raises.
+            0 件または 1 件の Empire（シングルトン）。例外は送出しない。
         """
         return await self._repo.find_all()
 
     async def find_by_id(self, empire_id: EmpireId) -> Empire:
-        """Hydrate a single Empire by its primary key (REQ-EM-HTTP-003).
+        """主キーで単一の Empire をハイドレートする（REQ-EM-HTTP-003）。
 
         Args:
-            empire_id: Target Empire's UUID.
+            empire_id: 対象 Empire の UUID。
 
         Returns:
-            The hydrated Empire.
+            ハイドレートされた Empire。
 
         Raises:
-            EmpireNotFoundError: if no Empire with ``empire_id`` exists.
+            EmpireNotFoundError: ``empire_id`` の Empire が存在しない場合。
         """
         empire = await self._repo.find_by_id(empire_id)
         if empire is None:
@@ -106,22 +105,22 @@ class EmpireService:
         return empire
 
     async def update(self, empire_id: EmpireId, name: str | None) -> Empire:
-        """Apply a partial update to an Empire (REQ-EM-HTTP-004).
+        """Empire に部分更新を適用する（REQ-EM-HTTP-004）。
 
         Args:
-            empire_id: Target Empire's UUID.
-            name: New name, or ``None`` to leave it unchanged.
+            empire_id: 対象 Empire の UUID。
+            name: 新しい名前。``None`` の場合は変更しない。
 
         Returns:
-            The updated Empire.
+            更新後の Empire。
 
         Raises:
-            EmpireNotFoundError: if the Empire does not exist.
-            EmpireArchivedError: if the Empire is archived (R1-8).
-            EmpireInvariantViolation: if the new name fails domain validation.
+            EmpireNotFoundError: Empire が存在しない場合。
+            EmpireArchivedError: Empire がアーカイブ済みの場合（R1-8）。
+            EmpireInvariantViolation: 新しい名前がドメイン検証に失敗した場合。
         """
-        # BUG-EM-001: find_by_id triggers autobegin. Keep everything in one
-        # begin() so there is only one transaction boundary.
+        # BUG-EM-001: find_by_id が autobegin を起動する。
+        # トランザクション境界を 1 つに保つため、すべてを単一の begin() 内にまとめる。
         async with self._session.begin():
             empire = await self._repo.find_by_id(empire_id)
             if empire is None:
@@ -129,7 +128,7 @@ class EmpireService:
             if empire.archived:
                 raise EmpireArchivedError(str(empire_id))
             if name is None:
-                # No fields changed — nothing to persist.
+                # 変更フィールドなし — 永続化対象なし。
                 return empire
             updated = Empire(
                 id=empire.id,
@@ -142,16 +141,16 @@ class EmpireService:
         return updated
 
     async def archive(self, empire_id: EmpireId) -> None:
-        """Logically delete an Empire (REQ-EM-HTTP-005 / UC-EM-010).
+        """Empire を論理削除する（REQ-EM-HTTP-005 / UC-EM-010）。
 
         Args:
-            empire_id: Target Empire's UUID.
+            empire_id: 対象 Empire の UUID。
 
         Raises:
-            EmpireNotFoundError: if the Empire does not exist.
+            EmpireNotFoundError: Empire が存在しない場合。
         """
-        # BUG-EM-001: find_by_id triggers autobegin. Keep everything in one
-        # begin() so there is only one transaction boundary.
+        # BUG-EM-001: find_by_id が autobegin を起動する。
+        # トランザクション境界を 1 つに保つため、すべてを単一の begin() 内にまとめる。
         async with self._session.begin():
             empire = await self._repo.find_by_id(empire_id)
             if empire is None:

--- a/backend/src/bakufu/domain/__init__.py
+++ b/backend/src/bakufu/domain/__init__.py
@@ -1,5 +1,5 @@
-"""bakufu domain layer.
+"""bakufu ドメイン層。
 
-Aggregate roots, value objects, and domain exceptions live here.
-This package has zero external I/O dependencies (no HTTP, DB, file, time).
+集約ルート、値オブジェクト、ドメイン例外をここに配置する。
+このパッケージは外部 I/O 依存を持たない（HTTP / DB / ファイル / 時刻に一切依存しない）。
 """

--- a/backend/src/bakufu/domain/agent/__init__.py
+++ b/backend/src/bakufu/domain/agent/__init__.py
@@ -1,23 +1,22 @@
-"""Agent Aggregate Root package.
+"""Agent Aggregate Root パッケージ。
 
-Implements ``REQ-AG-001``〜``REQ-AG-006`` per ``docs/features/agent``.
-Split into four sibling modules along the design's responsibility lines so
-each file stays under the 500-line readability budget and the file-level
-boundary mirrors the design's twin-defense pattern (Stage's self-check vs
-the aggregate's collection check):
+``docs/features/agent`` に従って ``REQ-AG-001``〜``REQ-AG-006`` を実装する。
+設計の責務境界に沿って 4 つの兄弟モジュールに分割し、各ファイルが 500 行の
+可読性予算を下回るようにし、ファイル レベル境界が設計の twin-defense パターン
+（Stage の自己チェック vs Aggregate のコレクション チェック）を踏襲する:
 
 * :mod:`bakufu.domain.agent.value_objects` — :class:`Persona` /
-  :class:`ProviderConfig` / :class:`SkillRef` Pydantic VOs with self-checks.
-* :mod:`bakufu.domain.agent.path_validators` — H1〜H10 path traversal
-  defense for ``SkillRef.path`` (Confirmation H), each rule a pure function.
-* :mod:`bakufu.domain.agent.aggregate_validators` — five module-level
-  invariant helpers covering provider capacity / uniqueness / default count
-  and skill capacity / uniqueness.
-* :mod:`bakufu.domain.agent.agent` — :class:`Agent` Aggregate Root that
-  dispatches over the helpers in deterministic order.
+  :class:`ProviderConfig` / :class:`SkillRef` の Pydantic VO（自己チェック付き）。
+* :mod:`bakufu.domain.agent.path_validators` — ``SkillRef.path`` の H1〜H10
+  パス トラバーサル防御（Confirmation H）。各ルールは純粋関数。
+* :mod:`bakufu.domain.agent.aggregate_validators` — provider 容量 / 一意性 /
+  default 個数、および skill 容量 / 一意性を網羅するモジュール レベルの不変
+  条件ヘルパ 5 つ。
+* :mod:`bakufu.domain.agent.agent` — ヘルパを決定的順序でディスパッチする
+  :class:`Agent` Aggregate Root。
 
-This ``__init__`` re-exports the public surface plus the underscore-prefixed
-helpers tests need to invoke directly.
+この ``__init__`` はパブリック表面に加え、テストが直接呼ぶ必要のある
+アンダースコア プレフィックス ヘルパも再 export する。
 """
 
 from __future__ import annotations

--- a/backend/src/bakufu/domain/agent/agent.py
+++ b/backend/src/bakufu/domain/agent/agent.py
@@ -1,28 +1,26 @@
-"""Agent Aggregate Root (REQ-AG-001〜006).
+"""Agent Aggregate Root（REQ-AG-001〜006）。
 
-Implements per ``docs/features/agent``. The aggregate dispatches over five
-helpers in :mod:`bakufu.domain.agent.aggregate_validators` and delegates
-SkillRef.path traversal defense (H1〜H10) to
-:mod:`bakufu.domain.agent.path_validators`.
+``docs/features/agent`` に従って実装する。Aggregate は
+:mod:`bakufu.domain.agent.aggregate_validators` の 5 つのヘルパへディスパッチし、
+SkillRef.path のトラバーサル防御（H1〜H10）は
+:mod:`bakufu.domain.agent.path_validators` に委譲する。
 
-Design contracts:
+設計コントラクト:
 
-* **Pre-validate rebuild (Confirmation A)** — ``set_default_provider`` /
-  ``add_skill`` / ``remove_skill`` / ``archive`` all go through
-  :meth:`Agent._rebuild_with` (``model_dump → swap → model_validate``).
-* **NFC pipeline (Confirmation E)** — ``Agent.name`` reuses the empire /
-  workflow ``nfc_strip`` helper. Length judgement happens in the model
-  validator so the resulting :class:`AgentInvariantViolation` carries
-  ``kind='name_range'`` with MSG-AG-001 wording.
-* **archive idempotency (Confirmation D)** — ``archive()`` always returns a
-  *new* instance. Idempotency means "result state matches", not "object
-  identity". Pydantic v2 frozen + ``model_validate`` rebuild guarantees this
-  by construction; the docstring/tests document the contract so users do not
-  rely on ``is`` comparisons.
-* **provider_kind MVP gate (Confirmation I)** — *not* implemented in the
-  aggregate. ``AgentService.hire()`` (a Phase-2 application service) is the
-  responsibility owner; the aggregate trusts that the enum value is well
-  formed and lets the service decide whether the Adapter exists.
+* **Pre-validate rebuild（Confirmation A）** — ``set_default_provider`` /
+  ``add_skill`` / ``remove_skill`` / ``archive`` はすべて :meth:`Agent._rebuild_with`
+  （``model_dump → swap → model_validate``）を経由する。
+* **NFC パイプライン（Confirmation E）** — ``Agent.name`` は empire / workflow の
+  ``nfc_strip`` ヘルパを再利用する。長さ判定はモデル バリデータで行うため、結果の
+  :class:`AgentInvariantViolation` は MSG-AG-001 文言の ``kind='name_range'`` を持つ。
+* **archive 冪等性（Confirmation D）** — ``archive()`` は常に *新* インスタンスを
+  返す。冪等性とは「結果状態が一致する」ことであり「オブジェクト同一性」ではない。
+  Pydantic v2 frozen + ``model_validate`` 再構築がこれを構造的に保証する。docstring
+  とテストでコントラクトを文書化し、利用者が ``is`` 比較に依存しないようにする。
+* **provider_kind MVP ゲート（Confirmation I）** — Aggregate には *実装しない*。
+  ``AgentService.hire()``（Phase-2 アプリケーション サービス）が責任を持つ。
+  Aggregate は enum 値が適切に整形されていることを信頼し、Adapter の存在判定は
+  サービスに委ねる。
 """
 
 from __future__ import annotations
@@ -58,13 +56,13 @@ from bakufu.domain.value_objects import (
     nfc_strip,
 )
 
-# Confirmation E: name length bounds (1〜40 after NFC + strip).
+# Confirmation E: 名前長境界（NFC + strip 後で 1〜40）。
 MIN_NAME_LENGTH: int = 1
 MAX_NAME_LENGTH: int = 40
 
 
 class Agent(BaseModel):
-    """Hireable LLM agent owned by an :class:`Empire`."""
+    """:class:`Empire` が所有する雇用可能な LLM エージェント。"""
 
     model_config = ConfigDict(
         frozen=True,
@@ -73,13 +71,11 @@ class Agent(BaseModel):
     )
 
     id: AgentId
-    # ``empire_id`` is the back-reference required by
-    # ``feature/agent-repository`` (Issue #32). The Repository
-    # persists Agents under an Empire so the table-level FK
-    # ``agents.empire_id REFERENCES empires.id ON DELETE CASCADE``
-    # has somewhere to source its value, and ``find_by_name`` can
-    # scope its lookup with ``WHERE empire_id = :empire_id`` —
-    # detailed-design §確定 F.
+    # ``empire_id`` は ``feature/agent-repository``（Issue #32）が要求する逆参照。
+    # リポジトリは Empire の下に Agent を永続化するため、テーブル レベルの FK
+    # ``agents.empire_id REFERENCES empires.id ON DELETE CASCADE`` が値を取得できる
+    # 場所が必要であり、``find_by_name`` も ``WHERE empire_id = :empire_id`` で
+    # ルックアップをスコープできる — detailed-design §確定 F。
     empire_id: EmpireId
     name: str
     persona: Persona
@@ -88,7 +84,7 @@ class Agent(BaseModel):
     skills: list[SkillRef] = []
     archived: bool = False
 
-    # ---- pre-validation -------------------------------------------------
+    # ---- 事前検証 -------------------------------------------------------
     @field_validator("name", mode="before")
     @classmethod
     def _normalize_name(cls, value: object) -> object:
@@ -96,11 +92,11 @@ class Agent(BaseModel):
 
     @model_validator(mode="after")
     def _check_invariants(self) -> Self:
-        """Dispatch over the aggregate-level helpers in deterministic order.
+        """Aggregate レベルのヘルパを決定的順序でディスパッチする。
 
-        Order: name range → provider capacity / uniqueness / default count
-        → skill capacity / uniqueness. Earlier failures hide later ones so
-        error messages stay focused on the root cause.
+        順序: name range → provider capacity / 一意性 / default 個数 →
+        skill capacity / 一意性。先行する失敗が後続を隠すため、エラー メッセージは
+        根本原因に集中する。
         """
         self._check_name_range()
         _validate_provider_capacity(self.providers)
@@ -123,17 +119,16 @@ class Agent(BaseModel):
                 detail={"length": length},
             )
 
-    # ---- behaviors (Tell, Don't Ask) ------------------------------------
+    # ---- 振る舞い（Tell, Don't Ask） -----------------------------------
     def set_default_provider(self, provider_kind: ProviderKind) -> Agent:
-        """Switch the default provider to the entry whose ``provider_kind`` matches.
+        """``provider_kind`` が一致するエントリにデフォルト プロバイダを切り替える。
 
-        Linear scan over ``providers`` (small N ≤ 10). Raises if the kind is
-        not registered — the caller cannot mark a never-configured provider
-        as default.
+        ``providers`` を線形スキャンする（N ≤ 10 で小さい）。kind が未登録の場合
+        例外を送出する — 呼び元は構成されていない provider をデフォルトにできない。
 
         Raises:
-            AgentInvariantViolation: ``kind='provider_not_found'`` when no
-                ``ProviderConfig`` matches ``provider_kind``.
+            AgentInvariantViolation: ``provider_kind`` に一致する
+                ``ProviderConfig`` がないとき ``kind='provider_not_found'``。
         """
         if not any(provider.provider_kind == provider_kind for provider in self.providers):
             raise AgentInvariantViolation(
@@ -152,14 +147,14 @@ class Agent(BaseModel):
         return self._rebuild_with(providers=new_providers)
 
     def add_skill(self, skill_ref: SkillRef) -> Agent:
-        """Append ``skill_ref`` to ``skills``; aggregate validation catches duplicates."""
+        """``skill_ref`` を ``skills`` に追加する。重複は Aggregate 検証で捕捉される。"""
         return self._rebuild_with(skills=[*self.skills, skill_ref])
 
     def remove_skill(self, skill_id: SkillId) -> Agent:
-        """Drop the SkillRef whose ``skill_id`` matches.
+        """``skill_id`` が一致する SkillRef を削除する。
 
         Raises:
-            AgentInvariantViolation: ``kind='skill_not_found'`` (MSG-AG-008).
+            AgentInvariantViolation: ``kind='skill_not_found'``（MSG-AG-008）。
         """
         if not any(skill.skill_id == skill_id for skill in self.skills):
             raise AgentInvariantViolation(
@@ -172,23 +167,22 @@ class Agent(BaseModel):
         )
 
     def archive(self) -> Agent:
-        """Return a new :class:`Agent` with ``archived=True`` (Confirmation D).
+        """``archived=True`` を持つ新しい :class:`Agent` を返す（Confirmation D）。
 
-        Idempotent: calling on an already-archived Agent yields a fresh
-        Agent that is **structurally equal** to the input but has a
-        different ``id()``. Callers must not rely on object identity —
-        always reassign the returned value (``agent = agent.archive()``).
+        冪等: 既にアーカイブ済みの Agent に対して呼んでも、入力と **構造的に等しく**、
+        ``id()`` のみ異なる新規 Agent を生成する。呼び元はオブジェクト同一性に依存
+        してはならず、常に返値を代入し直すこと（``agent = agent.archive()``）。
         """
         return self._rebuild_with_state({"archived": True})
 
-    # ---- internal: pre-validate rebuild (Confirmation A) ----------------
+    # ---- 内部実装: 事前検証 rebuild（Confirmation A） -------------------
     def _rebuild_with(
         self,
         *,
         providers: list[ProviderConfig] | None = None,
         skills: list[SkillRef] | None = None,
     ) -> Agent:
-        """Re-construct via ``model_validate`` so ``_check_invariants`` re-fires."""
+        """``model_validate`` で再構築し ``_check_invariants`` を再発火させる。"""
         state = self.model_dump()
         if providers is not None:
             state["providers"] = [provider.model_dump() for provider in providers]
@@ -197,7 +191,7 @@ class Agent(BaseModel):
         return Agent.model_validate(state)
 
     def _rebuild_with_state(self, updates: dict[str, Any]) -> Agent:
-        """Pre-validate rebuild for scalar attribute updates (e.g. ``archived``)."""
+        """スカラ属性更新（例 ``archived``）のための pre-validate rebuild。"""
         state = self.model_dump()
         state.update(updates)
         return Agent.model_validate(state)

--- a/backend/src/bakufu/domain/agent/aggregate_validators.py
+++ b/backend/src/bakufu/domain/agent/aggregate_validators.py
@@ -1,21 +1,21 @@
-"""Aggregate-level invariant helpers for :class:`Agent`.
+""":class:`Agent` のための Aggregate レベル不変条件ヘルパ。
 
-Each helper is a **module-level pure function** so tests can ``import`` and
-invoke directly — same testability pattern Norman / Steve approved for the
-workflow package's ``dag_validators.py``. The Aggregate Root in
-:mod:`bakufu.domain.agent.agent` stays a thin dispatch over them; rule
-changes touch only the helper, never the orchestration code.
+各ヘルパは **モジュール レベルの純粋関数** であるため、テストから ``import`` して
+直接呼べる — Norman / Steve が workflow パッケージの ``dag_validators.py`` で
+承認したのと同じテスタビリティ パターン。:mod:`bakufu.domain.agent.agent` の
+Aggregate Root はそれらの薄いディスパッチに留まり、ルール変更はヘルパのみに触れ、
+オーケストレーション コードは触らない。
 
-Helpers (run in this order in :class:`Agent.model_validator`):
+ヘルパ（:class:`Agent.model_validator` ではこの順で実行）:
 
 1. :func:`_validate_provider_capacity` — ``1 ≤ len(providers) ≤ 10``
-2. :func:`_validate_provider_kind_unique` — no duplicate ``provider_kind``
-3. :func:`_validate_default_provider_count` — exactly one ``is_default=True``
+2. :func:`_validate_provider_kind_unique` — ``provider_kind`` の重複なし
+3. :func:`_validate_default_provider_count` — ``is_default=True`` がちょうど 1 つ
 4. :func:`_validate_skill_capacity` — ``len(skills) ≤ 20``
-5. :func:`_validate_skill_id_unique` — no duplicate ``skill_id``
+5. :func:`_validate_skill_id_unique` — ``skill_id`` の重複なし
 
-Naming follows the workflow precedent ``_validate_*_unique`` for collection
-uniqueness checks (Steve's twin-defense symmetry rule from PR #16).
+命名は workflow の先例（コレクション一意性チェックには ``_validate_*_unique``）
+に従う（Steve の PR #16 twin-defense 対称性ルール）。
 """
 
 from __future__ import annotations
@@ -24,14 +24,14 @@ from bakufu.domain.agent.value_objects import ProviderConfig, SkillRef
 from bakufu.domain.exceptions import AgentInvariantViolation
 from bakufu.domain.value_objects import ProviderKind, SkillId
 
-# Confirmation C: capacity bounds.
+# Confirmation C: 容量境界。
 MIN_PROVIDERS: int = 1
 MAX_PROVIDERS: int = 10
 MAX_SKILLS: int = 20
 
 
 def _validate_provider_capacity(providers: list[ProviderConfig]) -> None:
-    """T2-DoS guard + REQ-AG-001 contract (1 件以上、上限 10 件)."""
+    """T2-DoS ガード + REQ-AG-001 コントラクト（1 件以上、上限 10 件）。"""
     count = len(providers)
     if count < MIN_PROVIDERS:
         raise AgentInvariantViolation(
@@ -51,7 +51,7 @@ def _validate_provider_capacity(providers: list[ProviderConfig]) -> None:
 
 
 def _validate_provider_kind_unique(providers: list[ProviderConfig]) -> None:
-    """No two ProviderConfig may share ``provider_kind`` (MSG-AG-004)."""
+    """2 つの ProviderConfig が ``provider_kind`` を共有してはならない（MSG-AG-004）。"""
     seen: set[ProviderKind] = set()
     for provider in providers:
         if provider.provider_kind in seen:
@@ -64,7 +64,7 @@ def _validate_provider_kind_unique(providers: list[ProviderConfig]) -> None:
 
 
 def _validate_default_provider_count(providers: list[ProviderConfig]) -> None:
-    """Exactly one provider must be marked ``is_default=True`` (MSG-AG-003)."""
+    """``is_default=True`` を持つ provider はちょうど 1 つでなければならない（MSG-AG-003）。"""
     count = sum(1 for provider in providers if provider.is_default)
     if count != 1:
         raise AgentInvariantViolation(
@@ -75,7 +75,7 @@ def _validate_default_provider_count(providers: list[ProviderConfig]) -> None:
 
 
 def _validate_skill_capacity(skills: list[SkillRef]) -> None:
-    """Cap skills at 20 (REQ-AG-001 / Confirmation C)."""
+    """skills を 20 で頭打ちにする（REQ-AG-001 / Confirmation C）。"""
     count = len(skills)
     if count > MAX_SKILLS:
         raise AgentInvariantViolation(
@@ -89,13 +89,13 @@ def _validate_skill_capacity(skills: list[SkillRef]) -> None:
 
 
 def _validate_skill_id_unique(skills: list[SkillRef]) -> None:
-    """No two SkillRef may share ``skill_id`` (MSG-AG-007).
+    """2 つの SkillRef が ``skill_id`` を共有してはならない（MSG-AG-007）。
 
-    Naming mirrors workflow's ``_validate_stage_id_unique`` /
-    ``_validate_transition_id_unique`` symmetry that Steve required in
-    PR #16: every collection contract that says "no duplicate id" gets a
-    dedicated helper so the Boy Scout rule ("first leak breaks all") never
-    catches us off-guard on the next aggregate.
+    命名は workflow の ``_validate_stage_id_unique`` /
+    ``_validate_transition_id_unique`` の対称性をミラーしている — Steve が PR #16
+    で要求したルール: 「id 重複なし」を謳うすべてのコレクション コントラクトに専用
+    ヘルパを設けることで、Boy Scout ルール（「最初のリークが全てを壊す」）が次の
+    Aggregate で不意打ちにならないようにする。
     """
     seen: set[SkillId] = set()
     for skill in skills:

--- a/backend/src/bakufu/domain/agent/path_validators.py
+++ b/backend/src/bakufu/domain/agent/path_validators.py
@@ -1,19 +1,18 @@
-"""SkillRef.path traversal defense (Agent feature §確定 H, H1〜H10).
+"""SkillRef.path のトラバーサル防御（Agent feature §確定 H, H1〜H10）。
 
-Each Hx check is a **module-level pure function** so:
+各 Hx チェックは **モジュールレベルの純粋関数** として実装する。理由は以下:
 
-1. Tests can ``import`` them and invoke directly to prove each rule works
-   independently — same testability pattern as Workflow's
-   :mod:`bakufu.domain.workflow.dag_validators` (Confirmation F).
-2. :func:`_validate_skill_path` stays a thin sequencer over the ten checks,
-   with order locked by the design document.
-3. Future ``feature/skill-loader`` Phase-2 work that adds a runtime I/O
-   recheck can re-use the exact same helpers — single source of truth for
-   path policy, no rule drift.
+1. テストから ``import`` して直接呼べるため、各ルールが独立して機能することを
+   個別に検証できる（Workflow の :mod:`bakufu.domain.workflow.dag_validators` と
+   同じテスタビリティ パターン — Confirmation F）。
+2. :func:`_validate_skill_path` は 10 個のチェックの薄いシーケンサとして留まり、
+   実行順序は設計ドキュメントによりロックされる。
+3. 将来 ``feature/skill-loader`` Phase-2 でランタイム I/O 再チェックを追加する
+   際、同じヘルパを再利用できる — パスポリシーの単一情報源。ルールの揺らぎが起きない。
 
-The functions raise :class:`AgentInvariantViolation` directly so callers
-(``SkillRef`` field validator) get the structured ``kind='skill_path_invalid'``
-discriminator without going through Pydantic's ``ValidationError`` wrapping.
+これらの関数は :class:`AgentInvariantViolation` を直接送出する。これにより呼び元
+（``SkillRef`` フィールド バリデータ）は、Pydantic の ``ValidationError`` ラッピング
+を経由せずに構造化された ``kind='skill_path_invalid'`` 識別子を受け取れる。
 """
 
 from __future__ import annotations
@@ -25,20 +24,20 @@ from pathlib import Path, PurePosixPath
 
 from bakufu.domain.exceptions import AgentInvariantViolation
 
-# H2: 1〜500 chars (NFC-normalized form).
+# H2: 1〜500 文字（NFC 正規化後の長さ）。
 MIN_PATH_LENGTH: int = 1
 MAX_PATH_LENGTH: int = 500
 
-# H7: required prefix segments. Anything not under bakufu-data/skills/* is
-# rejected at the VO boundary, regardless of what the file system says.
+# H7: 必須のプレフィックス セグメント。bakufu-data/skills/* 配下にないものは
+# ファイル システムの状態にかかわらず VO 境界で拒否する。
 REQUIRED_PARTS_PREFIX: tuple[str, str] = ("bakufu-data", "skills")
 SKILLS_SUBDIR: str = "skills"
 
-# H4: leading-character rejections.
+# H4: 先頭文字による拒否。
 _WINDOWS_ABSOLUTE_RE = re.compile(r"^[A-Za-z]:[\\/]")
 
-# H9: Windows reserved device names. Compared case-insensitive on the part
-# stem (without extension) so "CON.md" is rejected too.
+# H9: Windows 予約デバイス名。拡張子を除いた part stem に対して
+# 大文字小文字を無視して比較するため、"CON.md" も拒否される。
 _WINDOWS_RESERVED_NAMES: frozenset[str] = frozenset(
     {
         "CON",
@@ -50,16 +49,16 @@ _WINDOWS_RESERVED_NAMES: frozenset[str] = frozenset(
     }
 )
 
-# H3: forbidden characters — NUL, ASCII C0/C1 control, backslash.
+# H3: 禁止文字 — NUL、ASCII C0/C1 制御文字、バックスラッシュ。
 _ASCII_CONTROL_RANGE = frozenset(chr(c) for c in range(0x00, 0x20)) | {chr(0x7F)}
 _FORBIDDEN_CHARS: frozenset[str] = _ASCII_CONTROL_RANGE | {"\\"}
 
 
 def _violation(check_id: str, detail_extra: dict[str, object]) -> AgentInvariantViolation:
-    """Centralize the ``AgentInvariantViolation`` shape used by every Hx helper.
+    """各 Hx ヘルパが共通で使う ``AgentInvariantViolation`` 形状を集約する。
 
-    Keeps the message format and ``kind`` consistent so callers can switch on
-    ``detail['check']`` to attribute the failure without parsing strings.
+    メッセージ書式と ``kind`` を一貫させるため、呼び元は文字列をパースせずに
+    ``detail['check']`` で失敗箇所を特定できる。
     """
     detail = {"check": check_id, **detail_extra}
     return AgentInvariantViolation(
@@ -70,15 +69,15 @@ def _violation(check_id: str, detail_extra: dict[str, object]) -> AgentInvariant
 
 
 # ---------------------------------------------------------------------------
-# H1: NFC normalization
+# H1: NFC 正規化
 # ---------------------------------------------------------------------------
 def _h1_nfc_normalize(raw_path: str) -> str:
-    """Apply NFC. Returned string is what every subsequent helper inspects."""
+    """NFC を適用する。返却された文字列が以降のヘルパが検査する対象となる。"""
     return unicodedata.normalize("NFC", raw_path)
 
 
 # ---------------------------------------------------------------------------
-# H2: length 1〜500
+# H2: 長さ 1〜500
 # ---------------------------------------------------------------------------
 def _h2_check_length(path: str) -> None:
     length = len(path)
@@ -94,7 +93,7 @@ def _h2_check_length(path: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# H3: forbidden chars (NUL / control / backslash)
+# H3: 禁止文字（NUL / 制御文字 / バックスラッシュ）
 # ---------------------------------------------------------------------------
 def _h3_check_forbidden_chars(path: str) -> None:
     for ch in path:
@@ -103,7 +102,7 @@ def _h3_check_forbidden_chars(path: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# H4: leading-character rejection (POSIX abs / Windows abs / home tilde)
+# H4: 先頭文字の拒否（POSIX 絶対 / Windows 絶対 / ホームのチルダ）
 # ---------------------------------------------------------------------------
 def _h4_check_leading(path: str) -> None:
     if path.startswith("/"):
@@ -115,32 +114,32 @@ def _h4_check_leading(path: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# H5: traversal sequences and surrounding whitespace
+# H5: トラバーサル列と前後の空白
 # ---------------------------------------------------------------------------
 def _h5_check_traversal_sequences(path: str) -> None:
     if path != path.strip():
         raise _violation("H5", {"reason": "leading or trailing whitespace"})
-    # ``path == '.'`` / ``path == '..'`` / leading ``./`` or ``../`` are
-    # current-dir or parent-dir aliases that round-trip through
-    # PurePosixPath silently — reject them at this layer.
+    # ``path == '.'`` / ``path == '..'`` / 先頭の ``./`` や ``../`` は、
+    # PurePosixPath を通すとサイレントに往復してしまうカレント／親ディレクトリ
+    # エイリアスとなる。この層で明示的に拒否する。
     if path in {".", ".."} or path.startswith(("./", "../")):
         raise _violation("H5", {"reason": "path starts with '.' or '..'"})
     if path.endswith(("/.", "/..", "/")):
         raise _violation("H5", {"reason": "path ends with '.' or '..' or trailing slash"})
-    # Two-dot traversal anywhere — most common attack form.
+    # 任意の位置に出現する `..` トラバーサル — 最も一般的な攻撃形態。
     if ".." in path.split("/"):
         raise _violation("H5", {"reason": "'..' parent-dir traversal in path"})
 
 
 # ---------------------------------------------------------------------------
-# H6: parse via PurePosixPath, return parts
+# H6: PurePosixPath でパースして parts を返す
 # ---------------------------------------------------------------------------
 def _h6_parse_parts(path: str) -> tuple[str, ...]:
     return PurePosixPath(path).parts
 
 
 # ---------------------------------------------------------------------------
-# H7: prefix must be ('bakufu-data', 'skills', <rest>)
+# H7: プレフィックスは ('bakufu-data', 'skills', <rest>) でなければならない
 # ---------------------------------------------------------------------------
 def _h7_check_prefix(parts: tuple[str, ...]) -> None:
     if len(parts) < 3:
@@ -159,7 +158,7 @@ def _h7_check_prefix(parts: tuple[str, ...]) -> None:
 
 
 # ---------------------------------------------------------------------------
-# H8: re-check every part for forbidden chars (defense in depth post-parse)
+# H8: パース後の各 part を再度禁止文字でチェック（多層防御）
 # ---------------------------------------------------------------------------
 def _h8_recheck_parts(parts: tuple[str, ...]) -> None:
     for index, part in enumerate(parts):
@@ -172,11 +171,11 @@ def _h8_recheck_parts(parts: tuple[str, ...]) -> None:
 
 
 # ---------------------------------------------------------------------------
-# H9: Windows reserved names
+# H9: Windows 予約名
 # ---------------------------------------------------------------------------
 def _h9_check_windows_reserved(parts: tuple[str, ...]) -> None:
     for index, part in enumerate(parts):
-        # Strip extension for the comparison: "CON.md" → "CON".
+        # 比較のため拡張子を除いて stem を取得: "CON.md" → "CON"。
         stem = part.split(".", 1)[0].upper()
         if stem in _WINDOWS_RESERVED_NAMES:
             raise _violation(
@@ -189,18 +188,18 @@ def _h9_check_windows_reserved(parts: tuple[str, ...]) -> None:
 
 
 # ---------------------------------------------------------------------------
-# H10: filesystem-grounded base-escape verification
+# H10: ファイルシステム実体に基づく base-escape 検証
 # ---------------------------------------------------------------------------
 def _h10_check_base_escape(path: str) -> None:
-    """Resolve ``BAKUFU_DATA_DIR / path`` and require it to live under
-    ``BAKUFU_DATA_DIR / 'bakufu-data' / 'skills'`` (the canonical skills root).
+    """``BAKUFU_DATA_DIR / path`` を resolve し、``BAKUFU_DATA_DIR / 'bakufu-data' / 'skills'``
+    （正準 skills ルート）の配下にあることを要求する。
 
-    The relative path ``bakufu-data/skills/<rest>`` is resolved against
-    ``BAKUFU_DATA_DIR``; the joined absolute path must stay under the
-    skills root. ``Path.resolve()`` follows symlinks, so symlink-via-skills-subdir
-    escape is detected here — the final defensive line. If
-    ``BAKUFU_DATA_DIR`` is unset we raise a structured failure rather than
-    silently skipping (defense in depth).
+    相対パス ``bakufu-data/skills/<rest>`` は ``BAKUFU_DATA_DIR`` を起点として
+    解決される。連結された絶対パスは skills ルートの配下に留まらなければならない。
+    ``Path.resolve()`` はシンボリックリンクを辿るため、skills サブディレクトリ
+    経由のシンボリックリンク エスケープも検出される — 最終的な防御ライン。
+    ``BAKUFU_DATA_DIR`` 未設定の場合はサイレントにスキップせず、構造化された
+    失敗を送出する（多層防御）。
     """
     base_dir_str = os.environ.get("BAKUFU_DATA_DIR")
     if not base_dir_str:
@@ -209,8 +208,8 @@ def _h10_check_base_escape(path: str) -> None:
             {"reason": "BAKUFU_DATA_DIR not set"},
         )
     base_dir = Path(base_dir_str)
-    # ``REQUIRED_PARTS_PREFIX`` is ``('bakufu-data', 'skills')``, so the
-    # canonical skills root is exactly that prefix joined under the env var.
+    # ``REQUIRED_PARTS_PREFIX`` は ``('bakufu-data', 'skills')`` であるため、
+    # 正準 skills ルートはちょうどこのプレフィックスを環境変数の下に連結したもの。
     skills_root = base_dir.joinpath(*REQUIRED_PARTS_PREFIX).resolve()
     candidate = (base_dir / path).resolve()
     if not candidate.is_relative_to(skills_root):
@@ -224,20 +223,20 @@ def _h10_check_base_escape(path: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Orchestrator (used by SkillRef.field_validator)
+# オーケストレータ（SkillRef.field_validator から使用）
 # ---------------------------------------------------------------------------
 def _validate_skill_path(raw_path: str) -> str:
-    """Run H1〜H10 in the design's locked order and return the NFC-normalized form.
+    """設計でロックされた順序で H1〜H10 を実行し、NFC 正規化済みの形を返す。
 
-    The returned value is what :class:`SkillRef` stores as ``path`` — callers
-    must always replace their input with the function's output so downstream
-    consumers never see un-normalized strings.
+    返り値は :class:`SkillRef` が ``path`` として保存する値である。呼び元は必ず
+    入力をこの関数の出力で置き換えなければならない。これによりダウンストリーム
+    の利用側に未正規化文字列が渡ることを防ぐ。
 
     Raises:
-        AgentInvariantViolation: with ``kind='skill_path_invalid'`` on any
-            failure. ``detail['check']`` carries the Hx identifier (``'H1'``
-            ... ``'H10'``) so HTTP/API layers can localize without parsing
-            the message string.
+        AgentInvariantViolation: 失敗時に ``kind='skill_path_invalid'`` で送出。
+            ``detail['check']`` には Hx 識別子（``'H1'`` ... ``'H10'``）が入り、
+            HTTP / API 層はメッセージ文字列をパースせずに失敗箇所をローカライズ
+            できる。
     """
     normalized = _h1_nfc_normalize(raw_path)
     _h2_check_length(normalized)

--- a/backend/src/bakufu/domain/agent/value_objects.py
+++ b/backend/src/bakufu/domain/agent/value_objects.py
@@ -1,19 +1,19 @@
-"""Agent-specific Value Objects (Persona / ProviderConfig / SkillRef).
+"""Agent 固有の Value Object（Persona / ProviderConfig / SkillRef）。
 
-These VOs live in the ``agent/`` package rather than the global
-:mod:`bakufu.domain.value_objects` so the file-level boundary mirrors the
-responsibility boundary — same pattern Norman approved for the workflow
-package. ``SkillId`` and ``ProviderKind`` remain in the global module
-because they cross feature boundaries (Skill loader, LLM Adapter).
+これらの VO はファイル レベル境界が責務境界を反映するよう、グローバルな
+:mod:`bakufu.domain.value_objects` ではなく ``agent/`` パッケージに置く —
+Norman が workflow パッケージで承認したのと同じパターン。``SkillId`` と
+``ProviderKind`` はフィーチャー境界（Skill loader、LLM Adapter）を跨ぐため
+グローバル モジュールに残す。
 
-The Persona / archetype / display_name validations all share the
-:func:`bakufu.domain.value_objects.nfc_strip` pipeline (Confirmation B
-shared policy carried forward from empire / workflow). ``prompt_body``
-applies NFC only — Markdown leading/trailing newlines must be preserved
-because downstream renderers depend on them (Confirmation E).
+Persona / archetype / display_name のバリデーションは全て
+:func:`bakufu.domain.value_objects.nfc_strip` パイプラインを共有する
+（Confirmation B の共有ポリシーを empire / workflow から継承）。``prompt_body``
+は NFC のみを適用する — Markdown の先頭／末尾改行は下流レンダラが依存するため
+保持しなければならない（Confirmation E）。
 
-``SkillRef.path`` runs the full H1〜H10 traversal-defense pipeline from
-:mod:`bakufu.domain.agent.path_validators`.
+``SkillRef.path`` は :mod:`bakufu.domain.agent.path_validators` の H1〜H10
+完全トラバーサル防御パイプラインを実行する。
 """
 
 from __future__ import annotations
@@ -28,7 +28,7 @@ from bakufu.domain.exceptions import AgentInvariantViolation
 from bakufu.domain.value_objects import ProviderKind, SkillId, nfc_strip
 
 # ---------------------------------------------------------------------------
-# Persona (Agent feature §確定 E length policy)
+# Persona（Agent feature §確定 E の長さポリシー）
 # ---------------------------------------------------------------------------
 DISPLAY_NAME_MIN: int = 1
 DISPLAY_NAME_MAX: int = 40
@@ -37,11 +37,11 @@ PROMPT_BODY_MAX: int = 10_000
 
 
 class Persona(BaseModel):
-    """Character / authoring profile attached to an :class:`Agent`.
+    """:class:`Agent` に紐づくキャラクタ／著作プロフィール。
 
-    ``display_name`` and ``archetype`` go through NFC + strip (Confirmation E).
-    ``prompt_body`` only goes through NFC — strip would eat the Markdown
-    leading/trailing whitespace that downstream prompt rendering relies on.
+    ``display_name`` と ``archetype`` は NFC + strip を通過する（Confirmation E）。
+    ``prompt_body`` は NFC のみ — strip は下流のプロンプト レンダリングが依存する
+    Markdown の先頭／末尾空白を食ってしまう。
     """
 
     model_config = ConfigDict(
@@ -62,7 +62,7 @@ class Persona(BaseModel):
     @field_validator("prompt_body", mode="before")
     @classmethod
     def _normalize_prompt_body(cls, value: object) -> object:
-        # NFC only — preserves Markdown leading/trailing whitespace.
+        # NFC のみ — Markdown の先頭／末尾空白を保持する。
         if isinstance(value, str):
             return unicodedata.normalize("NFC", value)
         return value
@@ -111,12 +111,12 @@ PROVIDER_MODEL_MAX: int = 80
 
 
 class ProviderConfig(BaseModel):
-    """LLM provider configuration entry inside an :class:`Agent`.
+    """:class:`Agent` 内部の LLM プロバイダ構成エントリ。
 
-    ``provider_kind`` enum ensures only known providers slip through; the
-    "is this provider's Adapter implemented in MVP" check belongs to the
-    application layer (``AgentService.hire``), not the VO — see Agent
-    detailed-design §確定 I for responsibility split.
+    ``provider_kind`` enum により既知のプロバイダのみが通過する。「この provider の
+    Adapter が MVP で実装済みか」のチェックは VO ではなくアプリケーション層
+    （``AgentService.hire``）の責務である — 責務分離は Agent detailed-design §確定 I
+    を参照。
     """
 
     model_config = ConfigDict(
@@ -132,26 +132,25 @@ class ProviderConfig(BaseModel):
     @field_validator("model", mode="before")
     @classmethod
     def _strip_model(cls, value: object) -> object:
-        # Strip-only (no NFC) per Confirmation E — model names are ASCII
-        # identifiers in practice and applying NFC has no behavioral effect.
+        # Confirmation E に従い strip のみ（NFC 無し） — モデル名は実運用上 ASCII
+        # 識別子であり、NFC を適用しても動作上の効果はない。
         if isinstance(value, str):
             return value.strip()
         return value
 
 
 # ---------------------------------------------------------------------------
-# SkillRef (H1〜H10 path traversal defense delegated to path_validators)
+# SkillRef（H1〜H10 のパス トラバーサル防御は path_validators に委譲）
 # ---------------------------------------------------------------------------
 SKILL_NAME_MIN: int = 1
 SKILL_NAME_MAX: int = 80
 
 
 class SkillRef(BaseModel):
-    """Reference to a Skill markdown file inside ``BAKUFU_DATA_DIR/skills/``.
+    """``BAKUFU_DATA_DIR/skills/`` 内の Skill Markdown ファイルへの参照。
 
-    The path validation contract is comprehensive (10 separate checks); see
-    :func:`bakufu.domain.agent.path_validators._validate_skill_path` for the
-    full ordered policy.
+    パス検証コントラクトは包括的（10 個の独立したチェック）。完全な順序付きポリシー
+    は :func:`bakufu.domain.agent.path_validators._validate_skill_path` を参照。
     """
 
     model_config = ConfigDict(
@@ -172,8 +171,8 @@ class SkillRef(BaseModel):
     @field_validator("path", mode="after")
     @classmethod
     def _validate_path(cls, value: str) -> str:
-        # H1〜H10 in one shot. Returns the NFC-normalized form so the stored
-        # value is canonical (no later code paths see an un-normalized string).
+        # H1〜H10 を一度に実行。NFC 正規化された形を返し、保存値が正準形となる
+        # （以降のコード経路は未正規化文字列を見ない）。
         return _validate_skill_path(value)
 
 

--- a/backend/src/bakufu/domain/directive/__init__.py
+++ b/backend/src/bakufu/domain/directive/__init__.py
@@ -1,20 +1,18 @@
-"""Directive Aggregate Root package.
+"""Directive Aggregate Root パッケージ。
 
-Implements ``REQ-DR-001``〜``REQ-DR-003`` per ``docs/features/directive``.
-M1 5 兄弟目 (after empire / workflow / agent / room) — slim by design:
-five attributes, two structural invariants, one behavior. Split into
-two sibling modules for the sake of consistency with the older M1
-packages even though everything fits comfortably in one file:
+``docs/features/directive`` に従って ``REQ-DR-001``〜``REQ-DR-003`` を実装する。
+M1 5 兄弟目（empire / workflow / agent / room の後）— 設計上スリム: 5 属性、
+2 構造的不変条件、1 振る舞い。すべて 1 ファイルに快適に収まるが、過去の M1
+パッケージとの整合性のために 2 つの兄弟モジュールに分割する:
 
-* :mod:`bakufu.domain.directive.aggregate_validators` — two
-  module-level invariant helpers (``_validate_text_range`` /
-  ``_validate_task_link_immutable``).
-* :mod:`bakufu.domain.directive.directive` — :class:`Directive`
-  Aggregate Root.
+* :mod:`bakufu.domain.directive.aggregate_validators` — モジュール レベルの
+  不変条件ヘルパ 2 つ（``_validate_text_range`` /
+  ``_validate_task_link_immutable``）。
+* :mod:`bakufu.domain.directive.directive` — :class:`Directive` Aggregate Root。
 
-This ``__init__`` re-exports the public surface plus the
-underscore-prefixed helpers tests need to invoke directly (the same
-pattern Norman approved for the agent / room packages).
+この ``__init__`` はパブリック表面に加え、テストが直接呼ぶ必要のある
+アンダースコア プレフィックス ヘルパも再 export する（Norman が agent / room
+パッケージで承認したのと同じパターン）。
 """
 
 from __future__ import annotations

--- a/backend/src/bakufu/domain/directive/aggregate_validators.py
+++ b/backend/src/bakufu/domain/directive/aggregate_validators.py
@@ -1,24 +1,21 @@
-"""Aggregate-level invariant helpers for :class:`Directive`.
+""":class:`Directive` のための Aggregate レベル不変条件ヘルパ。
 
-Each helper is a **module-level pure function** so tests can ``import``
-and invoke directly — same testability pattern Norman / Steve approved
-for the agent ``aggregate_validators.py`` and the room
-``aggregate_validators.py``.
+各ヘルパは **モジュール レベルの純粋関数** であるため、テストから ``import``
+して直接呼べる — Norman / Steve が agent の ``aggregate_validators.py`` と
+room の ``aggregate_validators.py`` で承認したのと同じテスタビリティ パターン。
 
-Helpers:
+ヘルパ:
 
-1. :func:`_validate_text_range` — ``1 ≤ NFC(text) ≤ 10000``. Length is
-   judged on the **NFC-normalized** text without ``strip``; CEO
-   directives may carry meaningful leading / trailing whitespace and
-   newlines (multi-paragraph briefs).
-2. :func:`_validate_task_link_immutable` — Fail Fast when ``link_task``
-   is invoked on a Directive that already has a non-``None``
-   ``task_id``. The constructor path (used by Repository hydration)
-   accepts any ``TaskId | None`` value because a permanent attribute
-   value is not a *transition*; only ``link_task`` watches for
-   transition violations (see Directive detailed-design §確定 C).
+1. :func:`_validate_text_range` — ``1 ≤ NFC(text) ≤ 10000``。長さは ``strip``
+   無しの **NFC 正規化済み** テキストに対して判定する。CEO ディレクティブは
+   意味のある先頭／末尾空白や改行（複数段落のブリーフ）を含む可能性がある。
+2. :func:`_validate_task_link_immutable` — 既に non-``None`` ``task_id`` を持つ
+   Directive に対する ``link_task`` 呼び出しを Fail Fast する。コンストラクタ
+   経路（リポジトリ水和で使用）は任意の ``TaskId | None`` を受理する。永続的な
+   属性値は *遷移* ではないため。``link_task`` のみが遷移違反を監視する
+   （Directive detailed-design §確定 C 参照）。
 
-Naming follows the agent / room precedent (``_validate_*``).
+命名は agent / room の先例（``_validate_*``）に従う。
 """
 
 from __future__ import annotations
@@ -27,18 +24,18 @@ from uuid import UUID
 
 from bakufu.domain.exceptions import DirectiveInvariantViolation
 
-# Confirmation B: text length bounds (1〜10000 after NFC normalization).
+# Confirmation B: text 長境界（NFC 正規化後で 1〜10000）。
 MIN_TEXT_LENGTH: int = 1
 MAX_TEXT_LENGTH: int = 10_000
 
 
 def _validate_text_range(text: str) -> None:
-    """``Directive.text`` must fall in 1〜10000 characters (MSG-DR-001).
+    """``Directive.text`` は 1〜10000 文字でなければならない（MSG-DR-001）。
 
-    Length is judged on the **NFC-normalized** string (the field
-    validator runs the pipeline before this helper is invoked) without
-    ``strip`` — CEO directives may include leading / trailing
-    whitespace + multi-paragraph blocks that carry meaning.
+    長さは **NFC 正規化済み** 文字列に対して判定される（フィールド バリデータが
+    本ヘルパ呼び出し前にパイプラインを走らせる）。``strip`` は適用しない —
+    CEO ディレクティブは意味のある先頭／末尾空白や複数段落ブロックを含む可能性
+    がある。
     """
     length = len(text)
     if not (MIN_TEXT_LENGTH <= length <= MAX_TEXT_LENGTH):
@@ -61,18 +58,17 @@ def _validate_task_link_immutable(
     existing_task_id: UUID | None,
     attempted_task_id: UUID,
 ) -> None:
-    """Reject a ``link_task`` call against an already-linked Directive.
+    """既にリンク済みの Directive に対する ``link_task`` 呼び出しを拒否する。
 
-    Confirmation C / D / Norman 凍結: 1 Directive maps to 1 Task by
-    design; a second ``link_task`` call is **always** a Fail Fast
-    rather than a no-op, regardless of whether the new TaskId equals
-    the existing one. The simpler contract avoids special cases in the
-    aggregate validator and matches the business rule "re-issuing a
-    directive means creating a *new* Directive."
+    Confirmation C / D / Norman 凍結: 1 つの Directive が 1 つの Task に対応する
+    のは設計上の前提。2 回目の ``link_task`` 呼び出しは新 TaskId が既存と等しい
+    かに関わらず **常に** Fail Fast し、no-op にはしない。シンプルなコントラクト
+    は Aggregate バリデータの特例を避け、ビジネス ルール「ディレクティブの再発行
+    とは *新しい* Directive の作成を意味する」と一致する。
 
     Raises:
-        DirectiveInvariantViolation: ``kind='task_already_linked'``
-            (MSG-DR-002) when ``existing_task_id is not None``.
+        DirectiveInvariantViolation: ``existing_task_id is not None`` の場合に
+            ``kind='task_already_linked'``（MSG-DR-002）。
     """
     if existing_task_id is None:
         return

--- a/backend/src/bakufu/domain/directive/directive.py
+++ b/backend/src/bakufu/domain/directive/directive.py
@@ -1,29 +1,25 @@
-"""Directive Aggregate Root (REQ-DR-001〜003).
+"""Directive Aggregate Root（REQ-DR-001〜003）。
 
-Implements per ``docs/features/directive``. The aggregate is
-intentionally slim: five attributes, two structural invariants, one
-behavior. Application-layer concerns (``$``-prefix normalization,
-``target_room_id`` existence, Task creation) live in
-``DirectiveService.issue()`` per §確定 G / H.
+``docs/features/directive`` に従って実装する。Aggregate は意図的にスリム: 5 つの
+属性、2 つの構造的不変条件、1 つの振る舞い。アプリケーション層の関心事
+（``$`` プレフィックス正規化、``target_room_id`` 存在検証、Task 作成）は §確定 G / H
+により ``DirectiveService.issue()`` に置く。
 
-Design contracts:
+設計コントラクト:
 
-* **Pre-validate rebuild (Confirmation A)** — :meth:`Directive.link_task`
-  goes through :meth:`_rebuild_with_state`
-  (``model_dump → swap → model_validate``).
-* **NFC-only normalization (Confirmation B)** — ``Directive.text``
-  applies ``unicodedata.normalize('NFC', ...)`` *without* ``strip``.
-  CEO directives may include meaningful leading / trailing whitespace
-  and multi-paragraph blocks; the agent ``Persona.prompt_body`` /
-  room ``PromptKit.prefix_markdown`` precedent applies here too.
-* **task_id transition uniqueness (Confirmation C / D)** — only the
-  ``link_task`` path watches for transition violations. The
-  constructor path accepts any ``TaskId | None`` value to support
-  Repository hydration of an already-linked Directive without a
-  separate "rebuild" code path.
-* **No idempotency (Confirmation D)** — a second ``link_task`` is
-  *always* a Fail Fast, even when the new TaskId equals the existing
-  one. Re-issuing a directive means creating a new Directive.
+* **Pre-validate rebuild（Confirmation A）** — :meth:`Directive.link_task` は
+  :meth:`_rebuild_with_state`（``model_dump → swap → model_validate``）を経由する。
+* **NFC のみの正規化（Confirmation B）** — ``Directive.text`` は ``strip`` *無し* で
+  ``unicodedata.normalize('NFC', ...)`` を適用する。CEO ディレクティブには意味のある
+  先頭／末尾空白や複数段落ブロックを含み得るため、Agent ``Persona.prompt_body`` /
+  Room ``PromptKit.prefix_markdown`` の先例がここでも適用される。
+* **task_id 遷移の一意性（Confirmation C / D）** — ``link_task`` 経路だけが遷移違反を
+  監視する。コンストラクタ経路は任意の ``TaskId | None`` 値を受理する。これにより、
+  既にリンク済みの Directive をリポジトリから水和する際に「rebuild」用の別経路を
+  必要としない。
+* **冪等性なし（Confirmation D）** — 2 回目の ``link_task`` は新 TaskId が既存と
+  一致しても *常に* Fail Fast。ディレクティブの再発行とは新しい Directive の作成を
+  意味する。
 """
 
 from __future__ import annotations
@@ -50,13 +46,11 @@ from bakufu.domain.value_objects import (
 
 
 class Directive(BaseModel):
-    """CEO directive issued against a target :class:`Room` (REQ-DR-001).
+    """対象 :class:`Room` に対して CEO が発行するディレクティブ（REQ-DR-001）。
 
-    The aggregate captures the *intent* of an instruction: the text
-    body, the room it is delegated to, the time it was issued, and
-    the optional generated Task it was linked to. ``DirectiveService``
-    (application layer) is responsible for creating the Task and
-    calling :meth:`link_task` to establish the back-reference.
+    Aggregate は指示の *意図* を捉える: テキスト本文、委譲先の Room、発行時刻、
+    リンクされた生成 Task（任意）。``DirectiveService``（アプリケーション層）が
+    Task を作成し、:meth:`link_task` を呼び出して逆参照を確立する。
     """
 
     model_config = ConfigDict(
@@ -68,20 +62,19 @@ class Directive(BaseModel):
     id: DirectiveId
     text: str
     target_room_id: RoomId
-    # ``created_at`` arrives as a tz-aware ``datetime`` from the
-    # application layer (see Directive detailed-design §設計判断の補足
-    # "なぜ created_at を引数で受け取るか"). The post-validator below
-    # rejects naive datetimes so the contract is enforced at the
-    # aggregate boundary rather than by every caller.
+    # ``created_at`` はアプリケーション層から tz-aware ``datetime`` として渡される
+    # （Directive detailed-design §設計判断の補足「なぜ created_at を引数で受け取るか」
+    # を参照）。下の post-validator が naive datetime を拒否するため、コントラクトは
+    # 各呼び出し元ではなく Aggregate 境界で強制される。
     created_at: datetime
     task_id: TaskId | None = None
 
-    # ---- pre-validation -------------------------------------------------
+    # ---- 事前検証 -------------------------------------------------------
     @field_validator("text", mode="before")
     @classmethod
     def _normalize_text(cls, value: object) -> object:
-        # Confirmation B: NFC only — no ``strip``. CEO directives may
-        # rely on leading / trailing whitespace + newlines.
+        # Confirmation B: NFC のみ — ``strip`` 無し。CEO ディレクティブは先頭／末尾
+        # 空白や改行に意味を持たせている可能性がある。
         if isinstance(value, str):
             return unicodedata.normalize("NFC", value)
         return value
@@ -89,9 +82,8 @@ class Directive(BaseModel):
     @field_validator("created_at", mode="after")
     @classmethod
     def _require_tz_aware(cls, value: datetime) -> datetime:
-        # Naive datetimes carry no timezone info and would silently
-        # round-trip through SQLite as wall-clock strings, breaking
-        # ordering. Fail Fast at the aggregate boundary instead.
+        # naive datetime はタイムゾーン情報を持たず、SQLite を壁時計文字列として
+        # サイレントに往復し、順序が壊れる。Aggregate 境界で Fail Fast する。
         if value.tzinfo is None:
             raise ValueError(
                 "Directive.created_at must be a timezone-aware UTC datetime "
@@ -101,34 +93,31 @@ class Directive(BaseModel):
 
     @model_validator(mode="after")
     def _check_invariants(self) -> Self:
-        """Run the structural invariant checks.
+        """構造的不変条件チェックを実行する。
 
-        Confirmation C: only ``_validate_text_range`` runs at
-        construction time. ``_validate_task_link_immutable`` watches
-        the *transition* enforced inside :meth:`link_task` itself,
-        not the snapshot value, because the constructor path is also
-        used to hydrate Directives from a Repository where the
-        ``task_id`` may already be a real value.
+        Confirmation C: 構築時に走るのは ``_validate_text_range`` のみ。
+        ``_validate_task_link_immutable`` は :meth:`link_task` 内部で強制される *遷移*
+        を監視するもので、スナップショット値は対象としない。コンストラクタ経路は
+        ``task_id`` が既に実値となっている Directive をリポジトリから水和する用途
+        にも使われるため。
         """
         _validate_text_range(self.text)
         return self
 
-    # ---- behaviors (Tell, Don't Ask) ------------------------------------
+    # ---- 振る舞い（Tell, Don't Ask） -----------------------------------
     def link_task(self, task_id: TaskId) -> Directive:
-        """Bind this Directive to ``task_id``; reject re-linking.
+        """この Directive を ``task_id`` に紐づける。再リンクは拒否する。
 
-        Returns a new :class:`Directive` instance with ``task_id``
-        populated. A subsequent call against the new instance always
-        Fails Fast — there is no idempotent "same TaskId" path
-        (Confirmation D).
+        ``task_id`` が埋まった新しい :class:`Directive` インスタンスを返す。新インス
+        タンスに対する次回呼び出しは常に Fail Fast — 「同じ TaskId だから OK」と
+        いう冪等経路は存在しない（Confirmation D）。
 
         Raises:
-            DirectiveInvariantViolation: ``kind='task_already_linked'``
-                (MSG-DR-002) when this Directive already has a
-                non-``None`` ``task_id``.
+            DirectiveInvariantViolation: この Directive が既に non-``None`` の
+                ``task_id`` を持つ場合に ``kind='task_already_linked'``（MSG-DR-002）。
         """
-        # Local import keeps the module-level import graph minimal —
-        # the validator only matters on the failing path.
+        # ローカル import によりモジュール レベルの import グラフを最小に保つ —
+        # バリデータは失敗経路でのみ意味を持つ。
         from bakufu.domain.directive.aggregate_validators import (
             _validate_task_link_immutable,
         )
@@ -140,13 +129,12 @@ class Directive(BaseModel):
         )
         return self._rebuild_with_state({"task_id": task_id})
 
-    # ---- internal -------------------------------------------------------
+    # ---- 内部実装 -------------------------------------------------------
     def _rebuild_with_state(self, updates: dict[str, Any]) -> Directive:
-        """Pre-validate rebuild for scalar attribute updates.
+        """スカラ属性更新のための pre-validate rebuild。
 
-        Confirmation A — same pattern as
-        :class:`bakufu.domain.agent.agent.Agent` and
-        :class:`bakufu.domain.room.room.Room`.
+        Confirmation A — :class:`bakufu.domain.agent.agent.Agent` および
+        :class:`bakufu.domain.room.room.Room` と同じパターン。
         """
         state = self.model_dump()
         state.update(updates)

--- a/backend/src/bakufu/domain/empire.py
+++ b/backend/src/bakufu/domain/empire.py
@@ -1,23 +1,23 @@
-"""Empire Aggregate Root.
+"""Empire 集約ルート。
 
-Implements ``REQ-EM-001``〜``REQ-EM-005`` per ``docs/features/empire``.
+``docs/features/empire`` に従って ``REQ-EM-001``〜``REQ-EM-005`` を実装する。
 
-Design contract (do not break without re-running design review):
+設計契約（設計レビューを再実施しない限り変更不可）:
 
-* **Pre-validate rebuild (Confirmation A)** — every state-changing behavior
-  serializes the current state via ``model_dump()``, swaps the target list,
-  and re-runs ``Empire.model_validate(...)`` so the ``model_validator(mode='after')``
-  fires on the *candidate* aggregate. Failure raises
-  :class:`EmpireInvariantViolation` *before* any new instance is observable,
-  keeping the original aggregate strictly unchanged. ``model_copy(update=...)``
-  is intentionally avoided because Pydantic v2 defaults it to ``validate=False``.
-* **NFC normalization pipeline (Confirmation B)** — ``raw → NFC → strip → len``;
-  the resulting cleaned form is what gets persisted and what ``MSG-EM-001``'s
-  ``{length}`` reports.
-* **Capacity (Confirmation C)** — ``len(rooms) ≤ 100`` and ``len(agents) ≤ 100``.
-* **Linear search (Confirmation D)** — ``archive_room`` walks ``rooms`` linearly
-  rather than maintaining a side-index dict. ``N ≤ 100`` keeps this trivially
-  cheap and avoids parallel-state bugs.
+* **事前検証付き再構築（確定 A）** — 状態を変更するすべての振る舞いは
+  ``model_dump()`` で現在の状態をシリアライズし、対象リストを差し替え、
+  ``Empire.model_validate(...)`` を再実行することで *候補* 集約に対して
+  ``model_validator(mode='after')`` を発火させる。失敗時は新インスタンスが
+  観測可能になる *前* に :class:`EmpireInvariantViolation` を送出し、
+  元の集約は厳密に変更されないままにする。``model_copy(update=...)`` は
+  Pydantic v2 がデフォルトで ``validate=False`` とするため意図的に避ける。
+* **NFC 正規化パイプライン（確定 B）** — ``raw → NFC → strip → len``。
+  クリーニング後の形式が永続化され、``MSG-EM-001`` の ``{length}`` も
+  この形式の長さを報告する。
+* **容量制約（確定 C）** — ``len(rooms) ≤ 100`` かつ ``len(agents) ≤ 100``。
+* **線形探索（確定 D）** — ``archive_room`` は補助インデックス dict を
+  保持せず ``rooms`` を線形に走査する。``N ≤ 100`` のためコストは無視でき、
+  状態の二重管理によるバグを避ける。
 """
 
 from __future__ import annotations
@@ -35,24 +35,24 @@ from bakufu.domain.value_objects import (
     nfc_strip,
 )
 
-# Capacity ceiling per detailed-design §Confirmation C. Module-level constant
-# so test/factory code can import the same source of truth.
+# 詳細設計 §確定 C の容量上限。テスト・ファクトリコードが同じ
+# 真実の源を import できるようモジュールレベル定数とする。
 MAX_ROOMS: int = 100
 MAX_AGENTS: int = 100
 
-# Empire.name length bounds per detailed-design §Confirmation B.
+# 詳細設計 §確定 B の Empire.name 長さ範囲。
 MIN_NAME_LENGTH: int = 1
 MAX_NAME_LENGTH: int = 80
 
 
 class Empire(BaseModel):
-    """Root aggregate that owns the references to Rooms and Agents.
+    """Room と Agent への参照を保持するルート集約。
 
-    State-changing methods (:meth:`hire_agent`, :meth:`establish_room`,
-    :meth:`archive_room`) return a *new* :class:`Empire` instance — this
-    aggregate is frozen.  The caller swaps its own reference; Pydantic v2's
-    ``frozen=True`` makes in-place mutation impossible at the language level,
-    so concurrent callers cannot observe a partially-updated aggregate.
+    状態を変更するメソッド（:meth:`hire_agent` / :meth:`establish_room` /
+    :meth:`archive_room`）は *新しい* :class:`Empire` インスタンスを返す。
+    この集約は frozen であり、呼び出し側は自身の参照を差し替える。
+    Pydantic v2 の ``frozen=True`` により言語レベルでインプレース変更が
+    不可能となるため、並行呼び出し側が部分更新中の集約を観測できない。
     """
 
     model_config = ConfigDict(
@@ -64,34 +64,35 @@ class Empire(BaseModel):
     id: EmpireId
     name: str
     archived: bool = False
-    # Pydantic v2 deep-copies these defaults per instance, so the empty-list
-    # literal is safe and pyright-friendly (no `default_factory=list` Unknown).
+    # Pydantic v2 はインスタンスごとにこれらのデフォルトをディープコピーするため、
+    # 空リストリテラルは安全かつ pyright フレンドリー
+    # （`default_factory=list` の Unknown が出ない）。
     rooms: list[RoomRef] = []
     agents: list[AgentRef] = []
 
     # ------------------------------------------------------------------
-    # Pre-validation hooks
+    # 事前検証フック
     # ------------------------------------------------------------------
     @field_validator("name", mode="before")
     @classmethod
     def _normalize_name(cls, value: object) -> object:
-        """Apply the Confirmation B pipeline up to (but not including) ``len``.
+        """確定 B のパイプラインを ``len`` 直前まで適用する。
 
-        Delegates to :func:`nfc_strip` so Empire / Room / Agent / Workflow share
-        the **single** NFC+strip implementation (DRY). Length / range judgment
-        is intentionally kept in :meth:`_check_invariants` so the resulting
-        :class:`EmpireInvariantViolation` carries the structured
-        ``kind='name_range'`` rather than a generic Pydantic ``ValidationError``.
+        Empire / Room / Agent / Workflow が **単一の** NFC+strip 実装を共有する
+        ため :func:`nfc_strip` に委譲する（DRY）。長さ・範囲判定は意図的に
+        :meth:`_check_invariants` に残し、結果として汎用的な Pydantic
+        ``ValidationError`` ではなく構造化された ``kind='name_range'`` を持つ
+        :class:`EmpireInvariantViolation` を返せるようにしている。
         """
         return nfc_strip(value)
 
     @model_validator(mode="after")
     def _check_invariants(self) -> Self:
-        """Run all aggregate-level invariants on the candidate instance.
+        """候補インスタンスに対して集約レベルの不変条件を全て実行する。
 
-        Custom (non-``ValueError``) exceptions raised here propagate to the
-        caller without being wrapped in ``ValidationError`` — Pydantic v2's
-        documented behavior for ``mode='after'`` validators.
+        ここで送出される独自例外（``ValueError`` 以外）は ``ValidationError``
+        にラップされず呼び出し側へ伝搬する — これは Pydantic v2 の
+        ``mode='after'`` バリデータの仕様として明記されている挙動。
         """
         self._check_name_range()
         self._check_capacity()
@@ -99,7 +100,7 @@ class Empire(BaseModel):
         return self
 
     # ------------------------------------------------------------------
-    # Invariant checks (split for SRP / readability)
+    # 不変条件チェック（SRP / 可読性のため分割）
     # ------------------------------------------------------------------
     def _check_name_range(self) -> None:
         length = len(self.name)
@@ -158,38 +159,39 @@ class Empire(BaseModel):
             seen_rooms.add(room.room_id)
 
     # ------------------------------------------------------------------
-    # Behaviors (Tell, Don't Ask)
+    # 振る舞い（Tell, Don't Ask）
     # ------------------------------------------------------------------
     def hire_agent(self, agent_ref: AgentRef) -> Empire:
-        """Return a new :class:`Empire` with ``agent_ref`` appended to ``agents``.
+        """``agents`` に ``agent_ref`` を追加した新しい :class:`Empire` を返す。
 
         Raises:
-            EmpireInvariantViolation: if ``agent_ref.agent_id`` duplicates an
-                existing agent (``kind='agent_duplicate'``) or the resulting
-                count exceeds :data:`MAX_AGENTS` (``kind='capacity_exceeded'``).
-                The original aggregate is left unchanged.
+            EmpireInvariantViolation: ``agent_ref.agent_id`` が既存の
+                Agent と重複する場合（``kind='agent_duplicate'``）、または
+                追加後の件数が :data:`MAX_AGENTS` を超える場合
+                （``kind='capacity_exceeded'``）。元の集約は変更されない。
         """
         return self._rebuild_with(agents=[*self.agents, agent_ref])
 
     def establish_room(self, room_ref: RoomRef) -> Empire:
-        """Return a new :class:`Empire` with ``room_ref`` appended to ``rooms``.
+        """``rooms`` に ``room_ref`` を追加した新しい :class:`Empire` を返す。
 
         Raises:
-            EmpireInvariantViolation: on duplicate ``room_id`` or capacity
-                breach. Original aggregate unchanged.
+            EmpireInvariantViolation: ``room_id`` 重複または容量超過時。
+                元の集約は変更されない。
         """
         return self._rebuild_with(rooms=[*self.rooms, room_ref])
 
     def archive_room(self, room_id: RoomId) -> Empire:
-        """Return a new :class:`Empire` with the matching room marked archived.
+        """該当 Room を archived 化した新しい :class:`Empire` を返す。
 
-        The room is *not* physically removed — bakufu's audit trail must be
-        able to resolve historical ``room_id`` references (detailed-design
-        §"なぜ archive_room は物理削除しないか"). Re-archiving an already
-        archived room is idempotent: the resulting room state is the same.
+        Room は *物理削除* されない — bakufu の監査証跡は過去の ``room_id``
+        参照を解決できる必要があるため（詳細設計 §"なぜ archive_room は
+        物理削除しないか"）。アーカイブ済み Room の再アーカイブは冪等であり、
+        結果の Room 状態は同一になる。
 
         Raises:
-            EmpireInvariantViolation: if no room matches (``kind='room_not_found'``).
+            EmpireInvariantViolation: 該当 Room が存在しない場合
+                （``kind='room_not_found'``）。
         """
         for index, room in enumerate(self.rooms):
             if room.room_id == room_id:
@@ -203,17 +205,16 @@ class Empire(BaseModel):
         )
 
     def archive(self) -> Empire:
-        """Return a new :class:`Empire` with ``archived=True``.
+        """``archived=True`` を持つ新しい :class:`Empire` を返す。
 
-        Implements the logical delete (UC-EM-010 / 確定 H). Returns a new
-        frozen instance; callers pass the result to
-        ``EmpireRepository.save(archived_empire)`` to persist the state
-        change inside the Unit-of-Work.
+        論理削除（UC-EM-010 / 確定 H）を実装する。新しい frozen インスタンスを
+        返すので、呼び出し側はその結果を ``EmpireRepository.save(archived_empire)``
+        に渡し、Unit-of-Work 内部で状態変更を永続化する。
         """
         return Empire.model_validate(self.model_dump() | {"archived": True})
 
     # ------------------------------------------------------------------
-    # Internal: pre-validate rebuild (Confirmation A)
+    # 内部: 事前検証付き再構築（確定 A）
     # ------------------------------------------------------------------
     def _rebuild_with(
         self,
@@ -221,12 +222,12 @@ class Empire(BaseModel):
         rooms: list[RoomRef] | None = None,
         agents: list[AgentRef] | None = None,
     ) -> Empire:
-        """Re-construct via ``model_validate`` so ``model_validator`` re-fires.
+        """``model_validate`` で再構築し、``model_validator`` を再発火させる。
 
-        The candidate dict is built from ``model_dump()`` (which yields fully
-        primitive structures) so swapped-in lists end up homogeneous: Pydantic
-        re-coerces dicts back into ``RoomRef`` / ``AgentRef`` instances during
-        validation, matching the form taken when an Empire is first constructed.
+        候補 dict は ``model_dump()`` から組み立てる（完全にプリミティブな構造を
+        生成する）ため、差し替えたリストは同質になる: 検証中に Pydantic が
+        dict を ``RoomRef`` / ``AgentRef`` インスタンスへ再強制し、
+        Empire 初期構築時と同じ形になる。
         """
         state = self.model_dump()
         if rooms is not None:

--- a/backend/src/bakufu/domain/exceptions.py
+++ b/backend/src/bakufu/domain/exceptions.py
@@ -372,33 +372,31 @@ type InternalReviewGateViolationKind = Literal[
     "duplicate_role_verdict",
     "gate_decision_inconsistent",
 ]
-"""Discriminator for :class:`InternalReviewGateInvariantViolation` per
-internal-review-gate detailed-design. The closed set of eight kinds covers the
-submit-verdict guard conditions and the four structural invariants enforced by
-``model_validator(mode='after')``."""
+"""internal-review-gate 詳細設計に対応する :class:`InternalReviewGateInvariantViolation`
+の判別子。8 種類で閉じた集合で、submit-verdict のガード条件と
+``model_validator(mode='after')`` で強制される 4 つの構造的不変条件を網羅する。"""
 
 
-# DDD: "Violation" describes an invariant breach, not a programming bug, so
-# the N818 "Error suffix" rule does not apply here.
+# DDD: "Violation" は不変条件違反を表現するもので、プログラミングのバグではない。
+# そのため N818 "Error suffix" ルールは適用しない。
 class InternalReviewGateInvariantViolation(Exception):  # noqa: N818
-    """Raised when an :class:`InternalReviewGate` aggregate invariant is violated.
+    """:class:`InternalReviewGate` 集約の不変条件違反時に送出される。
 
-    Mirrors :class:`ExternalReviewGateInvariantViolation` in shape
-    (``kind`` + ``message`` + ``detail`` + immutable copy of detail).
-    Internal-review content (comments, role names) is agent-authored
-    and does not embed Discord webhook URLs, so no secret masking is
-    applied at this layer — the standard ``kind`` / ``message`` /
-    ``detail`` triple is sufficient.
+    形（``kind`` + ``message`` + ``detail`` + detail の不変コピー）は
+    :class:`ExternalReviewGateInvariantViolation` と同一。内部レビュー コンテンツ
+    （コメント、ロール名）はエージェント著作で Discord webhook URL を埋め込まない
+    ため、本層ではシークレット マスキングを適用しない — 標準の ``kind`` /
+    ``message`` / ``detail`` 三つ組で十分。
 
     Attributes:
-        kind: One of the canonical violation discriminators in
-            :data:`InternalReviewGateViolationKind`. Stable string values
-            used by tests and HTTP API mappers; never localized.
-        message: The full ``[FAIL] ...`` user-facing string per the
-            internal-review-gate detailed-design §MSG.
-        detail: Structured context (role names, lengths, counts) for
-            diagnostics and audit logging. Stored as a fresh ``dict`` copy
-            to keep the exception immutable from the caller's view.
+        kind: :data:`InternalReviewGateViolationKind` の正式な違反判別子の
+            いずれか。テストや HTTP API マッパーが使う安定した文字列値であり、
+            ローカライズしない。
+        message: internal-review-gate 詳細設計 §MSG に対応する完全な
+            ``[FAIL] ...`` 形式のユーザ向け文字列。
+        detail: 診断・監査ログ向けの構造化コンテキスト（ロール名、長さ、件数等）。
+            呼び出し側から見て例外が不変であるよう、新しい ``dict`` コピー
+            として格納する。
     """
 
     def __init__(
@@ -421,32 +419,30 @@ type ExternalReviewGateViolationKind = Literal[
     "feedback_text_range",
     "audit_trail_append_only",
 ]
-"""Discriminator for :class:`ExternalReviewGateInvariantViolation` per
-external-review-gate detailed-design §確定 I. The closed set of five
-kinds covers state-machine bypass (PENDING-only decision transitions),
-the four ``model_validator(mode='after')`` structural invariants, and
-the audit-trail append-only contract. Type / required-field violations
-surface as :class:`pydantic.ValidationError` (MSG-GT-006) so they never
-leak into this discriminator namespace."""
+"""external-review-gate 詳細設計 §確定 I に対応する
+:class:`ExternalReviewGateInvariantViolation` の判別子。5 種類で閉じた集合で、
+state-machine バイパス（PENDING 限定の decision 遷移）、4 つの
+``model_validator(mode='after')`` 構造的不変条件、そして audit-trail 追記専用
+コントラクトを網羅する。型・必須フィールド違反は
+:class:`pydantic.ValidationError`（MSG-GT-006）として表面化するため、本判別子
+名前空間には漏れ出さない。"""
 
 
-# DDD: "Violation" describes an invariant breach, not a programming bug, so
-# the N818 "Error suffix" rule does not apply here.
+# DDD: "Violation" は不変条件違反を表現するもので、プログラミングのバグではない。
+# そのため N818 "Error suffix" ルールは適用しない。
 class ExternalReviewGateInvariantViolation(Exception):  # noqa: N818
-    """Raised when an :class:`ExternalReviewGate` aggregate invariant is violated.
+    """:class:`ExternalReviewGate` 集約の不変条件違反時に送出される。
 
-    Mirrors :class:`TaskInvariantViolation` /
-    :class:`DirectiveInvariantViolation` /
-    :class:`RoomInvariantViolation` /
-    :class:`AgentInvariantViolation` /
-    :class:`WorkflowInvariantViolation` in shape (``kind`` +
-    ``message`` + ``detail`` + immutable copy of detail) and applies
-    the same Discord webhook secret masking. Gate ``feedback_text``
-    and ``audit_trail.comment`` are CEO-authored fields that may
-    embed a webhook URL pasted from a Discord channel; masking
-    ``message`` / ``detail`` at construction time means callers
-    cannot leak a token by serializing the exception (multi-layer
-    defense, see external-review-gate detailed-design §確定 H).
+    形（``kind`` + ``message`` + ``detail`` + detail の不変コピー）は
+    :class:`TaskInvariantViolation` / :class:`DirectiveInvariantViolation` /
+    :class:`RoomInvariantViolation` / :class:`AgentInvariantViolation` /
+    :class:`WorkflowInvariantViolation` と同一で、同じ Discord webhook
+    シークレット マスキングを適用する。Gate の ``feedback_text`` と
+    ``audit_trail.comment`` は CEO 著作のフィールドで、Discord チャンネルから
+    貼り付けられた webhook URL を埋め込まれる可能性があるため、構築時に
+    ``message`` / ``detail`` をマスクすれば、呼び出し側は例外をシリアライズした
+    だけでトークンを漏洩できなくなる（多層防御。external-review-gate 詳細設計
+    §確定 H 参照）。
     """
 
     def __init__(

--- a/backend/src/bakufu/domain/exceptions.py
+++ b/backend/src/bakufu/domain/exceptions.py
@@ -1,27 +1,26 @@
-"""Domain exceptions for the bakufu domain layer.
+"""bakufu ドメイン層のドメイン例外。
 
-Each violation carries a structured ``kind`` discriminator alongside a
-human-readable ``message`` and a ``detail`` dict for programmatic introspection
-(used by HTTP API mappers and tests).
+各違反は、人間可読な ``message`` と機械処理用の ``detail`` dict
+（HTTP API マッパーやテストで利用）に加え、構造化された ``kind`` 判別子を持つ。
 
-* :class:`EmpireInvariantViolation` — empire feature, see
-  ``docs/features/empire/detailed-design.md`` §Exception.
-* :class:`WorkflowInvariantViolation` — workflow feature, see
-  ``docs/features/workflow/detailed-design.md`` §Exception.
-* :class:`StageInvariantViolation` — workflow Stage entity-level violation,
-  inherits from :class:`WorkflowInvariantViolation` so callers can ``except``
-  the parent and still receive the more-specific subclass.
-* :class:`AgentInvariantViolation` — agent feature, see
-  ``docs/features/agent/detailed-design.md`` §Exception.
-* :class:`RoomInvariantViolation` — room feature, see
-  ``docs/features/room/detailed-design.md`` §Exception.
+* :class:`EmpireInvariantViolation` — empire 機能。
+  ``docs/features/empire/detailed-design.md`` §Exception 参照。
+* :class:`WorkflowInvariantViolation` — workflow 機能。
+  ``docs/features/workflow/detailed-design.md`` §Exception 参照。
+* :class:`StageInvariantViolation` — workflow の Stage エンティティレベル違反。
+  :class:`WorkflowInvariantViolation` を継承するため、呼び出し側は
+  親クラスを ``except`` してもより具体的なサブクラスを受け取れる。
+* :class:`AgentInvariantViolation` — agent 機能。
+  ``docs/features/agent/detailed-design.md`` §Exception 参照。
+* :class:`RoomInvariantViolation` — room 機能。
+  ``docs/features/room/detailed-design.md`` §Exception 参照。
 
-Workflow / Agent / Room violations automatically apply
-:func:`mask_discord_webhook_in` to both ``message`` and ``detail`` so a
-webhook secret can never leak through exception text or its diagnostic
-payload — multi-layer defense covering webhook URLs that may slip into
+Workflow / Agent / Room の違反は ``message`` と ``detail`` の両方に
+自動的に :func:`mask_discord_webhook_in` を適用するため、webhook シークレットは
+例外テキストや診断ペイロードを介して漏洩しない。これは
 ``NotifyChannel.target`` / ``Persona.prompt_body`` / ``SkillRef.path`` /
-``PromptKit.prefix_markdown`` / ``Room.{name,description}``.
+``PromptKit.prefix_markdown`` / ``Room.{name,description}`` に紛れ込む可能性がある
+webhook URL を多層防御するためのもの。
 """
 
 from __future__ import annotations
@@ -38,28 +37,27 @@ type EmpireViolationKind = Literal[
     "room_not_found",
     "capacity_exceeded",
 ]
-"""Discriminator for ``EmpireInvariantViolation`` matching detailed-design §Exception."""
+"""詳細設計 §Exception に対応する ``EmpireInvariantViolation`` の判別子。"""
 
 
-# Domain naming convention follows DDD: "Violation" expresses an invariant breach,
-# not a programming error. The N818 "Error suffix" rule does not apply here.
+# ドメイン命名規約は DDD に従う: "Violation" は不変条件違反を表現するもので、
+# プログラミングエラーではない。そのため N818 "Error suffix" ルールは適用しない。
 class EmpireInvariantViolation(Exception):  # noqa: N818
-    """Raised when an :class:`Empire` aggregate invariant is violated.
+    """:class:`Empire` 集約の不変条件違反時に送出される。
 
-    Pydantic v2's ``model_validator(mode='after')`` re-raises non-``ValueError`` /
-    non-``AssertionError`` exceptions without wrapping them in ``ValidationError``,
-    so callers receive this exception directly with full ``kind`` / ``detail``
-    structure intact.
+    Pydantic v2 の ``model_validator(mode='after')`` は ``ValueError`` /
+    ``AssertionError`` 以外の例外を ``ValidationError`` でラップせずに
+    再送出するため、呼び出し側は完全な ``kind`` / ``detail`` 構造を保ったまま
+    本例外を直接受け取る。
 
     Attributes:
-        kind: One of the canonical violation discriminators in
-            :data:`EmpireViolationKind`. Stable string values used by tests
-            and HTTP API mappers; never localized.
-        message: The full ``[FAIL] ...`` user-facing string per
-            ``MSG-EM-001``〜``MSG-EM-005`` in detailed-design §MSG.
-        detail: Structured context (UUIDs, lengths, counts) for diagnostics
-            and audit logging. Stored as a fresh ``dict`` copy to keep the
-            exception immutable from the caller's view.
+        kind: :data:`EmpireViolationKind` の正式な違反判別子のいずれか。
+            テストや HTTP API マッパーが使う安定した文字列値であり、
+            ローカライズしない。
+        message: 詳細設計 §MSG の ``MSG-EM-001``〜``MSG-EM-005`` に対応する
+            ``[FAIL] ...`` 形式のユーザー向け完全文字列。
+        detail: 診断・監査ログ向けの構造化コンテキスト（UUID, 長さ, 件数等）。
+            呼び出し側から見て例外が不変であるよう、新しい ``dict`` コピーとして格納する。
     """
 
     def __init__(
@@ -91,34 +89,33 @@ type WorkflowViolationKind = Literal[
     "empty_required_role_aggregate",
     "from_dict_invalid",
 ]
-"""Discriminator for :class:`WorkflowInvariantViolation` matching workflow
-detailed-design §Exception. The list extends the design's 11 canonical kinds
-with three operational discriminators that surface in MSG-WF-001 / MSG-WF-008
-(``name_range`` / ``stage_duplicate``) and the symmetric ``transition_id_duplicate``
-that mirrors ``stage_duplicate`` for the Transition collection contract
-(detailed-design §Aggregate Root: Workflow row ``transitions: 0〜60 件、
-transition_id の重複なし``)."""
+"""workflow 詳細設計 §Exception に対応する :class:`WorkflowInvariantViolation`
+の判別子。設計上の正式 11 種類に加え、MSG-WF-001 / MSG-WF-008 で表面化する
+3 つの運用判別子（``name_range`` / ``stage_duplicate`` 等）と、Transition
+コレクション契約に対する ``stage_duplicate`` の対となる
+``transition_id_duplicate`` を追加している（詳細設計 §Aggregate Root: Workflow
+の ``transitions: 0〜60 件、transition_id の重複なし`` 行参照）。"""
 
 
 type StageViolationKind = Literal[
     "empty_required_role",
     "missing_notify",
 ]
-"""Discriminator for :class:`StageInvariantViolation` (Workflow detailed-design)."""
+""":class:`StageInvariantViolation` の判別子（Workflow 詳細設計）。"""
 
 
-# DDD: "Violation" describes an invariant breach, not a programming bug, so
-# the N818 "Error suffix" rule does not apply here.
+# DDD: "Violation" は不変条件違反を表現するもので、プログラミングのバグではない。
+# そのため N818 "Error suffix" ルールは適用しない。
 class WorkflowInvariantViolation(Exception):  # noqa: N818
-    """Raised when a :class:`Workflow` aggregate invariant is violated.
+    """:class:`Workflow` 集約の不変条件違反時に送出される。
 
-    All ``message`` / ``detail`` strings are passed through
-    :func:`mask_discord_webhook_in` at construction time so the secret
-    ``token`` segment of any embedded Discord webhook URL is replaced with
-    ``<REDACTED:DISCORD_WEBHOOK>``. This makes it impossible for downstream
-    log/audit consumers to leak a webhook credential just by serializing
-    the exception (Workflow detailed-design §確定 G "target のシークレット扱い"
-    line "例外 message / detail").
+    すべての ``message`` / ``detail`` 文字列は構築時に
+    :func:`mask_discord_webhook_in` を通すため、埋め込まれた Discord
+    webhook URL のシークレット ``token`` 部分は
+    ``<REDACTED:DISCORD_WEBHOOK>`` に置換される。これにより、例外を
+    シリアライズしただけで下流のログ・監査利用側が webhook 資格情報を
+    漏洩することは不可能になる（Workflow 詳細設計 §確定 G
+    「target のシークレット扱い」の「例外 message / detail」行）。
     """
 
     def __init__(
@@ -138,15 +135,15 @@ class WorkflowInvariantViolation(Exception):  # noqa: N818
         self.detail: dict[str, object] = masked_detail
 
 
-# Subclass so ``except WorkflowInvariantViolation`` catches Stage-level
-# violations too (the aggregate path may delegate to Stage's own validator,
-# and callers should handle both uniformly).
+# ``except WorkflowInvariantViolation`` で Stage レベル違反も捕捉できるよう
+# サブクラス化する（集約パスは Stage 自身のバリデータに委譲する場合があり、
+# 呼び出し側は両者を一様に扱うべき）。
 class StageInvariantViolation(WorkflowInvariantViolation):
-    """Raised by :class:`Stage` self-validation (independent of the aggregate).
+    """:class:`Stage` の自己検証（集約とは独立）から送出される。
 
-    ``kind`` narrows to :data:`StageViolationKind` but the surrounding
-    ``WorkflowInvariantViolation`` type contract is preserved — including
-    secret masking on ``message`` / ``detail``.
+    ``kind`` は :data:`StageViolationKind` に絞られるが、周囲の
+    ``WorkflowInvariantViolation` 型契約（``message`` / ``detail`` への
+    シークレットマスク含む）は維持される。
     """
 
     def __init__(
@@ -156,8 +153,8 @@ class StageInvariantViolation(WorkflowInvariantViolation):
         message: str,
         detail: Mapping[str, object] | None = None,
     ) -> None:
-        # Forward to parent so masking and the discriminator field are
-        # populated identically. Re-narrow self.kind for the static type.
+        # 親へ転送し、マスクと判別子フィールドを同一に設定させる。
+        # 静的型のため self.kind を再度狭める。
         super().__init__(
             kind=kind,  # type: ignore[arg-type]
             message=message,
@@ -182,23 +179,22 @@ type AgentViolationKind = Literal[
     "skill_capacity_exceeded",
     "provider_capacity_exceeded",
 ]
-"""Discriminator for :class:`AgentInvariantViolation` per Agent detailed-design
-§Exception. Extends the design's 12 documented kinds with two operational
-``*_capacity_exceeded`` discriminators that surface the §確定 C bounds
-(providers ≤ 10, skills ≤ 20) — without them the same MSG would have to
-double up an existing kind and lose discrimination at the HTTP API layer."""
+"""Agent 詳細設計 §Exception に対応する :class:`AgentInvariantViolation` の
+判別子。設計上の 12 種類に加え、§確定 C の境界値（providers ≤ 10, skills ≤ 20）を
+表面化する 2 つの ``*_capacity_exceeded`` 運用判別子を追加している。これらが
+なければ既存 kind と MSG が重複し、HTTP API 層での判別ができなくなる。"""
 
 
-# DDD: "Violation" describes an invariant breach, not a programming bug, so
-# the N818 "Error suffix" rule does not apply here.
+# DDD: "Violation" は不変条件違反を表現するもので、プログラミングのバグではない。
+# そのため N818 "Error suffix" ルールは適用しない。
 class AgentInvariantViolation(Exception):  # noqa: N818
-    """Raised when an :class:`Agent` aggregate invariant is violated.
+    """:class:`Agent` 集約の不変条件違反時に送出される。
 
-    Mirrors :class:`EmpireInvariantViolation` in shape (``kind`` + ``message``
-    + ``detail`` + immutable copy of detail) and applies the same Discord
-    webhook secret masking that :class:`WorkflowInvariantViolation` uses, so
-    if a SkillRef.path or Persona.prompt_body ever happens to contain a
-    Discord webhook URL fragment it cannot leak through exception text.
+    形（``kind`` + ``message`` + ``detail`` + detail の不変コピー）は
+    :class:`EmpireInvariantViolation` と同一で、:class:`WorkflowInvariantViolation`
+    と同じ Discord webhook シークレットマスクを適用する。SkillRef.path や
+    Persona.prompt_body に Discord webhook URL の断片が含まれた場合でも、
+    例外テキスト経由で漏洩することはない。
     """
 
     def __init__(
@@ -226,29 +222,30 @@ type RoomViolationKind = Literal[
     "member_not_found",
     "room_archived",
 ]
-"""Discriminator for :class:`RoomInvariantViolation` per Room detailed-design
-§Exception (§確定 I 例外型統一規約).
+"""Room 詳細設計 §Exception（§確定 I 例外型統一規約）に対応する
+:class:`RoomInvariantViolation` の判別子。
 
-The set is **closed at six kinds**: ``prompt_kit_too_long`` is *intentionally
-omitted* because the PromptKit VO raises :class:`pydantic.ValidationError`
-on its own ``model_validator`` before any Room invariant check fires. Adding
-it here would create a dead-code path that ``RoomInvariantViolation`` cannot
-reach by construction — see Room detailed-design §確定 I 2 段階 catch.
+集合は **6 種類で閉じている**: ``prompt_kit_too_long`` は *意図的に省略* されている。
+PromptKit VO は Room 不変条件チェックが走る前に自身の ``model_validator`` で
+:class:`pydantic.ValidationError` を送出するためであり、ここに追加しても
+``RoomInvariantViolation`` から構造上到達できないデッドコードになる
+（Room 詳細設計 §確定 I の 2 段階 catch 参照）。
 """
 
 
-# DDD: "Violation" describes an invariant breach, not a programming bug, so
-# the N818 "Error suffix" rule does not apply here.
+# DDD: "Violation" は不変条件違反を表現するもので、プログラミングのバグではない。
+# そのため N818 "Error suffix" ルールは適用しない。
 class RoomInvariantViolation(Exception):  # noqa: N818
-    """Raised when a :class:`Room` aggregate invariant is violated.
+    """:class:`Room` 集約の不変条件違反時に送出される。
 
-    Mirrors :class:`AgentInvariantViolation` / :class:`WorkflowInvariantViolation`
-    in shape (``kind`` + ``message`` + ``detail`` + immutable copy of detail) and
-    applies the same Discord webhook secret masking. ``Room.name`` /
-    ``Room.description`` / ``PromptKit.prefix_markdown`` may all carry user-pasted
-    text that contains a webhook URL, so masking ``message`` / ``detail`` at
-    construction time means callers cannot leak a token by serializing the
-    exception (multi-layer defense, see Room detailed-design §確定 H).
+    形（``kind`` + ``message`` + ``detail`` + detail の不変コピー）は
+    :class:`AgentInvariantViolation` / :class:`WorkflowInvariantViolation`
+    と同一で、同じ Discord webhook シークレットマスクを適用する。
+    ``Room.name`` / ``Room.description`` / ``PromptKit.prefix_markdown`` は
+    いずれもユーザーが貼り付けた webhook URL を含む可能性があるため、
+    構築時に ``message`` / ``detail`` をマスクすることで、呼び出し側が
+    例外をシリアライズしただけでトークンを漏洩することはなくなる
+    （多層防御。Room 詳細設計 §確定 H 参照）。
     """
 
     def __init__(
@@ -272,30 +269,28 @@ type DirectiveViolationKind = Literal[
     "text_range",
     "task_already_linked",
 ]
-"""Discriminator for :class:`DirectiveInvariantViolation` per Directive
-detailed-design §確定 F.
+"""Directive 詳細設計 §確定 F に対応する :class:`DirectiveInvariantViolation` の
+判別子。
 
-The set is **closed at two kinds**. Type / required-field violations
-surface as :class:`pydantic.ValidationError` (MSG-DR-003) and the
-``$``-prefix normalization is an application-layer responsibility
-(``DirectiveService.issue()``), so neither leaks into the aggregate's
-discriminator namespace.
+集合は **2 種類で閉じている**。型・必須フィールド違反は
+:class:`pydantic.ValidationError`（MSG-DR-003）として表面化し、``$``
+プレフィックス正規化はアプリケーション層の責務（``DirectiveService.issue()``）
+であるため、いずれも集約の判別子名前空間には漏れ出さない。
 """
 
 
-# DDD: "Violation" describes an invariant breach, not a programming bug, so
-# the N818 "Error suffix" rule does not apply here.
+# DDD: "Violation" は不変条件違反を表現するもので、プログラミングのバグではない。
+# そのため N818 "Error suffix" ルールは適用しない。
 class DirectiveInvariantViolation(Exception):  # noqa: N818
-    """Raised when a :class:`Directive` aggregate invariant is violated.
+    """:class:`Directive` 集約の不変条件違反時に送出される。
 
-    Mirrors :class:`RoomInvariantViolation` / :class:`AgentInvariantViolation`
-    in shape (``kind`` + ``message`` + ``detail`` + immutable copy of
-    detail) and applies the same Discord webhook secret masking.
-    ``Directive.text`` is user-pasted CEO directive content that may
-    embed a webhook URL, so masking ``message`` / ``detail`` at
-    construction time means callers cannot leak a token by serializing
-    the exception (multi-layer defense, see Directive detailed-design
-    §確定 E).
+    形（``kind`` + ``message`` + ``detail`` + detail の不変コピー）は
+    :class:`RoomInvariantViolation` / :class:`AgentInvariantViolation` と
+    同一で、同じ Discord webhook シークレットマスクを適用する。
+    ``Directive.text`` はユーザーが貼り付ける CEO 指示の本文であり、
+    webhook URL を埋め込まれる可能性があるため、構築時に ``message`` /
+    ``detail`` をマスクすれば、呼び出し側は例外をシリアライズしただけで
+    トークンを漏洩できなくなる（多層防御。Directive 詳細設計 §確定 E 参照）。
     """
 
     def __init__(
@@ -324,32 +319,30 @@ type TaskViolationKind = Literal[
     "blocked_requires_last_error",
     "timestamp_order",
 ]
-"""Discriminator for :class:`TaskInvariantViolation` per Task detailed-design
-§確定 J. The closed set of seven kinds covers terminal violation, state-machine
-bypass, the four structural invariants enforced by ``model_validator(mode='after')``,
-and the timestamp-order check. Type / required-field violations surface as
-``pydantic.ValidationError`` (MSG-TS-008 / MSG-TS-009) and never leak into this
-discriminator namespace."""
+"""Task 詳細設計 §確定 J に対応する :class:`TaskInvariantViolation` の判別子。
+7 種類の閉じた集合で、ターミナル違反・状態機械バイパス・
+``model_validator(mode='after')`` で強制される 4 つの構造不変条件・
+タイムスタンプ順序チェックを網羅する。型・必須フィールド違反は
+``pydantic.ValidationError``（MSG-TS-008 / MSG-TS-009）として表面化し、
+本判別子名前空間には漏れ出さない。"""
 
 
-# DDD: "Violation" describes an invariant breach, not a programming bug, so
-# the N818 "Error suffix" rule does not apply here.
+# DDD: "Violation" は不変条件違反を表現するもので、プログラミングのバグではない。
+# そのため N818 "Error suffix" ルールは適用しない。
 class TaskInvariantViolation(Exception):  # noqa: N818
-    """Raised when a :class:`Task` aggregate invariant is violated.
+    """:class:`Task` 集約の不変条件違反時に送出される。
 
-    Mirrors :class:`DirectiveInvariantViolation` /
-    :class:`RoomInvariantViolation` /
-    :class:`AgentInvariantViolation` /
-    :class:`WorkflowInvariantViolation` in shape (``kind`` + ``message``
-    + ``detail`` + immutable copy of detail) and applies the same Discord
-    webhook secret masking. ``Task.last_error`` may carry an LLM-Adapter
-    stack trace that includes a webhook URL (the MVP runs Discord
-    notifications), and ``Deliverable.body_markdown`` is CEO / Agent
-    authored content; both can land in ``message`` / ``detail`` via
-    ``state_transition_invalid`` or ``last_error_consistency`` paths, so
-    masking ``message`` / ``detail`` at construction time means callers
-    cannot leak a token by serializing the exception (multi-layer defense,
-    see Task detailed-design §確定 I).
+    形（``kind`` + ``message`` + ``detail`` + detail の不変コピー）は
+    :class:`DirectiveInvariantViolation` / :class:`RoomInvariantViolation` /
+    :class:`AgentInvariantViolation` / :class:`WorkflowInvariantViolation` と
+    同一で、同じ Discord webhook シークレットマスクを適用する。
+    ``Task.last_error`` は webhook URL を含む LLM-Adapter スタックトレースを
+    保持する可能性があり（MVP は Discord 通知を行う）、
+    ``Deliverable.body_markdown`` は CEO / Agent が書いたコンテンツである。
+    両者は ``state_transition_invalid`` や ``last_error_consistency`` の経路を介して
+    ``message`` / ``detail`` に流入し得るため、構築時に ``message`` /
+    ``detail`` をマスクすれば、呼び出し側は例外をシリアライズしただけでトークンを
+    漏洩できなくなる（多層防御。Task 詳細設計 §確定 I 参照）。
     """
 
     def __init__(

--- a/backend/src/bakufu/domain/external_review_gate/__init__.py
+++ b/backend/src/bakufu/domain/external_review_gate/__init__.py
@@ -1,28 +1,24 @@
-"""ExternalReviewGate Aggregate Root package.
+"""ExternalReviewGate Aggregate Root パッケージ。
 
-Implements ``REQ-GT-001``〜``REQ-GT-007`` per
-``docs/features/external-review-gate``. M1 7 兄弟目 — the **last**
-M1 aggregate, completing the domain skeleton (after empire /
-workflow / agent / room / directive / task). The package is split
-along the responsibility lines that the design calls out:
+``docs/features/external-review-gate`` に従って ``REQ-GT-001``〜``REQ-GT-007`` を
+実装する。M1 7 兄弟目 — **最後** の M1 Aggregate であり、ドメイン スケルトン
+を完成させる（empire / workflow / agent / room / directive / task の後）。
+設計が指摘する責務境界に沿ってパッケージを分割する:
 
-* :mod:`bakufu.domain.external_review_gate.state_machine` —
-  decision-table state machine (``Final[Mapping]`` +
-  :class:`types.MappingProxyType`, §確定 B). 7 entries matching
-  §確定 A's 4 x 4 dispatch table 1:1.
-* :mod:`bakufu.domain.external_review_gate.aggregate_validators` —
-  four module-level ``_validate_*`` helpers for the structural
-  invariants (§確定 J kinds 2〜5; ``decision_already_decided`` is
-  enforced by the state-machine lookup itself).
-* :mod:`bakufu.domain.external_review_gate.gate` —
-  :class:`ExternalReviewGate` Aggregate Root exposing four behavior
-  methods whose names map 1:1 to the state-machine action names
-  (§確定 A — task #42 §確定 A-2 パターン継承).
+* :mod:`bakufu.domain.external_review_gate.state_machine` — decision-table
+  state machine（``Final[Mapping]`` + :class:`types.MappingProxyType`、§確定 B）。
+  §確定 A の 4 x 4 ディスパッチ表と 1:1 で対応する 7 エントリ。
+* :mod:`bakufu.domain.external_review_gate.aggregate_validators` — 構造的
+  不変条件（§確定 J kinds 2〜5、``decision_already_decided`` は state machine
+  ルックアップ自体で強制される）のためのモジュール レベル ``_validate_*``
+  ヘルパ 4 つ。
+* :mod:`bakufu.domain.external_review_gate.gate` — state machine アクション名と
+  1:1 対応する 4 個の振る舞いメソッドを公開する :class:`ExternalReviewGate`
+  Aggregate Root（§確定 A — task #42 §確定 A-2 パターン継承）。
 
-This ``__init__`` re-exports the public surface plus the
-underscore-prefixed validators tests need to invoke directly (the
-same pattern Norman approved for the agent / room / directive /
-task packages).
+この ``__init__`` はパブリック表面に加え、テストが直接呼ぶ必要のあるアンダー
+スコア プレフィックス バリデータも再 export する（Norman が agent / room /
+directive / task パッケージで承認したのと同じパターン）。
 """
 
 from __future__ import annotations

--- a/backend/src/bakufu/domain/external_review_gate/aggregate_validators.py
+++ b/backend/src/bakufu/domain/external_review_gate/aggregate_validators.py
@@ -1,30 +1,25 @@
-"""Aggregate-level invariant helpers for :class:`ExternalReviewGate`.
+""":class:`ExternalReviewGate` のための Aggregate レベル不変条件ヘルパ。
 
-Each helper is a **module-level pure function** so tests can ``import``
-and invoke directly — the same testability pattern Norman / Steve
-approved for the agent / room / directive / task aggregate validators.
+各ヘルパは **モジュール レベルの純粋関数** であるため、テストから ``import``
+して直接呼べる — Norman / Steve が agent / room / directive / task の Aggregate
+バリデータで承認したのと同じテスタビリティ パターン。
 
-Helpers (5 total, matching detailed-design.md §確定 J):
+ヘルパ（5 つ、detailed-design.md §確定 J に対応）:
 
-1. :func:`_validate_decided_at_consistency` — ``decision == PENDING``
-   ⇔ ``decided_at is None``; the four other states must carry a
-   tz-aware decided_at.
-2. :func:`_validate_snapshot_immutable` — placeholder; the structural
-   guard is the absence of ``deliverable_snapshot`` in
-   ``_rebuild_with_state``'s argument set (§確定 D). The function
-   stays for symmetry with the validator dispatch and to provide a
-   well-defined failure path if a rebuild ever supplies a different
-   snapshot.
-3. :func:`_validate_feedback_text_range` — NFC code-point length
-   0〜10000.
-4. :func:`_validate_audit_trail_append_only` — checked at rebuild
-   time by comparing the new list against the previous one (§確定 C
-   inputs/expectations table).
+1. :func:`_validate_decided_at_consistency` — ``decision == PENDING`` ⇔
+   ``decided_at is None``。他 4 状態は tz-aware decided_at を持たなければならない。
+2. :func:`_validate_snapshot_immutable` — プレースホルダ。構造的ガードは
+   ``_rebuild_with_state`` の引数集合に ``deliverable_snapshot`` を含めないこと
+   （§確定 D）。本関数はバリデータ ディスパッチとの対称性のため、また rebuild が
+   万一異なるスナップショットを供給した場合に明確な失敗経路を提供するために
+   残されている。
+3. :func:`_validate_feedback_text_range` — NFC コードポイント長 0〜10000。
+4. :func:`_validate_audit_trail_append_only` — rebuild 時に新リストを旧リストと
+   比較してチェックする（§確定 C inputs/expectations 表）。
 
-The decision-immutability invariant (PENDING → 1 transition only) is
-enforced inside the state-machine ``lookup`` path; this module owns
-only the structural invariants that fire on every
-``model_validate``.
+決定の不変性不変条件（PENDING → 1 遷移のみ）は state machine ``lookup`` 経路で
+強制される。本モジュールはすべての ``model_validate`` で発火する構造的不変条件
+のみを所有する。
 """
 
 from __future__ import annotations
@@ -38,7 +33,7 @@ from bakufu.domain.value_objects import ReviewDecision
 if TYPE_CHECKING:
     from bakufu.domain.value_objects import AuditEntry, Deliverable
 
-# Confirmation F: feedback_text length bounds (NFC, no strip).
+# Confirmation F: feedback_text 長境界（NFC、strip 無し）。
 MIN_FEEDBACK_LENGTH: int = 0
 MAX_FEEDBACK_LENGTH: int = 10_000
 
@@ -47,14 +42,12 @@ def _validate_decided_at_consistency(
     decision: ReviewDecision,
     decided_at: datetime | None,
 ) -> None:
-    """``decision == PENDING`` ⇔ ``decided_at is None`` (MSG-GT-002).
+    """``decision == PENDING`` ⇔ ``decided_at is None``（MSG-GT-002）。
 
-    Detects Repository row corruption such as
-    ``decision=APPROVED, decided_at=None`` (terminal Gate without a
-    decided_at timestamp) or the reverse, ``decision=PENDING`` with a
-    populated ``decided_at`` — both shapes are structurally illegal
-    and catching them at hydration means the application layer
-    cannot be handed an inconsistent Gate.
+    ``decision=APPROVED, decided_at=None``（decided_at 未設定の終端 Gate）または
+    逆に ``decision=PENDING`` で ``decided_at`` が埋まっているといったリポジトリ
+    行破損を検出する — どちらの形も構造的に違法。水和時に捕捉することで、
+    アプリケーション層に一貫性のない Gate が渡されることを防ぐ。
     """
     is_pending = decision == ReviewDecision.PENDING
     has_timestamp = decided_at is not None
@@ -78,7 +71,7 @@ def _validate_decided_at_consistency(
 
 
 def _validate_feedback_text_range(feedback_text: str) -> None:
-    """``0 <= len(NFC(feedback_text)) <= 10000`` (MSG-GT-004)."""
+    """``0 <= len(NFC(feedback_text)) <= 10000``（MSG-GT-004）。"""
     length = len(feedback_text)
     if not (MIN_FEEDBACK_LENGTH <= length <= MAX_FEEDBACK_LENGTH):
         raise ExternalReviewGateInvariantViolation(
@@ -98,19 +91,18 @@ def _validate_audit_trail_append_only(
     previous: list[AuditEntry] | None,
     current: list[AuditEntry],
 ) -> None:
-    """Existing entries must stay byte-equal and at the head of the list (MSG-GT-005).
+    """既存エントリはバイト等価のまま、リスト先頭に留まらなければならない（MSG-GT-005）。
 
-    Construction (``previous is None``) accepts any list — the
-    aggregate's first instance simply locks in whatever Repository
-    hydration / the issuing application service hands over. Every
-    subsequent ``_rebuild_with_state`` call must satisfy:
+    構築時（``previous is None``）は任意のリストを受理する — Aggregate の最初の
+    インスタンスは、リポジトリ水和や発行側アプリケーション サービスが渡す内容を
+    そのまま固定する。以降の ``_rebuild_with_state`` 呼び出しは下記を満たさな
+    ければならない:
 
-    1. ``len(current) >= len(previous)`` (no deletions).
-    2. ``current[: len(previous)] == previous`` (no edits, no
-       reorderings, no prepends, no middle inserts).
+    1. ``len(current) >= len(previous)``（削除なし）。
+    2. ``current[: len(previous)] == previous``（編集、並べ替え、prepend、
+       中間挿入のいずれも無し）。
 
-    The §確定 C inputs/expectations table is the canonical reference
-    for the failure cases this guards against.
+    §確定 C inputs/expectations 表が、本ガードが対象とする失敗ケースの正準参照。
     """
     if previous is None:
         return
@@ -151,16 +143,15 @@ def _validate_snapshot_immutable(
     previous: Deliverable | None,
     current: Deliverable,
 ) -> None:
-    """The construction-time ``deliverable_snapshot`` may not be replaced (MSG-GT-003).
+    """構築時の ``deliverable_snapshot`` は置き換えられない（MSG-GT-003）。
 
-    Construction (``previous is None``) accepts any Deliverable — the
-    aggregate's first instance pins whatever the application service
-    or Repository hydration supplies. Subsequent ``_rebuild_with_state``
-    calls **must not** pass a different snapshot; the implementation
-    contract (§確定 D) is to leave ``deliverable_snapshot`` out of
-    the rebuild's argument set entirely so the value carries through
-    unchanged. This validator is the failure-path safety net if that
-    contract ever leaks.
+    構築時（``previous is None``）は任意の Deliverable を受理する — Aggregate
+    の最初のインスタンスは、アプリケーション サービスやリポジトリ水和が供給する
+    値をそのまま固定する。以降の ``_rebuild_with_state`` 呼び出しは異なる
+    スナップショットを渡しては **ならない**。実装コントラクト（§確定 D）は
+    ``deliverable_snapshot`` を rebuild の引数集合から完全に外し、値が変更
+    されないまま継承されるようにすること。本バリデータは、そのコントラクトが
+    万一漏れた場合の失敗経路セーフティ ネット。
     """
     if previous is None:
         return

--- a/backend/src/bakufu/domain/external_review_gate/gate.py
+++ b/backend/src/bakufu/domain/external_review_gate/gate.py
@@ -1,57 +1,46 @@
-"""ExternalReviewGate Aggregate Root (REQ-GT-001〜007).
+"""ExternalReviewGate Aggregate Root（REQ-GT-001〜007）。
 
-Implements ``docs/features/external-review-gate/`` as the M1 7th and
-final sibling. The aggregate follows the same shape established by
-empire / workflow / agent / room / directive / task but is **scoped
-much tighter**: 4 methods x 4 decision states = 16-cell dispatch
-table with **7 ✓ transitions + 9 ✗ cells**. The narrow surface lines
-up with the Gate's job — bind a single human review round to a
-single Stage outcome, then freeze.
+``docs/features/external-review-gate/`` を M1 の 7 番目かつ最後の兄弟として実装する。
+この Aggregate は empire / workflow / agent / room / directive / task で確立された
+形を踏襲するが、**スコープがより絞り込まれている**: 4 メソッド × 4 decision 状態 =
+16 セルのディスパッチ表で **7 ✓ 遷移 + 9 ✗ セル**。狭い表面は Gate の役割と一致する
+— 単一の人間レビュー ラウンドを単一の Stage 結果に結び付け、その後固定する。
 
-Two structural elements unique to the Gate's lifecycle:
+Gate のライフサイクル特有の構造要素は 2 つ:
 
-* a **decision-table state machine** in
-  :mod:`bakufu.domain.external_review_gate.state_machine`, locked by
-  ``Final[Mapping]`` + :class:`types.MappingProxyType` per §確定 B; and
-* **four dedicated behavior methods** whose names map 1:1 to the
-  action names in the state-machine table per §確定 A (the same
-  Steve R2 凍結 pattern that task #42 §確定 A-2 introduced).
+* :mod:`bakufu.domain.external_review_gate.state_machine` 内の **decision-table
+  state machine**。§確定 B により ``Final[Mapping]`` + :class:`types.MappingProxyType`
+  でロックされる。
+* §確定 A により state-machine テーブルのアクション名と 1:1 対応する **4 つの専用
+  ビヘイビア メソッド**（task #42 §確定 A-2 が導入した Steve R2 凍結パターン）。
 
-Design contracts (do not break without re-running design review):
+設計コントラクト（再設計レビュー無しに破壊しないこと）:
 
-* **Pre-validate rebuild (§確定 E)** — every behavior calls
-  :meth:`_rebuild_with_state` which goes through ``model_dump`` /
-  ``swap`` / ``model_validate``. ``model_copy(update=...)`` is
-  intentionally avoided.
-* **State-machine bypass Fail-Fast (§確定 A)** — illegal
-  ``(decision, action)`` pairs raise
-  :class:`ExternalReviewGateInvariantViolation` with
-  ``kind='decision_already_decided'`` so MSG-GT-001 lands with the
-  "Next:" hint already populated (the Gate is single-decision by
-  design).
-* **Snapshot immutable (§確定 D)** — :meth:`_rebuild_with_state`
-  does **not** accept a ``deliverable_snapshot`` argument; every
-  rebuild path inherits the construction-time snapshot byte-for-byte.
-  The structural absence is the strongest possible guarantee against
-  accidental mutation.
-* **Audit-trail append-only (§確定 C)** — every behavior appends
-  exactly one new :class:`AuditEntry` at the end of the list.
-  :meth:`_rebuild_with_state` runs
-  :func:`_validate_audit_trail_append_only` against the previous
-  trail before reconstructing, so a misbehaving rebuild path
-  surfaces ``audit_trail_append_only`` (MSG-GT-005) before the new
-  instance is constructed.
-* **Webhook auto-mask (§確定 H)** —
-  :class:`ExternalReviewGateInvariantViolation` applies
-  ``mask_discord_webhook`` / ``mask_discord_webhook_in`` to
-  ``message`` / ``detail`` at construction time so a webhook URL
-  embedded in ``feedback_text`` cannot leak through the exception
-  stream.
-* **Aggregate boundary (§確定 J)** — the Gate does **not** import
-  Task / Workflow / Stage methods. ``GateService.approve()`` →
-  ``task.approve_review(...)`` (and the symmetric REJECTED /
-  CANCELLED legs) is dispatched by the application layer, keeping
-  the Gate ignorant of Task internals.
+* **Pre-validate rebuild（§確定 E）** — 全ビヘイビアは :meth:`_rebuild_with_state`
+  を呼び、``model_dump`` / ``swap`` / ``model_validate`` を経由する。
+  ``model_copy(update=...)`` は意図的に避ける。
+* **State-machine bypass Fail-Fast（§確定 A）** — 不正な ``(decision, action)`` 対は
+  :class:`ExternalReviewGateInvariantViolation` を ``kind='decision_already_decided'``
+  で送出するため、MSG-GT-001 が「Next:」ヒント込みで投入される（Gate は設計上
+  単一決定）。
+* **Snapshot immutable（§確定 D）** — :meth:`_rebuild_with_state` は
+  ``deliverable_snapshot`` 引数を **受け取らない**。再構築のあらゆる経路は構築時の
+  スナップショットをバイト単位で継承する。構造的な不在こそが偶発的な変異に対する
+  最強の保証である。
+* **Audit-trail append-only（§確定 C）** — 全ビヘイビアは末尾に厳密に 1 つの新しい
+  :class:`AuditEntry` を追記する。:meth:`_rebuild_with_state` は再構築前に
+  :func:`_validate_audit_trail_append_only` を旧 trail に対して実行するため、
+  rebuild 経路が誤動作した場合は新インスタンス構築の *前* に
+  ``audit_trail_append_only``（MSG-GT-005）が表面化する。
+* **Webhook auto-mask（§確定 H）** —
+  :class:`ExternalReviewGateInvariantViolation` は構築時に ``mask_discord_webhook`` /
+  ``mask_discord_webhook_in`` を ``message`` / ``detail`` に適用するため、
+  ``feedback_text`` に埋め込まれた webhook URL が例外ストリームから漏洩することは
+  ない。
+* **Aggregate boundary（§確定 J）** — Gate は Task / Workflow / Stage のメソッドを
+  **import しない**。``GateService.approve()`` → ``task.approve_review(...)``
+  （および対称な REJECTED / CANCELLED 経路）はアプリケーション層がディスパッチし、
+  Gate は Task の内部に対して無知のままとなる。
 """
 
 from __future__ import annotations
@@ -93,18 +82,17 @@ from bakufu.domain.value_objects import (
 
 
 class ExternalReviewGate(BaseModel):
-    """One human-review checkpoint binding a Task's Stage to a Decision.
+    """Task の Stage を Decision に結び付ける 1 つの人間レビュー チェックポイント。
 
-    A Gate is created in PENDING by ``GateService.create()`` (after
-    Task.request_external_review fires), accumulates audit views via
-    :meth:`record_view`, and terminates exactly once via
-    :meth:`approve` / :meth:`reject` / :meth:`cancel`. The terminal
-    states still permit :meth:`record_view` (audit reads of decided
-    Gates are legitimate and tracked, §確定 G "誰がいつ何度見たか").
+    Gate は ``GateService.create()``（Task.request_external_review が発火した後）に
+    よって PENDING で生成され、:meth:`record_view` で監査ビューを蓄積し、
+    :meth:`approve` / :meth:`reject` / :meth:`cancel` のいずれか 1 つで終端する。
+    終端状態でも :meth:`record_view` は許可される（決定済み Gate に対する監査読取は
+    正当でありトラックする、§確定 G「誰がいつ何度見たか」）。
 
-    Out-of-aggregate concerns (Task / Stage / Owner reference
-    integrity, snapshot inline-copy persistence, Gate-to-Task
-    dispatch) live in ``GateService`` per §確定 J.
+    Aggregate 外の関心事（Task / Stage / Owner 参照整合性、スナップショットの
+    インライン コピー永続化、Gate-to-Task ディスパッチ）は §確定 J により
+    ``GateService`` に置く。
     """
 
     model_config = ConfigDict(
@@ -124,7 +112,7 @@ class ExternalReviewGate(BaseModel):
     created_at: datetime
     decided_at: datetime | None = None
 
-    # ---- pre-validation -------------------------------------------------
+    # ---- 事前検証 -------------------------------------------------------
     @field_validator("created_at", mode="after")
     @classmethod
     def _require_created_at_tz_aware(cls, value: datetime) -> datetime:
@@ -150,14 +138,13 @@ class ExternalReviewGate(BaseModel):
     @field_validator("feedback_text", mode="before")
     @classmethod
     def _normalize_feedback_text(cls, value: object) -> object:
-        """NFC-only normalization (§確定 F).
+        """NFC のみの正規化（§確定 F）。
 
-        ``strip`` is intentionally **not** applied — CEO-authored
-        review comments may include indented quoting / multi-paragraph
-        bodies whose leading whitespace carries meaning, the same
-        precedent set by ``Persona.prompt_body`` /
+        ``strip`` は意図的に **適用しない** — CEO が書くレビュー コメントには
+        インデント引用や複数段落の本文が含まれる場合があり、その先頭空白に
+        意味を持たせている。``Persona.prompt_body`` /
         ``PromptKit.prefix_markdown`` / ``Directive.text`` /
-        ``Task.last_error``.
+        ``Task.last_error`` と同じ先例。
         """
         if isinstance(value, str):
             return unicodedata.normalize("NFC", value)
@@ -165,24 +152,21 @@ class ExternalReviewGate(BaseModel):
 
     @model_validator(mode="after")
     def _check_invariants(self) -> Self:
-        """Run the structural invariants (§確定 J kinds 2 + 4).
+        """構造的不変条件を実行する（§確定 J kinds 2 + 4）。
 
-        ``decision_already_decided`` is enforced by the state-machine
-        ``lookup`` path (raises before this validator runs);
-        ``snapshot_immutable`` is enforced structurally by
-        :meth:`_rebuild_with_state` not accepting a snapshot argument;
-        ``audit_trail_append_only`` is enforced by
-        :meth:`_rebuild_with_state` running the validator against the
-        previous trail before constructing the new instance. What
-        stays on the after-validator is the pair of single-instance
-        invariants that hydration paths (Repository round-trip) must
-        also satisfy.
+        ``decision_already_decided`` は state-machine ``lookup`` 経路で強制される
+        （このバリデータより前に送出される）。``snapshot_immutable`` は
+        :meth:`_rebuild_with_state` が snapshot 引数を受理しないことで構造的に
+        強制される。``audit_trail_append_only`` は :meth:`_rebuild_with_state`
+        が新インスタンス構築前に旧 trail に対してバリデータを走らせて強制する。
+        after-validator に残るのは、水和経路（リポジトリ往復）も満たさなければならない
+        単一インスタンス不変条件のペア。
         """
         _validate_decided_at_consistency(self.decision, self.decided_at)
         _validate_feedback_text_range(self.feedback_text)
         return self
 
-    # ---- behaviors (Tell, Don't Ask) ------------------------------------
+    # ---- 振る舞い（Tell, Don't Ask） -----------------------------------
     def approve(
         self,
         by_owner_id: OwnerId,
@@ -190,12 +174,11 @@ class ExternalReviewGate(BaseModel):
         *,
         decided_at: datetime,
     ) -> ExternalReviewGate:
-        """PENDING → APPROVED, attach ``feedback_text`` + audit entry (REQ-GT-002).
+        """PENDING → APPROVED、``feedback_text`` と監査エントリを追加（REQ-GT-002）。
 
-        ``by_owner_id`` records the human who approved. The
-        ``decided_at`` argument is taken explicitly (per §設計判断補足
-        "なぜ decided_at を引数で受け取るか") so the aggregate stays
-        time-pure and tests don't need ``freezegun``.
+        ``by_owner_id`` は承認した人間を記録する。``decided_at`` 引数は明示的に取る
+        （§設計判断補足「なぜ decided_at を引数で受け取るか」）ので Aggregate は
+        time-pure に保たれ、テストは ``freezegun`` を必要としない。
         """
         next_decision = self._lookup_or_raise("approve")
         return self._rebuild_with_state(
@@ -215,11 +198,10 @@ class ExternalReviewGate(BaseModel):
         *,
         decided_at: datetime,
     ) -> ExternalReviewGate:
-        """PENDING → REJECTED, attach ``feedback_text`` + audit entry (REQ-GT-003).
+        """PENDING → REJECTED、``feedback_text`` と監査エントリを追加（REQ-GT-003）。
 
-        Same shape as :meth:`approve` — the only differences are the
-        target ``decision`` (REJECTED) and the audit row's
-        :class:`AuditAction` discriminator.
+        :meth:`approve` と同形 — 違いは目的の ``decision``（REJECTED）と監査行の
+        :class:`AuditAction` 識別子のみ。
         """
         next_decision = self._lookup_or_raise("reject")
         return self._rebuild_with_state(
@@ -239,12 +221,11 @@ class ExternalReviewGate(BaseModel):
         *,
         decided_at: datetime,
     ) -> ExternalReviewGate:
-        """PENDING → CANCELLED, attach ``feedback_text`` + audit entry (REQ-GT-004).
+        """PENDING → CANCELLED、``feedback_text`` と監査エントリを追加（REQ-GT-004）。
 
-        ``reason`` lands in both ``feedback_text`` (so the
-        application layer can surface why the Gate was withdrawn)
-        and the audit entry's ``comment`` (so the audit trail
-        records the reasoning).
+        ``reason`` は ``feedback_text``（アプリケーション層が Gate 取り下げ理由を
+        表面化できるよう）と監査エントリの ``comment``（監査証跡が理由を記録できる
+        よう）の両方に格納する。
         """
         next_decision = self._lookup_or_raise("cancel")
         return self._rebuild_with_state(
@@ -263,19 +244,17 @@ class ExternalReviewGate(BaseModel):
         *,
         viewed_at: datetime,
     ) -> ExternalReviewGate:
-        """Append a VIEWED audit entry; permitted in **every** decision state (REQ-GT-005, §確定 G).
+        """VIEWED 監査エントリを追記。**全** decision 状態で許可（REQ-GT-005、§確定 G）。
 
-        ``decision`` / ``decided_at`` / ``feedback_text`` are
-        deliberately *not* updated — record_view is purely an audit
-        operation. Idempotency is **not** offered (§確定 G "冪等性
-        なし"): two calls with the same ``(by_owner_id, viewed_at)``
-        produce two distinct entries because the audit requirement is
-        "誰がいつ何度見たか" — collapsing duplicates would discard
-        the very signal the audit trail is supposed to preserve.
+        ``decision`` / ``decided_at`` / ``feedback_text`` は意図的に *更新しない* —
+        record_view は純粋な監査操作。冪等性は **提供しない**（§確定 G「冪等性なし」）:
+        同じ ``(by_owner_id, viewed_at)`` での 2 回の呼び出しは別個のエントリを 2 つ
+        生成する。監査要件が「誰がいつ何度見たか」だからであり、重複を畳み込むと監査
+        証跡が保持すべきシグナルそのものを破棄してしまう。
         """
-        # State-machine lookup confirms the action is legal from the
-        # current decision; the result is the same value (self-loop)
-        # but the call documents the contract.
+        # State-machine ルックアップにより現在の decision からアクションが正当である
+        # ことを確認する。結果は同じ値（self-loop）だが、呼び出し自体がコントラクトを
+        # 文書化する。
         self._lookup_or_raise("record_view")
         return self._rebuild_with_state(
             new_audit_action=AuditAction.VIEWED,
@@ -284,15 +263,14 @@ class ExternalReviewGate(BaseModel):
             new_audit_at=viewed_at,
         )
 
-    # ---- internal -------------------------------------------------------
+    # ---- 内部実装 -------------------------------------------------------
     def _lookup_or_raise(self, action: GateAction) -> ReviewDecision:
-        """State-machine lookup, translating ``KeyError`` into MSG-GT-001.
+        """State-machine ルックアップ。``KeyError`` を MSG-GT-001 に翻訳する。
 
-        Returns the ``next_decision`` for the (current_decision,
-        action) pair. The four PENDING-only actions (``approve`` /
-        ``reject`` / ``cancel``) raise here when the Gate has already
-        been decided — the lookup table simply has no row for
-        ``(APPROVED, 'approve')`` etc.
+        (current_decision, action) ペアの ``next_decision`` を返す。PENDING 限定の
+        4 つのアクション（``approve`` / ``reject`` / ``cancel``）は Gate が既に決定
+        済みの場合ここで送出する — ルックアップ表に ``(APPROVED, 'approve')`` 等の
+        行が単に存在しないため。
         """
         try:
             return lookup(self.decision, action)
@@ -326,28 +304,24 @@ class ExternalReviewGate(BaseModel):
         feedback_text: str | None = None,
         decided_at: datetime | None = None,
     ) -> ExternalReviewGate:
-        """Pre-validate rebuild for behavior outputs (§確定 E).
+        """ビヘイビア出力のための pre-validate rebuild（§確定 E）。
 
-        The rebuild path is the **only** legal way to mutate the
-        Gate's audit_trail / decision / feedback_text / decided_at
-        fields. ``deliverable_snapshot`` is intentionally absent
-        from the keyword-only argument list so no rebuild path can
-        replace it (§確定 D).
+        rebuild 経路は Gate の audit_trail / decision / feedback_text / decided_at
+        フィールドを変異させる **唯一の** 合法経路である。``deliverable_snapshot``
+        はキーワード専用引数リストから意図的に除外されているため、いかなる rebuild
+        経路もこれを置き換えられない（§確定 D）。
 
-        Step order:
+        ステップ順:
 
-        1. Build the new :class:`AuditEntry` — every behavior
-           appends exactly one entry, so the constructor lives here
-           rather than at every call site.
-        2. Compose ``new_audit_trail = self.audit_trail + [new]`` and
-           validate it against the previous trail
-           (:func:`_validate_audit_trail_append_only`). Failure
-           here surfaces *before* a potentially-broken instance is
-           constructed — Fail-Fast on programming bugs that
-           accidentally drop or reorder existing entries.
-        3. ``model_dump`` the current state, swap in the supplied
-           field deltas, and re-construct via ``model_validate`` so
-           ``_check_invariants`` re-fires.
+        1. 新しい :class:`AuditEntry` を構築する — 全ビヘイビアは厳密に 1 エントリを
+           追記するため、コンストラクタ呼出は各呼び出し箇所ではなくここに置く。
+        2. ``new_audit_trail = self.audit_trail + [new]`` を作り、旧 trail に対して
+           （:func:`_validate_audit_trail_append_only`）検証する。ここでの失敗は
+           壊れている可能性のあるインスタンスが構築される *前* に表面化する —
+           既存エントリを誤って落とす / 並べ替えるプログラミング バグに対する
+           Fail-Fast。
+        3. 現在状態を ``model_dump`` し、与えられたフィールド差分をスワップ し、
+           ``model_validate`` で再構築する。これにより ``_check_invariants`` が再発火する。
         """
         new_entry = AuditEntry(
             id=uuid4(),
@@ -367,18 +341,16 @@ class ExternalReviewGate(BaseModel):
         if decided_at is not None:
             state["decided_at"] = decided_at
         state["audit_trail"] = [entry.model_dump() for entry in new_audit_trail]
-        # ``deliverable_snapshot`` carries through ``model_dump`` /
-        # ``model_validate`` byte-for-byte: the snapshot pinned at
-        # construction time is what the rebuilt Gate sees too
-        # (§確定 D §不変条件).
+        # ``deliverable_snapshot`` は ``model_dump`` / ``model_validate`` を
+        # バイト単位で通過する: 構築時に固定したスナップショットが再構築された
+        # Gate にもそのまま継承される（§確定 D §不変条件）。
         rebuilt = ExternalReviewGate.model_validate(state)
-        # §確定 D 3 重防衛 safety net: the keyword-only signature above
-        # is the *structural* guarantee (no rebuild path can pass a new
-        # snapshot), but Steve R-S1 requires the validator be **active**
-        # so a future refactor that breaks the structural guarantee is
-        # caught here too. With the structural guarantee in place this
-        # call is a no-op on the happy path and Fail-Fast otherwise —
-        # exactly what a defense-in-depth safety net should be.
+        # §確定 D 3 重防衛 セーフティ ネット: 上記のキーワード専用シグネチャが
+        # *構造的* 保証（rebuild 経路は新スナップショットを渡せない）であるが、
+        # Steve R-S1 はバリデータを **アクティブ** に保つことを要求するため、構造的
+        # 保証を破る将来のリファクタもここで捕捉される。構造的保証が機能している
+        # 限り、この呼び出しはハッピーパスでは no-op、それ以外では Fail-Fast —
+        # 多層防御セーフティ ネットの理想的な振る舞い。
         _validate_snapshot_immutable(self.deliverable_snapshot, rebuilt.deliverable_snapshot)
         return rebuilt
 

--- a/backend/src/bakufu/domain/external_review_gate/state_machine.py
+++ b/backend/src/bakufu/domain/external_review_gate/state_machine.py
@@ -1,47 +1,40 @@
-"""Decision-table state machine for the :class:`ExternalReviewGate` aggregate.
+""":class:`ExternalReviewGate` Aggregate のための decision-table state machine。
 
-Implements ``docs/features/external-review-gate/detailed-design.md``
-§確定 B (state machine table lock) and §確定 A (Method x
-current_decision dispatch table). The contract is intentionally a
-**flat ``Mapping[(ReviewDecision, str), ReviewDecision]``** rather
-than an ``if-elif`` ladder so:
+``docs/features/external-review-gate/detailed-design.md`` §確定 B
+（state machine テーブル ロック）と §確定 A（Method x current_decision の
+ディスパッチ表）を実装する。コントラクトは意図的に
+**フラットな ``Mapping[(ReviewDecision, str), ReviewDecision]``** であり、
+``if-elif`` 階段ではない。理由:
 
-1. The exact set of allowed transitions is enumerable in one
-   structure — code review can compare it against §確定 A's
-   16-cell dispatch table (4 method x 4 state) at a glance.
-2. The lookup function refuses unknown ``(decision, action)`` pairs
-   with ``KeyError`` so the caller wraps the failure in
+1. 許可遷移の集合がきっちり 1 つの構造で列挙可能 — コードレビュー時に §確定 A の
+   16 セル ディスパッチ表（4 メソッド × 4 状態）と一目で照合できる。
+2. ルックアップ関数は未知の ``(decision, action)`` 対を ``KeyError`` で拒否する
+   ため、呼び元は失敗を
    :class:`ExternalReviewGateInvariantViolation(kind='decision_already_decided')`
-   — Fail-Fast on illegal ``approve`` / ``reject`` / ``cancel`` calls
-   against a Gate that is no longer PENDING.
-3. ``Final[Mapping]`` + :func:`types.MappingProxyType` makes both
-   pyright (re-assignment detection) and the runtime (``setitem``
-   rejection) refuse to mutate the table after import. A future PR
-   that wants to add a transition has to edit *this* file plus the
-   corresponding test.
+   で包む — もう PENDING ではない Gate に対する不正な ``approve`` / ``reject`` /
+   ``cancel`` 呼び出しに対する Fail-Fast。
+3. ``Final[Mapping]`` + :func:`types.MappingProxyType` により、pyright（再代入検出）
+   と ランタイム（``setitem`` 拒否）の両方が import 後の変異を拒否する。遷移を追加
+   したい将来の PR は *この* ファイルと対応するテストの両方を編集する必要がある。
 
-The 7 entries below correspond 1:1 with the ``→`` cells in §確定 A's
-dispatch table:
+下記 7 エントリは §確定 A ディスパッチ表の ``→`` セルと 1:1 対応する:
 
-* ``PENDING`` → ``approve`` / ``reject`` / ``cancel`` (the three
-  decision-emitting actions, terminating to APPROVED / REJECTED /
-  CANCELLED respectively).
-* ``record_view`` self-loops on **every** decision value (PENDING,
-  APPROVED, REJECTED, CANCELLED) — auditing a decided Gate is
-  legitimate (§確定 G "誰がいつ何度見たか"). The four self-loops are
-  enumerated explicitly so test side can mirror the dispatch table
-  and a future PR cannot silently restrict ``record_view`` to a
-  subset.
+* ``PENDING`` → ``approve`` / ``reject`` / ``cancel``（決定を発行する 3 アクション、
+  それぞれ APPROVED / REJECTED / CANCELLED に終端）。
+* ``record_view`` は **すべての** decision 値（PENDING、APPROVED、REJECTED、
+  CANCELLED）で自己ループする — 決定済み Gate の監査は正当な操作（§確定 G
+  「誰がいつ何度見たか」）。4 つの自己ループは明示的に列挙し、テスト側がディスパッチ
+  表をミラーできるようにし、将来の PR が ``record_view`` を一部の状態にサイレント
+  に制限できないようにする。
 
-The remaining 9 illegal cells (PENDING-only actions invoked on a
-non-PENDING Gate) hit ``KeyError`` on lookup and translate to
-``decision_already_decided`` (MSG-GT-001) at the Aggregate boundary.
+残り 9 個の違法セル（PENDING 限定アクションを非 PENDING Gate に対して呼び出す）は
+ルックアップで ``KeyError`` に当たり、Aggregate 境界で ``decision_already_decided``
+（MSG-GT-001）に翻訳される。
 
-``action`` is constrained at the type level by :data:`GateAction` so
-typo-driven typos (``'approv'`` etc.) are caught by pyright strict
-before they reach runtime. The 4 ``Literal`` values mirror the 4
-:class:`ExternalReviewGate` methods one-for-one — adding a method
-without updating this list (or vice versa) is a type error.
+``action`` は :data:`GateAction` で型レベルに制約されているため、タイプミス
+（``'approv'`` 等）は実行前に pyright strict が捕捉する。4 個の ``Literal`` 値は
+4 個の :class:`ExternalReviewGate` メソッドと 1:1 で対応する — このリストを更新せず
+にメソッドを追加（あるいはその逆）するのは型エラーになる。
 """
 
 from __future__ import annotations
@@ -58,78 +51,71 @@ type GateAction = Literal[
     "cancel",
     "record_view",
 ]
-"""Closed set of action names matching :class:`ExternalReviewGate`
-method names 1:1.
+""":class:`ExternalReviewGate` のメソッド名と 1:1 対応するアクション名のクローズド集合。
 
-Per §確定 A (task #42 §確定 A-2 パターン継承), Gate methods do **not**
-dispatch on runtime values. Each method calls
-``state_machine.lookup(self.decision, '<method_name>')`` so the action
-name is a compile-time string literal — the table lookup result and
-the method's behavior are statically tied together.
+§確定 A（task #42 §確定 A-2 パターン継承）に従い、Gate メソッドはランタイム値で
+**ディスパッチしない**。各メソッドは
+``state_machine.lookup(self.decision, '<method_name>')`` を呼び出し、アクション名は
+コンパイル時の文字列リテラルとなる — テーブル ルックアップ結果とメソッドの振る舞い
+が静的に紐付く。
 """
 
 
 _TRANSITIONS: Mapping[tuple[ReviewDecision, GateAction], ReviewDecision] = MappingProxyType(
     {
-        # PENDING — the three decision-emitting transitions plus the
-        # record_view self-loop. After any of approve / reject / cancel
-        # the Gate is terminal for those three actions.
+        # PENDING — 決定を発行する 3 つの遷移と record_view 自己ループ。
+        # approve / reject / cancel のいずれかの後、Gate はその 3 アクションについて
+        # 終端となる。
         (ReviewDecision.PENDING, "approve"): ReviewDecision.APPROVED,
         (ReviewDecision.PENDING, "reject"): ReviewDecision.REJECTED,
         (ReviewDecision.PENDING, "cancel"): ReviewDecision.CANCELLED,
         (ReviewDecision.PENDING, "record_view"): ReviewDecision.PENDING,
-        # APPROVED / REJECTED / CANCELLED — only ``record_view`` is
-        # legal so the Gate's audit trail can keep tracking late
-        # readers. The four self-loops are enumerated rather than
-        # inferred so the dispatch table mirrors the implementation
-        # exactly (§確定 A §"4 行明示列挙する根拠").
+        # APPROVED / REJECTED / CANCELLED — ``record_view`` のみ合法。Gate の監査
+        # 証跡は遅れて読みに来た者を引き続き追跡できる。4 つの自己ループは推論
+        # ではなく列挙する — ディスパッチ表が実装と完全に一致するよう
+        # （§確定 A §「4 行明示列挙する根拠」）。
         (ReviewDecision.APPROVED, "record_view"): ReviewDecision.APPROVED,
         (ReviewDecision.REJECTED, "record_view"): ReviewDecision.REJECTED,
         (ReviewDecision.CANCELLED, "record_view"): ReviewDecision.CANCELLED,
     }
 )
-"""Read-only view of the canonical 7-entry transition map.
+"""正準 7 エントリ遷移マップへの読み取り専用ビュー。
 
-Wrapping the underlying ``dict`` in :class:`types.MappingProxyType`
-makes ``_TRANSITIONS[k] = v`` raise ``TypeError`` at runtime even
-when somebody `cast`s the table. ``Final`` blocks re-assignment of
-the symbol itself in pyright strict mode.
+基底の ``dict`` を :class:`types.MappingProxyType` で包むことで、誰かがテーブルを
+`cast` した場合でも ``_TRANSITIONS[k] = v`` がランタイムで ``TypeError`` になる。
+``Final`` は pyright strict モードでシンボル自体の再代入をブロックする。
 """
 
 TRANSITIONS: Final[Mapping[tuple[ReviewDecision, GateAction], ReviewDecision]] = _TRANSITIONS
-"""Public alias for the transition table.
+"""遷移テーブルのパブリック エイリアス。
 
-Tests import this to assert the table size (``len(TRANSITIONS) == 7``)
-and to walk every legal transition without going through ``lookup``.
-The :class:`MappingProxyType` wrapper still applies, so code that
-imports it cannot mutate it.
+テストはこれを import してテーブル サイズ（``len(TRANSITIONS) == 7``）をアサート
+し、``lookup`` を経由せずに全合法遷移を巡回する。:class:`MappingProxyType` ラッパは
+依然として有効なので、import したコードもこれを変異できない。
 """
 
 
 def lookup(current_decision: ReviewDecision, action: GateAction) -> ReviewDecision:
-    """Return the allowed ``next_decision`` for ``(current_decision, action)``.
+    """``(current_decision, action)`` に対する許可された ``next_decision`` を返す。
 
     Raises:
-        KeyError: when the pair is not in the canonical transition
-            table. The :class:`ExternalReviewGate` aggregate catches
-            this and re-raises as
+        KeyError: 対が正準遷移テーブルに存在しない場合。
+            :class:`ExternalReviewGate` Aggregate がこれを捕捉し、診断のために元の／
+            試行された decision を付与した
             :class:`ExternalReviewGateInvariantViolation(kind='decision_already_decided')`
-            with the original / attempted decision attached for
-            diagnostics — that translation lives in ``gate.py`` so
-            this module stays free of the exception package import
-            cycle.
+            として再送出する — その変換は ``gate.py`` に置き、本モジュールを例外
+            パッケージの import サイクルから解放する。
     """
     return _TRANSITIONS[(current_decision, action)]
 
 
 def allowed_actions_from(current_decision: ReviewDecision) -> list[GateAction]:
-    """Return the subset of actions legal from ``current_decision``.
+    """``current_decision`` から合法なアクション部分集合を返す。
 
-    Used by :class:`ExternalReviewGate` to populate the
-    ``allowed_actions`` field of MSG-GT-001 so the human-readable
-    next-action hint surfaces *which* transitions would have worked.
-    Returned in stable insertion order (Python 3.7+ dict iteration)
-    so test snapshots stay deterministic.
+    :class:`ExternalReviewGate` が MSG-GT-001 の ``allowed_actions`` フィールドを
+    埋めるために使う。これにより人間可読な next-action ヒントが *どの* 遷移であれば
+    成功したかを表面化する。挿入順を保つ Python 3.7+ dict iteration を使うため、
+    テスト スナップショットも決定的に保たれる。
     """
     return [action for (decision, action) in _TRANSITIONS if decision == current_decision]
 

--- a/backend/src/bakufu/domain/internal_review_gate/aggregate_validators.py
+++ b/backend/src/bakufu/domain/internal_review_gate/aggregate_validators.py
@@ -1,32 +1,30 @@
-"""Aggregate-level invariant helpers for :class:`InternalReviewGate`.
+""":class:`InternalReviewGate` のための Aggregate レベル不変条件ヘルパ。
 
-Each helper is a **module-level pure function** so tests can ``import``
-and invoke directly — the same testability pattern used by the
-agent / room / directive / task / external_review_gate aggregate
-validators.
+各ヘルパは **モジュール レベルの純粋関数** であるため、テストから ``import``
+して直接呼べる — agent / room / directive / task / external_review_gate の
+Aggregate バリデータと同じテスタビリティ パターン。
 
-Four invariants (matching internal-review-gate detailed-design §確定 J):
+internal-review-gate detailed-design §確定 J に対応する 4 つの不変条件:
 
 1. :func:`_validate_required_gate_roles_nonempty` — ``required_gate_roles``
-   must contain at least one role; an empty set would make
-   ALL_APPROVED unreachable by design and is a workflow-author mistake
-   that should surface immediately.
-2. :func:`_validate_verdict_roles_in_required` — every verdict's
-   ``role`` must appear in ``required_gate_roles``; a verdict from an
-   unrecognized role indicates a stale or misconfigured agent and should
-   be rejected before it influences the decision.
-3. :func:`_validate_no_duplicate_roles` — each GateRole may have at most
-   one verdict; duplicate submissions are rejected (the agent must be
-   ``submit_verdict``-guarded at the behavior layer too, but the
-   aggregate validator provides a second line of defense during
-   hydration).
-4. :func:`_validate_gate_decision_consistency` — the stored
-   ``gate_decision`` must equal what ``compute_decision`` produces from
-   the current ``verdicts`` and ``required_gate_roles``; detects
-   Repository row corruption or a misbehaving behavior method.
+   は少なくとも 1 つのロールを含まなければならない。空集合では設計上
+   ALL_APPROVED に到達できなくなり、ワークフロー作成者の間違いが即座に表面化
+   すべきである。
+2. :func:`_validate_verdict_roles_in_required` — 各 verdict の ``role`` は
+   ``required_gate_roles`` に含まれなければならない。認識されないロールから
+   の verdict は、stale または誤構成のエージェントを示しており、決定に影響を
+   与える前に拒否すべきである。
+3. :func:`_validate_no_duplicate_roles` — 各 GateRole は最大 1 つの verdict
+   しか持てない。重複提出は拒否される（エージェントは振る舞い層でも
+   ``submit_verdict`` でガードされなければならないが、Aggregate バリデータは
+   水和時に第二の防御線を提供する）。
+4. :func:`_validate_gate_decision_consistency` — 保存された ``gate_decision``
+   は現在の ``verdicts`` と ``required_gate_roles`` から ``compute_decision``
+   が生成する値と等しくなければならない。リポジトリ行破損や誤動作する振る舞い
+   メソッドを検出する。
 
-The public :func:`validate_all` function runs all four in order and is
-called by :meth:`InternalReviewGate._check_invariants`.
+パブリックな :func:`validate_all` 関数は全 4 つを順序通りに実行し、
+:meth:`InternalReviewGate._check_invariants` から呼ばれる。
 """
 
 from __future__ import annotations
@@ -41,15 +39,14 @@ if TYPE_CHECKING:
 
 
 def _validate_required_gate_roles_nonempty(gate: InternalReviewGate) -> None:
-    """``required_gate_roles`` must not be empty (invariant 1).
+    """``required_gate_roles`` は空であってはならない（不変条件 1）。
 
-    An empty set would make ``GateDecision.ALL_APPROVED`` structurally
-    unreachable (no roles to approve means the condition ``all required
-    roles approved`` is vacuously true from the state-machine's
-    perspective, but the business rule intends that at least one human
-    reviewer category participates).  Raising here at construction time
-    surfaces the workflow-author mistake before any agent can interact
-    with the Gate.
+    空集合では ``GateDecision.ALL_APPROVED`` が構造的に到達不可能になる（承認
+    すべきロールが無いことは state machine の観点では「全 required ロールが
+    承認」条件が真空に真となるが、ビジネス ルールは少なくとも 1 つの人間
+    レビュアー カテゴリが参加することを意図している）。構築時にここで送出する
+    ことで、ワークフロー作成者の間違いがエージェントが Gate と相互作用する前に
+    表面化する。
     """
     if not gate.required_gate_roles:
         raise InternalReviewGateInvariantViolation(
@@ -63,14 +60,12 @@ def _validate_required_gate_roles_nonempty(gate: InternalReviewGate) -> None:
 
 
 def _validate_verdict_roles_in_required(gate: InternalReviewGate) -> None:
-    """Every verdict role must be in ``required_gate_roles`` (invariant 2).
+    """全 verdict のロールは ``required_gate_roles`` に含まれなければならない（不変条件 2）。
 
-    A verdict whose ``role`` is absent from ``required_gate_roles``
-    indicates either a stale Gate configuration (the role was removed
-    after the Gate was created) or a misconfigured agent (it is
-    presenting a role it was never granted). Either case is a data
-    integrity violation that should surface before the Gate's decision
-    is computed.
+    ``role`` が ``required_gate_roles`` に不在の verdict は、stale な Gate 構成
+    （Gate 作成後にロールが削除された）または誤構成のエージェント（付与されて
+    いないロールを名乗る）のいずれかを示す。どちらのケースも Gate 決定計算前に
+    表面化すべきデータ整合性違反。
     """
     required = gate.required_gate_roles
     for verdict in gate.verdicts:
@@ -92,12 +87,11 @@ def _validate_verdict_roles_in_required(gate: InternalReviewGate) -> None:
 
 
 def _validate_no_duplicate_roles(gate: InternalReviewGate) -> None:
-    """Each GateRole must appear at most once in ``verdicts`` (invariant 3).
+    """各 GateRole は ``verdicts`` 内に最大 1 回しか現れてはならない（不変条件 3）。
 
-    Duplicate role verdicts are a programming error — ``submit_verdict``
-    guards against re-submission at the behavior layer, but the
-    aggregate validator enforces the same invariant during hydration so
-    a corrupt Repository row does not yield a silently-inconsistent Gate.
+    重複ロール verdict はプログラミング エラー — ``submit_verdict`` が振る舞い層
+    で再提出をガードするが、Aggregate バリデータは水和時にも同じ不変条件を強制
+    するため、破損したリポジトリ行がサイレントに一貫性のない Gate を生成しない。
     """
     seen: set[str] = set()
     for verdict in gate.verdicts:
@@ -117,11 +111,11 @@ def _validate_no_duplicate_roles(gate: InternalReviewGate) -> None:
 
 
 def _validate_gate_decision_consistency(gate: InternalReviewGate) -> None:
-    """``gate_decision`` must equal ``compute_decision(...)`` (invariant 4).
+    """``gate_decision`` は ``compute_decision(...)`` と等しくなければならない（不変条件 4）。
 
-    Detects Repository row corruption (e.g. ``gate_decision=ALL_APPROVED``
-    when no verdicts exist) or a misbehaving behavior method that updated
-    the decision field without going through the state machine.
+    リポジトリ行破損（例 verdict が存在しないのに ``gate_decision=ALL_APPROVED``）
+    や、state machine を経由せずに decision フィールドを更新する誤動作な振る舞い
+    メソッドを検出する。
     """
     expected = compute_decision(gate.verdicts, gate.required_gate_roles)
     if gate.gate_decision != expected:
@@ -142,17 +136,16 @@ def _validate_gate_decision_consistency(gate: InternalReviewGate) -> None:
 
 
 def validate_all(gate: InternalReviewGate) -> None:
-    """Run all four aggregate invariants in order.
+    """4 つの Aggregate 不変条件を順序通りに実行する。
 
-    Called by :meth:`InternalReviewGate._check_invariants` so every
-    construction path (direct instantiation, ``model_validate``, and
-    Repository hydration) runs the same checks. The invariants are
-    ordered from cheapest to most expensive:
+    :meth:`InternalReviewGate._check_invariants` から呼ばれるため、すべての構築
+    経路（直接インスタンス化、``model_validate``、リポジトリ水和）で同じチェック
+    が走る。不変条件は安価な順から最も高価な順に並ぶ:
 
-    1. Non-empty roles (O(1) set truth check).
-    2. Verdict roles subset check (O(n) over verdicts).
-    3. Duplicate role detection (O(n) with a ``set`` accumulator).
-    4. Decision consistency (O(n) ``compute_decision`` fold).
+    1. 非空ロール（O(1) 集合真偽チェック）。
+    2. Verdict ロールの部分集合チェック（verdict 数 n に対し O(n)）。
+    3. 重複ロール検出（``set`` アキュムレータで O(n)）。
+    4. 決定の一貫性（O(n) ``compute_decision`` 畳み込み）。
     """
     _validate_required_gate_roles_nonempty(gate)
     _validate_verdict_roles_in_required(gate)

--- a/backend/src/bakufu/domain/internal_review_gate/aggregate_validators.py
+++ b/backend/src/bakufu/domain/internal_review_gate/aggregate_validators.py
@@ -80,7 +80,7 @@ def _validate_verdict_roles_in_required(gate: InternalReviewGate) -> None:
                 message=(
                     f'[FAIL] Verdict の GateRole "{verdict.role}" は '
                     f"required_gate_roles に含まれていません。\n"
-                    f"Next: 有効な GateRole（{sorted(required)}）の verdict のみ "  # noqa: RUF001
+                    f"Next: 有効な GateRole（{sorted(required)}）の verdict のみ "
                     f"InternalReviewGate に追加してください。"
                 ),
                 detail={
@@ -129,8 +129,8 @@ def _validate_gate_decision_consistency(gate: InternalReviewGate) -> None:
             kind="gate_decision_inconsistent",
             message=(
                 f"[FAIL] gate_decision が不整合です "
-                f"（stored={gate.gate_decision.value}, "  # noqa: RUF001
-                f"computed={expected.value}）。\n"  # noqa: RUF001
+                f"（stored={gate.gate_decision.value}, "
+                f"computed={expected.value}）。\n"
                 f"Next: Repository 行の整合性を確認してください。"
             ),
             detail={

--- a/backend/src/bakufu/domain/internal_review_gate/internal_review_gate.py
+++ b/backend/src/bakufu/domain/internal_review_gate/internal_review_gate.py
@@ -154,7 +154,7 @@ class InternalReviewGate(BaseModel):
                 kind="gate_already_decided",
                 message=(
                     f"[FAIL] InternalReviewGate は既に判断確定済みです"
-                    f"（{self.gate_decision.value}）。\n"  # noqa: RUF001
+                    f"（{self.gate_decision.value}）。\n"
                     f"Next: 新しい Gate が生成されるまでお待ちください。"
                 ),
                 detail={
@@ -194,7 +194,7 @@ class InternalReviewGate(BaseModel):
                 message=(
                     f'[FAIL] GateRole "{role}" は本 Gate の required_gate_roles に'
                     f"含まれていません。\n"
-                    f"Next: 有効な GateRole（{sorted(self.required_gate_roles)}）"  # noqa: RUF001
+                    f"Next: 有効な GateRole（{sorted(self.required_gate_roles)}）"
                     f"で提出してください。"
                 ),
                 detail={
@@ -210,8 +210,8 @@ class InternalReviewGate(BaseModel):
             raise InternalReviewGateInvariantViolation(
                 kind="comment_too_long",
                 message=(
-                    f"[FAIL] コメントが文字数上限（5000文字）を超えています"  # noqa: RUF001
-                    f"（{comment_length}文字）。\n"  # noqa: RUF001
+                    f"[FAIL] コメントが文字数上限（5000文字）を超えています"
+                    f"（{comment_length}文字）。\n"
                     f"Next: 5000文字以内に短縮してください。"
                 ),
                 detail={

--- a/backend/src/bakufu/domain/internal_review_gate/internal_review_gate.py
+++ b/backend/src/bakufu/domain/internal_review_gate/internal_review_gate.py
@@ -1,25 +1,23 @@
-"""InternalReviewGate Aggregate Root.
+"""InternalReviewGate Aggregate Root。
 
-Implements the internal (agent-to-agent) review gate for
-``INTERNAL_REVIEW`` Stage completion. The aggregate collects per-role
-:class:`Verdict` objects submitted by agents, derives the overall
-:class:`GateDecision` from them via the state machine, and enforces
-four structural invariants via ``model_validator(mode='after')``.
+``INTERNAL_REVIEW`` Stage 完了のための内部（エージェント間）レビュー ゲートを実装
+する。Aggregate は agent が提出する role 別 :class:`Verdict` を集約し、state machine
+を介してそれらから全体の :class:`GateDecision` を導出し、
+``model_validator(mode='after')`` で 4 つの構造的不変条件を強制する。
 
-Design contracts (do not break without re-running design review):
+設計コントラクト（再設計レビュー無しに破壊しないこと）:
 
-* **Pre-validate rebuild** — ``submit_verdict`` uses ``model_dump`` /
-  dict-update / ``model_validate`` (not ``model_copy(update=...)``),
-  mirroring the ExternalReviewGate §確定 E pattern.
-* **Frozen aggregate** — all fields are immutable; every behavior
-  returns a **new** instance.
-* **Comment NFC-only** — the ``comment`` field on :class:`Verdict` is
-  NFC-normalized but never stripped (multi-line review comments whose
-  leading whitespace carries meaning).
-* **Decision computed, not stored independently** — ``gate_decision``
-  stored in the aggregate must always equal ``compute_decision(verdicts,
-  required_gate_roles)``; this is enforced by both the behavior method
-  and the aggregate invariant validator.
+* **Pre-validate rebuild** — ``submit_verdict`` は ``model_dump`` / dict-update /
+  ``model_validate`` を使う（``model_copy(update=...)`` ではない）。
+  ExternalReviewGate §確定 E パターンと対称。
+* **Frozen aggregate** — 全フィールド不変。すべての振る舞いは **新** インスタンスを
+  返す。
+* **Comment NFC のみ** — :class:`Verdict` の ``comment`` フィールドは NFC 正規化のみ
+  行い、strip は適用しない（先頭空白に意味を持たせ得る複数行レビュー コメント）。
+* **Decision は計算であり独立保存ではない** — Aggregate に保存される
+  ``gate_decision`` は常に ``compute_decision(verdicts, required_gate_roles)`` と
+  等しくなければならない。これは振る舞いメソッドと Aggregate 不変条件バリデータの
+  両方で強制される。
 """
 
 from __future__ import annotations
@@ -46,18 +44,16 @@ from bakufu.domain.value_objects import (
 
 
 class InternalReviewGate(BaseModel):
-    """Multi-role internal review checkpoint for ``INTERNAL_REVIEW`` Stages.
+    """``INTERNAL_REVIEW`` Stage 用の複数ロール内部レビュー チェックポイント。
 
-    A Gate is created in ``GateDecision.PENDING`` with an empty
-    ``verdicts`` tuple and a non-empty ``required_gate_roles`` set.
-    Agents submit verdicts via :meth:`submit_verdict`; the Gate
-    transitions to ``ALL_APPROVED`` when every required role has
-    approved, or to ``REJECTED`` as soon as any verdict is
-    ``VerdictDecision.REJECTED`` (most-pessimistic-wins rule).
+    Gate は空の ``verdicts`` タプルと非空の ``required_gate_roles`` 集合と共に
+    ``GateDecision.PENDING`` で生成される。エージェントは :meth:`submit_verdict`
+    で判定を提出する。Gate は全 required role が承認した時に ``ALL_APPROVED`` に、
+    いずれかの判定が ``VerdictDecision.REJECTED`` になった時点で ``REJECTED`` に遷移
+    する（most-pessimistic-wins ルール）。
 
-    The aggregate is frozen — every behavior returns a **new**
-    :class:`InternalReviewGate` instance, leaving the original
-    unchanged.
+    Aggregate はフローズン — すべての振る舞いは **新** :class:`InternalReviewGate`
+    インスタンスを返し、元のインスタンスは変更しない。
     """
 
     model_config = ConfigDict(frozen=True, extra="forbid", arbitrary_types_allowed=False)
@@ -82,18 +78,17 @@ class InternalReviewGate(BaseModel):
 
     @model_validator(mode="after")
     def _check_invariants(self) -> InternalReviewGate:
-        """Run the four structural invariants (internal-review-gate §確定 J).
+        """4 つの構造的不変条件を実行する（internal-review-gate §確定 J）。
 
-        Importing inside the method breaks the circular dependency
-        between this module and ``aggregate_validators`` (which imports
-        this class for its type annotation).
+        メソッド内 import によって、本モジュールと ``aggregate_validators``
+        （型アノテーションのために本クラスを import する）の間の循環依存を解消する。
         """
         from bakufu.domain.internal_review_gate.aggregate_validators import validate_all
 
         validate_all(self)
         return self
 
-    # ---- behaviors (Tell, Don't Ask) -------------------------------------
+    # ---- 振る舞い（Tell, Don't Ask） ------------------------------------
 
     def submit_verdict(
         self,
@@ -104,51 +99,48 @@ class InternalReviewGate(BaseModel):
         comment: str,
         decided_at: datetime,
     ) -> InternalReviewGate:
-        """Append one agent verdict and recompute the gate decision.
+        """1 つのエージェント判定を追加し、ゲート判定を再計算する。
 
-        Step order (§確定 A 8 ステップ厳守):
+        ステップ順（§確定 A 8 ステップ厳守）:
 
-        1. Guard: ``gate_decision`` must be PENDING (decided Gates are
-           immutable).
-        2. Guard: ``role`` must not already have a verdict in
-           ``self.verdicts`` (one verdict per role per Gate).
-        3. NFC-normalize ``comment`` (strip is **not** applied).
-        4. Guard: ``role`` must be in ``required_gate_roles``
-           (invalid roles are rejected before Verdict construction).
-        5. Guard: NFC-normalized ``comment`` length must not exceed
-           5000 characters.
-        6. Build the new :class:`Verdict` and append to the tuple.
-        7. Compute the new :class:`GateDecision` via
-           :func:`compute_decision`.
-        8. Reconstruct via ``model_dump`` / dict-update /
-           ``model_validate`` so ``_check_invariants`` re-fires
-           (pre-validate rebuild pattern, §確定 E), then return the
-           new instance.
+        1. ガード: ``gate_decision`` は PENDING でなければならない（決定済み Gate
+           は不変）。
+        2. ガード: ``role`` は ``self.verdicts`` に既に判定を持っていてはならない
+           （Gate ごと role ごとに 1 判定）。
+        3. ``comment`` を NFC 正規化（strip は **適用しない**）。
+        4. ガード: ``role`` は ``required_gate_roles`` に含まれていなければならない
+           （無効なロールは Verdict 構築前に拒否）。
+        5. ガード: NFC 正規化済み ``comment`` の長さは 5000 文字を超えてはならない。
+        6. 新しい :class:`Verdict` を構築してタプルに追加する。
+        7. :func:`compute_decision` で新しい :class:`GateDecision` を計算する。
+        8. ``model_dump`` / dict-update / ``model_validate`` で再構築し
+           ``_check_invariants`` を再発火させ（pre-validate rebuild パターン、§確定 E）、
+           新インスタンスを返す。
 
         Args:
-            role: The GateRole the submitting agent is acting as.
-                Must be in ``required_gate_roles`` (enforced by
-                invariant 2 in ``_check_invariants``).
-            agent_id: UUID of the submitting agent.
-            decision: APPROVED or REJECTED.
-            comment: Free-form review comment, 0〜5000 NFC chars.
-                Strip is **not** applied.
-            decided_at: UTC tz-aware moment of submission.
+            role: 提出エージェントが代表する GateRole。``required_gate_roles`` に
+                含まれていなければならない（``_check_invariants`` の不変条件 2 で
+                強制）。
+            agent_id: 提出エージェントの UUID。
+            decision: APPROVED または REJECTED。
+            comment: 自由形式のレビュー コメント、0〜5000 NFC 文字。strip は
+                **適用しない**。
+            decided_at: 提出時の UTC tz-aware モーメント。
 
         Returns:
-            A new :class:`InternalReviewGate` with the verdict
-            appended and ``gate_decision`` recomputed.
+            判定が追加され、``gate_decision`` が再計算された新しい
+            :class:`InternalReviewGate`。
 
         Raises:
             :class:`InternalReviewGateInvariantViolation`:
-                ``gate_already_decided`` — the Gate is no longer PENDING.
-                ``role_already_submitted`` — the role already has a verdict.
-                ``invalid_role`` — role not in required_gate_roles.
-                ``comment_too_long`` — NFC-normalized comment exceeds 5000 chars.
-                (The last two are also caught by ``_check_invariants`` on
-                rebuild, but are checked early here for user-friendly messages.)
+                ``gate_already_decided`` — Gate がもう PENDING ではない。
+                ``role_already_submitted`` — そのロールは既に判定済み。
+                ``invalid_role`` — ロールが required_gate_roles にない。
+                ``comment_too_long`` — NFC 正規化コメントが 5000 文字超過。
+                （後者 2 つは rebuild 時に ``_check_invariants`` でも捕捉されるが、
+                ユーザフレンドリなメッセージのためにここで早期チェックする。）
         """
-        # Step 1: gate must be PENDING.
+        # Step 1: gate は PENDING でなければならない。
         if self.gate_decision != GateDecision.PENDING:
             raise InternalReviewGateInvariantViolation(
                 kind="gate_already_decided",
@@ -163,7 +155,7 @@ class InternalReviewGate(BaseModel):
                 },
             )
 
-        # Step 2: role must not already have a verdict.
+        # Step 2: role は既に判定を持っていてはならない。
         existing_roles = frozenset(v.role for v in self.verdicts)
         if role in existing_roles:
             raise InternalReviewGateInvariantViolation(
@@ -178,10 +170,10 @@ class InternalReviewGate(BaseModel):
                 },
             )
 
-        # Step 3: NFC-normalize comment (strip is intentionally not applied).
+        # Step 3: コメントを NFC 正規化（strip は意図的に適用しない）。
         normalized_comment = unicodedata.normalize("NFC", comment)
 
-        # Step 4: validate role membership before building Verdict.
+        # Step 4: Verdict 構築前に role のメンバーシップを検証する。
         # Behavior 層での早期チェック:
         # invariant 層 (_validate_verdict_roles_in_required) でも同一条件を検査するが、
         # MSG-IRG-004 の日本語エラーメッセージを返すためにここで先に raise する。
@@ -204,7 +196,7 @@ class InternalReviewGate(BaseModel):
                 },
             )
 
-        # Step 5: comment length check (NFC-normalized, no strip).
+        # Step 5: コメント長チェック（NFC 正規化済み、strip 無し）。
         comment_length = len(normalized_comment)
         if comment_length > _VERDICT_COMMENT_MAX_CHARS:
             raise InternalReviewGateInvariantViolation(
@@ -221,7 +213,7 @@ class InternalReviewGate(BaseModel):
                 },
             )
 
-        # Step 6: build new Verdict and append to tuple.
+        # Step 6: 新しい Verdict を構築してタプルに追加する。
         new_verdict = Verdict(
             role=role,
             agent_id=agent_id,
@@ -231,11 +223,11 @@ class InternalReviewGate(BaseModel):
         )
         new_verdicts = (*self.verdicts, new_verdict)
 
-        # Step 7: compute new gate_decision.
+        # Step 7: 新しい gate_decision を計算する。
         new_gate_decision = compute_decision(new_verdicts, self.required_gate_roles)
 
-        # Step 8: pre-validate rebuild (model_dump → update → model_validate)
-        # so _check_invariants re-fires, then return the new instance.
+        # Step 8: pre-validate rebuild（model_dump → update → model_validate）で
+        # _check_invariants を再発火させ、新インスタンスを返す。
         state: dict[str, Any] = self.model_dump()
         state["verdicts"] = [v.model_dump() for v in new_verdicts]
         state["gate_decision"] = new_gate_decision

--- a/backend/src/bakufu/domain/internal_review_gate/state_machine.py
+++ b/backend/src/bakufu/domain/internal_review_gate/state_machine.py
@@ -1,22 +1,22 @@
-"""Decision computation for the :class:`InternalReviewGate` aggregate.
+""":class:`InternalReviewGate` Aggregate のための決定計算。
 
-Implements the most-pessimistic-wins rule per internal-review-gate
-detailed-design §確定 B:
+internal-review-gate detailed-design §確定 B の most-pessimistic-wins ルールを
+実装する:
 
-1. Any :attr:`VerdictDecision.REJECTED` verdict → :attr:`GateDecision.REJECTED`
-   (highest priority; a single dissent blocks the Gate immediately).
-2. All ``required_gate_roles`` have an APPROVED verdict →
-   :attr:`GateDecision.ALL_APPROVED`.
-3. Otherwise → :attr:`GateDecision.PENDING`.
+1. 任意の :attr:`VerdictDecision.REJECTED` verdict → :attr:`GateDecision.REJECTED`
+   （最優先。1 つの反対意見が即座に Gate をブロックする）。
+2. 全 ``required_gate_roles`` が APPROVED verdict を持つ →
+   :attr:`GateDecision.ALL_APPROVED`。
+3. それ以外 → :attr:`GateDecision.PENDING`。
 
-The computation is a **pure function** with no side effects, locked
-behind a ``Final`` binding so pyright strict rejects re-assignment.
+計算は副作用のない **純粋関数** で、再代入を pyright strict が拒否できるよう
+``Final`` バインディングの背後にロックされている。
 
-Unlike :mod:`bakufu.domain.external_review_gate.state_machine` which
-models a *transition table* (action x state -> next_state), the
-InternalReviewGate's decision is **computed** from the current
-``verdicts`` collection and ``required_gate_roles`` set — there is no
-explicit action dispatch, only a fold over the verdict tuple.
+*遷移表*（action x state -> next_state）をモデル化する
+:mod:`bakufu.domain.external_review_gate.state_machine` と異なり、
+InternalReviewGate の決定は現在の ``verdicts`` コレクションと
+``required_gate_roles`` 集合から **計算** される — 明示的なアクション
+ディスパッチは存在せず、verdict タプルへの fold のみ。
 """
 
 from __future__ import annotations
@@ -34,55 +34,52 @@ def _compute_decision(
     verdicts: tuple[Verdict, ...],
     required_gate_roles: frozenset[GateRole],
 ) -> GateDecision:
-    """Return the :class:`GateDecision` implied by the current state.
+    """現在の状態が含意する :class:`GateDecision` を返す。
 
-    Decision table (most-pessimistic-wins):
+    決定表（most-pessimistic-wins）:
 
-    1. Any verdict with ``decision == REJECTED`` → ``REJECTED``
-       (checked first; a single dissent closes the Gate immediately,
-       regardless of how many approvals exist).
-    2. Every role in ``required_gate_roles`` has a corresponding
-       APPROVED verdict → ``ALL_APPROVED``.
-    3. Otherwise → ``PENDING`` (some required roles are still missing).
+    1. ``decision == REJECTED`` の verdict が存在 → ``REJECTED``
+       （最初にチェック。1 つの反対意見が承認数に関わらず即座に Gate を閉じる）。
+    2. ``required_gate_roles`` の全ロールが対応する APPROVED verdict を持つ →
+       ``ALL_APPROVED``。
+    3. それ以外 → ``PENDING``（required ロールの一部がまだ欠けている）。
 
     Args:
-        verdicts: All verdicts collected so far. May be empty.
-        required_gate_roles: The closed set of role slugs that **must**
-            all vote APPROVED before the Gate can reach ALL_APPROVED.
-            Must be non-empty (enforced by
+        verdicts: 現時点で集まった全 verdict。空であってもよい。
+        required_gate_roles: Gate が ALL_APPROVED に到達するために **すべて**
+            APPROVED 投票しなければならないロール slug の閉じた集合。
+            非空でなければならない（本関数呼び出し前に
             :func:`bakufu.domain.internal_review_gate.aggregate_validators
-            ._validate_required_gate_roles_nonempty` before this
-            function is called).
+            ._validate_required_gate_roles_nonempty` が強制する）。
 
     Returns:
-        The :class:`GateDecision` that best describes the current
-        verdict collection.
+        現在の verdict コレクションを最もよく表す :class:`GateDecision`。
     """
-    # Rule 1: any REJECTED verdict → REJECTED (most pessimistic wins).
+    # ルール 1: REJECTED verdict があれば → REJECTED（most pessimistic wins）。
     for verdict in verdicts:
         if verdict.decision == VerdictDecision.REJECTED:
             return GateDecision.REJECTED
 
-    # Rule 2: all required roles have APPROVED verdicts → ALL_APPROVED.
+    # ルール 2: 全 required ロールが APPROVED verdict を持つ → ALL_APPROVED。
     approved_roles = frozenset(
         verdict.role for verdict in verdicts if verdict.decision == VerdictDecision.APPROVED
     )
     if required_gate_roles.issubset(approved_roles):
         return GateDecision.ALL_APPROVED
 
-    # Rule 3: still waiting on one or more required roles.
+    # ルール 3: 1 つ以上の required ロールをまだ待っている。
     return GateDecision.PENDING
 
 
 compute_decision: Final[Callable[[tuple[Verdict, ...], frozenset[GateRole]], GateDecision]] = (
     _compute_decision
 )
-"""Public alias for the decision computation function.
+"""決定計算関数のパブリック エイリアス。
 
-Locked as ``Final`` so pyright strict catches any re-assignment attempt.
-Import this symbol (not ``_compute_decision``) from application code and
-tests so the public contract is explicit and the private implementation
-detail remains free to be renamed.
+``Final`` でロックされているため、pyright strict は再代入の試みを捕捉する。
+アプリケーション コードやテストからは ``_compute_decision`` ではなくこのシンボル
+を import し、公開コントラクトを明示する。プライベート実装詳細は自由にリネーム
+できる状態に保つ。
 """
 
 __all__ = ["compute_decision"]

--- a/backend/src/bakufu/domain/room/__init__.py
+++ b/backend/src/bakufu/domain/room/__init__.py
@@ -1,21 +1,21 @@
-"""Room Aggregate Root package.
+"""Room Aggregate Root パッケージ。
 
-Implements ``REQ-RM-001``〜``REQ-RM-006`` per ``docs/features/room``. Split
-into three sibling modules along the design's responsibility lines so each
-file stays well under the 270-line readability budget and the file-level
-boundary mirrors the agent / workflow precedent:
+``docs/features/room`` に従って ``REQ-RM-001``〜``REQ-RM-006`` を実装する。
+設計の責務境界に沿って 3 つの兄弟モジュールに分割し、各ファイルが 270 行の
+可読性予算を十分に下回るようにし、ファイル レベル境界が agent / workflow の
+先例を踏襲するようにする:
 
-* :mod:`bakufu.domain.room.value_objects` — :class:`AgentMembership` and
-  :class:`PromptKit` Pydantic VOs with their self-checks.
-* :mod:`bakufu.domain.room.aggregate_validators` — four module-level
-  invariant helpers covering name range / description length / member
-  uniqueness / member capacity.
-* :mod:`bakufu.domain.room.room` — :class:`Room` Aggregate Root that
-  dispatches over the helpers in deterministic order.
+* :mod:`bakufu.domain.room.value_objects` — :class:`AgentMembership` と
+  :class:`PromptKit` の Pydantic VO（自己チェック付き）。
+* :mod:`bakufu.domain.room.aggregate_validators` — name range / description
+  length / member 一意性 / member 容量を網羅するモジュール レベルの不変条件
+  ヘルパ 4 つ。
+* :mod:`bakufu.domain.room.room` — ヘルパを決定的順序でディスパッチする
+  :class:`Room` Aggregate Root。
 
-This ``__init__`` re-exports the public surface plus the underscore-prefixed
-helpers tests need to invoke directly (same pattern Norman approved for the
-agent package).
+この ``__init__`` はパブリック表面に加え、テストが直接呼ぶ必要のある
+アンダースコア プレフィックス ヘルパも再 export する（Norman が agent
+パッケージで承認したのと同じパターン）。
 """
 
 from __future__ import annotations

--- a/backend/src/bakufu/domain/room/aggregate_validators.py
+++ b/backend/src/bakufu/domain/room/aggregate_validators.py
@@ -1,22 +1,22 @@
-"""Aggregate-level invariant helpers for :class:`Room`.
+""":class:`Room` のための Aggregate レベル不変条件ヘルパ。
 
-Each helper is a **module-level pure function** so tests can ``import`` and
-invoke directly — same testability pattern Norman / Steve approved for the
-agent ``aggregate_validators.py`` and the workflow ``dag_validators.py``.
-The Aggregate Root in :mod:`bakufu.domain.room.room` stays a thin dispatch
-over them; rule changes touch only the helper, never the orchestration code.
+各ヘルパは **モジュール レベルの純粋関数** であるため、テストから ``import`` して
+直接呼べる — Norman / Steve が agent の ``aggregate_validators.py`` と workflow の
+``dag_validators.py`` で承認したのと同じテスタビリティ パターン。
+:mod:`bakufu.domain.room.room` の Aggregate Root はそれらの薄いディスパッチに留まり、
+ルール変更はヘルパのみに触れ、オーケストレーション コードは触らない。
 
-Helpers (run in this order in :class:`Room.model_validator`):
+ヘルパ（:class:`Room.model_validator` ではこの順で実行）:
 
 1. :func:`_validate_name_range` — ``1 ≤ NFC+strip(name) ≤ 80``
 2. :func:`_validate_description_length` — ``0 ≤ NFC+strip(description) ≤ 500``
-3. :func:`_validate_member_unique` — no duplicate ``(agent_id, role)`` pair
+3. :func:`_validate_member_unique` — ``(agent_id, role)`` 対の重複なし
 4. :func:`_validate_member_capacity` — ``len(members) ≤ 50``
 
-Naming follows the agent / workflow precedent (``_validate_*_unique`` for
-collection uniqueness checks). Boy Scout: every collection contract that says
-"no duplicate (a, b) pair" gets a dedicated helper so the rule survives
-future refactors (Steve's twin-defense symmetry rule from PR #16).
+命名は agent / workflow の先例（コレクション一意性チェックには
+``_validate_*_unique``）に従う。Boy Scout: 「(a, b) 対の重複なし」を謳うすべての
+コレクション コントラクトに専用ヘルパを設けることで、将来のリファクタにルールが
+生き残る（Steve の PR #16 twin-defense 対称性ルール）。
 """
 
 from __future__ import annotations
@@ -24,23 +24,23 @@ from __future__ import annotations
 from bakufu.domain.exceptions import RoomInvariantViolation
 from bakufu.domain.room.value_objects import AgentMembership
 
-# Confirmation B: name length bounds (1〜80 after NFC + strip).
+# Confirmation B: 名前長境界（NFC + strip 後で 1〜80）。
 MIN_NAME_LENGTH: int = 1
 MAX_NAME_LENGTH: int = 80
 
-# Confirmation B: description length bounds (0〜500 after NFC + strip).
+# Confirmation B: description 長境界（NFC + strip 後で 0〜500）。
 MAX_DESCRIPTION_LENGTH: int = 500
 
-# Confirmation C: member capacity (≤ 50).
+# Confirmation C: メンバ容量（≤ 50）。
 MAX_MEMBERS: int = 50
 
 
 def _validate_name_range(name: str) -> None:
-    """``Room.name`` must fall in 1〜80 characters after NFC + strip (MSG-RM-001).
+    """``Room.name`` は NFC + strip 後で 1〜80 文字でなければならない（MSG-RM-001）。
 
-    Length is judged on the *normalized* string (the field validator runs the
-    pipeline before this helper is invoked), so the count reflects what the
-    user will see in audit logs and UI labels.
+    長さは *正規化済み* 文字列に対して判定される（フィールド バリデータが本ヘルパ
+    呼び出し前にパイプラインを走らせる）ため、カウントは監査ログや UI ラベルで
+    ユーザが目にする文字数を反映する。
     """
     length = len(name)
     if not (MIN_NAME_LENGTH <= length <= MAX_NAME_LENGTH):
@@ -57,7 +57,7 @@ def _validate_name_range(name: str) -> None:
 
 
 def _validate_description_length(description: str) -> None:
-    """``Room.description`` must fall in 0〜500 characters after NFC + strip (MSG-RM-002)."""
+    """``Room.description`` は NFC + strip 後で 0〜500 文字でなければならない（MSG-RM-002）。"""
     length = len(description)
     if length > MAX_DESCRIPTION_LENGTH:
         raise RoomInvariantViolation(
@@ -74,13 +74,12 @@ def _validate_description_length(description: str) -> None:
 
 
 def _validate_member_unique(members: list[AgentMembership]) -> None:
-    """No two memberships may share the same ``(agent_id, role)`` pair (MSG-RM-003).
+    """2 つのメンバーシップが同じ ``(agent_id, role)`` 対を共有してはならない（MSG-RM-003）。
 
-    Allowing the same agent to hold multiple roles (LEADER + REVIEWER, etc.)
-    is a Room §確定 F design choice — the unique key is the **pair**, not
-    ``agent_id`` alone. ``joined_at`` participates in equality of the VO but
-    is intentionally **not** part of the uniqueness key here, so re-adding
-    the same pair at a later timestamp is still rejected as a duplicate.
+    同じエージェントが複数ロール（LEADER + REVIEWER 等）を持つことを許すのは
+    Room §確定 F の設計選択 — 一意キーは ``agent_id`` 単独ではなく **対**。
+    ``joined_at`` は VO の等価性には関与するが、ここでの一意性キーには意図的に
+    **含めない** ため、同じ対を異なるタイムスタンプで再追加しても重複として拒否される。
     """
     seen: set[tuple[object, str]] = set()
     for membership in members:
@@ -104,7 +103,7 @@ def _validate_member_unique(members: list[AgentMembership]) -> None:
 
 
 def _validate_member_capacity(members: list[AgentMembership]) -> None:
-    """Cap members at :data:`MAX_MEMBERS` (MSG-RM-004 / Room §確定 C)."""
+    """メンバ数を :data:`MAX_MEMBERS` で頭打ちにする（MSG-RM-004 / Room §確定 C）。"""
     count = len(members)
     if count > MAX_MEMBERS:
         raise RoomInvariantViolation(

--- a/backend/src/bakufu/domain/room/room.py
+++ b/backend/src/bakufu/domain/room/room.py
@@ -1,35 +1,33 @@
-"""Room Aggregate Root (REQ-RM-001〜006).
+"""Room Aggregate Root（REQ-RM-001〜006）。
 
-Implements per ``docs/features/room``. The aggregate dispatches over four
-helpers in :mod:`bakufu.domain.room.aggregate_validators` and composes
-:class:`AgentMembership` + :class:`PromptKit` VOs from
-:mod:`bakufu.domain.room.value_objects`.
+``docs/features/room`` に従って実装する。Aggregate は
+:mod:`bakufu.domain.room.aggregate_validators` の 4 つのヘルパへディスパッチし、
+:mod:`bakufu.domain.room.value_objects` から :class:`AgentMembership` と
+:class:`PromptKit` の VO を組み合わせる。
 
-Design contracts:
+設計コントラクト:
 
-* **Pre-validate rebuild (Confirmation A)** — ``add_member`` /
-  ``remove_member`` / ``update_prompt_kit`` / ``archive`` all go through
-  :meth:`Room._rebuild_with` (``model_dump → swap → model_validate``).
-* **NFC pipeline (Confirmation B)** — ``Room.name`` and ``Room.description``
-  reuse the empire / workflow / agent ``nfc_strip`` helper. Length judgement
-  happens in the aggregate validators so the resulting
-  :class:`RoomInvariantViolation` carries ``kind='name_range'`` /
-  ``'description_too_long'`` with MSG-RM-001 / 002 wording.
-* **archive idempotency (Confirmation D)** — ``archive()`` always returns a
-  *new* instance. Idempotency means "result state matches", not "object
-  identity". Pydantic v2 frozen + ``model_validate`` rebuild guarantees
-  this; the docstring documents the contract so callers do not rely on
-  ``is`` comparisons.
-* **archived terminal (Confirmation E)** — ``add_member`` / ``remove_member``
-  / ``update_prompt_kit`` Fail Fast on archived Rooms with
-  ``kind='room_archived'`` (MSG-RM-006). ``archive()`` itself is idempotent
-  and bypasses this check.
-* **`(agent_id, role)` pair uniqueness (Confirmation F)** — same agent can
-  hold multiple roles; the validator uses the pair as the key.
-* **Application-layer responsibilities** — Workflow existence, Agent
-  existence, leader-required-by-Workflow, and Empire-scoped name uniqueness
-  live in ``RoomService`` / ``EmpireService``. The aggregate trusts only
-  what it can observe locally.
+* **Pre-validate rebuild（Confirmation A）** — ``add_member`` /
+  ``remove_member`` / ``update_prompt_kit`` / ``archive`` はすべて
+  :meth:`Room._rebuild_with`（``model_dump → swap → model_validate``）を経由する。
+* **NFC パイプライン（Confirmation B）** — ``Room.name`` と ``Room.description`` は
+  empire / workflow / agent の ``nfc_strip`` ヘルパを再利用する。長さ判定は
+  Aggregate バリデータで行うため、結果の :class:`RoomInvariantViolation` は
+  MSG-RM-001 / 002 の文言で ``kind='name_range'`` / ``'description_too_long'``
+  を持つ。
+* **archive 冪等性（Confirmation D）** — ``archive()`` は常に *新* インスタンスを
+  返す。冪等性とは「結果状態が一致する」ことであり「オブジェクト同一性」ではない。
+  Pydantic v2 frozen + ``model_validate`` 再構築がこれを保証する。docstring が
+  コントラクトを文書化するため、呼び元は ``is`` 比較に依存しない。
+* **archived 終端（Confirmation E）** — ``add_member`` / ``remove_member`` /
+  ``update_prompt_kit`` は archived な Room に対して ``kind='room_archived'``
+  （MSG-RM-006）で Fail Fast する。``archive()`` 自体は冪等でこのチェックをバイパス
+  する。
+* **`(agent_id, role)` 対の一意性（Confirmation F）** — 同じエージェントが複数の
+  ロールを持てる。バリデータは対をキーとして使う。
+* **アプリケーション層の責務** — Workflow 存在、Agent 存在、Workflow 要求の leader、
+  Empire スコープ名一意性は ``RoomService`` / ``EmpireService`` に置く。Aggregate
+  はローカルに観測できる範囲のみを信頼する。
 """
 
 from __future__ import annotations
@@ -61,12 +59,12 @@ from bakufu.domain.value_objects import (
 
 
 class Room(BaseModel):
-    """Editable composition space within an :class:`Empire` (REQ-RM-001).
+    """:class:`Empire` 内の編集可能な構成スペース（REQ-RM-001）。
 
-    Composes a :class:`PromptKit` preamble and ``list[AgentMembership]`` over
-    a fixed :class:`WorkflowId`. The aggregate enforces structural invariants
-    only — Workflow existence and leader-required-by-Workflow checks belong
-    to the application layer because they require external knowledge.
+    固定の :class:`WorkflowId` 上で :class:`PromptKit` プリアンブルと
+    ``list[AgentMembership]`` を構成する。Aggregate は構造的不変条件のみを強制する
+    — Workflow 存在および Workflow 要求 leader チェックは外部知識を要するため
+    アプリケーション層の責務。
     """
 
     model_config = ConfigDict(
@@ -83,20 +81,20 @@ class Room(BaseModel):
     prompt_kit: PromptKit = PromptKit()
     archived: bool = False
 
-    # ---- pre-validation -------------------------------------------------
+    # ---- 事前検証 -------------------------------------------------------
     @field_validator("name", "description", mode="before")
     @classmethod
     def _normalize_short_text(cls, value: object) -> object:
-        # NFC + strip pipeline shared with empire / workflow / agent (Confirmation B).
+        # empire / workflow / agent と共有する NFC + strip パイプライン
+        # （Confirmation B）。
         return nfc_strip(value)
 
     @model_validator(mode="after")
     def _check_invariants(self) -> Self:
-        """Dispatch over the aggregate-level helpers in deterministic order.
+        """Aggregate レベル ヘルパを決定的順序でディスパッチする。
 
-        Order: name range → description length → member uniqueness → member
-        capacity. Earlier failures hide later ones so error messages stay
-        focused on the root cause.
+        順序: name range → description length → member 一意性 → member 容量。
+        先行する失敗が後続を隠すため、エラー メッセージは根本原因に集中する。
         """
         _validate_name_range(self.name)
         _validate_description_length(self.description)
@@ -104,34 +102,35 @@ class Room(BaseModel):
         _validate_member_capacity(self.members)
         return self
 
-    # ---- behaviors (Tell, Don't Ask) ------------------------------------
+    # ---- 振る舞い（Tell, Don't Ask） -----------------------------------
     def add_member(self, membership: AgentMembership) -> Room:
-        """Append ``membership`` to ``members``; aggregate validation catches duplicates.
+        """``membership`` を ``members`` に追加。重複は Aggregate 検証で捕捉される。
 
-        Fail Fast on archived Rooms (Confirmation E). The
-        ``(agent_id, role)`` pair-uniqueness check fires inside
-        :meth:`_check_invariants` after the rebuild.
+        archived な Room には Fail Fast（Confirmation E）。
+        ``(agent_id, role)`` 対の一意性チェックは rebuild 後の
+        :meth:`_check_invariants` 内部で発火する。
 
         Raises:
-            RoomInvariantViolation: ``kind='room_archived'`` (MSG-RM-006) if
-                the Room is already archived; ``kind='member_duplicate'``
-                (MSG-RM-003) if the pair already exists; ``kind='capacity_exceeded'``
-                (MSG-RM-004) if adding pushes the count over :data:`MAX_MEMBERS`.
+            RoomInvariantViolation: 既にアーカイブ済みの場合
+                ``kind='room_archived'``（MSG-RM-006）。対が既存の場合
+                ``kind='member_duplicate'``（MSG-RM-003）。追加で件数が
+                :data:`MAX_MEMBERS` を超える場合 ``kind='capacity_exceeded'``
+                （MSG-RM-004）。
         """
         self._reject_if_archived()
         return self._rebuild_with(members=[*self.members, membership])
 
     def remove_member(self, agent_id: AgentId, role: Role) -> Room:
-        """Drop the membership matching ``(agent_id, role)``.
+        """``(agent_id, role)`` に一致するメンバーシップを削除する。
 
-        Fail Fast on archived Rooms (Confirmation E) and on missing pair
-        (MSG-RM-005) — the caller cannot blindly retry a remove without
-        observing the current member list.
+        archived な Room には Fail Fast（Confirmation E）。対が見つからない場合も
+        Fail Fast（MSG-RM-005） — 呼び元は現在のメンバ リストを観測せずに削除を盲目
+        的に再試行できない。
 
         Raises:
-            RoomInvariantViolation: ``kind='room_archived'`` (MSG-RM-006);
-                ``kind='member_not_found'`` (MSG-RM-005) when no membership
-                matches the pair.
+            RoomInvariantViolation: ``kind='room_archived'``（MSG-RM-006）。対に
+                一致するメンバーシップが無い場合 ``kind='member_not_found'``
+                （MSG-RM-005）。
         """
         self._reject_if_archived()
         if not any(m.agent_id == agent_id and m.role == role for m in self.members):
@@ -150,36 +149,35 @@ class Room(BaseModel):
         )
 
     def update_prompt_kit(self, prompt_kit: PromptKit) -> Room:
-        """Replace ``prompt_kit`` with ``prompt_kit``.
+        """``prompt_kit`` を新しい ``prompt_kit`` に置き換える。
 
-        Fail Fast on archived Rooms (Confirmation E). PromptKit length
-        violations surface as :class:`pydantic.ValidationError` at VO
-        construction time (Confirmation I two-stage catch), so by the time
-        this method is invoked the VO is already valid.
+        archived な Room には Fail Fast（Confirmation E）。PromptKit の長さ違反は
+        VO 構築時に :class:`pydantic.ValidationError` として表面化するため
+        （Confirmation I の 2 段階キャッチ）、本メソッドが呼ばれる時点では VO は
+        既に valid。
 
         Raises:
-            RoomInvariantViolation: ``kind='room_archived'`` (MSG-RM-006).
+            RoomInvariantViolation: ``kind='room_archived'``（MSG-RM-006）。
         """
         self._reject_if_archived()
         return self._rebuild_with(prompt_kit=prompt_kit)
 
     def archive(self) -> Room:
-        """Return a new :class:`Room` with ``archived=True`` (Confirmation D).
+        """``archived=True`` を持つ新しい :class:`Room` を返す（Confirmation D）。
 
-        Idempotent: calling on an already-archived Room yields a fresh Room
-        that is **structurally equal** to the input but has a different
-        ``id()``. Callers must not rely on object identity — always reassign
-        the returned value (``room = room.archive()``). Same contract Norman
-        approved for the agent / empire ``archive()`` behaviors.
+        冪等: 既にアーカイブ済みの Room に対して呼んでも、入力と **構造的に等しく**、
+        ``id()`` のみ異なる新規 Room を生成する。呼び元はオブジェクト同一性に依存
+        してはならず、常に返値を代入し直すこと（``room = room.archive()``）。Norman
+        が agent / empire の ``archive()`` 振る舞いで承認したのと同じコントラクト。
         """
         return self._rebuild_with_state({"archived": True})
 
-    # ---- internal -------------------------------------------------------
+    # ---- 内部実装 -------------------------------------------------------
     def _reject_if_archived(self) -> None:
-        """Raise ``room_archived`` (MSG-RM-006) when the Room is terminal.
+        """Room が終端状態のとき ``room_archived``（MSG-RM-006）を送出する。
 
-        Confirmation E: archived Rooms reject all mutating behaviors except
-        :meth:`archive` itself, which stays idempotent for retry tolerance.
+        Confirmation E: archived な Room は :meth:`archive` 自身を除く全ての変異
+        振る舞いを拒否する。``archive`` は再試行耐性のため冪等のまま保たれる。
         """
         if self.archived:
             raise RoomInvariantViolation(
@@ -198,7 +196,7 @@ class Room(BaseModel):
         members: list[AgentMembership] | None = None,
         prompt_kit: PromptKit | None = None,
     ) -> Room:
-        """Re-construct via ``model_validate`` so ``_check_invariants`` re-fires."""
+        """``model_validate`` で再構築し ``_check_invariants`` を再発火させる。"""
         state = self.model_dump()
         if members is not None:
             state["members"] = [m.model_dump() for m in members]
@@ -207,7 +205,7 @@ class Room(BaseModel):
         return Room.model_validate(state)
 
     def _rebuild_with_state(self, updates: dict[str, Any]) -> Room:
-        """Pre-validate rebuild for scalar attribute updates (e.g. ``archived``)."""
+        """スカラ属性更新（例 ``archived``）のための pre-validate rebuild。"""
         state = self.model_dump()
         state.update(updates)
         return Room.model_validate(state)

--- a/backend/src/bakufu/domain/room/value_objects.py
+++ b/backend/src/bakufu/domain/room/value_objects.py
@@ -1,15 +1,14 @@
-"""Room-specific Value Objects (:class:`AgentMembership` / :class:`PromptKit`).
+"""Room 固有の Value Object（:class:`AgentMembership` / :class:`PromptKit`）。
 
-These VOs live in the ``room/`` package rather than the global
-:mod:`bakufu.domain.value_objects` so the file-level boundary mirrors the
-responsibility boundary — same pattern Norman approved for the agent /
-workflow packages. ``Role`` and ``AgentId`` remain in the global module
-because they cross feature boundaries.
+これらの VO はファイル レベル境界が責務境界を反映するよう、グローバルな
+:mod:`bakufu.domain.value_objects` ではなく ``room/`` パッケージに置く —
+Norman が agent / workflow パッケージで承認したのと同じパターン。``Role`` と
+``AgentId`` はフィーチャー境界を跨ぐためグローバル モジュールに残す。
 
-``PromptKit.prefix_markdown`` applies **NFC only** (no strip): the field
-holds Markdown text where leading/trailing newlines are semantically
-significant for the downstream prompt renderer. Same rule the agent
-``Persona.prompt_body`` follows (Agent §確定 E / Room §確定 B).
+``PromptKit.prefix_markdown`` は **NFC のみ**（strip 無し）を適用する: このフィールド
+は Markdown テキストを保持し、先頭／末尾の改行は下流のプロンプト レンダラに対して
+意味的に重要。Agent の ``Persona.prompt_body`` と同じルール（Agent §確定 E /
+Room §確定 B）。
 """
 
 from __future__ import annotations
@@ -23,21 +22,21 @@ from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 from bakufu.domain.value_objects import AgentId, Role
 
 # ---------------------------------------------------------------------------
-# AgentMembership (Room §確定 F — (agent_id, role) pair as the unique key)
+# AgentMembership（Room §確定 F — (agent_id, role) 対が一意キー）
 # ---------------------------------------------------------------------------
 
 
 class AgentMembership(BaseModel):
-    """Frozen membership entry: an :class:`Agent` taking on a :class:`Role`.
+    """フローズン メンバシップ エントリ: :class:`Role` を担う :class:`Agent`。
 
-    The Room aggregate stores a ``list[AgentMembership]`` and enforces
-    ``(agent_id, role)`` pair uniqueness — **not** ``agent_id`` alone — so a
-    single agent can hold multiple roles (e.g. LEADER + REVIEWER). Storing
-    ``joined_at`` per-role lets the UI surface "joined as LEADER on X, then
-    added REVIEWER on Y" naturally.
+    Room Aggregate は ``list[AgentMembership]`` を保持し、``(agent_id, role)`` 対の
+    一意性を強制する — ``agent_id`` 単独 **ではない** — そのため 1 体のエージェントが
+    複数のロールを持てる（例 LEADER + REVIEWER）。``joined_at`` をロール毎に保存する
+    ことで、UI は「X 日に LEADER として参加、Y 日に REVIEWER 追加」のような表示が
+    自然にできる。
 
-    Stored under ``docs/design/domain-model/value-objects.md`` §AgentMembership;
-    Room is the only feature that composes this VO today.
+    ``docs/design/domain-model/value-objects.md`` §AgentMembership に格納。現時点で
+    この VO を構成するのは Room のみ。
     """
 
     model_config = ConfigDict(
@@ -52,23 +51,23 @@ class AgentMembership(BaseModel):
 
 
 # ---------------------------------------------------------------------------
-# PromptKit (Room §確定 G — single-attribute VO, retained for Phase-2 growth)
+# PromptKit（Room §確定 G — 単一属性 VO、Phase-2 拡張のために構造を維持）
 # ---------------------------------------------------------------------------
 PROMPT_KIT_PREFIX_MAX: int = 10_000
 
 
 class PromptKit(BaseModel):
-    """Room-scoped system-prompt preamble (Markdown text).
+    """Room スコープのシステム プロンプト プリアンブル（Markdown テキスト）。
 
-    Single-attribute VO today; the structure exists so Phase 2 can extend it
-    with ``variables``, ``role_specific_prefix``, or ``sections`` without
-    forcing a schema migration on :class:`Room` (Room §確定 G).
+    現時点では単一属性 VO。構造は Phase 2 が ``variables``、``role_specific_prefix``、
+    ``sections`` で拡張する際に :class:`Room` のスキーマ マイグレーションを強いない
+    ようにするため存在する（Room §確定 G）。
 
-    The persistence layer applies secret masking to ``prefix_markdown``
-    *before* it lands in the SQLite ``rooms`` row — see
-    ``docs/design/domain-model/storage.md`` §シークレットマスキング規則.
-    The aggregate keeps the raw user input so the UI can read it back
-    unchanged; the masking gateway is **only** at the persistence boundary.
+    永続化層は ``prefix_markdown`` が SQLite の ``rooms`` 行に到達する *前* に
+    シークレット マスキングを適用する —
+    ``docs/design/domain-model/storage.md`` §シークレットマスキング規則 を参照。
+    Aggregate は UI が変更されない値を読み戻せるように生のユーザ入力を保持する。
+    マスキング ゲートウェイは **永続化境界のみ** に存在する。
     """
 
     model_config = ConfigDict(
@@ -82,21 +81,20 @@ class PromptKit(BaseModel):
     @field_validator("prefix_markdown", mode="before")
     @classmethod
     def _normalize_prefix(cls, value: object) -> object:
-        # NFC only — preserves leading/trailing Markdown whitespace (Room §確定 B).
+        # NFC のみ — Markdown の先頭／末尾空白を保持する（Room §確定 B）。
         if isinstance(value, str):
             return unicodedata.normalize("NFC", value)
         return value
 
     @model_validator(mode="after")
     def _check_self_invariants(self) -> Self:
-        """Length cap raises :class:`pydantic.ValidationError` (MSG-RM-007).
+        """長さ上限超過時に :class:`pydantic.ValidationError` を送出（MSG-RM-007）。
 
-        Room detailed-design §確定 I freezes that PromptKit length violations
-        surface as ``ValidationError`` — not ``RoomInvariantViolation`` —
-        because the failure happens *before* any Room aggregate is in scope.
-        ``RoomService.update_prompt_kit`` then catches in two layers (VO
-        construction → ``ValidationError``; aggregate behavior → archived
-        terminal etc.).
+        Room detailed-design §確定 I は PromptKit の長さ違反が
+        ``RoomInvariantViolation`` ではなく ``ValidationError`` として表面化する
+        ことを凍結する — Room Aggregate がスコープに入る *前* に失敗するため。
+        ``RoomService.update_prompt_kit`` は 2 層で捕捉する（VO 構築 →
+        ``ValidationError``、Aggregate 振る舞い → archived 終端 等）。
         """
         length = len(self.prefix_markdown)
         if length > PROMPT_KIT_PREFIX_MAX:

--- a/backend/src/bakufu/domain/task/__init__.py
+++ b/backend/src/bakufu/domain/task/__init__.py
@@ -1,25 +1,21 @@
-"""Task Aggregate Root package.
+"""Task Aggregate Root パッケージ。
 
-Implements ``REQ-TS-001``〜``REQ-TS-009`` per ``docs/features/task``.
-M1 6 兄弟目 (after empire / workflow / agent / room / directive). The
-package is split along the responsibility lines that the design
-calls out:
+``docs/features/task`` に従って ``REQ-TS-001``〜``REQ-TS-009`` を実装する。
+M1 6 兄弟目（empire / workflow / agent / room / directive の後）。設計が指摘する
+責務境界に沿ってパッケージを分割する:
 
-* :mod:`bakufu.domain.task.state_machine` — decision-table state
-  machine (``Final[Mapping]`` + :class:`types.MappingProxyType`,
-  §確定 B). 13 entries matching §確定 A-2's dispatch table 1:1.
-* :mod:`bakufu.domain.task.aggregate_validators` — five module-level
-  ``_validate_*`` helpers for the structural invariants (§確定 J
-  kinds 3〜7).
-* :mod:`bakufu.domain.task.task` — :class:`Task` Aggregate Root
-  exposing ten behavior methods whose names map 1:1 to the state
-  machine action names (§確定 A-2 Steve R2 凍結 — no internal
-  dispatch, no ``advance(...)`` umbrella method).
+* :mod:`bakufu.domain.task.state_machine` — decision-table state machine
+  （``Final[Mapping]`` + :class:`types.MappingProxyType`、§確定 B）。
+  §確定 A-2 ディスパッチ表と 1:1 で対応する 13 エントリ。
+* :mod:`bakufu.domain.task.aggregate_validators` — 構造的不変条件
+  （§確定 J kinds 3〜7）のためのモジュール レベル ``_validate_*`` ヘルパ 5 つ。
+* :mod:`bakufu.domain.task.task` — state machine アクション名と 1:1 対応する
+  10 個の振る舞いメソッドを公開する :class:`Task` Aggregate Root（§確定 A-2 Steve
+  R2 凍結 — 内部ディスパッチ無し、``advance(...)`` umbrella メソッド無し）。
 
-This ``__init__`` re-exports the public surface plus the
-underscore-prefixed validators tests need to invoke directly (the
-same pattern Norman approved for the agent / room / directive
-packages).
+この ``__init__`` はパブリック表面に加え、テストが直接呼ぶ必要のあるアンダー
+スコア プレフィックス バリデータも再 export する（Norman が agent / room /
+directive パッケージで承認したのと同じパターン）。
 """
 
 from __future__ import annotations

--- a/backend/src/bakufu/domain/task/aggregate_validators.py
+++ b/backend/src/bakufu/domain/task/aggregate_validators.py
@@ -1,28 +1,28 @@
-"""Aggregate-level invariant helpers for :class:`Task`.
+""":class:`Task` のための Aggregate レベル不変条件ヘルパ。
 
-Each helper is a **module-level pure function** so tests can ``import``
-and invoke directly — same testability pattern Norman / Steve approved
-for the agent / room / directive ``aggregate_validators.py`` modules
-(M1 5 兄弟).
+各ヘルパは **モジュール レベルの純粋関数** であるため、テストから ``import``
+して直接呼べる — Norman / Steve が agent / room / directive の
+``aggregate_validators.py`` モジュール（M1 5 兄弟）で承認したのと同じテスタ
+ビリティ パターン。
 
-Helpers:
+ヘルパ:
 
-1. :func:`_validate_assigned_agents_unique` — no duplicate ``AgentId`` in
-   ``assigned_agent_ids``.
-2. :func:`_validate_assigned_agents_capacity` — at most 5 agents per Task.
+1. :func:`_validate_assigned_agents_unique` — ``assigned_agent_ids`` に重複
+   ``AgentId`` を含めない。
+2. :func:`_validate_assigned_agents_capacity` — Task あたり最大 5 エージェント。
 3. :func:`_validate_last_error_consistency` — ``status == BLOCKED`` ⇔
-   ``last_error`` is a non-empty string; otherwise ``last_error is None``.
-   Detects Repository-side row corruption at hydration time.
-4. :func:`_validate_blocked_has_last_error` — when ``status == BLOCKED``,
-   ``last_error`` length (NFC code-points) must be 1〜10000. Bridges the
-   §確定 R1-C "no strip" rule with the structural consistency check.
-5. :func:`_validate_timestamp_order` — ``created_at <= updated_at``.
+   ``last_error`` が非空文字列。それ以外では ``last_error is None``。水和時に
+   リポジトリ側の行破損を検出する。
+4. :func:`_validate_blocked_has_last_error` — ``status == BLOCKED`` のとき、
+   ``last_error`` の長さ（NFC コードポイント）は 1〜10000 でなければならない。
+   §確定 R1-C「strip 無し」ルールと構造的一貫性チェックを橋渡しする。
+5. :func:`_validate_timestamp_order` — ``created_at <= updated_at``。
 
-All helpers raise :class:`TaskInvariantViolation` with the matching
-``kind`` discriminator from §確定 J. ``message`` strings follow the
-two-line "[FAIL] ... / Next: ..." structure (§確定 J § MSG ID 確定文言)
-so the CI assertion ``assert "Next:" in str(exc)`` (TC-UT-TS-046〜052)
-fires consistently across all paths.
+すべてのヘルパは §確定 J に対応する ``kind`` 識別子を持つ
+:class:`TaskInvariantViolation` を送出する。``message`` 文字列は 2 行の
+「[FAIL] ... / Next: ...」構造（§確定 J § MSG ID 確定文言）に従うため、
+CI アサート ``assert "Next:" in str(exc)``（TC-UT-TS-046〜052）が全経路で
+一貫して発火する。
 """
 
 from __future__ import annotations
@@ -34,14 +34,14 @@ from uuid import UUID
 from bakufu.domain.exceptions import TaskInvariantViolation
 from bakufu.domain.value_objects import TaskStatus
 
-# Confirmation A: hard caps frozen by detailed-design §クラス設計.
+# Confirmation A: detailed-design §クラス設計 で凍結されたハード上限。
 MAX_ASSIGNED_AGENTS: int = 5
 MIN_LAST_ERROR_LENGTH: int = 1
 MAX_LAST_ERROR_LENGTH: int = 10_000
 
 
 def _validate_assigned_agents_unique(assigned_agent_ids: list[UUID]) -> None:
-    """``assigned_agent_ids`` may not contain duplicate values (MSG-TS-003)."""
+    """``assigned_agent_ids`` に重複値を含めない（MSG-TS-003）。"""
     counts = Counter(assigned_agent_ids)
     duplicates = sorted({str(agent_id) for agent_id, count in counts.items() if count > 1})
     if duplicates:
@@ -58,7 +58,7 @@ def _validate_assigned_agents_unique(assigned_agent_ids: list[UUID]) -> None:
 
 
 def _validate_assigned_agents_capacity(assigned_agent_ids: list[UUID]) -> None:
-    """``len(assigned_agent_ids) <= MAX_ASSIGNED_AGENTS`` (MSG-TS-004)."""
+    """``len(assigned_agent_ids) <= MAX_ASSIGNED_AGENTS``（MSG-TS-004）。"""
     count = len(assigned_agent_ids)
     if count > MAX_ASSIGNED_AGENTS:
         raise TaskInvariantViolation(
@@ -78,13 +78,12 @@ def _validate_last_error_consistency(
     status: TaskStatus,
     last_error: str | None,
 ) -> None:
-    """``status == BLOCKED`` ⇔ ``last_error`` is non-empty string (MSG-TS-005).
+    """``status == BLOCKED`` ⇔ ``last_error`` が非空文字列（MSG-TS-005）。
 
-    Detects Repository row corruption such as
-    ``status=DONE, last_error='AuthExpired: ...'`` (terminal Task with
-    leftover error text) — that combination is structurally illegal and
-    catching it here means hydration paths cannot smuggle an inconsistent
-    state into the application layer.
+    ``status=DONE, last_error='AuthExpired: ...'`` のようなリポジトリ行破損
+    （エラー テキストが残った終端 Task）を検出する — その組み合わせは構造的に
+    違法であり、ここで捕捉することで水和経路が一貫性のない状態をアプリケーション
+    層に持ち込めなくなる。
     """
     is_blocked = status == TaskStatus.BLOCKED
     has_error = isinstance(last_error, str) and last_error != ""
@@ -110,18 +109,18 @@ def _validate_blocked_has_last_error(
     status: TaskStatus,
     last_error: str | None,
 ) -> None:
-    """When ``status == BLOCKED``, ``last_error`` length must be 1〜10000 (MSG-TS-006).
+    """``status == BLOCKED`` のとき ``last_error`` の長さは 1〜10000（MSG-TS-006）。
 
-    The check operates on the **NFC-normalized** string per §確定 R1-C —
-    callers (``Task.block()``) run normalization upstream, so this helper
-    sees the canonical form. ``strip`` is intentionally **not** applied:
-    LLM stack traces rely on leading whitespace for indentation.
+    §確定 R1-C に従い、チェックは **NFC 正規化済み** 文字列に対して行う —
+    呼び元（``Task.block()``）が上流で正規化を実行するため、本ヘルパは正準形を
+    見る。``strip`` は意図的に **適用しない**: LLM のスタック トレースは
+    インデントのために先頭空白に依存する。
     """
     if status != TaskStatus.BLOCKED:
         return
-    # ``None`` falls through with length 0 so the kind=blocked_requires_last_error
-    # message stays specific to "BLOCKED but the string is empty";
-    # ``_validate_last_error_consistency`` already catches the structural form.
+    # ``None`` は長さ 0 で通過させる。これにより kind=blocked_requires_last_error の
+    # メッセージは「BLOCKED だが文字列が空」に特化したものになる。
+    # 構造形は ``_validate_last_error_consistency`` が既に捕捉している。
     length = 0 if last_error is None else len(last_error)
     if not (MIN_LAST_ERROR_LENGTH <= length <= MAX_LAST_ERROR_LENGTH):
         raise TaskInvariantViolation(
@@ -142,7 +141,7 @@ def _validate_blocked_has_last_error(
 
 
 def _validate_timestamp_order(created_at: datetime, updated_at: datetime) -> None:
-    """``created_at <= updated_at`` (MSG-TS-007)."""
+    """``created_at <= updated_at``（MSG-TS-007）。"""
     if created_at > updated_at:
         raise TaskInvariantViolation(
             kind="timestamp_order",

--- a/backend/src/bakufu/domain/task/state_machine.py
+++ b/backend/src/bakufu/domain/task/state_machine.py
@@ -1,42 +1,37 @@
-"""Decision-table state machine for the :class:`Task` aggregate.
+""":class:`Task` Aggregate のための decision-table state machine。
 
-Implements ``docs/features/task/detailed-design.md`` §確定 B (state
-machine table lock) and §確定 A-2 (Method x current_status ->
-action 名 dispatch table). The contract is intentionally a **flat
-``Mapping[(TaskStatus, str), TaskStatus]``** rather than an
-``if-elif`` ladder so:
+``docs/features/task/detailed-design.md`` §確定 B（state machine テーブル ロック）
+および §確定 A-2（Method x current_status -> action 名 のディスパッチ表）を実装する。
+コントラクトは意図的に **フラットな ``Mapping[(TaskStatus, str), TaskStatus]``** で
+あり、``if-elif`` 階段ではない。理由:
 
-1. The exact set of allowed transitions is **enumerable in one
-   structure** — code review can compare it against §確定 A-2's
-   60-cell dispatch table at a glance.
-2. The lookup function refuses unknown ``(status, action)`` pairs
-   with ``KeyError`` so the caller (``Task.<method>``) wraps the
-   failure in :class:`TaskInvariantViolation(kind='state_transition_invalid')`
-   — Fail-Fast on illegal state-machine bypass attempts.
-3. ``Final[Mapping]`` + :func:`types.MappingProxyType` makes both
-   pyright (re-assignment detection) and the runtime (``setitem``
-   rejection) refuse to mutate the table after import. A future PR
-   that wants to add a transition has to edit *this* file plus the
-   corresponding test, matching the design's "physical lock" intent.
+1. 許可遷移の集合がきっちり **1 つの構造で列挙可能** — コードレビュー時に
+   §確定 A-2 の 60 セル ディスパッチ表と一目で照合できる。
+2. ルックアップ関数は未知の ``(status, action)`` 対を ``KeyError`` で拒否するため、
+   呼び元（``Task.<method>``）は失敗を
+   :class:`TaskInvariantViolation(kind='state_transition_invalid')` で包む — 不正な
+   state-machine バイパス試行への Fail-Fast。
+3. ``Final[Mapping]`` + :func:`types.MappingProxyType` により、pyright（再代入検出）
+   と ランタイム（``setitem`` 拒否）の両方が import 後の変異を拒否する。遷移を追加
+   したい将来の PR は *この* ファイルと対応するテストの両方を編集する必要があり、
+   設計の「物理的ロック」意図と一致する。
 
-The 13 entries below correspond 1:1 with the ``→`` cells in
-§確定 A-2's dispatch table:
+下記 13 エントリは §確定 A-2 ディスパッチ表の ``→`` セルと 1:1 対応する:
 
 * ``PENDING``        — assign / cancel
 * ``IN_PROGRESS``    — commit_deliverable / request_external_review /
                        advance_to_next / complete / block / cancel
 * ``AWAITING_EXTERNAL_REVIEW`` — approve_review / reject_review / cancel
 * ``BLOCKED``        — unblock_retry / cancel
-* ``DONE`` / ``CANCELLED`` — terminal, **no entries** (60 - 13 = 47
-                              illegal cells, of which DONE/CANCELLED's
-                              20 hit the terminal_violation gate first;
-                              the remaining 27 hit ``state_transition_invalid``).
+* ``DONE`` / ``CANCELLED`` — 終端、**エントリ無し**（60 - 13 = 47 違法セルのうち、
+                              DONE/CANCELLED の 20 は terminal_violation ゲートで
+                              先に捕捉。残り 27 が ``state_transition_invalid``
+                              に当たる）。
 
-``action`` is constrained at the type level by :data:`TaskAction` so
-typo-driven typos (``'aproove_review'`` etc.) are caught by pyright
-strict before they reach runtime. The 10 ``Literal`` values mirror the
-10 Task methods one-for-one — adding a method without updating this
-list (or vice versa) is a type error.
+``action`` は :data:`TaskAction` で型レベルに制約されているため、タイプミス
+（``'aproove_review'`` 等）は実行前に pyright strict が捕捉する。10 個の ``Literal``
+値は 10 個の Task メソッドと 1:1 で対応する — このリストを更新せずにメソッドを追加
+（あるいはその逆）するのは型エラーになる。
 """
 
 from __future__ import annotations
@@ -59,85 +54,78 @@ type TaskAction = Literal[
     "unblock_retry",
     "cancel",
 ]
-"""Closed set of action names matching :class:`Task` method names 1:1.
+""":class:`Task` のメソッド名と 1:1 対応するアクション名のクローズド集合。
 
-Per §確定 A-2 (Steve R2 凍結), Task methods do **not** dispatch on
-runtime values. Each method calls
-``state_machine.lookup(self.status, '<method_name>')`` so the action
-name is a compile-time string literal — the table lookup result and
-the method's behavior are statically tied together.
+§確定 A-2（Steve R2 凍結）に従い、Task メソッドはランタイム値で **ディスパッチしない**。
+各メソッドは ``state_machine.lookup(self.status, '<method_name>')`` を呼び出し、
+アクション名はコンパイル時の文字列リテラルとなる — テーブル ルックアップ結果と
+メソッドの振る舞いが静的に紐付く。
 """
 
 
 _TRANSITIONS: Mapping[tuple[TaskStatus, TaskAction], TaskStatus] = MappingProxyType(
     {
-        # PENDING — only ``assign`` / ``cancel`` are reachable.
+        # PENDING — ``assign`` / ``cancel`` のみ到達可能。
         (TaskStatus.PENDING, "assign"): TaskStatus.IN_PROGRESS,
         (TaskStatus.PENDING, "cancel"): TaskStatus.CANCELLED,
-        # IN_PROGRESS — six legal actions including the two self-loops
-        # (``commit_deliverable`` / ``advance_to_next``) that update
-        # ``deliverables`` / ``current_stage_id`` without changing status.
+        # IN_PROGRESS — 6 つの正規アクション。``deliverables`` / ``current_stage_id``
+        # を更新しつつ status を変えない 2 つの自己ループ
+        # （``commit_deliverable`` / ``advance_to_next``）を含む。
         (TaskStatus.IN_PROGRESS, "commit_deliverable"): TaskStatus.IN_PROGRESS,
         (TaskStatus.IN_PROGRESS, "request_external_review"): TaskStatus.AWAITING_EXTERNAL_REVIEW,
         (TaskStatus.IN_PROGRESS, "advance_to_next"): TaskStatus.IN_PROGRESS,
         (TaskStatus.IN_PROGRESS, "complete"): TaskStatus.DONE,
         (TaskStatus.IN_PROGRESS, "block"): TaskStatus.BLOCKED,
         (TaskStatus.IN_PROGRESS, "cancel"): TaskStatus.CANCELLED,
-        # AWAITING_EXTERNAL_REVIEW — Gate decision dispatch is application-side.
-        # The two specialised methods replace the older single ``advance``
-        # method (§確定 A-2 採用 (B)), which kept Task ignorant of the
-        # ``ReviewDecision`` Aggregate VO across the boundary.
+        # AWAITING_EXTERNAL_REVIEW — Gate 判定ディスパッチはアプリケーション側。
+        # 2 つの専用メソッドは古い単一の ``advance`` メソッドを置き換える
+        # （§確定 A-2 採用 (B)）。これにより Task は境界を越えて
+        # ``ReviewDecision`` Aggregate VO に対して無知のままで済む。
         (TaskStatus.AWAITING_EXTERNAL_REVIEW, "approve_review"): TaskStatus.IN_PROGRESS,
         (TaskStatus.AWAITING_EXTERNAL_REVIEW, "reject_review"): TaskStatus.IN_PROGRESS,
         (TaskStatus.AWAITING_EXTERNAL_REVIEW, "cancel"): TaskStatus.CANCELLED,
-        # BLOCKED — only retry / cancel reactivate the lifecycle.
+        # BLOCKED — retry / cancel のみがライフサイクルを再開する。
         (TaskStatus.BLOCKED, "unblock_retry"): TaskStatus.IN_PROGRESS,
         (TaskStatus.BLOCKED, "cancel"): TaskStatus.CANCELLED,
     }
 )
-"""Read-only view of the canonical 13-entry transition map.
+"""正準 13 エントリ遷移マップへの読み取り専用ビュー。
 
-Wrapping the underlying ``dict`` in :class:`types.MappingProxyType`
-makes ``_TRANSITIONS[k] = v`` raise ``TypeError`` at runtime even
-when somebody `cast`s the table. ``Final`` blocks re-assignment of
-the symbol itself in pyright strict mode. Together they enforce the
-"after import the table is frozen" contract end-to-end.
+基底の ``dict`` を :class:`types.MappingProxyType` で包むことで、誰かがテーブルを
+`cast` した場合でも ``_TRANSITIONS[k] = v`` がランタイムで ``TypeError`` になる。
+``Final`` は pyright strict モードでシンボル自体の再代入をブロックする。両者あわせて
+「import 後はテーブルが凍結される」コントラクトを端から端まで強制する。
 """
 
 TRANSITIONS: Final[Mapping[tuple[TaskStatus, TaskAction], TaskStatus]] = _TRANSITIONS
-"""Public alias for the transition table.
+"""遷移テーブルのパブリック エイリアス。
 
-Tests import this to assert the table size (``len(TRANSITIONS) == 13``)
-and to walk every legal transition without going through ``lookup``.
-The :class:`MappingProxyType` wrapper still applies, so code that
-imports it cannot mutate it.
+テストはこれを import してテーブル サイズ（``len(TRANSITIONS) == 13``）をアサート
+し、``lookup`` を経由せずに全合法遷移を巡回する。:class:`MappingProxyType` ラッパは
+依然として有効なので、import したコードもこれを変異できない。
 """
 
 
 def lookup(current_status: TaskStatus, action: TaskAction) -> TaskStatus:
-    """Return the allowed ``next_status`` for ``(current_status, action)``.
+    """``(current_status, action)`` に対する許可された ``next_status`` を返す。
 
     Raises:
-        KeyError: when the pair is not in the canonical transition
-            table. The :class:`Task` aggregate catches this and
-            re-raises as
-            :class:`TaskInvariantViolation(kind='state_transition_invalid')`
-            with the ``allowed_actions`` list attached for
-            diagnostics — that translation lives in ``task.py`` so
-            this module stays free of the exception package import
-            cycle.
+        KeyError: 対が正準遷移テーブルに存在しない場合。:class:`Task` Aggregate が
+            これを捕捉し、診断のために ``allowed_actions`` リストを付与した
+            :class:`TaskInvariantViolation(kind='state_transition_invalid')` として
+            再送出する — その変換は ``task.py`` に置き、本モジュールを例外パッケージ
+            の import サイクルから解放する。
     """
     return _TRANSITIONS[(current_status, action)]
 
 
 def allowed_actions_from(current_status: TaskStatus) -> list[TaskAction]:
-    """Return the subset of actions legal from ``current_status``.
+    """``current_status`` から合法なアクション部分集合を返す。
 
-    Used by :class:`Task` to populate the ``allowed_actions`` field
-    of MSG-TS-002 so the human-readable next-action hint surfaces
-    *which* transitions would have worked. Returned in stable
-    insertion order (Python 3.7+ dict iteration) so test snapshots
-    stay deterministic.
+    :class:`Task` が MSG-TS-002 の ``allowed_actions`` フィールドを埋めるために
+    使う。これにより人間可読な next-action ヒントが *どの* 遷移であれば成功した
+    かを表面化する。挿入順を保つ Python 3.7+ dict iteration を使うため、テスト
+    スナップショットも決定的に保たれる。
     """
     return [action for (status, action) in _TRANSITIONS if status == current_status]
 

--- a/backend/src/bakufu/domain/task/task.py
+++ b/backend/src/bakufu/domain/task/task.py
@@ -1,44 +1,37 @@
-"""Task Aggregate Root (REQ-TS-001〜009).
+"""Task Aggregate Root（REQ-TS-001〜009）。
 
-Implements ``docs/features/task/`` as the M1 6th sibling. The aggregate
-follows the same shape established by empire / workflow / agent / room /
-directive but adds two structural elements unique to the lifecycle-driven
-nature of a Task:
+``docs/features/task/`` を M1 の 6 番目の兄弟として実装する。Aggregate は
+empire / workflow / agent / room / directive で確立された形を踏襲するが、Task の
+ライフサイクル駆動的性質に固有の構造要素を 2 つ追加する:
 
-* a **decision-table state machine** in
-  :mod:`bakufu.domain.task.state_machine`, locked by
-  ``Final[Mapping]`` + :class:`types.MappingProxyType` per §確定 B; and
-* **ten dedicated behavior methods** whose names map 1:1 to the action
-  names in the state-machine table per §確定 A-2 (Steve R2 凍結) — no
-  internal dispatch, no ``advance(..., gate_decision=...)`` argument
-  shape. ``method x current_status -> action`` is statically determined
-  by the method definition itself.
+* :mod:`bakufu.domain.task.state_machine` 内の **decision-table state machine**。
+  §確定 B により ``Final[Mapping]`` + :class:`types.MappingProxyType` でロックされる。
+* §確定 A-2（Steve R2 凍結）により state-machine テーブルのアクション名と 1:1 対応
+  する **10 個の専用ビヘイビア メソッド** — 内部ディスパッチ無し、
+  ``advance(..., gate_decision=...)`` の引数形も無し。
+  ``method x current_status -> action`` はメソッド定義そのものによって静的に決定される。
 
-Design contracts (do not break without re-running design review):
+設計コントラクト（再設計レビュー無しに破壊しないこと）:
 
-* **Pre-validate rebuild (§確定 A)** — every behavior calls
-  :meth:`_rebuild_with_state` which goes through ``model_dump`` /
-  ``swap`` / ``model_validate``. ``model_copy(update=...)`` is
-  intentionally avoided: Pydantic v2 defaults that path to
-  ``validate=False`` and would silently bypass the model validator.
-* **Terminal Fail-Fast (§確定 R1-B)** — DONE / CANCELLED Tasks are
-  immutable. Every method enters through :meth:`_assert_not_terminal`
-  before touching the state machine.
-* **State-machine bypass Fail-Fast (§確定 R1-A)** — illegal
-  ``(status, action)`` pairs raise
-  ``TaskInvariantViolation(kind='state_transition_invalid')`` with
-  the legal-action set attached in ``detail`` so MSG-TS-002 lands
-  with the "next action" hint already populated.
-* **Webhook auto-mask (§確定 I)** — :class:`TaskInvariantViolation`
-  applies ``mask_discord_webhook`` /
-  ``mask_discord_webhook_in`` to ``message`` / ``detail`` at
-  construction time, so even if ``last_error`` carries a Discord
-  webhook URL the exception stream stays redacted.
-* **Aggregate boundary (§確定 K)** — the Task does **not** import
-  ``ReviewDecision`` (Gate VO) or any other Aggregate's value
-  object. ``approve_review`` / ``reject_review`` are dispatched by
-  the application layer (``GateService``) on Gate APPROVED /
-  REJECTED, keeping the Task ignorant of Gate internals.
+* **Pre-validate rebuild（§確定 A）** — 全ビヘイビアは :meth:`_rebuild_with_state`
+  を呼び、``model_dump`` / ``swap`` / ``model_validate`` を経由する。
+  ``model_copy(update=...)`` は意図的に避ける: Pydantic v2 はその経路を
+  ``validate=False`` にデフォルトし、モデル バリデータをサイレントにバイパスして
+  しまう。
+* **Terminal Fail-Fast（§確定 R1-B）** — DONE / CANCELLED の Task は不変。全メソッド
+  は state machine に触れる前に :meth:`_assert_not_terminal` を通る。
+* **State-machine bypass Fail-Fast（§確定 R1-A）** — 不正な ``(status, action)`` 対は
+  ``TaskInvariantViolation(kind='state_transition_invalid')`` を送出し、合法アクション
+  集合を ``detail`` に添付する。これにより MSG-TS-002 が「next action」ヒント込みで
+  投入される。
+* **Webhook auto-mask（§確定 I）** — :class:`TaskInvariantViolation` は構築時に
+  ``mask_discord_webhook`` / ``mask_discord_webhook_in`` を ``message`` / ``detail``
+  に適用するため、``last_error`` に Discord webhook URL が含まれていても例外
+  ストリームは伏字化された状態を保つ。
+* **Aggregate boundary（§確定 K）** — Task は ``ReviewDecision``（Gate VO）や他の
+  Aggregate の Value Object を **import しない**。``approve_review`` / ``reject_review``
+  は Gate APPROVED / REJECTED 時にアプリケーション層（``GateService``）が
+  ディスパッチし、Task は Gate の内部に対して無知のままとなる。
 """
 
 from __future__ import annotations
@@ -81,18 +74,16 @@ from bakufu.domain.value_objects import (
 
 
 class Task(BaseModel):
-    """Lifecycle-aware unit of work delegated to one or more Agents.
+    """1 体以上の Agent に委譲されるライフサイクル対応の作業単位。
 
-    A Task is created by ``DirectiveService.issue()`` (PENDING with
-    no assigned agents), advances through a Workflow's Stages while
-    accumulating per-Stage :class:`Deliverable` snapshots, and
-    eventually terminates as DONE or CANCELLED. The lifecycle is
-    driven by ten behavior methods whose names match the state
-    machine action names exactly — there is no implicit dispatch.
+    Task は ``DirectiveService.issue()`` によって生成される（PENDING、agent
+    アサイン無し）。Workflow の Stage を進みながら Stage ごとの :class:`Deliverable`
+    スナップショットを蓄積し、最終的に DONE または CANCELLED で終端する。
+    ライフサイクルは 10 個のビヘイビア メソッドで駆動され、それらの名前は state
+    machine のアクション名と完全に一致する — 暗黙ディスパッチは存在しない。
 
-    Out-of-aggregate concerns (Workflow / Room / Agent reference
-    integrity, ``current_stage_id`` lookup, Gate decision bridging)
-    live in ``TaskService`` per §確定 K.
+    Aggregate 外の関心事（Workflow / Room / Agent 参照整合性、``current_stage_id``
+    ルックアップ、Gate 判定ブリッジ）は §確定 K により ``TaskService`` に置く。
     """
 
     model_config = ConfigDict(
@@ -112,11 +103,11 @@ class Task(BaseModel):
     updated_at: datetime
     last_error: str | None = None
 
-    # ---- pre-validation -------------------------------------------------
+    # ---- 事前検証 -------------------------------------------------------
     @field_validator("created_at", "updated_at", mode="after")
     @classmethod
     def _require_tz_aware(cls, value: datetime) -> datetime:
-        """Reject naive datetimes at the aggregate boundary (§確定 H)."""
+        """Aggregate 境界で naive datetime を拒否する（§確定 H）。"""
         if value.tzinfo is None:
             raise ValueError(
                 "Task timestamps must be timezone-aware UTC datetimes (received a naive datetime)"
@@ -126,12 +117,11 @@ class Task(BaseModel):
     @field_validator("last_error", mode="before")
     @classmethod
     def _normalize_last_error(cls, value: object) -> object:
-        """Apply NFC normalization without ``strip`` (§確定 C).
+        """``strip`` 無しで NFC 正規化を適用する（§確定 C）。
 
-        LLM stack traces rely on leading whitespace for indentation;
-        the precedent set by ``Persona.prompt_body`` /
-        ``PromptKit.prefix_markdown`` / ``Directive.text`` (NFC-only,
-        no strip) carries forward to ``Task.last_error``.
+        LLM のスタック トレースはインデントのために先頭空白に依存する。
+        ``Persona.prompt_body`` / ``PromptKit.prefix_markdown`` / ``Directive.text``
+        が確立した先例（NFC のみ、strip 無し）を ``Task.last_error`` でも踏襲する。
         """
         if isinstance(value, str):
             return unicodedata.normalize("NFC", value)
@@ -139,28 +129,25 @@ class Task(BaseModel):
 
     @model_validator(mode="after")
     def _check_invariants(self) -> Self:
-        """Run the structural invariants (§確定 J kinds 3〜7).
+        """構造的不変条件を実行する（§確定 J kinds 3〜7）。
 
-        Validator ordering — BUG-TSK-001 fix:
+        バリデータ順序 — BUG-TSK-001 修正:
 
-        ``_validate_blocked_has_last_error`` runs **before**
-        ``_validate_last_error_consistency`` so that the BLOCKED-side
-        violation surfaces with the more specific
-        ``blocked_requires_last_error`` (MSG-TS-006) — the
-        "block() requires non-empty last_error" Next-action hint test
-        designers and operators expect when ``Task.block()`` rejects
-        ``last_error=''`` / ``last_error=None``. Pydantic's
-        ``model_validator(mode='after')`` short-circuits on the first
-        raise, so this ordering is the lever.
+        ``_validate_blocked_has_last_error`` を ``_validate_last_error_consistency``
+        より **先** に実行することで、BLOCKED 側の違反がより具体的な
+        ``blocked_requires_last_error``（MSG-TS-006）として表面化する — テスト
+        設計者およびオペレータが ``Task.block()`` が ``last_error=''`` /
+        ``last_error=None`` を拒否したときに期待する「block() は非空の last_error
+        を要求する」Next-action ヒント。Pydantic の ``model_validator(mode='after')``
+        は最初の raise で短絡するため、この順序がレバーとなる。
 
-        ``_validate_last_error_consistency`` is retained to catch the
-        **opposite** mismatch — ``status != BLOCKED`` paired with a
-        non-None ``last_error`` (e.g. a corrupted Repository row where
-        ``status=DONE`` still carries leftover error text). Its 1〜2
-        positive paths (BLOCKED+None / BLOCKED+'') are now preempted by
-        the BLOCKED helper above, but the validator's own test cases
-        in ``test_invariants.py::TestLastErrorConsistency`` still pin
-        the in-isolation contract.
+        ``_validate_last_error_consistency`` は **逆向き** の不整合
+        — ``status != BLOCKED`` かつ non-None ``last_error``（例えば ``status=DONE``
+        にエラー テキストが残ったままの破損リポジトリ行）を捕捉するために残す。
+        正例の 1〜2 パス（BLOCKED+None / BLOCKED+''）は上記 BLOCKED ヘルパで先行
+        遮断されるが、バリデータ自身のテストケース
+        ``test_invariants.py::TestLastErrorConsistency`` は依然として独立した
+        コントラクトを固定する。
         """
         _validate_assigned_agents_unique(self.assigned_agent_ids)
         _validate_assigned_agents_capacity(self.assigned_agent_ids)
@@ -169,13 +156,12 @@ class Task(BaseModel):
         _validate_timestamp_order(self.created_at, self.updated_at)
         return self
 
-    # ---- behaviors (Tell, Don't Ask) ------------------------------------
+    # ---- 振る舞い（Tell, Don't Ask） -----------------------------------
     def assign(self, agent_ids: list[AgentId], *, updated_at: datetime) -> Task:
-        """PENDING → IN_PROGRESS, attach ``agent_ids`` (REQ-TS-002).
+        """PENDING → IN_PROGRESS、``agent_ids`` を紐付ける（REQ-TS-002）。
 
-        The list is taken verbatim — uniqueness / capacity checks
-        live in the model validator so a Repository hydration path
-        hits the same gate as this method.
+        リストはそのまま受理する — 一意性／容量チェックはモデル バリデータに
+        あるため、リポジトリ水和経路でもこのメソッドと同じゲートを通る。
         """
         next_status = self._lookup_or_raise("assign")
         return self._rebuild_with_state(
@@ -194,16 +180,15 @@ class Task(BaseModel):
         *,
         updated_at: datetime,
     ) -> Task:
-        """IN_PROGRESS self-loop, ``deliverables[stage_id] = deliverable`` (REQ-TS-003).
+        """IN_PROGRESS 自己ループ、``deliverables[stage_id] = deliverable``（REQ-TS-003）。
 
-        ``by_agent_id`` is accepted for API symmetry with ``TaskService``
-        but is **not** validated against ``assigned_agent_ids`` here —
-        per §確定 G that membership check is the application layer's
-        job; the aggregate proves only that ``stage_id`` is structurally
-        a valid ``StageId`` and that the state machine permits the
-        action.
+        ``by_agent_id`` は ``TaskService`` との API 対称性のために受け取るが、ここでは
+        ``assigned_agent_ids`` に対する検証は **行わない** — §確定 G に従い、その
+        メンバシップ検査はアプリケーション層の責務。Aggregate は ``stage_id`` が
+        構造的に有効な ``StageId`` であること、および state machine がアクションを
+        許可することのみを保証する。
         """
-        del by_agent_id  # checked by TaskService.commit_deliverable, not here.
+        del by_agent_id  # ここではなく TaskService.commit_deliverable がチェックする。
         next_status = self._lookup_or_raise("commit_deliverable")
         new_deliverables = {**self.deliverables, stage_id: deliverable}
         return self._rebuild_with_state(
@@ -215,7 +200,7 @@ class Task(BaseModel):
         )
 
     def request_external_review(self, *, updated_at: datetime) -> Task:
-        """IN_PROGRESS → AWAITING_EXTERNAL_REVIEW (REQ-TS-004)."""
+        """IN_PROGRESS → AWAITING_EXTERNAL_REVIEW（REQ-TS-004）。"""
         next_status = self._lookup_or_raise("request_external_review")
         return self._rebuild_with_state(
             {
@@ -232,14 +217,13 @@ class Task(BaseModel):
         *,
         updated_at: datetime,
     ) -> Task:
-        """AWAITING_EXTERNAL_REVIEW → IN_PROGRESS (Gate APPROVED, REQ-TS-005a).
+        """AWAITING_EXTERNAL_REVIEW → IN_PROGRESS（Gate APPROVED、REQ-TS-005a）。
 
-        ``transition_id`` / ``by_owner_id`` are positional metadata
-        the application layer passes through for audit purposes; the
-        aggregate stores neither (audit_log is GateService's job).
-        ``next_stage_id`` is the Stage the Workflow says to advance
-        to — verifying it lives inside the Workflow's stages is the
-        application layer's job (§確定 K).
+        ``transition_id`` / ``by_owner_id`` は監査目的でアプリケーション層が
+        受け渡す位置メタデータ。Aggregate はどちらも保存しない（audit_log は
+        GateService の責務）。``next_stage_id`` は Workflow が進めるよう指示する
+        Stage — それが Workflow の stages 内に存在するかの検証はアプリケーション層
+        の責務（§確定 K）。
         """
         del transition_id, by_owner_id
         next_status = self._lookup_or_raise("approve_review")
@@ -259,13 +243,12 @@ class Task(BaseModel):
         *,
         updated_at: datetime,
     ) -> Task:
-        """AWAITING_EXTERNAL_REVIEW → IN_PROGRESS (Gate REJECTED, REQ-TS-005b).
+        """AWAITING_EXTERNAL_REVIEW → IN_PROGRESS（Gate REJECTED、REQ-TS-005b）。
 
-        Same shape as :meth:`approve_review`; ``next_stage_id`` is the
-        rollback / revision Stage rather than the forward one. Keeping
-        the methods separate (instead of a single ``advance(...,
-        gate_decision=...)``) is the §確定 A-2 凍結 — Tell-Don't-Ask
-        and Aggregate-boundary preservation.
+        :meth:`approve_review` と同形。``next_stage_id`` は前進ではなくロールバック
+        / リビジョン用の Stage となる。メソッドを分けたまま（単一の
+        ``advance(..., gate_decision=...)`` にしない）は §確定 A-2 凍結 —
+        Tell-Don't-Ask と Aggregate 境界保存のため。
         """
         del transition_id, by_owner_id
         next_status = self._lookup_or_raise("reject_review")
@@ -285,12 +268,11 @@ class Task(BaseModel):
         *,
         updated_at: datetime,
     ) -> Task:
-        """IN_PROGRESS self-loop, advance ``current_stage_id`` (REQ-TS-005c).
+        """IN_PROGRESS 自己ループ、``current_stage_id`` を進める（REQ-TS-005c）。
 
-        Used for Stage-to-Stage progression that does **not** go
-        through an EXTERNAL_REVIEW Gate (e.g. a WORK Stage feeding
-        the next WORK Stage). Status stays IN_PROGRESS; only the
-        ``current_stage_id`` moves.
+        EXTERNAL_REVIEW Gate を **通らない** Stage 間の進行（例: WORK Stage が次の
+        WORK Stage に流れる）に用いる。Status は IN_PROGRESS のまま、
+        ``current_stage_id`` のみが移動する。
         """
         del transition_id, by_owner_id
         next_status = self._lookup_or_raise("advance_to_next")
@@ -309,13 +291,11 @@ class Task(BaseModel):
         *,
         updated_at: datetime,
     ) -> Task:
-        """IN_PROGRESS → DONE (terminal, REQ-TS-005d).
+        """IN_PROGRESS → DONE（終端、REQ-TS-005d）。
 
-        ``current_stage_id`` is intentionally unchanged: the Task
-        terminates *at* its current Stage, and downstream consumers
-        can read the last Stage from this attribute. Verifying that
-        the current Stage is genuinely a sink is GateService /
-        TaskService's job (§確定 K).
+        ``current_stage_id`` は意図的に変更しない: Task は現在の Stage で終端し、
+        ダウンストリームの利用側はこの属性から最後の Stage を読める。現在の Stage
+        が本当に sink であるかの検証は GateService / TaskService の責務（§確定 K）。
         """
         del transition_id, by_owner_id
         next_status = self._lookup_or_raise("complete")
@@ -333,14 +313,13 @@ class Task(BaseModel):
         *,
         updated_at: datetime,
     ) -> Task:
-        """{PENDING / IN_PROGRESS / AWAITING_EXTERNAL_REVIEW / BLOCKED} → CANCELLED (REQ-TS-006).
+        """{PENDING / IN_PROGRESS / AWAITING_EXTERNAL_REVIEW / BLOCKED} → CANCELLED（REQ-TS-006）。
 
-        ``reason`` is application-layer audit metadata; the
-        aggregate does **not** persist it (§設計判断補足 §"なぜ
-        cancel reason を Aggregate 属性として持たないか"). The cancel
-        path also resets ``last_error`` to ``None`` so the
-        ``status != BLOCKED ⇔ last_error is None`` consistency
-        invariant holds for the new instance.
+        ``reason`` はアプリケーション層の監査メタデータ。Aggregate はこれを
+        **永続化しない**（§設計判断補足 §「なぜ cancel reason を Aggregate 属性
+        として持たないか」）。cancel 経路は ``last_error`` も ``None`` にリセット
+        するため、``status != BLOCKED ⇔ last_error is None`` の一貫性不変条件が
+        新インスタンスでも成立する。
         """
         del by_owner_id, reason
         next_status = self._lookup_or_raise("cancel")
@@ -359,30 +338,28 @@ class Task(BaseModel):
         *,
         updated_at: datetime,
     ) -> Task:
-        """IN_PROGRESS → BLOCKED, attach ``last_error`` (REQ-TS-007).
+        """IN_PROGRESS → BLOCKED、``last_error`` を紐付ける（REQ-TS-007）。
 
-        ``reason`` is an application-layer audit annotation
-        (recorded by ``TaskService`` before the ``audit_log`` write);
-        only ``last_error`` reaches the aggregate. The model
-        validator runs ``_validate_blocked_has_last_error`` against
-        the NFC-normalized form so an empty / whitespace-only
-        ``last_error`` is rejected at construction time.
+        ``reason`` はアプリケーション層の監査注記（``TaskService`` が
+        ``audit_log`` 書込前に記録する）。Aggregate に届くのは ``last_error`` のみ。
+        モデル バリデータが NFC 正規化済みの形に対して
+        ``_validate_blocked_has_last_error`` を実行するため、空 ／ 空白のみの
+        ``last_error`` は構築時に拒否される。
         """
-        del reason  # recorded by TaskService.block, not stored on Task.
+        del reason  # Task には保存せず TaskService.block が記録する。
         next_status = self._lookup_or_raise("block")
         return self._rebuild_with_state(
             {
                 "status": next_status,
-                # The field validator on ``last_error`` re-applies NFC
-                # normalization on rebuild, so passing the raw value
-                # through is fine.
+                # ``last_error`` のフィールド バリデータが rebuild 時に NFC 正規化を
+                # 再適用するため、生の値をそのまま渡してよい。
                 "last_error": last_error,
                 "updated_at": updated_at,
             }
         )
 
     def unblock_retry(self, *, updated_at: datetime) -> Task:
-        """BLOCKED → IN_PROGRESS, clear ``last_error`` (REQ-TS-008, §確定 D)."""
+        """BLOCKED → IN_PROGRESS、``last_error`` をクリアする（REQ-TS-008、§確定 D）。"""
         next_status = self._lookup_or_raise("unblock_retry")
         return self._rebuild_with_state(
             {
@@ -392,16 +369,15 @@ class Task(BaseModel):
             }
         )
 
-    # ---- internal -------------------------------------------------------
+    # ---- 内部実装 -------------------------------------------------------
     def _assert_not_terminal(self) -> None:
-        """Reject behaviors invoked on DONE / CANCELLED Tasks (MSG-TS-001).
+        """DONE / CANCELLED の Task で呼ばれた振る舞いを拒否する（MSG-TS-001）。
 
-        Centralised here so all ten methods share the same Fail-Fast
-        path; future readers can search for "terminal_violation" and
-        find a single implementation. The terminal check runs *before*
-        the state-machine lookup so a callable on a DONE Task gets
-        the more specific ``MSG-TS-001`` message rather than the
-        generic ``state_transition_invalid``.
+        ここに集約することで、10 メソッド全てが同じ Fail-Fast 経路を共有する。
+        将来の読者は「terminal_violation」を検索すれば単一の実装を見つけられる。
+        terminal チェックは state-machine ルックアップの *前* に走るため、DONE Task
+        への呼び出しは汎用の ``state_transition_invalid`` ではなくより具体的な
+        ``MSG-TS-001`` メッセージを得る。
         """
         if self.status not in (TaskStatus.DONE, TaskStatus.CANCELLED):
             return
@@ -420,15 +396,13 @@ class Task(BaseModel):
         )
 
     def _lookup_or_raise(self, action: TaskAction) -> TaskStatus:
-        """Combine terminal check + state-machine lookup for behaviors.
+        """振る舞い向けに terminal チェック + state-machine ルックアップを束ねる。
 
-        Returns the ``next_status`` decided by the state machine. Any
-        of the three failure paths
-        (``terminal_violation`` / ``state_transition_invalid``)
-        raises a :class:`TaskInvariantViolation` before
-        :meth:`_rebuild_with_state` runs, so the original Task is
-        guaranteed to be untouched on failure (pre-validate
-        contract).
+        state machine が決定した ``next_status`` を返す。3 つの失敗経路のいずれか
+        （``terminal_violation`` / ``state_transition_invalid``）が
+        :meth:`_rebuild_with_state` の実行前に :class:`TaskInvariantViolation` を
+        送出するため、失敗時に元の Task が変更されないことが保証される
+        （pre-validate コントラクト）。
         """
         self._assert_not_terminal()
         try:
@@ -453,14 +427,13 @@ class Task(BaseModel):
             ) from exc
 
     def _rebuild_with_state(self, updates: dict[str, Any]) -> Task:
-        """Pre-validate rebuild for behavior outputs (§確定 A).
+        """振る舞い出力のための pre-validate rebuild（§確定 A）。
 
-        Same pattern as the M1 5 兄弟 (Empire / Workflow / Agent /
-        Room / Directive). ``model_dump`` produces the canonical
-        Python-mode payload, the dict swap applies the behavior's
-        delta, and ``model_validate`` re-runs every field validator
-        + the post-validator so structural invariants fire
-        regardless of how the new state was reached.
+        M1 の 5 兄弟（Empire / Workflow / Agent / Room / Directive）と同じパターン。
+        ``model_dump`` が正準 Python モード ペイロードを生成し、dict swap が振る舞い
+        の差分を適用し、``model_validate`` が全フィールド バリデータと post-validator
+        を再実行するため、新状態がどのように到達されたかに関わらず構造的不変条件
+        が発火する。
         """
         state = self.model_dump()
         state.update(updates)

--- a/backend/src/bakufu/domain/value_objects/__init__.py
+++ b/backend/src/bakufu/domain/value_objects/__init__.py
@@ -1,19 +1,20 @@
-"""Shared domain value objects and ID types.
+"""共有ドメイン Value Object および ID 型。
 
-This package hosts identifiers, enums, and reference VOs that other Aggregates
-in the bakufu domain depend on. Per ``docs/design/domain-model/value-objects.md``,
-ID types are conceptually distinct UUIDv4 values; they are exposed as PEP 695
-``type`` aliases over ``UUID`` to keep the surface minimal and Pydantic
-serialization unambiguous.
+このパッケージは bakufu ドメイン内の他 Aggregate が依存する識別子、enum、
+参照 VO を集約する。``docs/design/domain-model/value-objects.md`` によれば、
+ID 型は概念的に区別される UUIDv4 値である。表面を最小に保ち Pydantic の
+シリアライズを曖昧にしないため、これらは ``UUID`` 上の PEP 695 ``type``
+エイリアスとして公開する。
 
-Sub-modules:
-- :mod:`.identifiers` — ID type aliases (EmpireId, AgentId, etc.)
-- :mod:`.enums` — StrEnum definitions (Role, GateDecision, etc.)
-- :mod:`.gate_role` — GateRole validated slug type alias
-- :mod:`.verdict` — Verdict VO and _VERDICT_COMMENT_MAX_CHARS
-- :mod:`.helpers` — nfc_strip / mask_discord_webhook / NormalizedShortName etc.
-- :mod:`.references` — RoomRef / AgentRef / CompletionPolicy / NotifyChannel / AuditEntry
-- :mod:`.attachments` — Attachment / Deliverable VOs
+サブモジュール:
+- :mod:`.identifiers` — ID 型エイリアス（EmpireId、AgentId 等）
+- :mod:`.enums` — StrEnum 定義（Role、GateDecision 等）
+- :mod:`.gate_role` — GateRole 検証済み slug 型エイリアス
+- :mod:`.verdict` — Verdict VO および _VERDICT_COMMENT_MAX_CHARS
+- :mod:`.helpers` — nfc_strip / mask_discord_webhook / NormalizedShortName 等
+- :mod:`.references` — RoomRef / AgentRef / CompletionPolicy / NotifyChannel /
+  AuditEntry
+- :mod:`.attachments` — Attachment / Deliverable VO
 """
 
 from __future__ import annotations

--- a/backend/src/bakufu/domain/value_objects/attachments.py
+++ b/backend/src/bakufu/domain/value_objects/attachments.py
@@ -1,7 +1,7 @@
-"""Attachment and Deliverable value objects for the Task feature.
+"""Task feature 用の Attachment / Deliverable Value Object。
 
-Implements Task detailed-design §確定 R1-E: per-Stage deliverable snapshots
-and the file-reference (Attachment) VO with storage.md validation rules.
+Task detailed-design §確定 R1-E を実装する: Stage ごとの成果物スナップショット、
+および storage.md のバリデーション規則を備えたファイル参照（Attachment）VO。
 """
 
 from __future__ import annotations
@@ -16,10 +16,10 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from bakufu.domain.value_objects.identifiers import AgentId, StageId
 
 # ---------------------------------------------------------------------------
-# Attachment / Deliverable VOs (Task feature §確定 R1-E)
+# Attachment / Deliverable VO（Task feature §確定 R1-E）
 # ---------------------------------------------------------------------------
-# §Attachment storage.md 凍結値. Mirror them as module-level constants so the
-# field validators read clearly and tests can import the same source.
+# §Attachment storage.md 凍結値。フィールド バリデータが読みやすく、テストも
+# 同じ情報源を import できるよう、モジュール レベルの定数としてミラーする。
 
 _ATTACHMENT_SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
 _ATTACHMENT_MAX_BYTES: int = 10 * 1024 * 1024  # 10 MiB
@@ -27,13 +27,13 @@ _ATTACHMENT_MAX_FILENAME_CHARS: int = 255
 _ATTACHMENT_FILENAME_REJECTED_CHARS: frozenset[str] = frozenset(
     {"/", "\\", "\0"} | {chr(c) for c in range(0x00, 0x20)} | {chr(0x7F)}
 )
-# Windows reserved device names — case-insensitive, with or without extensions.
+# Windows 予約デバイス名 — 大文字小文字を区別せず、拡張子の有無も問わない。
 _ATTACHMENT_WINDOWS_RESERVED: frozenset[str] = frozenset(
     {"CON", "PRN", "AUX", "NUL"}
     | {f"COM{i}" for i in range(1, 10)}
     | {f"LPT{i}" for i in range(1, 10)}
 )
-# Whitelist per storage.md §MIME タイプ検証 (text/html / text/csv 拒否).
+# storage.md §MIME タイプ検証によるホワイトリスト（text/html / text/csv は拒否）。
 _ATTACHMENT_MIME_WHITELIST: frozenset[str] = frozenset(
     {
         "text/markdown",
@@ -50,14 +50,13 @@ _DELIVERABLE_BODY_MAX_CHARS: int = 1_000_000
 
 
 class Attachment(BaseModel):
-    """File reference held inside :class:`Deliverable`.
+    """:class:`Deliverable` 内部に保持されるファイル参照。
 
-    Implements the storage.md §filename サニタイズ規則 6 段階, the MIME
-    whitelist, the 10 MiB byte cap, and the 64-hex sha256 contract per
-    Task detailed-design §VO: Attachment. The Aggregate (Task) does not
-    re-validate these — the VO ``model_validator(mode='after')`` is the
-    single gate so a hydration path (Repository round-trip) hits the same
-    checks as construction time.
+    storage.md §filename サニタイズ規則 6 段階、MIME ホワイトリスト、10 MiB バイト
+    上限、64-hex sha256 コントラクト（Task detailed-design §VO: Attachment）を
+    実装する。Aggregate（Task）はこれらを再検証しない — VO の
+    ``model_validator(mode='after')`` が単一ゲートとなり、水和経路（リポジトリ往復）
+    でも構築時と同じチェックが走る。
     """
 
     model_config = ConfigDict(
@@ -83,8 +82,8 @@ class Attachment(BaseModel):
     @field_validator("filename", mode="before")
     @classmethod
     def _normalize_filename(cls, value: object) -> object:
-        # Storage.md §filename サニタイズ規則 step 1-2: NFC normalize first
-        # so the length / character checks below see the canonical form.
+        # Storage.md §filename サニタイズ規則 step 1-2: 以降の長さ／文字チェックが
+        # 正規形を見るよう、まず NFC 正規化する。
         if isinstance(value, str):
             return unicodedata.normalize("NFC", value)
         return value
@@ -92,21 +91,21 @@ class Attachment(BaseModel):
     @field_validator("filename", mode="after")
     @classmethod
     def _validate_filename(cls, value: str) -> str:
-        # Step 1: length (NFC-normalized code-point count).
+        # Step 1: 長さ（NFC 正規化済みコードポイント数）。
         length = len(value)
         if not (1 <= length <= _ATTACHMENT_MAX_FILENAME_CHARS):
             raise ValueError(
                 f"Attachment.filename must be 1-{_ATTACHMENT_MAX_FILENAME_CHARS} "
                 f"NFC-normalized characters (got length={length})"
             )
-        # Step 3: rejected characters (path separators, NUL, control chars).
+        # Step 3: 拒否文字（パス区切り、NUL、制御文字）。
         bad_chars = sorted({ch for ch in value if ch in _ATTACHMENT_FILENAME_REJECTED_CHARS})
         if bad_chars:
             raise ValueError(
                 f"Attachment.filename contains rejected characters: {bad_chars!r} "
                 "(path separators / NUL / ASCII control chars are not allowed)"
             )
-        # Step 4: rejected sequences.
+        # Step 4: 拒否シーケンス。
         if ".." in value:
             raise ValueError("Attachment.filename must not contain '..' (path traversal sequence)")
         if value.startswith(".") or value.endswith("."):
@@ -120,14 +119,13 @@ class Attachment(BaseModel):
             raise ValueError(
                 "Attachment.filename must not contain ':' (Windows ADS / drive-letter trick)"
             )
-        # Step 5: Windows reserved device names (with or without extension).
+        # Step 5: Windows 予約デバイス名（拡張子の有無を問わず）。
         stem = value.split(".", 1)[0].upper()
         if stem in _ATTACHMENT_WINDOWS_RESERVED:
             raise ValueError(f"Attachment.filename uses a reserved Windows device name: {stem!r}")
-        # Step 6: basename round-trip (path-traversal double-defense).
-        # ``PurePosixPath`` reads ``/`` as a separator regardless of the
-        # host OS, mirroring the storage.md sanitization rule which
-        # rejects POSIX path components by design.
+        # Step 6: basename 往復（パス トラバーサル ダブル防御）。
+        # ``PurePosixPath`` はホスト OS に関わらず ``/`` を区切り文字として扱うため、
+        # 設計上 POSIX パス成分を拒否する storage.md サニタイズ規則と一致する。
         if PurePosixPath(value).name != value:
             raise ValueError(
                 "Attachment.filename must equal its basename (path components are not allowed)"
@@ -157,14 +155,13 @@ class Attachment(BaseModel):
 
 
 class Deliverable(BaseModel):
-    """Per-Stage deliverable snapshot held inside :class:`Task`.
+    """:class:`Task` 内部に保持される Stage ごとの成果物スナップショット。
 
-    The Aggregate Root keeps a ``dict[StageId, Deliverable]`` so the
-    "Stage ごとに最新 1 件" contract (Task detailed-design §確定 R1-E)
-    is enforced by Python dict semantics. ``body_markdown`` is the
-    raw CEO/Agent-authored content — masking happens at the Repository
-    layer (``MaskedText`` TypeDecorator on ``task_deliverables.body_markdown``,
-    landed in ``feature/task-repository``).
+    Aggregate Root は ``dict[StageId, Deliverable]`` を保持するため、「Stage ごとに
+    最新 1 件」コントラクト（Task detailed-design §確定 R1-E）が Python の dict
+    セマンティクスで強制される。``body_markdown`` は CEO / Agent が書いた生のコンテ
+    ンツである — 伏字化はリポジトリ層で行う（``feature/task-repository`` で投入された
+    ``task_deliverables.body_markdown`` 上の ``MaskedText`` TypeDecorator）。
     """
 
     model_config = ConfigDict(

--- a/backend/src/bakufu/domain/value_objects/enums.py
+++ b/backend/src/bakufu/domain/value_objects/enums.py
@@ -1,9 +1,9 @@
-"""StrEnum definitions shared across the bakufu domain.
+"""bakufu ドメイン全体で共有される StrEnum 定義。
 
-All enums here are ``StrEnum`` so SQLite/JSON serialization is trivial without
-wrappers. Ordering within each enum matches the natural lifecycle progression
-where applicable (PENDING → terminal) so iteration in tests hits the realistic
-state walk.
+ここの全 enum は ``StrEnum`` であるため、ラッパ無しで SQLite/JSON シリアライズが
+自然に動作する。各 enum 内の順序は適用可能な範囲で自然なライフサイクル進行
+（PENDING → 終端）に一致させており、テストでの enum 反復が現実的な状態遷移を
+辿るようにしている。
 """
 
 from __future__ import annotations
@@ -12,11 +12,11 @@ from enum import StrEnum
 
 
 class Role(StrEnum):
-    """Roles an :class:`AgentRef` can take.
+    """:class:`AgentRef` が取れるロール。
 
-    Mirrors the canonical list in ``docs/design/domain-model/value-objects.md``.
-    Stored as ``str`` (StrEnum) so SQLite/JSON serialization is trivial in later
-    persistence features without wrappers.
+    ``docs/design/domain-model/value-objects.md`` の正準リストをミラーする。
+    ``str``（StrEnum）として保存されるため、後続の永続化機能でラッパ無しで
+    SQLite/JSON シリアライズが容易になる。
     """
 
     LEADER = "LEADER"
@@ -32,7 +32,7 @@ class Role(StrEnum):
 
 
 class StageKind(StrEnum):
-    """Workflow Stage kind per ``domain-model/value-objects.md`` §列挙型一覧."""
+    """``domain-model/value-objects.md`` §列挙型一覧 に従った Workflow Stage 種別。"""
 
     WORK = "WORK"
     INTERNAL_REVIEW = "INTERNAL_REVIEW"
@@ -40,7 +40,7 @@ class StageKind(StrEnum):
 
 
 class TransitionCondition(StrEnum):
-    """Workflow Transition firing condition per ``domain-model/value-objects.md``."""
+    """``domain-model/value-objects.md`` に従った Workflow Transition 発火条件。"""
 
     APPROVED = "APPROVED"
     REJECTED = "REJECTED"
@@ -49,12 +49,12 @@ class TransitionCondition(StrEnum):
 
 
 class ProviderKind(StrEnum):
-    """LLM provider per ``domain-model/value-objects.md`` §列挙型一覧.
+    """``domain-model/value-objects.md`` §列挙型一覧 に従った LLM プロバイダ。
 
-    All six values are defined upfront so adding a new provider in Phase 2
-    requires only an Adapter implementation + a ``BAKUFU_IMPLEMENTED_PROVIDERS``
-    update — never an enum migration that would force every persisted Agent
-    to be rebuilt (Agent feature §確定 I).
+    6 値全てを事前に定義することで、Phase 2 の新プロバイダ追加には Adapter 実装
+    + ``BAKUFU_IMPLEMENTED_PROVIDERS`` 更新のみで済むようにする — 永続化済みの
+    全 Agent を再構築させる enum マイグレーションを発生させない（Agent feature
+    §確定 I）。
     """
 
     CLAUDE_CODE = "CLAUDE_CODE"
@@ -66,12 +66,11 @@ class ProviderKind(StrEnum):
 
 
 class TaskStatus(StrEnum):
-    """Task lifecycle status per ``domain-model/value-objects.md`` §列挙型一覧.
+    """``domain-model/value-objects.md`` §列挙型一覧 に従った Task ライフサイクル状態。
 
-    Six values, frozen by ``docs/features/task/detailed-design.md`` §確定 A-2
-    dispatch table. The ordering here matches the natural lifecycle progression
-    (PENDING → IN_PROGRESS → terminal) so iterating over the enum in tests
-    hits the realistic state walk.
+    ``docs/features/task/detailed-design.md`` §確定 A-2 ディスパッチ表によって
+    凍結された 6 値。順序は自然なライフサイクル進行（PENDING → IN_PROGRESS →
+    終端）に一致させているため、テストでの enum 反復が現実的な状態遷移を辿る。
     """
 
     PENDING = "PENDING"
@@ -83,13 +82,12 @@ class TaskStatus(StrEnum):
 
 
 class LLMErrorKind(StrEnum):
-    """Coarse LLM-Adapter error classification per ``domain-model/value-objects.md``.
+    """``domain-model/value-objects.md`` に従った粒度の粗い LLM-Adapter エラー分類。
 
-    Used by application-layer dispatch / monitoring to decide retry vs
-    Task BLOCK. The Task aggregate itself does not reference this enum —
-    the value reaches it as a pre-built ``last_error`` string — but it
-    lives in the shared VO module because the Adapter feature and the
-    Admin CLI both need the same enum surface.
+    アプリケーション層のディスパッチ／モニタリングが retry vs Task BLOCK を判断
+    するために使う。Task Aggregate 自体はこの enum を参照しない — 値は事前
+    構築された ``last_error`` 文字列として届く — が、Adapter 機能と Admin CLI が
+    両方とも同じ enum 表面を必要とするため共有 VO モジュールに置く。
     """
 
     SESSION_LOST = "SESSION_LOST"
@@ -100,16 +98,14 @@ class LLMErrorKind(StrEnum):
 
 
 class ReviewDecision(StrEnum):
-    """ExternalReviewGate decision outcome per ``domain-model/value-objects.md``.
+    """``domain-model/value-objects.md`` に従った ExternalReviewGate の決定結果。
 
-    Four values, frozen by
-    ``docs/features/external-review-gate/detailed-design.md`` §確定 A
-    dispatch table. ``PENDING`` → 1 of {``APPROVED`` / ``REJECTED`` /
-    ``CANCELLED``} once-only; the three terminal values may not
-    transition further (the state machine table refuses any
-    ``approve`` / ``reject`` / ``cancel`` action from non-PENDING).
-    ``record_view`` self-loops on every value (audit trail allows
-    reads even after a Gate is decided — §確定 G).
+    ``docs/features/external-review-gate/detailed-design.md`` §確定 A ディスパッチ
+    表で凍結された 4 値。``PENDING`` → {``APPROVED`` / ``REJECTED`` /
+    ``CANCELLED``} のいずれか 1 つに 1 度だけ遷移し、3 つの終端値からはそれ以上
+    遷移しない（state machine テーブルが非 PENDING からの ``approve`` /
+    ``reject`` / ``cancel`` アクションを拒否する）。``record_view`` は全値で
+    自己ループする（決定済み Gate に対する読み取りも監査証跡で許可、§確定 G）。
     """
 
     PENDING = "PENDING"
@@ -119,19 +115,16 @@ class ReviewDecision(StrEnum):
 
 
 class AuditAction(StrEnum):
-    """Audit log action discriminator per ``domain-model/value-objects.md``.
+    """``domain-model/value-objects.md`` に従った監査ログ アクション識別子。
 
-    The MVP needs four values for the ExternalReviewGate aggregate
-    (``VIEWED`` from ``record_view`` plus ``APPROVED`` / ``REJECTED``
-    / ``CANCELLED`` mirroring the decision transitions); the
-    remaining six values frozen in
-    ``docs/design/domain-model/value-objects.md`` §列挙型一覧
-    (``RETRIED`` / ``ADMIN_RETRY_TASK`` / ``ADMIN_CANCEL_TASK`` /
-    ``ADMIN_RETRY_EVENT`` / ``ADMIN_LIST_BLOCKED`` /
-    ``ADMIN_LIST_DEAD_LETTERS``) join when the Admin CLI feature
-    lands. Adding them here ahead of time would advertise an enum
-    contract no production code consumes yet — wait until they're
-    needed (YAGNI, agent feature §確定 I 同方針).
+    MVP は ExternalReviewGate Aggregate のための 4 値（``record_view`` から来る
+    ``VIEWED`` と、decision 遷移をミラーする ``APPROVED`` / ``REJECTED`` /
+    ``CANCELLED``）を必要とする。``docs/design/domain-model/value-objects.md``
+    §列挙型一覧 で凍結された残り 6 値（``RETRIED`` / ``ADMIN_RETRY_TASK`` /
+    ``ADMIN_CANCEL_TASK`` / ``ADMIN_RETRY_EVENT`` / ``ADMIN_LIST_BLOCKED`` /
+    ``ADMIN_LIST_DEAD_LETTERS``）は Admin CLI 機能が投入された時点で参加する。
+    本番コードがまだ消費しない enum コントラクトを先回りで宣伝することは避ける —
+    必要になるまで待つ（YAGNI、agent feature §確定 I と同方針）。
     """
 
     VIEWED = "VIEWED"
@@ -141,20 +134,20 @@ class AuditAction(StrEnum):
 
 
 class GateDecision(StrEnum):
-    """InternalReviewGate overall decision per ``domain-model/value-objects.md``.
+    """``domain-model/value-objects.md`` に従った InternalReviewGate 全体決定。
 
-    Three values matching the internal-review-gate state machine:
+    internal-review-gate state machine と一致する 3 値:
 
-    * ``PENDING`` — one or more required roles have not submitted a
-      verdict yet, or no REJECTED verdict has been received.
-    * ``ALL_APPROVED`` — every required GateRole has submitted an
-      APPROVED verdict and none has rejected.
-    * ``REJECTED`` — at least one verdict carries
-      :attr:`VerdictDecision.REJECTED` (most-pessimistic-wins rule).
+    * ``PENDING`` — 1 つ以上の required ロールがまだ判定を提出していない、または
+      REJECTED 判定をまだ受けていない。
+    * ``ALL_APPROVED`` — 全 required GateRole が APPROVED 判定を提出し、誰も
+      reject していない。
+    * ``REJECTED`` — 少なくとも 1 つの判定が :attr:`VerdictDecision.REJECTED` を
+      持つ（most-pessimistic-wins ルール）。
 
-    Unlike :class:`ReviewDecision`, there is no ``CANCELLED`` value
-    because InternalReviewGate cancellation (Stage reassignment) is
-    handled at the Workflow / Task layer, not inside the Gate itself.
+    :class:`ReviewDecision` と異なり ``CANCELLED`` 値は無い。InternalReviewGate
+    のキャンセル（Stage 再アサイン）は Gate 内部ではなく Workflow / Task 層で扱う
+    ため。
     """
 
     PENDING = "PENDING"
@@ -163,12 +156,11 @@ class GateDecision(StrEnum):
 
 
 class VerdictDecision(StrEnum):
-    """Per-role verdict submitted to an :class:`InternalReviewGate`.
+    """:class:`InternalReviewGate` に提出される role 別判定。
 
-    Two values only — an agent either approves or rejects the
-    deliverable. Abstaining is not supported; the state machine
-    treats a missing verdict the same as "not yet submitted"
-    (``GateDecision.PENDING`` until all required roles vote).
+    2 値のみ — エージェントは成果物を承認するか拒否するかのいずれか。棄権は
+    サポートしない。state machine は欠落判定を「未提出」と同じく扱う（全 required
+    ロールが投票するまで ``GateDecision.PENDING`` のまま）。
     """
 
     APPROVED = "APPROVED"

--- a/backend/src/bakufu/domain/value_objects/gate_role.py
+++ b/backend/src/bakufu/domain/value_objects/gate_role.py
@@ -1,10 +1,9 @@
-"""GateRole validated type alias for InternalReviewGate.
+"""InternalReviewGate 用に検証済みの GateRole 型エイリアス。
 
-A GateRole is a free-form slug label identifying which logical reviewer
-category an agent belongs to (e.g. ``"security"``, ``"lead-dev"``,
-``"qa-1"``). It is **not** the same as :class:`Role` (which is a fixed enum
-of agent capabilities) — GateRoles are defined per-Gate as part of the
-Workflow Stage configuration.
+GateRole は、エージェントがどの論理レビュアー カテゴリに属するかを識別する
+自由形式の slug ラベル（例 ``"security"``、``"lead-dev"``、``"qa-1"``）。
+:class:`Role`（エージェント能力の固定 enum）とは **異なる** — GateRole は
+Workflow Stage 構成の一部として Gate ごとに定義される。
 """
 
 from __future__ import annotations
@@ -15,24 +14,24 @@ from typing import Annotated
 from pydantic import AfterValidator
 
 # ---------------------------------------------------------------------------
-# GateRole validated type alias
+# GateRole 検証済み型エイリアス
 # ---------------------------------------------------------------------------
 _GATE_ROLE_RE = re.compile(r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$")
 _GATE_ROLE_MAX_LEN: int = 40
 
 
 def _validate_gate_role(value: str) -> str:
-    """Enforce the slug pattern for :data:`GateRole`.
+    """:data:`GateRole` の slug パターンを強制する。
 
-    Rules (all checked after NFC normalization):
+    ルール（NFC 正規化後にすべてチェック）:
 
-    * 1〜40 characters (code-point count).
-    * Lowercase ASCII letters, digits, and hyphens only.
-    * Must start with a lowercase letter (digit-initial slugs are
-      rejected to avoid confusion with numeric IDs).
-    * No consecutive hyphens (``--`` fragments look like long-options
-      and confuse downstream tools).
-    * No leading or trailing hyphens (covered by the regex anchor).
+    * 1〜40 文字（コードポイント数）。
+    * 小文字 ASCII 文字、数字、ハイフンのみ。
+    * 小文字英字で開始しなければならない（数字始まりの slug は数値 ID と紛らわしい
+      ので拒否）。
+    * 連続ハイフン（``--``）禁止（long オプションのように見えてダウンストリーム
+      ツールを混乱させるため）。
+    * 先頭／末尾ハイフン禁止（正規表現アンカーがカバー）。
     """
     length = len(value)
     if not (1 <= length <= _GATE_ROLE_MAX_LEN):
@@ -49,22 +48,20 @@ def _validate_gate_role(value: str) -> str:
 
 
 type GateRole = Annotated[str, AfterValidator(_validate_gate_role)]
-"""Validated slug identifier for a role in an :class:`InternalReviewGate`.
+""":class:`InternalReviewGate` におけるロールの検証済み slug 識別子。
 
-A GateRole is a free-form string label that identifies which logical
-reviewer category an agent belongs to (e.g. ``"security"``,
-``"lead-dev"``, ``"qa-1"``). It is **not** the same as :class:`Role`
-(which is a fixed enum of agent capabilities) — GateRoles are
-defined per-Gate as part of the Workflow Stage configuration and may
-be arbitrary slugs chosen by the workflow author.
+GateRole は、エージェントがどの論理レビュアー カテゴリに属するかを識別する自由
+形式の文字列ラベル（例 ``"security"``、``"lead-dev"``、``"qa-1"``）。:class:`Role`
+（エージェント能力の固定 enum）とは **異なる** — GateRole は Workflow Stage 構成
+の一部として Gate ごとに定義され、ワークフロー作成者が選ぶ任意の slug が可能。
 
-Validation rules (enforced by :func:`_validate_gate_role`):
+検証ルール（:func:`_validate_gate_role` で強制）:
 
-* 1〜40 NFC-normalized characters.
-* Lowercase ASCII letters, digits, and hyphens only.
-* Must start with a lowercase letter.
-* No consecutive hyphens (``--``).
-* No trailing hyphen (covered by the regex anchor).
+* 1〜40 NFC 正規化文字。
+* 小文字 ASCII 文字、数字、ハイフンのみ。
+* 小文字英字で開始しなければならない。
+* 連続ハイフン（``--``）禁止。
+* 末尾ハイフン禁止（正規表現アンカーがカバー）。
 """
 
 

--- a/backend/src/bakufu/domain/value_objects/helpers.py
+++ b/backend/src/bakufu/domain/value_objects/helpers.py
@@ -1,13 +1,13 @@
-"""Cross-cutting helper functions and annotated string types for the bakufu domain.
+"""bakufu ドメインの横断的ヘルパー関数および注釈付き文字列型。
 
-Two helpers are shared by every Aggregate (Empire / Workflow / Agent / ...):
+すべての Aggregate（Empire / Workflow / Agent / ...）で共有される 2 つのヘルパ:
 
-* :func:`nfc_strip` — name normalization pipeline (NFC → strip → length),
-  fulfilling Empire detailed-design §Confirmation B and Workflow §Confirmation B.
-* :func:`mask_discord_webhook` — replaces the secret ``token`` segment of a
-  Discord webhook URL with ``<REDACTED:DISCORD_WEBHOOK>`` while preserving the
-  ``id`` segment for audit traceability. Required by Workflow detailed-design
-  §Confirmation G "target のシークレット扱い".
+* :func:`nfc_strip` — 名前正規化パイプライン（NFC → strip → 長さ）。
+  Empire detailed-design §Confirmation B と Workflow §Confirmation B を満たす。
+* :func:`mask_discord_webhook` — Discord webhook URL のシークレット ``token``
+  セグメントを ``<REDACTED:DISCORD_WEBHOOK>`` に置き換え、監査追跡用に ``id``
+  セグメントを保持する。Workflow detailed-design §Confirmation G「target のシーク
+  レット扱い」が要求する。
 """
 
 from __future__ import annotations
@@ -19,33 +19,32 @@ from typing import Annotated, cast
 from pydantic import BeforeValidator, Field
 
 # ---------------------------------------------------------------------------
-# Name normalization (Confirmation B)
+# 名前正規化（Confirmation B）
 # ---------------------------------------------------------------------------
 
 
 def nfc_strip(value: object) -> object:
-    """Apply NFC normalization and ``strip`` per detailed-design §Confirmation B.
+    """detailed-design §Confirmation B に従い NFC 正規化と ``strip`` を適用する。
 
-    Public so sibling Aggregates (Empire / Workflow / Agent / ...) can share
-    the **single** implementation of the normalization pipeline. Operates only
-    on ``str`` inputs; non-string values are passed through unchanged so
-    Pydantic's downstream type validation reports them with its standard error
-    shape rather than silently coercing.
+    パブリック関数として、兄弟 Aggregate（Empire / Workflow / Agent / ...）が正規化
+    パイプラインの **単一** 実装を共有できるようにする。``str`` 入力に対してのみ
+    動作し、非文字列値はそのまま通過させる。これにより、サイレントに型強制せず、
+    Pydantic の下流型検証が標準のエラー形で報告できる。
     """
     if isinstance(value, str):
         return unicodedata.normalize("NFC", value).strip()
     return value
 
 
-# Public alias used by sibling VOs/Aggregates that adopt the same pipeline.
+# 同じパイプラインを採用する兄弟 VO / Aggregate が使用するパブリック エイリアス。
 type NormalizedShortName = Annotated[
     str,
     BeforeValidator(nfc_strip),
     Field(min_length=1, max_length=80),
 ]
-"""``str`` annotated with NFC+strip BeforeValidator and 1〜80-char Field bounds.
+"""NFC+strip の BeforeValidator と 1〜80 文字 Field 境界が付与された ``str``。
 
-Used by :class:`RoomRef` and any future VO with the 80-char short-name contract.
+:class:`RoomRef` および 80 文字 short-name コントラクトを採用する将来の VO で使用。
 """
 
 type NormalizedAgentName = Annotated[
@@ -53,16 +52,16 @@ type NormalizedAgentName = Annotated[
     BeforeValidator(nfc_strip),
     Field(min_length=1, max_length=40),
 ]
-"""1〜40-char variant for :class:`AgentRef` (Agent.name regulation)."""
+""":class:`AgentRef`（Agent.name 規定）用の 1〜40 文字バリエーション。"""
 
 
 # ---------------------------------------------------------------------------
-# Discord webhook secret masking (Workflow §Confirmation G)
+# Discord webhook シークレット マスキング（Workflow §Confirmation G）
 # ---------------------------------------------------------------------------
-# Capture id (numeric) separately so it stays visible in audit/log output
-# while only the token segment is redacted. Anchored loosely (no ^/$) so the
-# pattern matches when the URL is embedded inside larger strings (exception
-# detail dicts, JSON payloads, log lines).
+# id（数値）を別キャプチャすることで、監査／ログ出力で id を可視のままにし、token
+# セグメントだけを伏字化する。^ / $ を付けない緩いアンカーで、URL がより大きい
+# 文字列（例外 detail dict、JSON ペイロード、ログ行）に埋め込まれていてもパターン
+# にマッチする。
 _DISCORD_WEBHOOK_PATTERN = re.compile(
     r"https://discord\.com/api/webhooks/([0-9]+)/([A-Za-z0-9_\-]+)"
 )
@@ -70,11 +69,11 @@ _DISCORD_WEBHOOK_REDACTED_TOKEN = "<REDACTED:DISCORD_WEBHOOK>"
 
 
 def mask_discord_webhook(text: str) -> str:
-    """Replace the secret ``token`` segment of every Discord webhook URL.
+    """Discord webhook URL のシークレット ``token`` セグメントを全て置き換える。
 
-    Retains the snowflake ``id`` for traceability (audit_log can identify
-    *which* webhook was involved) while redacting the credential segment.
-    Idempotent: applying it twice yields the same result.
+    snowflake の ``id`` は追跡性のため保持する（audit_log が *どの* webhook が関与
+    したかを特定できる）一方、認証セグメントを伏字化する。冪等: 2 回適用しても
+    同じ結果になる。
     """
     return _DISCORD_WEBHOOK_PATTERN.sub(
         rf"https://discord.com/api/webhooks/\1/{_DISCORD_WEBHOOK_REDACTED_TOKEN}",
@@ -83,12 +82,12 @@ def mask_discord_webhook(text: str) -> str:
 
 
 def mask_discord_webhook_in(value: object) -> object:
-    """Recursively apply :func:`mask_discord_webhook` to strings within a value.
+    """値内の文字列に :func:`mask_discord_webhook` を再帰的に適用する。
 
-    Walks ``str`` / ``list`` / ``tuple`` / ``dict`` structures so nested
-    diagnostic payloads (used in exception ``detail``) cannot leak a token
-    via a list element or dict value. ``cast`` calls give pyright strict the
-    element typing it cannot infer from a bare ``isinstance`` narrowing.
+    ``str`` / ``list`` / ``tuple`` / ``dict`` 構造を巡回するため、ネストされた診断
+    ペイロード（例外の ``detail`` で使用）がリスト要素や dict 値を介してトークンを
+    漏洩することを防ぐ。``cast`` 呼び出しは、bare ``isinstance`` ナローイングだけ
+    では pyright strict が推論できない要素型情報を与える。
     """
     if isinstance(value, str):
         return mask_discord_webhook(value)

--- a/backend/src/bakufu/domain/value_objects/identifiers.py
+++ b/backend/src/bakufu/domain/value_objects/identifiers.py
@@ -1,8 +1,8 @@
-"""ID type aliases for the bakufu domain.
+"""bakufu ドメインの ID 型エイリアス。
 
-All identifiers are PEP 695 ``type`` aliases over ``UUID`` (UUIDv4 in
-production). They are kept conceptually distinct so call-sites read clearly
-and future ``NewType`` refinements are non-breaking.
+全ての識別子は ``UUID``（本番では UUIDv4）上の PEP 695 ``type`` エイリアス。
+呼び出し箇所が明確に読めるよう概念的に区別されており、将来 ``NewType`` への
+refinement を行っても破壊的変更にならない。
 """
 
 from __future__ import annotations
@@ -10,57 +10,56 @@ from __future__ import annotations
 from uuid import UUID
 
 # ---------------------------------------------------------------------------
-# Identifier types
+# 識別子型
 # ---------------------------------------------------------------------------
 type EmpireId = UUID
-"""Empire aggregate identifier (UUIDv4 per domain-model/value-objects.md)."""
+"""Empire Aggregate 識別子（domain-model/value-objects.md に従い UUIDv4）。"""
 
 type RoomId = UUID
-"""Room aggregate identifier (UUIDv4)."""
+"""Room Aggregate 識別子（UUIDv4）。"""
 
 type AgentId = UUID
-"""Agent aggregate identifier (UUIDv4)."""
+"""Agent Aggregate 識別子（UUIDv4）。"""
 
 type WorkflowId = UUID
-"""Workflow aggregate identifier (UUIDv4)."""
+"""Workflow Aggregate 識別子（UUIDv4）。"""
 
 type StageId = UUID
-"""Stage entity identifier (within Workflow aggregate)."""
+"""Stage Entity 識別子（Workflow Aggregate 内）。"""
 
 type TransitionId = UUID
-"""Transition entity identifier (within Workflow aggregate)."""
+"""Transition Entity 識別子（Workflow Aggregate 内）。"""
 
 type SkillId = UUID
-"""Skill identifier (referenced by :class:`SkillRef` inside Agent aggregate)."""
+"""Skill 識別子（Agent Aggregate 内の :class:`SkillRef` から参照）。"""
 
 type DirectiveId = UUID
-"""Directive aggregate identifier (UUIDv4)."""
+"""Directive Aggregate 識別子（UUIDv4）。"""
 
 type TaskId = UUID
-"""Task aggregate identifier (UUIDv4). Referenced by :class:`Directive`
-via ``task_id``; the Task aggregate itself ships in :mod:`bakufu.domain.task`."""
+"""Task Aggregate 識別子（UUIDv4）。:class:`Directive` から ``task_id`` で参照
+される。Task Aggregate 本体は :mod:`bakufu.domain.task` に存在する。"""
 
 type OwnerId = UUID
-"""Owner / Reviewer identifier (UUIDv4 per domain-model/value-objects.md).
+"""Owner / Reviewer 識別子（domain-model/value-objects.md に従い UUIDv4）。
 
-Used by Task Aggregate behaviors that record an external-review actor
-(``approve_review`` / ``reject_review`` / ``advance_to_next`` / ``complete`` /
-``cancel``). The ``OwnerId`` is treated as opaque from the domain's point of
-view; user-account binding is the application layer's job."""
+外部レビュー アクタを記録する Task Aggregate の振る舞い（``approve_review`` /
+``reject_review`` / ``advance_to_next`` / ``complete`` / ``cancel``）が使用する。
+``OwnerId`` はドメインから見て不透明として扱う。ユーザ アカウントへの紐付けは
+アプリケーション層の責務。"""
 
 type GateId = UUID
-"""ExternalReviewGate aggregate identifier (UUIDv4).
+"""ExternalReviewGate Aggregate 識別子（UUIDv4）。
 
-The Gate is independent of Task (it has its own lifecycle, Tx
-boundary, and supports multiple review rounds), so it carries its
-own UUID rather than inheriting the parent ``TaskId`` —
-external-review-gate detailed-design §確定 R1-A."""
+Gate は Task から独立している（独自のライフサイクル、Tx 境界を持ち、複数の
+レビュー ラウンドをサポートする）ため、親の ``TaskId`` を継承せず独自の UUID
+を持つ — external-review-gate detailed-design §確定 R1-A。"""
 
 type InternalGateId = UUID
-"""InternalReviewGate aggregate identifier (UUIDv4).
+"""InternalReviewGate Aggregate 識別子（UUIDv4）。
 
-Parallel to :data:`GateId` for the internal (agent-to-agent) review
-Gate that gates ``INTERNAL_REVIEW`` Stage completion."""
+``INTERNAL_REVIEW`` Stage の完了をゲートする内部（エージェント間）レビュー Gate
+用で、:data:`GateId` と並列。"""
 
 
 __all__ = [

--- a/backend/src/bakufu/domain/value_objects/references.py
+++ b/backend/src/bakufu/domain/value_objects/references.py
@@ -1,11 +1,11 @@
-"""Reference value objects held inside aggregates.
+"""Aggregate 内部で保持される参照型 Value Object。
 
-Contains:
-- :class:`RoomRef` — frozen reference to a Room aggregate (used in Empire).
-- :class:`AgentRef` — frozen reference to an Agent aggregate (used in Empire).
-- :class:`CompletionPolicy` — how a Stage is judged complete (Workflow VO).
-- :class:`NotifyChannel` — webhook channel for ``EXTERNAL_REVIEW`` Stages.
-- :class:`AuditEntry` — one row of an ExternalReviewGate audit trail.
+含まれるもの:
+- :class:`RoomRef` — Room Aggregate へのフローズン参照（Empire 内で使用）。
+- :class:`AgentRef` — Agent Aggregate へのフローズン参照（Empire 内で使用）。
+- :class:`CompletionPolicy` — Stage の完了判定方法（Workflow VO）。
+- :class:`NotifyChannel` — ``EXTERNAL_REVIEW`` Stage 用の Webhook チャネル。
+- :class:`AuditEntry` — ExternalReviewGate 監査証跡の 1 行。
 """
 
 from __future__ import annotations
@@ -28,17 +28,17 @@ from bakufu.domain.value_objects.helpers import (
 from bakufu.domain.value_objects.identifiers import AgentId, OwnerId, RoomId
 
 # ---------------------------------------------------------------------------
-# Reference value objects (held inside Empire aggregate)
+# 参照型 Value Object（Empire Aggregate 内部で保持）
 # ---------------------------------------------------------------------------
 
 
 class RoomRef(BaseModel):
-    """Frozen reference to a Room aggregate, kept inside :class:`Empire`.
+    """:class:`Empire` 内部で保持される Room Aggregate へのフローズン参照。
 
-    Equality and hashing are structural (Pydantic auto-implementation over all
-    fields including ``archived``), so two ``RoomRef`` values compare equal
-    only when both ``room_id`` *and* archived state agree — required for
-    correct list diffing during ``Empire.archive_room``.
+    等価性とハッシュは構造的（Pydantic が ``archived`` を含む全フィールドで自動実装）
+    である。したがって 2 つの ``RoomRef`` は ``room_id`` *と* archived 状態の両方が
+    一致するときのみ等しいと判定される — ``Empire.archive_room`` 中の正しいリスト
+    差分計算のために必要。
     """
 
     model_config = ConfigDict(
@@ -53,7 +53,7 @@ class RoomRef(BaseModel):
 
 
 class AgentRef(BaseModel):
-    """Frozen reference to an Agent aggregate, kept inside :class:`Empire`."""
+    """:class:`Empire` 内部で保持される Agent Aggregate へのフローズン参照。"""
 
     model_config = ConfigDict(
         frozen=True,
@@ -77,7 +77,7 @@ type CompletionPolicyKind = Literal[
 
 
 class CompletionPolicy(BaseModel):
-    """How a :class:`Stage` is judged complete (Workflow detailed-design §VO)."""
+    """:class:`Stage` の完了判定方法（Workflow detailed-design §VO）。"""
 
     model_config = ConfigDict(
         frozen=True,
@@ -90,27 +90,27 @@ class CompletionPolicy(BaseModel):
 
 
 # ---------------------------------------------------------------------------
-# NotifyChannel VO (Workflow §Confirmation G — SSRF / A10 hardening)
+# NotifyChannel VO（Workflow §Confirmation G — SSRF / A10 対策）
 # ---------------------------------------------------------------------------
 type NotifyChannelKind = Literal["discord"]
-"""MVP only accepts ``'discord'``. ``'slack'`` / ``'email'`` are deferred to
-Phase 2 once their target normalization, SSRF rules, and secret-masking
-contracts are frozen — see Workflow detailed-design §確定 G."""
+"""MVP では ``'discord'`` のみ受け付ける。``'slack'`` / ``'email'`` は、ターゲット
+正規化、SSRF ルール、シークレット マスキングのコントラクトが凍結される Phase 2
+まで延期 — Workflow detailed-design §確定 G を参照。"""
 
-# G7: anchored regex for the Discord webhook URL path.
-# id  = 1〜30 digits (Discord snowflake range)
-# tok = 1〜100 URL-safe characters (Base64 alphabet + '-' + '_')
+# G7: Discord Webhook URL のパス用アンカー付き正規表現。
+# id  = 1〜30 桁の数字（Discord snowflake の範囲）
+# tok = 1〜100 文字の URL 安全文字（Base64 アルファベット + '-' + '_'）
 _DISCORD_WEBHOOK_PATH_RE = re.compile(r"^/api/webhooks/[0-9]{1,30}/[A-Za-z0-9_\-]{1,100}$")
 
 
 class NotifyChannel(BaseModel):
-    """Webhook channel attached to ``EXTERNAL_REVIEW`` Stages.
+    """``EXTERNAL_REVIEW`` Stage に紐づく Webhook チャネル。
 
-    Implements ``§Confirmation G`` rules **G1〜G10** as a single
-    ``field_validator`` over ``target`` so any one violation produces a
-    ``pydantic.ValidationError`` *before* an instance is observable. The
-    serializer downgrade to ``mode='json'`` masks the secret ``token`` segment
-    (G "target のシークレット扱い").
+    ``§Confirmation G`` のルール **G1〜G10** を ``target`` 上の単一の
+    ``field_validator`` として実装する。これにより、いずれか 1 つの違反でも
+    インスタンスが観測可能になる *前* に ``pydantic.ValidationError`` を発生
+    させる。``mode='json'`` へのシリアライザ ダウングレードはシークレットの
+    ``token`` セグメントを伏字化する（G「target のシークレット扱い」）。
     """
 
     model_config = ConfigDict(
@@ -122,83 +122,83 @@ class NotifyChannel(BaseModel):
     kind: NotifyChannelKind
     target: str = Field(min_length=1, max_length=500)
 
-    # G1 / G2 / G3 / G4 / G5 / G6 / G7 / G8 / G9 / G10 — single gate.
+    # G1 / G2 / G3 / G4 / G5 / G6 / G7 / G8 / G9 / G10 — 単一ゲート。
     @field_validator("target", mode="after")
     @classmethod
     def _validate_target(cls, target: str) -> str:
-        # G2: parse via urllib.parse.urlparse (no startswith / regex shortcuts).
+        # G2: urllib.parse.urlparse でパース（startswith / 正規表現の近道は使わない）。
         parsed = urlparse(target)
-        # G3: HTTPS only (urlparse already lowercases scheme).
+        # G3: HTTPS のみ（urlparse は scheme を小文字化済み）。
         if parsed.scheme != "https":
             raise ValueError(
                 f"NotifyChannel.target violates G3 (scheme): expected 'https', "
                 f"got {parsed.scheme!r}"
             )
-        # G4: hostname must be exactly 'discord.com' (urlparse lowercases host).
+        # G4: hostname は厳密に 'discord.com' でなければならない（urlparse がホストを
+        # 小文字化）。
         if parsed.hostname != "discord.com":
             raise ValueError(
                 f"NotifyChannel.target violates G4 (hostname): expected "
                 f"'discord.com', got {parsed.hostname!r}"
             )
-        # G5: port must be unset or 443.
+        # G5: port は未設定または 443 のみ。
         if parsed.port not in (None, 443):
             raise ValueError(
                 f"NotifyChannel.target violates G5 (port): expected None or 443, "
                 f"got {parsed.port!r}"
             )
-        # G6: no userinfo — blocks 'https://attacker@discord.com/...' tricks.
+        # G6: userinfo は持たない — 'https://attacker@discord.com/...' トリックを阻止。
         if parsed.username is not None or parsed.password is not None:
             raise ValueError(
                 "NotifyChannel.target violates G6 (userinfo): URL must not "
                 "contain user/password info"
             )
-        # G7 + G10: path must fullmatch the Discord webhook regex (case-sensitive).
+        # G7 + G10: path は Discord Webhook 正規表現と完全一致（大文字小文字を区別）。
         if not _DISCORD_WEBHOOK_PATH_RE.fullmatch(parsed.path):
             raise ValueError(
                 "NotifyChannel.target violates G7/G10 (path): expected "
                 "/api/webhooks/<id>/<token> (lowercase 'api/webhooks')"
             )
-        # G8: query must be empty.
+        # G8: query は空でなければならない。
         if parsed.query != "":
             raise ValueError("NotifyChannel.target violates G8 (query): expected empty")
-        # G9: fragment must be empty.
+        # G9: fragment は空でなければならない。
         if parsed.fragment != "":
             raise ValueError("NotifyChannel.target violates G9 (fragment): expected empty")
         return target
 
-    # Mask the secret token segment whenever the VO is serialized to JSON
-    # (model_dump(mode='json') / model_dump_json()). Default model_dump()
-    # in Python mode preserves the raw target for in-process Workflow
-    # manipulation; persistence/log boundaries always go through JSON mode.
+    # VO が JSON にシリアライズされる際は常にシークレット トークン セグメントを伏字化
+    # する（model_dump(mode='json') / model_dump_json()）。Python モードのデフォルト
+    # model_dump() はプロセス内 Workflow 操作のため raw target を保持する。永続化 /
+    # ログ境界は常に JSON モードを通る。
     @field_serializer("target", when_used="json")
     def _serialize_target_masked(self, target: str) -> str:
         return mask_discord_webhook(target)
 
 
 # ---------------------------------------------------------------------------
-# AuditEntry VO (ExternalReviewGate feature §確定 K)
+# AuditEntry VO（ExternalReviewGate feature §確定 K）
 # ---------------------------------------------------------------------------
 _AUDIT_COMMENT_MAX_CHARS: int = 2_000
 
 
 class AuditEntry(BaseModel):
-    """One row of an :class:`ExternalReviewGate.audit_trail`.
+    """:class:`ExternalReviewGate.audit_trail` の 1 行。
 
-    Stored append-only inside a Gate aggregate; see
-    ``docs/features/external-review-gate/detailed-design.md`` §確定 C.
-    The "誰がいつ何度見たか" requirement (§確定 G) means every
-    ``record_view`` call yields a fresh entry — same actor, same
-    moment, same comment is **not** deduplicated. Fields stay narrow:
+    Gate Aggregate 内部に追記専用で保存される。
+    ``docs/features/external-review-gate/detailed-design.md`` §確定 C を参照。
+    「誰がいつ何度見たか」要件（§確定 G）により、``record_view`` 呼び出しの度に
+    新しいエントリが生成される — 同一アクター・同一時刻・同一コメントでも
+    **重複排除しない**。フィールドは絞り込まれている:
 
-    * ``id`` — UUIDv4 distinguishes otherwise-equal entries.
-    * ``actor_id`` — :class:`OwnerId` of the human who triggered the
-      action.
-    * ``action`` — :class:`AuditAction` discriminator (VIEWED /
-      APPROVED / REJECTED / CANCELLED at MVP).
-    * ``comment`` — free-form NFC-normalized text, 0〜2000 chars,
-      **strip not applied** (the LLM stack-trace precedent carried
-      through directive / task / agent applies here too).
-    * ``occurred_at`` — UTC tz-aware moment.
+    * ``id`` — それ以外が等しいエントリを区別する UUIDv4。
+    * ``actor_id`` — アクションを発火した人間の :class:`OwnerId`。
+    * ``action`` — :class:`AuditAction` 識別子（MVP では VIEWED / APPROVED /
+      REJECTED / CANCELLED）。
+    * ``comment`` — 自由形式の NFC 正規化テキスト、0〜2000 文字、
+      **strip は適用しない**（directive / task / agent の LLM スタックトレース
+      先例がここでも踏襲される）。
+    * ``occurred_at`` — UTC タイムゾーン付きの瞬間。
     """
 
     model_config = ConfigDict(
@@ -216,8 +216,8 @@ class AuditEntry(BaseModel):
     @field_validator("comment", mode="before")
     @classmethod
     def _normalize_comment(cls, value: object) -> object:
-        # NFC only — preserves leading whitespace / multi-line context
-        # (CEO comments may include indented quoting).
+        # NFC のみ — 先頭の空白や複数行コンテキストを保持する（CEO のコメントは
+        # インデント引用を含むことがある）。
         if isinstance(value, str):
             return unicodedata.normalize("NFC", value)
         return value

--- a/backend/src/bakufu/domain/value_objects/verdict.py
+++ b/backend/src/bakufu/domain/value_objects/verdict.py
@@ -1,8 +1,7 @@
-"""Verdict value object for InternalReviewGate.
+"""InternalReviewGate 用の Verdict Value Object。
 
-A Verdict represents one agent's review decision submitted to an
-InternalReviewGate. Verdicts are append-only within the aggregate; each
-entry corresponds to exactly one role.
+Verdict は InternalReviewGate に提出されるエージェント 1 体のレビュー判定を表す。
+Aggregate 内では追記専用で保持され、各エントリは厳密に 1 つのロールに対応する。
 """
 
 from __future__ import annotations
@@ -17,30 +16,29 @@ from bakufu.domain.value_objects.gate_role import GateRole
 from bakufu.domain.value_objects.identifiers import AgentId
 
 # ---------------------------------------------------------------------------
-# Verdict VO (InternalReviewGate feature)
+# Verdict VO（InternalReviewGate feature）
 # ---------------------------------------------------------------------------
 _VERDICT_COMMENT_MAX_CHARS: int = 5_000
 
 
 class Verdict(BaseModel):
-    """One agent's verdict submitted to an :class:`InternalReviewGate`.
+    """:class:`InternalReviewGate` に提出されるエージェント 1 体の判定。
 
-    Stored as a ``tuple[Verdict, ...]`` inside the aggregate; the
-    tuple is append-only (frozen aggregate rebuild pattern) and each
-    entry corresponds to exactly one :attr:`role` — duplicate roles
-    are rejected by ``aggregate_validators._validate_no_duplicate_roles``.
+    Aggregate 内では ``tuple[Verdict, ...]`` として保持され、タプルは追記専用
+    （frozen Aggregate 再構築パターン）。各エントリは厳密に 1 つの :attr:`role`
+    に対応する — 重複ロールは ``aggregate_validators._validate_no_duplicate_roles``
+    で拒否される。
 
-    Fields:
+    フィールド:
 
-    * ``role`` — the :data:`GateRole` slug the submitting agent is
-      acting as.
-    * ``agent_id`` — the UUID of the submitting agent.
-    * ``decision`` — :class:`VerdictDecision` (APPROVED / REJECTED).
-    * ``comment`` — free-form NFC-normalized text, 0〜5000 chars;
-      **strip is not applied** (multi-line review comments whose
-      leading whitespace carries meaning must be preserved — same
-      precedent as ``AuditEntry.comment`` / ``Directive.text``).
-    * ``decided_at`` — UTC tz-aware moment the verdict was submitted.
+    * ``role`` — 提出エージェントが代表する :data:`GateRole` slug。
+    * ``agent_id`` — 提出エージェントの UUID。
+    * ``decision`` — :class:`VerdictDecision`（APPROVED / REJECTED）。
+    * ``comment`` — 自由形式の NFC 正規化テキスト、0〜5000 文字。
+      **strip は適用しない**（先頭空白に意味を持たせ得る複数行レビュー コメント
+      は保持しなければならない — ``AuditEntry.comment`` / ``Directive.text`` と
+      同じ先例）。
+    * ``decided_at`` — 判定が提出された UTC tz-aware モーメント。
     """
 
     model_config = ConfigDict(
@@ -58,7 +56,7 @@ class Verdict(BaseModel):
     @field_validator("comment", mode="before")
     @classmethod
     def _normalize_comment(cls, value: object) -> object:
-        """NFC normalization only — strip is intentionally **not** applied."""
+        """NFC 正規化のみ — strip は意図的に **適用しない**。"""
         if isinstance(value, str):
             return unicodedata.normalize("NFC", value)
         return value

--- a/backend/src/bakufu/domain/workflow/__init__.py
+++ b/backend/src/bakufu/domain/workflow/__init__.py
@@ -1,21 +1,21 @@
-"""Workflow Aggregate Root package.
+"""Workflow Aggregate Root パッケージ。
 
-Implements ``REQ-WF-001``〜``REQ-WF-007`` per ``docs/features/workflow``.
-Split into three sibling modules along the design's responsibility lines so
-each file stays under the 500-line readability budget and the file-level
-boundary mirrors Confirmation F's twin-defense:
+``docs/features/workflow`` に従って ``REQ-WF-001``〜``REQ-WF-007`` を実装する。
+設計の責務境界に沿って 3 つの兄弟モジュールに分割し、各ファイルが 500 行の
+可読性予算を下回るようにし、ファイル レベル境界が Confirmation F の twin-defense
+を踏襲する:
 
 * :mod:`bakufu.domain.workflow.entities` — :class:`Stage` / :class:`Transition`
-  Pydantic models with **self**-invariants only.
-* :mod:`bakufu.domain.workflow.dag_validators` — 10 module-level pure helper
-  functions enforcing **collection** invariants (DAG, uniqueness, capacity).
-* :mod:`bakufu.domain.workflow.workflow` — :class:`Workflow` Aggregate Root
-  that dispatches over the helpers in deterministic order.
+  の Pydantic モデル（**自己** 不変条件のみ）。
+* :mod:`bakufu.domain.workflow.dag_validators` — **コレクション** 不変条件
+  （DAG、一意性、容量）を強制するモジュール レベルの純粋ヘルパ関数 10 個。
+* :mod:`bakufu.domain.workflow.workflow` — ヘルパを決定的順序でディスパッチする
+  :class:`Workflow` Aggregate Root。
 
-This ``__init__`` re-exports the public surface plus the ``_validate_*``
-helpers that tests need to invoke directly (TC-UT-WF-060). The leading
-underscore is preserved to keep the "private to the aggregate" intent clear
-even though they are technically importable.
+この ``__init__`` はパブリック表面に加え、テスト（TC-UT-WF-060）が直接呼ぶ
+必要のある ``_validate_*`` ヘルパも再 export する。先頭アンダースコアは技術的に
+import 可能だが「Aggregate に対してプライベート」の意図を明確に保つために維持
+する。
 """
 
 from __future__ import annotations

--- a/backend/src/bakufu/domain/workflow/dag_validators.py
+++ b/backend/src/bakufu/domain/workflow/dag_validators.py
@@ -1,19 +1,17 @@
-"""Aggregate-level invariant validators for :class:`Workflow` (Confirmation F).
+""":class:`Workflow` の Aggregate レベル不変条件バリデータ（Confirmation F）。
 
-Each helper is a **module-level pure function** so:
+各ヘルパは **モジュールレベルの純粋関数** として実装する。理由:
 
-1. Tests can ``import`` them and invoke directly (TC-UT-WF-060) to prove the
-   aggregate path does not share code with :class:`Stage` self-validation —
-   the physical ground for Confirmation F's twin-defense (TC-UT-WF-006a vs
-   006b).
-2. :class:`Workflow.model_validator` stays a thin dispatch over the ten
-   checks, with order documented for failure attribution (capacity →
-   structural shape → reference integrity → semantic → graph topology).
+1. テストから ``import`` して直接呼べる（TC-UT-WF-060）。これにより、Aggregate
+   経路が :class:`Stage` 自己検証とコードを共有しないことを証明できる — Confirmation F
+   の twin-defense（TC-UT-WF-006a vs 006b）の物理的根拠。
+2. :class:`Workflow.model_validator` は 10 個のチェックの薄いディスパッチに留まり、
+   失敗箇所の特定のために順序が文書化されている（capacity → 構造形状 → 参照整合性 →
+   意味 → グラフ トポロジ）。
 
-Living in :mod:`dag_validators` (separate file from
-:mod:`bakufu.domain.workflow.entities` and ``workflow``) makes the
-twin-defense boundary visible at the directory level, not just the function
-prefix — Norman's review feedback.
+:mod:`dag_validators`（:mod:`bakufu.domain.workflow.entities` および ``workflow``
+とは別ファイル）に置くことで、関数プレフィックスだけでなくディレクトリ レベルでも
+twin-defense 境界を可視化する — Norman のレビュー フィードバック。
 """
 
 from __future__ import annotations
@@ -25,7 +23,7 @@ from bakufu.domain.value_objects import StageId, StageKind, TransitionCondition,
 from bakufu.domain.workflow.entities import Stage, Transition
 
 # ---------------------------------------------------------------------------
-# Module-level constants (Workflow §Confirmation E + name bounds)
+# モジュール レベル定数（Workflow §Confirmation E と名前境界）
 # ---------------------------------------------------------------------------
 MAX_STAGES: int = 30
 MAX_TRANSITIONS: int = 60
@@ -34,13 +32,13 @@ MAX_NAME_LENGTH: int = 80
 
 
 # ---------------------------------------------------------------------------
-# Helpers (each shares zero code with Stage._check_self_invariants)
+# ヘルパ（各々 Stage._check_self_invariants とコードを共有しない）
 # ---------------------------------------------------------------------------
 def _validate_capacity(
     stages: list[Stage],
     transitions: list[Transition],
 ) -> None:
-    """T2 DoS guard. Run **first** so huge payloads short-circuit before BFS."""
+    """T2 DoS ガード。BFS の前に巨大ペイロードを短絡させるため **最初** に実行。"""
     stages_count = len(stages)
     if stages_count > MAX_STAGES:
         raise WorkflowInvariantViolation(
@@ -52,7 +50,7 @@ def _validate_capacity(
             detail={"stages_count": stages_count, "max_stages": MAX_STAGES},
         )
     if stages_count < 1:
-        # 1〜30 is the contract; zero stages cannot satisfy entry_stage_id.
+        # 1〜30 がコントラクト。stage 0 個では entry_stage_id を満たせない。
         raise WorkflowInvariantViolation(
             kind="capacity_exceeded",
             message=(
@@ -77,7 +75,7 @@ def _validate_capacity(
 
 
 def _validate_stage_id_unique(stages: list[Stage]) -> None:
-    """No two Stages may share an id (MSG-WF-008)."""
+    """2 つの Stage が同じ id を共有してはならない（MSG-WF-008）。"""
     seen: set[StageId] = set()
     for stage in stages:
         if stage.id in seen:
@@ -90,13 +88,12 @@ def _validate_stage_id_unique(stages: list[Stage]) -> None:
 
 
 def _validate_transition_id_unique(transitions: list[Transition]) -> None:
-    """No two Transitions may share an id (symmetric to ``_validate_stage_id_unique``).
+    """2 つの Transition が同じ id を共有してはならない（``_validate_stage_id_unique`` と対称）。
 
-    The detailed-design row "transitions: 0〜60 件、transition_id の重複なし"
-    requires this; without it, two distinct edges with the same id slip
-    through and only the persistence-layer UNIQUE constraint catches them
-    later. Steve's PR #16 review caught this gap and required the helper to
-    sit alongside ``_validate_stage_id_unique`` for symmetry.
+    detailed-design 行「transitions: 0〜60 件、transition_id の重複なし」が要求する。
+    これがないと、同 id の異なる 2 エッジが通過し、永続化層の UNIQUE 制約が後で捕捉
+    することになる。Steve の PR #16 レビューがこのギャップを指摘し、対称性のため
+    ヘルパを ``_validate_stage_id_unique`` と並べて配置することを要求した。
     """
     seen: set[TransitionId] = set()
     for transition in transitions:
@@ -113,7 +110,7 @@ def _validate_entry_in_stages(
     stages: list[Stage],
     entry_stage_id: StageId,
 ) -> None:
-    """``entry_stage_id`` must reference a known Stage (MSG-WF-002)."""
+    """``entry_stage_id`` は既知の Stage を参照しなければならない（MSG-WF-002）。"""
     if not any(stage.id == entry_stage_id for stage in stages):
         raise WorkflowInvariantViolation(
             kind="entry_not_in_stages",
@@ -126,7 +123,7 @@ def _validate_transition_refs(
     stages: list[Stage],
     transitions: list[Transition],
 ) -> None:
-    """Every Transition's from/to must point at a known Stage (MSG-WF-009)."""
+    """全 Transition の from/to は既知の Stage を指していなければならない（MSG-WF-009）。"""
     stage_ids: set[StageId] = {stage.id for stage in stages}
     for transition in transitions:
         if transition.from_stage_id not in stage_ids or transition.to_stage_id not in stage_ids:
@@ -145,7 +142,7 @@ def _validate_transition_refs(
 
 
 def _validate_transition_determinism(transitions: list[Transition]) -> None:
-    """``(from_stage_id, condition)`` must be unique across Transitions (MSG-WF-005)."""
+    """``(from_stage_id, condition)`` は Transition 全体で一意でなければならない（MSG-WF-005）。"""
     seen: set[tuple[StageId, TransitionCondition]] = set()
     for transition in transitions:
         key = (transition.from_stage_id, transition.condition)
@@ -166,11 +163,11 @@ def _validate_transition_determinism(transitions: list[Transition]) -> None:
 
 
 def _validate_external_review_notify(stages: list[Stage]) -> None:
-    """All ``EXTERNAL_REVIEW`` Stages must declare notify_channels (MSG-WF-006).
+    """全 ``EXTERNAL_REVIEW`` Stage は notify_channels を宣言しなければならない（MSG-WF-006）。
 
-    Aggregate-side twin of ``Stage._check_self_invariants``; tests
-    (TC-UT-WF-006b) call this with stages whose self-validator was bypassed
-    to prove the aggregate path catches the violation independently.
+    ``Stage._check_self_invariants`` の Aggregate 側 twin。テスト（TC-UT-WF-006b）は
+    自己検証をバイパスした stages を渡してこれを呼び出し、Aggregate 経路が独立して
+    違反を捕捉することを証明する。
     """
     for stage in stages:
         if stage.kind is StageKind.EXTERNAL_REVIEW and not stage.notify_channels:
@@ -184,9 +181,9 @@ def _validate_external_review_notify(stages: list[Stage]) -> None:
 
 
 def _validate_required_role_non_empty(stages: list[Stage]) -> None:
-    """Every Stage's ``required_role`` must be non-empty (MSG-WF-007).
+    """全 Stage の ``required_role`` は非空でなければならない（MSG-WF-007）。
 
-    Aggregate twin-defense (mirrors :class:`Stage` self-check).
+    Aggregate 側の twin-defense（:class:`Stage` 自己チェックと対称）。
     """
     for stage in stages:
         if not stage.required_role:
@@ -202,16 +199,16 @@ def _validate_dag_reachability(
     transitions: list[Transition],
     entry_stage_id: StageId,
 ) -> None:
-    """BFS from ``entry`` over the transition graph; reject orphan stages (MSG-WF-003).
+    """transition グラフ上で ``entry`` から BFS を行い、孤立 stage を拒否する（MSG-WF-003）。
 
-    ``collections.deque`` keeps memory bounded and safely terminates even on
-    cyclic graphs (visited set rejects re-enqueue).
+    ``collections.deque`` がメモリを抑え、循環グラフでも安全に終了する（visited
+    集合が再エンキューを拒否）。
     """
     adjacency: dict[StageId, list[StageId]] = {stage.id: [] for stage in stages}
     for transition in transitions:
-        # Defensive: skip dangling refs; ``_validate_transition_refs`` runs
-        # before this and would have raised, but keep BFS robust if a caller
-        # invokes the helper directly with malformed input.
+        # 防御: 宙吊り参照はスキップ。``_validate_transition_refs`` がここより前に
+        # 走って例外を送出するはずだが、呼び元がヘルパを不正入力で直接呼ぶ場合でも
+        # BFS が頑健に動くようにする。
         if transition.from_stage_id in adjacency:
             adjacency[transition.from_stage_id].append(transition.to_stage_id)
 
@@ -240,10 +237,10 @@ def _validate_dag_sink_exists(
     transitions: list[Transition],
     entry_stage_id: StageId,
 ) -> None:
-    """At least one Stage must have no outgoing Transition (MSG-WF-004).
+    """少なくとも 1 つの Stage は外向き Transition を持たないこと（MSG-WF-004）。
 
-    Pure cycle-only workflows have zero sinks, which makes Task termination
-    impossible — reject them.
+    純粋な循環のみのワークフローは sink が 0 となり、Task の終了が不可能になる —
+    これを拒否する。
     """
     has_outgoing: set[StageId] = {transition.from_stage_id for transition in transitions}
     if all(stage.id in has_outgoing for stage in stages):

--- a/backend/src/bakufu/domain/workflow/entities.py
+++ b/backend/src/bakufu/domain/workflow/entities.py
@@ -1,18 +1,17 @@
-"""Workflow inner Entities: :class:`Stage` and :class:`Transition`.
+"""Workflow 内部 Entity: :class:`Stage` と :class:`Transition`。
 
-Both are Pydantic v2 frozen models. They live separately from
-:mod:`bakufu.domain.workflow.workflow` so the file-level boundary mirrors the
-*responsibility* boundary the design document calls out:
+両者は Pydantic v2 frozen モデル。設計ドキュメントが指摘する *責務* 境界を
+ファイル レベル境界に反映するため :mod:`bakufu.domain.workflow.workflow` から
+分離して配置する:
 
-* Entities own **self**-invariants (Stage's ``required_role`` non-empty and
-  ``EXTERNAL_REVIEW`` notify_channels rule). These fire even when the entity
-  is constructed standalone (preset definition, factory) so violations are
-  caught before a Workflow ever sees the value.
-* The Aggregate Root owns **collection** invariants (DAG, uniqueness,
-  capacity). Those are implemented as pure functions in
-  :mod:`bakufu.domain.workflow.dag_validators` so the file-level boundary
-  enforces "Stage self-validation does not share code with the aggregate
-  helpers" — the physical ground for Confirmation F's twin-defense.
+* Entity は **自己** 不変条件（Stage の ``required_role`` 非空および
+  ``EXTERNAL_REVIEW`` notify_channels ルール）を所有する。これらは entity が
+  単独で構築された場合（preset 定義、ファクトリ）でも発火するため、Workflow
+  が値を目にする前に違反を捕捉できる。
+* Aggregate Root は **コレクション** 不変条件（DAG、一意性、容量）を所有する。
+  それらは :mod:`bakufu.domain.workflow.dag_validators` の純粋関数として実装
+  されており、ファイル レベル境界が「Stage 自己検証は Aggregate ヘルパとコード
+  を共有しない」を強制する — Confirmation F twin-defense の物理的根拠。
 """
 
 from __future__ import annotations
@@ -41,14 +40,14 @@ from bakufu.domain.value_objects import (
 
 
 class Stage(BaseModel):
-    """Workflow stage with **self**-invariants checked in ``model_validator``.
+    """``model_validator`` で **自己** 不変条件をチェックする Workflow Stage。
 
-    Self-check raises :class:`StageInvariantViolation` so a Stage built outside
-    a Workflow (e.g. preset definition, factory) still surfaces violations
-    early. The Workflow aggregate later re-validates the same conditions in
+    自己チェックは :class:`StageInvariantViolation` を送出するため、Workflow の
+    外で構築された Stage（例 preset 定義、ファクトリ）でも違反が早期に表面化する。
+    Workflow Aggregate は後で同じ条件を
     :func:`bakufu.domain.workflow.dag_validators._validate_external_review_notify`
-    and ``_validate_required_role_non_empty`` — the dual path is by design
-    (Confirmation F twin-defense).
+    と ``_validate_required_role_non_empty`` で再検証する — この二重経路は
+    設計通り（Confirmation F twin-defense）。
     """
 
     model_config = ConfigDict(
@@ -72,14 +71,15 @@ class Stage(BaseModel):
 
     @model_validator(mode="after")
     def _check_self_invariants(self) -> Self:
-        # REQ-WF-007-① required_role non-empty (MSG-WF-007).
+        # REQ-WF-007-① required_role 非空（MSG-WF-007）。
         if not self.required_role:
             raise StageInvariantViolation(
                 kind="empty_required_role",
                 message=f"[FAIL] Stage {self.id} required_role must not be empty",
                 detail={"stage_id": str(self.id)},
             )
-        # REQ-WF-007-② EXTERNAL_REVIEW must declare notify_channels (MSG-WF-006).
+        # REQ-WF-007-② EXTERNAL_REVIEW は notify_channels を宣言しなければならない
+        # （MSG-WF-006）。
         if self.kind is StageKind.EXTERNAL_REVIEW and not self.notify_channels:
             raise StageInvariantViolation(
                 kind="missing_notify",
@@ -92,13 +92,12 @@ class Stage(BaseModel):
 
 
 class Transition(BaseModel):
-    """Directed edge between two Stages. Reference integrity is the aggregate's job.
+    """2 つの Stage 間の有向エッジ。参照整合性は Aggregate の責務。
 
-    Transition holds no self-invariants beyond Pydantic field-level type
-    coercion: its meaning depends on the surrounding ``stages`` collection,
-    so structural validation lives in
-    :func:`bakufu.domain.workflow.dag_validators._validate_transition_refs`
-    and ``_validate_transition_determinism``.
+    Transition は Pydantic フィールド レベルの型強制を超える自己不変条件を
+    持たない: その意味は周囲の ``stages`` コレクションに依存するため、構造
+    検証は :func:`bakufu.domain.workflow.dag_validators._validate_transition_refs`
+    および ``_validate_transition_determinism`` に置く。
     """
 
     model_config = ConfigDict(

--- a/backend/src/bakufu/domain/workflow/workflow.py
+++ b/backend/src/bakufu/domain/workflow/workflow.py
@@ -1,21 +1,20 @@
-"""Workflow Aggregate Root (REQ-WF-001〜006).
+"""Workflow Aggregate Root（REQ-WF-001〜006）。
 
-This module owns only the :class:`Workflow` class itself. The 10 invariant
-helpers it dispatches over live in
-:mod:`bakufu.domain.workflow.dag_validators`, and the inner Entities live in
-:mod:`bakufu.domain.workflow.entities`. The directory split is the *physical*
-ground for Confirmation F's twin-defense: aggregate-level checks cannot share
-code with Stage self-validation because they don't even share a file.
+本モジュールは :class:`Workflow` クラス自体のみを所有する。ディスパッチ対象の 10
+個の不変条件ヘルパは :mod:`bakufu.domain.workflow.dag_validators` に、内部 Entity
+は :mod:`bakufu.domain.workflow.entities` に置かれる。このディレクトリ分割は
+Confirmation F twin-defense の *物理的* 根拠である: Aggregate レベル チェックは
+そもそもファイルを共有しないため、Stage 自己検証とコードを共有できない。
 
-Design contract (do not break without re-running design review):
+設計コントラクト（再設計レビュー無しに破壊しないこと）:
 
-* **Pre-validate rebuild (Confirmation A)** — every state-changing behavior
-  serializes via ``model_dump()``, swaps the target collection, and re-runs
-  ``Workflow.model_validate(...)``. ``model_copy(update=...)`` is intentionally
-  avoided because Pydantic v2 defaults it to ``validate=False``.
-* **NotifyChannel SSRF / token masking (Confirmation G)** — handled inside
-  :class:`bakufu.domain.value_objects.NotifyChannel`; this module consumes
-  the validated VO without re-checking URL shape.
+* **Pre-validate rebuild（Confirmation A）** — 全ての状態変更ビヘイビアは
+  ``model_dump()`` でシリアライズし、対象コレクションをスワップし、
+  ``Workflow.model_validate(...)`` を再実行する。``model_copy(update=...)`` は
+  Pydantic v2 がデフォルトで ``validate=False`` とするため意図的に避ける。
+* **NotifyChannel SSRF / トークン マスキング（Confirmation G）** —
+  :class:`bakufu.domain.value_objects.NotifyChannel` 内部で処理される。本モジュール
+  は検証済み VO を消費するだけで URL 形状は再チェックしない。
 """
 
 from __future__ import annotations
@@ -53,7 +52,7 @@ from bakufu.domain.workflow.entities import Stage, Transition
 
 
 class Workflow(BaseModel):
-    """V-model orchestration graph composed of Stages and Transitions."""
+    """Stage と Transition で構成される V モデル オーケストレーション グラフ。"""
 
     model_config = ConfigDict(
         frozen=True,
@@ -67,7 +66,7 @@ class Workflow(BaseModel):
     transitions: list[Transition] = []
     entry_stage_id: StageId
 
-    # ---- pre-validation -------------------------------------------------
+    # ---- 事前検証 -------------------------------------------------------
     @field_validator("name", mode="before")
     @classmethod
     def _normalize_name(cls, value: object) -> object:
@@ -75,13 +74,12 @@ class Workflow(BaseModel):
 
     @model_validator(mode="after")
     def _check_invariants(self) -> Self:
-        """Dispatch over the aggregate-level helpers in deterministic order.
+        """Aggregate レベル ヘルパを決定的順序でディスパッチする。
 
-        Order matters for failure attribution: capacity → uniqueness →
-        reference integrity → semantic (notify / required_role) → graph
-        topology. Earlier failures hide later ones, which keeps error
-        messages focused on the *root* cause. Capacity is **first** so the
-        T2 DoS payload cannot reach BFS.
+        失敗箇所の特定のため順序が重要: capacity → 一意性 → 参照整合性 → 意味
+        （notify / required_role） → グラフ トポロジ。先行する失敗が後続を隠す
+        ため、エラー メッセージは *根本* 原因に集中する。Capacity は **最初**
+        にあり、T2 DoS ペイロードが BFS に到達できないようにする。
         """
         self._check_name_range()
         _validate_capacity(self.stages, self.transitions)
@@ -109,24 +107,25 @@ class Workflow(BaseModel):
                 detail={"length": length},
             )
 
-    # ---- behaviors (Tell, Don't Ask) ------------------------------------
+    # ---- 振る舞い（Tell, Don't Ask） -----------------------------------
     def add_stage(self, stage: Stage) -> Workflow:
-        """Return a new Workflow with ``stage`` appended (REQ-WF-002)."""
+        """``stage`` を追加した新しい Workflow を返す（REQ-WF-002）。"""
         return self._rebuild_with(stages=[*self.stages, stage])
 
     def add_transition(self, transition: Transition) -> Workflow:
-        """Return a new Workflow with ``transition`` appended (REQ-WF-003)."""
+        """``transition`` を追加した新しい Workflow を返す（REQ-WF-003）。"""
         return self._rebuild_with(transitions=[*self.transitions, transition])
 
     def remove_stage(self, stage_id: StageId) -> Workflow:
-        """Return a new Workflow with ``stage_id`` and its incident edges removed (REQ-WF-004).
+        """``stage_id`` とその接続エッジを除去した新しい Workflow を返す（REQ-WF-004）。
 
         Raises:
             WorkflowInvariantViolation:
-                * ``kind='cannot_remove_entry'`` (MSG-WF-010) if removing the entry stage.
-                * ``kind='stage_not_found'`` (MSG-WF-012) if no Stage matches.
-                * Any aggregate violation (e.g. ``unreachable_stage``) bubbling
-                  out of the rebuild — original Workflow stays unchanged.
+                * entry stage を削除しようとした場合 ``kind='cannot_remove_entry'``
+                  （MSG-WF-010）。
+                * 一致する Stage が無い場合 ``kind='stage_not_found'``（MSG-WF-012）。
+                * Aggregate 違反（例 ``unreachable_stage``）が rebuild から漏れる
+                  場合 — 元の Workflow は変更されない。
         """
         if stage_id == self.entry_stage_id:
             raise WorkflowInvariantViolation(
@@ -150,21 +149,20 @@ class Workflow(BaseModel):
 
     @classmethod
     def from_dict(cls, payload: object) -> Workflow:
-        """Bulk-import factory (REQ-WF-006).
+        """一括 import ファクトリ（REQ-WF-006）。
 
-        Accepts ``object`` so callers passing a non-dict still hit the
-        structured ``WorkflowInvariantViolation`` path rather than crashing
-        Pydantic with a confusing low-level error.
+        ``object`` を受け取るので、dict 以外を渡した呼び元も Pydantic の混乱した
+        低レベル エラーでクラッシュさせる代わりに、構造化された
+        ``WorkflowInvariantViolation`` 経路に到達できる。
 
-        Pydantic ``ValidationError`` (type, UUID, missing-field, NotifyChannel
-        URL allow list G1〜G10, MVP ``kind`` constraint) propagates as-is so
-        callers can introspect the loc/error structure.
+        Pydantic ``ValidationError``（型、UUID、欠落フィールド、NotifyChannel URL
+        の G1〜G10 アローリスト、MVP ``kind`` 制約）はそのまま伝播するため、呼び元
+        は loc / error 構造を内省できる。
 
-        ``StageInvariantViolation`` is wrapped into
-        ``WorkflowInvariantViolation(kind='from_dict_invalid')`` with the
-        offending stage index attached to ``detail`` — fulfilling
-        TC-UT-WF-027's debug-traceability contract from the design doc's
-        "なぜ from_dict はクラスメソッドか" section.
+        ``StageInvariantViolation`` は ``detail`` に該当 stage index を添付して
+        ``WorkflowInvariantViolation(kind='from_dict_invalid')`` にラップする —
+        設計ドキュメント「なぜ from_dict はクラスメソッドか」節の TC-UT-WF-027
+        デバッグ追跡コントラクトを満たす。
         """
         if not isinstance(payload, dict):
             raise WorkflowInvariantViolation(
@@ -194,19 +192,19 @@ class Workflow(BaseModel):
                         detail=detail,
                     ) from exc
                 except ValidationError:
-                    # Let cls.model_validate produce the canonical Pydantic
-                    # error with full loc paths so the caller can introspect.
+                    # 呼び元が内省できるよう、cls.model_validate に完全な loc パス
+                    # 込みの正準 Pydantic エラーを生成させる。
                     pass
         return cls.model_validate(payload_dict)
 
-    # ---- internal: pre-validate rebuild (Confirmation A) ----------------
+    # ---- 内部実装: 事前検証 rebuild（Confirmation A） -------------------
     def _rebuild_with(
         self,
         *,
         stages: list[Stage] | None = None,
         transitions: list[Transition] | None = None,
     ) -> Workflow:
-        """Re-construct via ``model_validate`` so ``_check_invariants`` re-fires."""
+        """``model_validate`` で再構築し ``_check_invariants`` を再発火させる。"""
         state = self.model_dump()
         if stages is not None:
             state["stages"] = [stage.model_dump() for stage in stages]

--- a/backend/src/bakufu/infrastructure/__init__.py
+++ b/backend/src/bakufu/infrastructure/__init__.py
@@ -1,11 +1,11 @@
-"""bakufu infrastructure layer.
+"""bakufu インフラストラクチャ層。
 
-Holds all I/O-heavy code: SQLite + Alembic persistence, secret masking
-gateway, OS-bound configuration (DATA_DIR / pid_registry GC), and the
-Backend bootstrap sequence. The dependency direction is **strictly**
-``domain → no one`` and ``infrastructure → domain``: domain code must not
-import from this package, and the test suite enforces that contract via
-``tests/architecture/test_dependency_direction.py``.
+I/O が中心となるコードを集約する: SQLite + Alembic 永続化、シークレット
+マスキング ゲートウェイ、OS 寄りの設定（DATA_DIR / pid_registry GC）、および
+Backend の Bootstrap シーケンス。依存方向は **厳密に** ``domain → no one`` /
+``infrastructure → domain``: ドメイン側のコードは本パッケージから
+import してはならない。テストスイート
+``tests/architecture/test_dependency_direction.py`` がこの契約を強制する。
 
-See ``docs/features/persistence-foundation`` for the full design.
+詳細設計は ``docs/features/persistence-foundation`` を参照。
 """

--- a/backend/src/bakufu/infrastructure/bootstrap.py
+++ b/backend/src/bakufu/infrastructure/bootstrap.py
@@ -1,23 +1,23 @@
-"""Backend startup sequencer (Confirmation E + G + J + K + L).
+"""Backend 起動シーケンサ（Confirmation E + G + J + K + L）。
 
-Owns the eight-stage cold-start choreography described in
-``docs/features/persistence-foundation/detailed-design/bootstrap.md``.
-Splitting it into one class lets us:
+``docs/features/persistence-foundation/detailed-design/bootstrap.md`` に
+記述された 8 段階のコールドスタート振付（choreography）を担う。1 つの
+クラスに集約することで以下の利点が得られる:
 
-* Read the order top-to-bottom in :meth:`Bootstrap.run` (Confirmation G).
-* Bind the LIFO cleanup contract to ``try/finally`` in one place
-  (Confirmation J — Schneier 中等 4).
-* Set ``os.umask(0o077)`` *before* SQLite ever opens a WAL/SHM file
-  (Confirmation L — Schneier 中等 1).
-* Surface the empty-handler-registry WARN at the end of stage 6
-  (Confirmation K — Schneier 中等 3).
-* Centralize the FATAL log + ``exit(1)`` flow so every stage failure
-  produces the same shape of telemetry.
+* :meth:`Bootstrap.run` 内で順序を上から下に読める（Confirmation G）。
+* LIFO クリーンアップ契約を ``try/finally`` で 1 か所に束ねられる
+  （Confirmation J — Schneier 中等 4）。
+* SQLite が WAL/SHM ファイルを開く *前* に ``os.umask(0o077)`` を
+  設定できる（Confirmation L — Schneier 中等 1）。
+* Stage 6 末尾でハンドラ未登録の WARN を可視化できる
+  （Confirmation K — Schneier 中等 3）。
+* 各 Stage 失敗時の FATAL ログ + ``exit(1)`` フローを集約し、テレメトリ
+  形状を均質化できる。
 
-The actual FastAPI bind (stage 8) is supplied via the
-``listener_starter`` callable so this PR can ship without dragging in
-the ``feature/http-api`` HTTP surface — tests pass ``None`` to skip
-stage 8 entirely.
+実際の FastAPI バインド（Stage 8）は ``listener_starter`` callable で注入
+する。これにより本 PR は ``feature/http-api`` の HTTP 表面を取り込まずに
+リリース可能となる。テストでは ``None`` を渡して Stage 8 をまるごと
+スキップする。
 """
 
 from __future__ import annotations
@@ -55,19 +55,19 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Confirmation L: secure-by-default file mode (POSIX only).
+# Confirmation L: secure-by-default のファイルモード（POSIX のみ）。
 SECURE_UMASK: int = 0o077
 
-# Type alias for the optional stage-8 callable.
+# 任意の Stage 8 callable 用の型エイリアス。
 ListenerStarter = Callable[[], Awaitable[None]]
 
 
 class Bootstrap:
-    """Eight-stage startup orchestrator.
+    """8 段階の起動オーケストレータ。
 
-    Tests construct one with ``listener_starter=None`` and call
-    :meth:`run` to verify the full sequence sans HTTP bind.
-    Production wires the FastAPI binder in.
+    テストは ``listener_starter=None`` で構築し :meth:`run` を呼んで、
+    HTTP バインドなしの全シーケンスを検証する。本番では FastAPI バインダ
+    を注入する。
     """
 
     def __init__(
@@ -77,13 +77,14 @@ class Bootstrap:
         migration_runner: Callable[[AsyncEngine], Awaitable[str]] | None = None,
     ) -> None:
         self._listener_starter = listener_starter
-        # Migration is decoupled so tests can inject a stub instead of
-        # spinning up Alembic. Production passes the Alembic-driven
-        # implementation from ``infrastructure.persistence.sqlite.migrations``.
+        # マイグレーションは Bootstrap から疎結合化されており、テストは
+        # Alembic を起動せずスタブを差し込める。本番では
+        # ``infrastructure.persistence.sqlite.migrations`` の Alembic 駆動
+        # 実装を渡す。
         self._migration_runner = migration_runner
 
-        # State populated as stages succeed; LIFO cleanup walks them in
-        # reverse on failure.
+        # Stage が成功するごとに状態を埋めていく。失敗時は LIFO クリーン
+        # アップが逆順に走査する。
         self._app_engine: AsyncEngine | None = None
         self._session_factory: async_sessionmaker[AsyncSession] | None = None
         self._dispatcher: dispatcher_mod.OutboxDispatcher | None = None
@@ -93,21 +94,21 @@ class Bootstrap:
 
     @property
     def app_engine(self) -> AsyncEngine | None:
-        """Application engine (``None`` until stage 2 succeeds)."""
+        """アプリケーション エンジン（Stage 2 成功までは ``None``）。"""
         return self._app_engine
 
     @property
     def session_factory(self) -> async_sessionmaker[AsyncSession] | None:
-        """Session factory (``None`` until stage 2 succeeds)."""
+        """セッション ファクトリ（Stage 2 成功までは ``None``）。"""
         return self._session_factory
 
     async def run(self) -> None:
-        """Execute stages 0〜8. ``finally`` block runs LIFO cleanup.
+        """Stage 0〜8 を実行する。``finally`` ブロックが LIFO クリーンアップを行う。
 
         Raises:
-            BakufuConfigError: any fatal stage failure (1/2/3/5/6/7/8).
-                Stage 4 (pid_gc) only emits WARNs; ``AccessDenied``
-                rows are left for the next sweep.
+            BakufuConfigError: いずれかの致命的 Stage（1/2/3/5/6/7/8）が
+                失敗した場合。Stage 4（pid_gc）は WARN のみで非致命。
+                ``AccessDenied`` 行は次回スイープに委ねる。
         """
         try:
             self._stage_0_umask()
@@ -123,15 +124,15 @@ class Bootstrap:
             await self._cleanup()
 
     # ------------------------------------------------------------------
-    # Stage 0: secure-by-default umask (Confirmation L).
+    # Stage 0: secure-by-default umask（Confirmation L）。
     # ------------------------------------------------------------------
     def _stage_0_umask(self) -> None:
-        """Set ``umask`` so SQLite-created files inherit ``0o600``.
+        """SQLite が作成するファイルが ``0o600`` を継承するよう ``umask`` を設定する。
 
-        POSIX only — Windows uses ACLs and ``os.umask`` is a no-op.
-        Failure to set a more-restrictive umask isn't fatal; the OS
-        default is still ``0o022`` and our explicit ``chmod`` calls in
-        stages 5 / Alembic compensate.
+        POSIX のみ — Windows は ACL を使うため ``os.umask`` は no-op となる。
+        より制限的な umask 設定の失敗自体は致命ではない。OS デフォルトは
+        ``0o022`` のままだが、Stage 5 / Alembic で明示的な ``chmod`` を
+        実施しているため補正される。
         """
         if platform.system() == "Windows":
             return
@@ -148,7 +149,7 @@ class Bootstrap:
             ) from exc
 
     # ------------------------------------------------------------------
-    # Stage 1: resolve BAKUFU_DATA_DIR.
+    # Stage 1: BAKUFU_DATA_DIR の解決。
     # ------------------------------------------------------------------
     def _stage_1_resolve_data_dir(self) -> None:
         logger.info("[INFO] Bootstrap stage 1/8: resolving BAKUFU_DATA_DIR...")
@@ -157,9 +158,8 @@ class Bootstrap:
         except BakufuConfigError as exc:
             logger.error("[FAIL] Bootstrap stage 1/8: %s", exc.message)
             raise
-        # Materialize the directory itself so subsequent stages can
-        # write into it without races. ``exist_ok=True`` keeps idempotent
-        # restarts cheap.
+        # 後続 Stage が競合なく書き込めるよう、ディレクトリ自体をここで
+        # 実体化する。``exist_ok=True`` により再起動時も安価に冪等動作する。
         try:
             self._data_dir.mkdir(parents=True, exist_ok=True)
         except OSError as exc:
@@ -176,7 +176,7 @@ class Bootstrap:
         )
 
     # ------------------------------------------------------------------
-    # Stage 2: SQLite engine + masking gateway init.
+    # Stage 2: SQLite エンジン + マスキング ゲートウェイ初期化。
     # ------------------------------------------------------------------
     async def _stage_2_init_engine(self) -> None:
         logger.info("[INFO] Bootstrap stage 2/8: initializing SQLite engine...")
@@ -187,14 +187,14 @@ class Bootstrap:
                     "[FAIL] Bootstrap stage 2/8: data_dir not resolved (stage 1 must run first)"
                 ),
             )
-        # Initialize the masking gateway *before* the engine because
-        # tables register listeners at import time and the listeners
-        # call ``mask`` immediately.
+        # マスキング ゲートウェイをエンジンより *前* に初期化する。テーブル
+        # 群は import 時にリスナを登録し、リスナは即座に ``mask`` を呼ぶ
+        # ためである。
         try:
             masking.init()
         except BakufuConfigError:
-            # Bubble the MSG-PF-008 case unchanged; Bootstrap exit is
-            # the contract for a Fail-Fast masking init failure.
+            # MSG-PF-008 のケースはそのまま再送出する。マスキング初期化
+            # 失敗時の Bootstrap 終了は Fail-Fast 契約である。
             raise
         url = f"sqlite+aiosqlite:///{self._data_dir / 'bakufu.db'}"
         try:
@@ -213,7 +213,7 @@ class Bootstrap:
         )
 
     # ------------------------------------------------------------------
-    # Stage 3: Alembic upgrade via migration engine (Confirmation D-3).
+    # Stage 3: マイグレーション エンジン経由の Alembic upgrade（Confirmation D-3）。
     # ------------------------------------------------------------------
     async def _stage_3_migrate(self) -> None:
         logger.info("[INFO] Bootstrap stage 3/8: applying Alembic migrations...")
@@ -223,8 +223,8 @@ class Bootstrap:
                 message="[FAIL] Bootstrap stage 3/8: app_engine not initialized",
             )
         if self._migration_runner is None:
-            # Tests / minimal startups pass no runner; skip with a
-            # WARN so production wiring failures are obvious.
+            # テストや最小起動構成では runner が渡されない。本番配線の
+            # 失敗を可視化するため WARN を出してスキップする。
             logger.warning(
                 "[WARN] Bootstrap stage 3/8: no migration_runner injected; "
                 "skipping Alembic upgrade (test-mode or minimal startup)."
@@ -239,13 +239,14 @@ class Bootstrap:
             ) from exc
         logger.info("[INFO] Bootstrap stage 3/8: schema at head %s", head)
 
-        # REQ-PF-002-A (Schneier 致命1): even though stage 0 set
-        # ``umask 0o077`` so newly-created files inherit ``0o600``, a
-        # *previous* bakufu run that started without the umask may
-        # have left these files at ``0o644``. Audit + repair while we
-        # know data_dir is resolved and the DB file definitely exists
-        # (Alembic just wrote to it). Non-fatal: if chmod fails, log
-        # ERROR and continue — refusing to start would block recovery.
+        # REQ-PF-002-A（Schneier 致命1）: Stage 0 で ``umask 0o077`` を
+        # 設定し新規作成ファイルが ``0o600`` を継承するようにしているが、
+        # umask を設定せずに起動した *過去の* bakufu 実行が、これらの
+        # ファイルを ``0o644`` のまま残している可能性がある。data_dir が
+        # 解決済みで DB ファイルが確実に存在する（Alembic が直前に書き
+        # 込んでいる）ここで監査と修復を実施する。chmod 失敗時は ERROR
+        # ログのみで継続する（非致命）。起動を拒否するとリカバリ経路を
+        # 塞いでしまうためである。
         if self._data_dir is not None:
             mode_results = db_file_mode.verify_and_repair(self._data_dir)
             logger.info(
@@ -254,7 +255,7 @@ class Bootstrap:
             )
 
     # ------------------------------------------------------------------
-    # Stage 4: pid_registry orphan GC (non-fatal).
+    # Stage 4: pid_registry オーファン GC（非致命）。
     # ------------------------------------------------------------------
     async def _stage_4_pid_gc(self) -> None:
         logger.info("[INFO] Bootstrap stage 4/8: pid_registry orphan GC...")
@@ -271,15 +272,15 @@ class Bootstrap:
                 counts["access_denied"],
             )
         except Exception as exc:
-            # Confirmation E + G: stage 4 is non-fatal. The unaffected
-            # rows survive to the next GC and the Backend continues.
+            # Confirmation E + G: Stage 4 は非致命。残った行は次回 GC で
+            # 処理し、Backend は起動を継続する。
             logger.warning(
                 "[WARN] Bootstrap stage 4/8: pid_registry GC raised (%r); continuing startup",
                 exc,
             )
 
     # ------------------------------------------------------------------
-    # Stage 5: attachments FS root (Confirmation E).
+    # Stage 5: 添付ファイル FS ルート（Confirmation E）。
     # ------------------------------------------------------------------
     def _stage_5_attachments(self) -> None:
         logger.info("[INFO] Bootstrap stage 5/8: ensuring attachment FS root...")
@@ -296,7 +297,7 @@ class Bootstrap:
         )
 
     # ------------------------------------------------------------------
-    # Stage 6: Outbox dispatcher (Confirmation K Fail Loud).
+    # Stage 6: Outbox ディスパッチャ（Confirmation K Fail Loud）。
     # ------------------------------------------------------------------
     async def _stage_6_dispatcher(self) -> None:
         logger.info(
@@ -317,7 +318,7 @@ class Bootstrap:
             "[INFO] Bootstrap stage 6/8: dispatcher running (handler_registry size=%d)",
             size,
         )
-        # Confirmation K row 1: empty registry WARN at startup.
+        # Confirmation K 行 1: 起動時にレジストリが空の場合 WARN を出す。
         if size == 0:
             logger.warning(
                 "[WARN] Bootstrap stage 6/8: No event handlers registered. "
@@ -327,7 +328,7 @@ class Bootstrap:
             )
 
     # ------------------------------------------------------------------
-    # Stage 7: attachments orphan GC scheduler.
+    # Stage 7: 添付ファイル オーファン GC スケジューラ。
     # ------------------------------------------------------------------
     def _stage_7_orphan_scheduler(self) -> None:
         logger.info(
@@ -337,7 +338,7 @@ class Bootstrap:
         logger.info("[INFO] Bootstrap stage 7/8: scheduler running")
 
     # ------------------------------------------------------------------
-    # Stage 8: FastAPI / WebSocket bind (delegated).
+    # Stage 8: FastAPI / WebSocket バインド（委譲）。
     # ------------------------------------------------------------------
     async def _stage_8_listener(self) -> None:
         if self._listener_starter is None:
@@ -357,20 +358,21 @@ class Bootstrap:
         logger.info("[INFO] Bootstrap stage 8/8: bakufu Backend ready")
 
     # ------------------------------------------------------------------
-    # LIFO cleanup (Confirmation J).
+    # LIFO クリーンアップ（Confirmation J）。
     # ------------------------------------------------------------------
     async def _cleanup(self) -> None:
-        """Cancel async tasks in reverse start order, then dispose engine.
+        """async タスクを起動と逆順でキャンセルし、最後にエンジンを破棄する。
 
-        Order (from Confirmation J):
+        順序（Confirmation J より）:
 
-        1. Cancel the attachments orphan-GC scheduler (stage 7).
-        2. Stop and cancel the Outbox dispatcher (stage 6).
-        3. Dispose the application engine (stage 2).
-        4. Flush log handlers.
+        1. 添付ファイル オーファン GC スケジューラを cancel（Stage 7）。
+        2. Outbox ディスパッチャを stop し、タスクを cancel（Stage 6）。
+        3. アプリケーション エンジンを dispose（Stage 2）。
+        4. ログハンドラを flush。
         """
-        # Stage 7 cleanup — gather() with return_exceptions so a single
-        # CancelledError doesn't mask issues in stage 6 cleanup.
+        # Stage 7 のクリーンアップ — Stage 6 側のクリーンアップで起こり
+        # 得る別の問題を 1 つの CancelledError でマスクしないよう、
+        # ``return_exceptions=True`` 付きの ``gather`` を使う。
         if self._attachments_task is not None:
             self._attachments_task.cancel()
             await asyncio.gather(self._attachments_task, return_exceptions=True)

--- a/backend/src/bakufu/infrastructure/config/__init__.py
+++ b/backend/src/bakufu/infrastructure/config/__init__.py
@@ -1,6 +1,6 @@
-"""Bootstrap-stage configuration helpers (DATA_DIR resolution etc.).
+"""Bootstrap Stage 用の設定ヘルパ群（DATA_DIR 解決など）。
 
-These modules wire OS-level state into the rest of the infrastructure
-layer. They sit *outside* the persistence package because they run
-before the SQLite engine is ready (Bootstrap stage 1).
+これらのモジュールは OS レベルの状態をインフラストラクチャ層の
+他の部分へ橋渡しする。SQLite エンジン準備前（Bootstrap Stage 1）に
+動作するため、persistence パッケージの *外側* に位置する。
 """

--- a/backend/src/bakufu/infrastructure/config/data_dir.py
+++ b/backend/src/bakufu/infrastructure/config/data_dir.py
@@ -1,24 +1,24 @@
-"""``BAKUFU_DATA_DIR`` resolution with absolute-path enforcement.
+"""``BAKUFU_DATA_DIR`` の解決と絶対パスの強制。
 
-The data directory is the ground truth for every persistent artefact
-bakufu manages: SQLite DB file, WAL / SHM, structured logs,
-``attachments/`` storage, and ``bakufu_pid_registry`` related files.
+データディレクトリは bakufu が管理するすべての永続成果物の真の出所
+（ground truth）である: SQLite DB ファイル、WAL / SHM、構造化ログ、
+``attachments/`` ストレージ、``bakufu_pid_registry`` 関連ファイル。
 
-Resolution policy
------------------
-1. If ``BAKUFU_DATA_DIR`` is set in the environment, use that.
-   - Reject relative paths, NUL bytes, and ``..`` segments — these
-     are the classic path-traversal vectors and the M1 ``SkillRef``
-     defense pattern (H1〜H10) is reapplied at this layer.
-2. If unset, default to the OS-conventional location:
+解決ポリシー
+-----------
+1. 環境変数 ``BAKUFU_DATA_DIR`` が設定されていればそれを使用する。
+   - 相対パス、NUL バイト、``..`` セグメントは拒否する。これらは
+     代表的なパストラバーサル攻撃ベクタであり、M1 ``SkillRef`` の
+     防御パターン（H1〜H10）を本層でも再適用する。
+2. 未設定の場合は OS の慣習的な配置に従う:
    - Linux/macOS: ``${XDG_DATA_HOME:-$HOME/.local/share}/bakufu``
    - Windows: ``%LOCALAPPDATA%\\bakufu``
-3. Resolve symlinks (``Path.resolve``) so downstream code never has
-   to second-guess what the absolute path means.
+3. シンボリックリンクは ``Path.resolve`` で解決し、下流コードが絶対
+   パスの意味を再確認しなくて済むようにする。
 
-The resolved path is cached at module level so subsequent ``resolve()``
-calls are O(1) — every Bootstrap stage can ask the resolver without
-worrying about repeating the I/O.
+解決済みパスはモジュールレベルでキャッシュされるため、以降の
+``resolve()`` 呼び出しは O(1) となる。各 Bootstrap Stage は I/O 反復を
+気にせず resolver を呼び出せる。
 """
 
 from __future__ import annotations
@@ -35,16 +35,16 @@ _resolved: Path | None = None
 
 
 def resolve() -> Path:
-    """Return the absolute, symlink-resolved data directory.
+    """シンボリックリンク解決済みの絶対データディレクトリを返す。
 
-    Cached: first call validates the environment / OS default, all
-    subsequent calls return the same :class:`Path`. Use :func:`reset`
-    in test setups to force a re-resolve.
+    キャッシュ動作: 初回呼び出しで環境変数 / OS デフォルトを検証し、
+    以降の呼び出しは同じ :class:`Path` を返す。テストセットアップで
+    再解決を強制する場合は :func:`reset` を使用する。
 
     Raises:
-        BakufuConfigError: ``msg_id='MSG-PF-001'`` for invalid env
-            values (relative path, NUL byte, ``..`` segment, or
-            unreadable HOME). Bootstrap exits non-zero.
+        BakufuConfigError: ``msg_id='MSG-PF-001'``。環境変数値が不正
+            （相対パス、NUL バイト、``..`` セグメント、HOME が読めない）
+            の場合。Bootstrap は非ゼロ終了する。
     """
     global _resolved
     if _resolved is not None:
@@ -53,20 +53,21 @@ def resolve() -> Path:
     raw = os.environ.get(ENV_VAR_NAME)
     path = _default_for_os() if raw is None or raw == "" else _validate_absolute(raw)
 
-    # Resolve symlinks once so callers get a canonical path. ``strict=False``
-    # because the directory may not exist yet — Bootstrap creates it later.
+    # シンボリックリンクを一度だけ解決し、呼び出し側に正規化済みパスを
+    # 返す。Bootstrap が後段でディレクトリを作成するため、この時点では
+    # 未存在でも構わないので ``strict=False``。
     _resolved = path.resolve(strict=False)
     return _resolved
 
 
 def reset() -> None:
-    """Clear the singleton cache. Test-only helper."""
+    """シングルトンキャッシュをクリアする。テスト用ヘルパ。"""
     global _resolved
     _resolved = None
 
 
 def _validate_absolute(value: str) -> Path:
-    """Reject relative paths, NUL bytes, and traversal sequences."""
+    """相対パス、NUL バイト、トラバーサル列を拒否する。"""
     home_safe_value = value.replace(str(Path("~").expanduser()), "<HOME>", 1)
     if "\x00" in value:
         raise BakufuConfigError(
@@ -94,7 +95,7 @@ def _validate_absolute(value: str) -> Path:
 
 
 def _default_for_os() -> Path:
-    """OS-conventional default location for ``BAKUFU_DATA_DIR``."""
+    """``BAKUFU_DATA_DIR`` の OS 別デフォルト配置。"""
     if platform.system() == "Windows":
         local_app_data = os.environ.get("LOCALAPPDATA")
         if not local_app_data:
@@ -107,8 +108,8 @@ def _default_for_os() -> Path:
             )
         return Path(local_app_data) / "bakufu"
 
-    # POSIX path: respect XDG_DATA_HOME if present, otherwise
-    # `$HOME/.local/share`.
+    # POSIX 系: XDG_DATA_HOME があれば優先、なければ
+    # ``$HOME/.local/share`` を採用する。
     xdg = os.environ.get("XDG_DATA_HOME")
     if xdg:
         return Path(xdg) / "bakufu"

--- a/backend/src/bakufu/infrastructure/exceptions.py
+++ b/backend/src/bakufu/infrastructure/exceptions.py
@@ -1,29 +1,30 @@
-"""Infrastructure-layer exceptions.
+"""インフラストラクチャ層の例外。
 
-These exceptions are raised by Bootstrap stages and the masking gateway.
-They map 1:1 with MSG-PF-001〜008 in
-``docs/features/persistence-foundation/detailed-design/messages.md``.
+Bootstrap の各 Stage およびマスキング ゲートウェイから送出される。
+``docs/features/persistence-foundation/detailed-design/messages.md`` の
+MSG-PF-001〜008 と 1:1 で対応する。
 
-* :class:`BakufuConfigError` — DATA_DIR / engine / migration / FS init
-  failures (MSG-PF-001 / 002 / 003 / 008). Bootstrap catches and exits
-  with a non-zero code.
-* :class:`BakufuMigrationError` — Alembic ``upgrade`` failures (MSG-PF-004).
-  Subclass of :class:`BakufuConfigError` so the Bootstrap top-level
-  ``except`` still catches it; subclassing keeps log filtering possible.
-* :class:`HandlerNotRegisteredError` — raised by the Outbox handler
-  registry when an event_kind has no registered handler. The Outbox
-  dispatcher catches and warns, returning the row to ``status='PENDING'``.
+* :class:`BakufuConfigError` — DATA_DIR / engine / migration / FS 初期化の
+  失敗（MSG-PF-001 / 002 / 003 / 008）。Bootstrap が捕捉し、非ゼロ終了する。
+* :class:`BakufuMigrationError` — Alembic ``upgrade`` 失敗（MSG-PF-004）。
+  :class:`BakufuConfigError` のサブクラスとし、Bootstrap トップレベルの
+  ``except`` で従来どおり捕捉できるようにしつつ、ログのフィルタリングを
+  可能にしている。
+* :class:`HandlerNotRegisteredError` — Outbox ハンドラレジストリに該当
+  event_kind のハンドラが登録されていない場合に送出される。Outbox
+  ディスパッチャは本例外を捕捉して WARN を出し、対象行を ``status='PENDING'``
+  に戻す。
 """
 
 from __future__ import annotations
 
 
 class BakufuConfigError(Exception):
-    """Raised when infrastructure configuration cannot be established.
+    """インフラストラクチャ設定が確立できない場合に送出される。
 
-    Carries an MSG-PF-NNN identifier in :attr:`msg_id` so downstream log
-    formatters / test assertions can branch on the specific failure
-    without parsing free-form text.
+    :attr:`msg_id` に MSG-PF-NNN 識別子を保持するため、下流のログ
+    フォーマッタやテストアサーションは自由形式の文字列を解析せずに、
+    特定の失敗ケースで分岐できる。
     """
 
     def __init__(self, *, msg_id: str, message: str) -> None:
@@ -33,20 +34,20 @@ class BakufuConfigError(Exception):
 
 
 class BakufuMigrationError(BakufuConfigError):
-    """Alembic ``upgrade`` failure (MSG-PF-004).
+    """Alembic ``upgrade`` 失敗（MSG-PF-004）。
 
-    Inherits from :class:`BakufuConfigError` so a top-level ``except``
-    in the Bootstrap loop still catches the failure while preserving the
-    ability to filter migration-specific issues in test setups.
+    :class:`BakufuConfigError` を継承するため、Bootstrap ループの
+    トップレベル ``except`` でそのまま捕捉できる。一方でテスト時に
+    マイグレーション固有の問題のみフィルタする能力も維持できる。
     """
 
 
 class HandlerNotRegisteredError(KeyError):
-    """Raised by :class:`HandlerRegistry.resolve` when no handler exists.
+    """:class:`HandlerRegistry.resolve` でハンドラが見つからない際に送出。
 
-    Inherits from :class:`KeyError` so callers that already handle
-    "missing key" generically degrade gracefully. The Outbox dispatcher
-    catches this and re-marks the row ``PENDING`` for the next cycle.
+    :class:`KeyError` を継承するため、汎用的に「キー不在」を扱う呼び出し
+    側コードはそのまま素直に縮退する。Outbox ディスパッチャは本例外を
+    捕捉し、対象行を ``PENDING`` として次サイクルにマークし直す。
     """
 
 

--- a/backend/src/bakufu/infrastructure/persistence/__init__.py
+++ b/backend/src/bakufu/infrastructure/persistence/__init__.py
@@ -1,11 +1,10 @@
-"""Persistence drivers (SQLite + Alembic) for the bakufu Backend.
+"""bakufu Backend 向けの永続化ドライバ（SQLite + Alembic）。
 
-The package is intentionally thin at the top: SQLite is the only
-storage target (see ``docs/design/tech-stack.md`` §DB), so the
-``sqlite/`` subpackage holds engine / session / base / table modules
-without an abstraction layer for "future Postgres support" (YAGNI).
-Aggregate-specific Repository implementations land in their own
-feature PRs (``feature/{aggregate}-repository``); this package
-provides only the cross-cutting tables: ``audit_log`` /
-``bakufu_pid_registry`` / ``domain_event_outbox``.
+このパッケージのトップは意図的に薄い: 唯一のストレージ対象は SQLite で
+あり（``docs/design/tech-stack.md`` §DB 参照）、``sqlite/`` サブパッケージが
+engine / session / base / table の各モジュールを保持する。「将来の
+Postgres 対応」のための抽象層は YAGNI として導入していない。Aggregate
+固有の Repository 実装は各機能 PR（``feature/{aggregate}-repository``）に
+配置する。本パッケージは横断的なテーブル ``audit_log`` /
+``bakufu_pid_registry`` / ``domain_event_outbox`` のみ提供する。
 """

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/__init__.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/__init__.py
@@ -1,20 +1,20 @@
-"""SQLite persistence layer (async via :mod:`sqlalchemy.ext.asyncio`).
+"""SQLite 永続化レイヤ（:mod:`sqlalchemy.ext.asyncio` による非同期実装）。
 
-The package boundary mirrors the design's responsibility split
-(see ``docs/features/persistence-foundation/detailed-design/``):
+パッケージ境界は設計上の責務分割に対応する
+（``docs/features/persistence-foundation/detailed-design/`` 参照）:
 
 * :mod:`bakufu.infrastructure.persistence.sqlite.engine` —
-  ``AsyncEngine`` factory with PRAGMA enforcement + dual-connection
-  separation (application vs. migration).
+  PRAGMA を強制し、デュアル接続（アプリケーション用 vs マイグレーション用）
+  を分離する ``AsyncEngine`` ファクトリ。
 * :mod:`bakufu.infrastructure.persistence.sqlite.session` —
-  ``async_sessionmaker`` factory (Unit-of-Work boundary).
-* :mod:`bakufu.infrastructure.persistence.sqlite.base` — declarative
-  base + UUID / UTC-aware datetime / JSON :class:`TypeDecorator` types.
+  ``async_sessionmaker`` ファクトリ（Unit-of-Work 境界）。
+* :mod:`bakufu.infrastructure.persistence.sqlite.base` — Declarative
+  ベース + UUID / UTC-aware datetime / JSON の :class:`TypeDecorator` 型群。
 * :mod:`bakufu.infrastructure.persistence.sqlite.tables` —
-  cross-cutting tables (``audit_log`` / ``bakufu_pid_registry`` /
-  ``domain_event_outbox``) with their masking listeners.
+  横断的なテーブル群（``audit_log`` / ``bakufu_pid_registry`` /
+  ``domain_event_outbox``）とそのマスキングリスナ。
 * :mod:`bakufu.infrastructure.persistence.sqlite.outbox` —
-  Outbox dispatcher + handler registry skeleton.
+  Outbox dispatcher とハンドラレジストリのスケルトン。
 * :mod:`bakufu.infrastructure.persistence.sqlite.pid_gc` —
-  Bootstrap-stage 4 orphan-process garbage collection.
+  Bootstrap stage 4 の孤児プロセスガーベジコレクション。
 """

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/base.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/base.py
@@ -1,23 +1,24 @@
-"""Declarative base + cross-cutting :class:`TypeDecorator` adapters.
+"""Declarative ベース + 横断的な :class:`TypeDecorator` アダプタ。
 
-Every table in the bakufu SQLite schema inherits from :class:`Base`
-(re-exported below). The custom column types here are **mandatory**
-for any table that holds the corresponding semantic value:
+bakufu の SQLite スキーマに含まれるすべてのテーブルは :class:`Base`
+（以下で再エクスポート）を継承する。ここで定義するカスタムカラム型は、
+対応する意味値を保持する任意のテーブルにとって **必須** である:
 
-* :class:`UUIDStr` — store ``uuid.UUID`` as a 32-character hex string
-  in SQLite (no native UUID type; ``BLOB(16)`` was rejected because it
-  hurts ``sqlite3`` CLI debuggability).
-* :class:`UTCDateTime` — Fail-Fast on naive ``datetime`` and store
-  the UTC ISO-8601 string. The "always tz-aware" contract eliminates
-  every "is this UTC or local?" bug in downstream code.
-* :class:`JSONEncoded` — ``dict`` / ``list`` → ``json.dumps`` with
-  ``sort_keys=True`` so logical equality is byte-equal in the row.
-* :class:`MaskedJSONEncoded` / :class:`MaskedText` — variants of the
-  above that route every bound value through the masking gateway
-  *before* JSON-encoding / persisting (BUG-PF-001 fix). The
-  ``process_bind_param`` hook fires for both ORM ``Session.add()``
-  flushes and Core ``insert(table).values(...)`` paths, so masking
-  is enforced regardless of how the row reaches the engine.
+* :class:`UUIDStr` — ``uuid.UUID`` を SQLite 上で 32 文字の 16 進文字列
+  として保存する（SQLite はネイティブな UUID 型を持たない。``BLOB(16)``
+  は ``sqlite3`` CLI でのデバッグ性を損なうため却下した）。
+* :class:`UTCDateTime` — naive な ``datetime`` を Fail-Fast で拒否し、
+  UTC ISO-8601 文字列として保存する。「常に tz-aware」契約により、
+  下流コードの「これは UTC？ローカル？」というバグを根絶する。
+* :class:`JSONEncoded` — ``dict`` / ``list`` → ``json.dumps`` を
+  ``sort_keys=True`` で実行するため、論理的に等しいペイロードは
+  行内でバイト等価になる。
+* :class:`MaskedJSONEncoded` / :class:`MaskedText` — 上記の派生で、
+  JSON エンコード／永続化の *前* にすべての bound 値をマスキング
+  ゲートウェイ経由にする（BUG-PF-001 の修正）。``process_bind_param``
+  フックは ORM の ``Session.add()`` フラッシュと Core の
+  ``insert(table).values(...)`` の両経路で発火するため、行が
+  どのように engine に到達してもマスキングは強制される。
 """
 
 from __future__ import annotations
@@ -38,16 +39,15 @@ from bakufu.infrastructure.security.masking import (
 
 
 class Base(DeclarativeBase):
-    """Common declarative base for all bakufu SQLite tables."""
+    """bakufu の SQLite テーブル全てに共通の Declarative ベース。"""
 
 
 class UUIDStr(TypeDecorator[UUID]):
-    """Store a :class:`uuid.UUID` as ``CHAR(32)`` hex in SQLite.
+    """:class:`uuid.UUID` を SQLite 上で ``CHAR(32)`` の 16 進文字列として保存する。
 
-    The 32-character hex form (no dashes) keeps the storage compact
-    while remaining trivially inspectable from the ``sqlite3`` CLI.
-    Round-trips ``uuid.UUID`` so ORM-side code never sees a string
-    representation.
+    32 文字の 16 進形式（ハイフンなし）はストレージをコンパクトに保ちつつ、
+    ``sqlite3`` CLI から自明に確認可能なまま維持する。``uuid.UUID`` で
+    ラウンドトリップするので、ORM 側コードは文字列表現を見ない。
     """
 
     impl = CHAR(32)
@@ -58,13 +58,13 @@ class UUIDStr(TypeDecorator[UUID]):
         value: UUID | str | None,
         dialect: Dialect,
     ) -> str | None:
-        del dialect  # unused; SQLite is the only target
+        del dialect  # 未使用。ターゲットは SQLite のみ
         if value is None:
             return None
         if isinstance(value, UUID):
             return value.hex
-        # Accept str inputs too so ad-hoc INSERTs from raw SQL still
-        # round-trip cleanly. ``UUID(str)`` validates the format.
+        # 生 SQL からのアドホックな INSERT もクリーンにラウンドトリップ
+        # できるよう、str 入力も受け付ける。``UUID(str)`` がフォーマットを検証する。
         return UUID(value).hex
 
     def process_result_value(  # pyright: ignore[reportIncompatibleMethodOverride]
@@ -79,11 +79,11 @@ class UUIDStr(TypeDecorator[UUID]):
 
 
 class UTCDateTime(TypeDecorator[datetime]):
-    """Always-UTC, always-tz-aware ``datetime`` column.
+    """常に UTC・常に tz-aware な ``datetime`` カラム。
 
-    Inserts a naive ``datetime`` raise ``ValueError`` immediately so
-    timezone bugs cannot land silently. The on-disk representation is
-    ISO-8601 with the ``+00:00`` offset, sortable as a string.
+    naive な ``datetime`` を渡すと即座に ``ValueError`` を送出するので、
+    タイムゾーン関連のバグが静かに紛れ込むことはない。ディスク上の表現は
+    ``+00:00`` オフセット付きの ISO-8601 で、文字列としてソート可能。
     """
 
     impl = Text()
@@ -115,12 +115,12 @@ class UTCDateTime(TypeDecorator[datetime]):
 
 
 class JSONEncoded(TypeDecorator[Any]):
-    """``dict`` / ``list`` ↔ JSON text column.
+    """``dict`` / ``list`` ↔ JSON テキストカラム。
 
-    Uses ``sort_keys=True`` so two semantically-equal payloads serialize
-    to byte-equal text — important for hash-comparison and migration
-    diffs. ``ensure_ascii=False`` keeps Japanese strings readable in
-    direct SQLite inspection.
+    ``sort_keys=True`` を使うので、意味的に等しい 2 つのペイロードは
+    バイト等価なテキストにシリアライズされる — ハッシュ比較や
+    マイグレーション diff にとって重要。``ensure_ascii=False`` により、
+    SQLite を直接覗いたときに日本語文字列が読みやすくなる。
     """
 
     impl = Text()
@@ -148,17 +148,17 @@ class JSONEncoded(TypeDecorator[Any]):
 
 
 class MaskedJSONEncoded(TypeDecorator[Any]):
-    """``dict`` / ``list`` ↔ JSON text column with secret masking.
+    """秘密情報のマスキング付き ``dict`` / ``list`` ↔ JSON テキストカラム。
 
-    Routes the bound value through :func:`mask_in` before
-    ``json.dumps``. ``process_bind_param`` is invoked for **both**
-    ORM-flushed inserts and Core ``insert(table).values(...)`` calls
-    (BUG-PF-001 fix), making this a true gateway: there is no syntax
-    a caller can choose that bypasses the redaction step.
+    ``json.dumps`` の前に bound 値を :func:`mask_in` に通す。
+    ``process_bind_param`` は ORM フラッシュによる insert と
+    Core の ``insert(table).values(...)`` の **両方** で発火する
+    （BUG-PF-001 の修正）。これにより本クラスは真のゲートウェイとなり、
+    呼び出し側がリダクションをバイパスする構文を選ぶ余地はない。
 
-    Confirmation F (Fail-Secure): if :func:`mask_in` itself raises,
-    we replace the entire payload with the listener-error sentinel
-    rather than letting raw bytes hit the disk.
+    確定 F（Fail-Secure）: :func:`mask_in` 自身が例外を送出した場合、
+    生のバイト列をディスクに到達させずペイロード全体を listener-error の
+    sentinel に置き換える。
     """
 
     impl = Text()
@@ -190,12 +190,11 @@ class MaskedJSONEncoded(TypeDecorator[Any]):
 
 
 class MaskedText(TypeDecorator[str]):
-    """``str`` text column with secret masking via :func:`mask`.
+    """:func:`mask` による秘密情報のマスキング付き ``str`` テキストカラム。
 
-    Same gateway guarantee as :class:`MaskedJSONEncoded`: every bound
-    value (ORM or Core) is masked before persistence, and a failing
-    masker yields :data:`REDACT_LISTENER_ERROR` instead of the raw
-    string.
+    :class:`MaskedJSONEncoded` と同じゲートウェイ保証: すべての bound 値
+    （ORM／Core）は永続化前にマスクされ、masker が失敗した場合は
+    生文字列ではなく :data:`REDACT_LISTENER_ERROR` を返す。
     """
 
     impl = Text()

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/db_file_mode.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/db_file_mode.py
@@ -1,26 +1,25 @@
-"""REQ-PF-002-A: forensic DB-file-mode check + WARN + repair.
+"""REQ-PF-002-A: DB ファイルモードの forensic チェック + WARN + 修復。
 
-Bootstrap stage 0 sets ``os.umask(0o077)`` so any **new** SQLite file
-inherits ``0o600``. That covers the happy path going forward, but
-not the forensic question: did an earlier bakufu run (started with
-the OS-default ``0o022`` umask) leave behind ``bakufu.db`` /
-``bakufu.db-wal`` / ``bakufu.db-shm`` at ``0o644``? If so, those
-files were world-readable for the duration of that run — operators
-need to know.
+Bootstrap stage 0 で ``os.umask(0o077)`` を設定するため、**新規** に作られる
+SQLite ファイルは ``0o600`` を継承する。これは以降の正常系をカバーするが、
+forensic な疑問は別問題: 過去の bakufu 実行（OS 既定の ``0o022`` umask で
+起動された）が ``bakufu.db`` / ``bakufu.db-wal`` / ``bakufu.db-shm`` を
+``0o644`` のまま残していなかったか？ もし残っていたなら、それらのファイルは
+その実行期間中 world-readable だったということで、運用者は把握する必要がある。
 
-Policy (Schneier 致命1):
+ポリシー（Schneier 致命1）:
 
-1. **Detect** any of the three SQLite files whose POSIX mode bits
-   differ from ``0o600``.
-2. **WARN-log** with the original mode so post-incident analysis
-   can correlate against process audit logs.
-3. **Repair** by ``chmod`` to ``0o600`` so the next run is safe.
-4. **Continue** rather than ``Fail Fast`` — refusing to start would
-   force operators into manual ``chmod`` work that loses the
-   forensic trail. The WARN line is the trail.
+1. 3 つの SQLite ファイルのうち、POSIX モードビットが ``0o600`` と
+   異なるものを **検出** する。
+2. インシデント後の解析でプロセス監査ログと突き合わせられるよう、
+   元のモードと共に **WARN ログ** を出す。
+3. 次回の実行が安全になるよう、``chmod`` で **修復** して ``0o600`` にする。
+4. ``Fail Fast`` ではなく **継続** する — 起動を拒否すると運用者を
+   forensic の手がかりを失う手作業の ``chmod`` に追い込む。WARN 行こそが
+   その手がかりとなる。
 
-POSIX-only. Windows ACLs are out of scope and the function returns
-``windows_skip`` for every file there.
+POSIX のみ。Windows ACL はスコープ外で、すべてのファイルに対して
+``windows_skip`` を返す。
 """
 
 from __future__ import annotations
@@ -33,9 +32,9 @@ from typing import Final, Literal
 
 logger = logging.getLogger(__name__)
 
-# The three SQLite files that bakufu manages. WAL / SHM are created
-# lazily by SQLite at first write so they may legitimately be absent
-# right after Alembic ``upgrade``.
+# bakufu が管理する 3 つの SQLite ファイル。WAL / SHM は最初の書き込み時に
+# SQLite が遅延的に作成するため、Alembic ``upgrade`` 直後には正当に
+# 存在しないことがある。
 DB_FILE_NAMES: Final[tuple[str, ...]] = (
     "bakufu.db",
     "bakufu.db-wal",
@@ -46,22 +45,22 @@ SECURE_FILE_MODE: Final[int] = 0o600
 
 FileModeStatus = Literal[
     "ok",  # mode == 0o600
-    "absent",  # file does not exist (legitimate for WAL/SHM pre-write)
-    "repaired",  # mode != 0o600 → chmod succeeded
-    "repair_failed",  # mode != 0o600 → chmod raised
-    "windows_skip",  # Windows ACL territory, no-op
+    "absent",  # ファイルが存在しない（書き込み前の WAL/SHM では正当）
+    "repaired",  # mode != 0o600 → chmod 成功
+    "repair_failed",  # mode != 0o600 → chmod が例外を送出
+    "windows_skip",  # Windows ACL の領域、no-op
 ]
 
 
 def verify_and_repair(data_dir: Path) -> dict[str, FileModeStatus]:
-    """Audit + repair DB file modes (Schneier 致命1).
+    """DB ファイルモードの監査 + 修復を行う（Schneier 致命1）。
 
     Args:
-        data_dir: Resolved BAKUFU_DATA_DIR.
+        data_dir: 解決済みの BAKUFU_DATA_DIR。
 
     Returns:
-        Mapping of filename → status. Bootstrap stage logs the dict so
-        the audit trail survives independently of the per-file WARN.
+        ファイル名 → ステータスのマッピング。Bootstrap stage がこの dict を
+        ログに出すので、ファイルごとの WARN とは独立に監査証跡が残る。
     """
     if platform.system() == "Windows":
         return dict.fromkeys(DB_FILE_NAMES, "windows_skip")
@@ -73,7 +72,7 @@ def verify_and_repair(data_dir: Path) -> dict[str, FileModeStatus]:
 
 
 def _check_one(path: Path) -> FileModeStatus:
-    """Inspect one file, WARN + repair if mode is not 0o600."""
+    """1 ファイルを検査し、モードが 0o600 でなければ WARN + 修復する。"""
     try:
         st = path.stat()
     except FileNotFoundError:

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/engine.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/engine.py
@@ -1,18 +1,19 @@
-"""SQLite ``AsyncEngine`` factory with PRAGMA enforcement (§確定 D).
+"""PRAGMA を強制する SQLite ``AsyncEngine`` ファクトリ（§確定 D）。
 
-Two engine flavors per Confirmation D-2 (Schneier 重大 2):
+確定 D-2（Schneier 重大 2）に従い、2 種類のエンジンを用意する:
 
-* :func:`create_engine` — **application** engine. Used by everything
-  except Alembic. Sets eight PRAGMAs, including ``defensive=ON`` and
-  ``writable_schema=OFF`` so the ``audit_log`` triggers cannot be
-  ``DROP``-ed at runtime.
-* :func:`create_migration_engine` — **migration** engine. Used only
-  inside Bootstrap stage 3, then ``dispose()``-ed. Relaxes
-  ``defensive`` / ``writable_schema`` so Alembic can issue DDL.
+* :func:`create_engine` — **アプリケーション** エンジン。Alembic 以外の
+  全箇所で使用する。``defensive=ON`` と ``writable_schema=OFF`` を含む
+  8 つの PRAGMA を設定するので、``audit_log`` トリガが実行時に
+  ``DROP`` されることはない。
+* :func:`create_migration_engine` — **マイグレーション** エンジン。
+  Bootstrap stage 3 の内側でのみ使用し、その後 ``dispose()`` する。
+  Alembic が DDL を発行できるよう ``defensive`` / ``writable_schema``
+  を緩める。
 
-The PRAGMA list is set per-connection via a ``connect`` event listener
-on the underlying sync engine — that is where SQLAlchemy / aiosqlite
-hand us a DBAPI connection before any ORM activity.
+PRAGMA 一覧は基盤の同期エンジンに対する ``connect`` イベントリスナで
+接続ごとに設定する — ここが SQLAlchemy / aiosqlite が DBAPI 接続を
+ORM 活動の前に渡してくる箇所である。
 """
 
 from __future__ import annotations
@@ -25,9 +26,9 @@ from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
 logger = logging.getLogger(__name__)
 
-# Confirmation D-1: eight PRAGMAs for the application connection.
-# Order matters — `journal_mode=WAL` first, defensive guards last so
-# they activate against everything that follows.
+# 確定 D-1: アプリケーション接続向けの 8 つの PRAGMA。
+# 順序が重要 — `journal_mode=WAL` を最初に、defensive ガードを最後に置き、
+# それらが以後すべてに対して有効になるようにする。
 _APP_PRAGMAS: Final[tuple[tuple[str, str], ...]] = (
     ("journal_mode", "WAL"),
     ("foreign_keys", "ON"),
@@ -39,10 +40,9 @@ _APP_PRAGMAS: Final[tuple[tuple[str, str], ...]] = (
     ("trusted_schema", "OFF"),
 )
 
-# Confirmation D-2: migration engine relaxes the defensive guards so
-# Alembic can issue CREATE TABLE / CREATE TRIGGER. The other PRAGMAs
-# stay identical — concurrency / FK / busy_timeout still matter even
-# during migrations.
+# 確定 D-2: マイグレーション用エンジンは defensive ガードを緩めて Alembic が
+# CREATE TABLE / CREATE TRIGGER を発行できるようにする。それ以外の PRAGMA は
+# 同一に保つ — 並行性 / FK / busy_timeout はマイグレーション中も依然重要。
 _MIGRATION_PRAGMAS: Final[tuple[tuple[str, str], ...]] = (
     ("journal_mode", "WAL"),
     ("foreign_keys", "ON"),
@@ -55,20 +55,21 @@ _MIGRATION_PRAGMAS: Final[tuple[tuple[str, str], ...]] = (
 
 
 def create_engine(url: str, *, debug: bool = False) -> AsyncEngine:
-    """Build the application-level :class:`AsyncEngine`.
+    """アプリケーションレベルの :class:`AsyncEngine` を構築する。
 
     Args:
-        url: SQLAlchemy URL (e.g. ``sqlite+aiosqlite:///<path>``).
-        debug: Forwarded to ``create_async_engine(echo=...)`` for
-            verbose SQL logging during development.
+        url: SQLAlchemy URL（例: ``sqlite+aiosqlite:///<path>``）。
+        debug: 開発時に詳細な SQL ログを出すため
+            ``create_async_engine(echo=...)`` に転送する。
 
-    Wires the eight PRAGMA listener (Confirmation D-1) on connect.
-    Secret masking is enforced via the ``Masked*`` column
-    :class:`TypeDecorator` adapters in
-    :mod:`bakufu.infrastructure.persistence.sqlite.base`; that layer
-    fires in ``process_bind_param`` for both ORM flushes and Core
-    ``insert(table).values(...)`` calls (BUG-PF-001 fix), so no
-    additional engine-level listener is needed for masking.
+    connect 時に確定 D-1 の 8 つの PRAGMA リスナを配線する。
+    秘密情報のマスキングは
+    :mod:`bakufu.infrastructure.persistence.sqlite.base` の
+    ``Masked*`` カラム :class:`TypeDecorator` アダプタで強制される。
+    そのレイヤは ORM フラッシュと Core
+    ``insert(table).values(...)`` の双方の ``process_bind_param`` で
+    発火する（BUG-PF-001 の修正）ため、マスキングのために engine レベルの
+    リスナを追加する必要はない。
     """
     engine = create_async_engine(url, echo=debug, future=True)
     event.listen(engine.sync_engine, "connect", _set_app_pragmas)
@@ -76,10 +77,10 @@ def create_engine(url: str, *, debug: bool = False) -> AsyncEngine:
 
 
 def create_migration_engine(url: str) -> AsyncEngine:
-    """Build the migration-only :class:`AsyncEngine` (Confirmation D-2).
+    """マイグレーション専用の :class:`AsyncEngine` を構築する（確定 D-2）。
 
-    Use only from Bootstrap stage 3 (Alembic ``upgrade head``) and
-    ``dispose()`` immediately after; never share with application code.
+    Bootstrap stage 3（Alembic ``upgrade head``）からのみ使用し、直後に
+    ``dispose()`` すること。アプリケーションコードと共有してはならない。
     """
     engine = create_async_engine(url, echo=False, future=True)
     event.listen(engine.sync_engine, "connect", _set_migration_pragmas)
@@ -90,12 +91,12 @@ def _apply_pragmas(
     dbapi_conn: object,
     pragmas: tuple[tuple[str, str], ...],
 ) -> None:
-    """Apply ``PRAGMA name=value;`` for each pair.
+    """各ペアに対して ``PRAGMA name=value;`` を適用する。
 
-    Some PRAGMAs (``defensive`` / ``writable_schema`` / ``trusted_schema``)
-    only exist on SQLite 3.31+; on older builds the ``execute`` raises
-    and we log the skip. The other PRAGMAs are mandatory — failures
-    propagate so Bootstrap can convert them to MSG-PF-002.
+    一部の PRAGMA（``defensive`` / ``writable_schema`` / ``trusted_schema``）
+    は SQLite 3.31+ にしか存在しない。古いビルドでは ``execute`` が例外を
+    送出するためスキップをログに出す。それ以外の PRAGMA は必須なので
+    失敗は伝播し、Bootstrap が MSG-PF-002 へ変換する。
     """
     cursor_factory = getattr(dbapi_conn, "cursor", None)
     if cursor_factory is None:
@@ -107,8 +108,8 @@ def _apply_pragmas(
                 cursor.execute(f"PRAGMA {name}={value}")
             except Exception as exc:
                 if name in {"defensive", "writable_schema", "trusted_schema"}:
-                    # Confirmation D-4 fallback: log + continue. The
-                    # threat-model entry covers this case.
+                    # 確定 D-4 のフォールバック: ログ + 継続。
+                    # 脅威モデルのエントリがこのケースをカバーしている。
                     logger.warning(
                         "[WARN] PRAGMA %s=%s not supported on this "
                         "SQLite build (%r); falling back to OS-level "
@@ -124,7 +125,7 @@ def _apply_pragmas(
 
 
 def _set_app_pragmas(dbapi_conn: object, _connection_record: object) -> None:
-    """``connect`` listener for the application engine."""
+    """アプリケーションエンジン用の ``connect`` リスナ。"""
     _apply_pragmas(dbapi_conn, _APP_PRAGMAS)
 
 
@@ -132,7 +133,7 @@ def _set_migration_pragmas(
     dbapi_conn: object,
     _connection_record: object,
 ) -> None:
-    """``connect`` listener for the migration engine."""
+    """マイグレーションエンジン用の ``connect`` リスナ。"""
     _apply_pragmas(dbapi_conn, _MIGRATION_PRAGMAS)
 
 

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/migrations.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/migrations.py
@@ -1,10 +1,10 @@
-"""Alembic migration runner for Bootstrap stage 3 (Confirmation D-3).
+"""Bootstrap stage 3 用の Alembic マイグレーション ランナー（Confirmation D-3）。
 
-Bootstrap stage 3 calls :func:`run_upgrade_head` with the *application*
-engine; this module replaces the engine with a fresh **migration**
-engine (``defensive=OFF`` / ``writable_schema=ON``), runs Alembic up to
-``head``, then disposes of it. The application engine is never touched
-by Alembic — Schneier 重大 2's defensive guarantee survives.
+Bootstrap stage 3 は :func:`run_upgrade_head` を *アプリケーション* エンジンで
+呼び出す。本モジュールはエンジンを新しい **マイグレーション** エンジン
+（``defensive=OFF`` / ``writable_schema=ON``）に置き換え、Alembic を ``head``
+まで実行した後で破棄する。アプリケーション エンジンは Alembic から触れられない —
+Schneier 重大 2 の防御的保証は維持される。
 """
 
 from __future__ import annotations
@@ -20,25 +20,26 @@ from bakufu.infrastructure.persistence.sqlite.engine import create_migration_eng
 
 logger = logging.getLogger(__name__)
 
-# Backend package layout: backend/src/bakufu/infrastructure/persistence/sqlite/migrations.py
-# alembic.ini lives at backend/alembic.ini
+# Backend パッケージ レイアウト:
+# backend/src/bakufu/infrastructure/persistence/sqlite/migrations.py
+# alembic.ini は backend/alembic.ini に存在。
 _ALEMBIC_INI: Path = Path(__file__).resolve().parents[5] / "alembic.ini"
 
 
 async def run_upgrade_head(app_engine: AsyncEngine) -> str:
-    """Apply ``alembic upgrade head`` via a temporary migration engine.
+    """一時的なマイグレーション エンジン経由で ``alembic upgrade head`` を適用する。
 
     Args:
-        app_engine: Application-level engine; only its URL is read so
-            the migration engine targets the same DB file.
+        app_engine: アプリケーション レベル エンジン。マイグレーション エンジンが
+            同じ DB ファイルを対象とできるよう、URL のみを読む。
 
     Returns:
-        The ``head`` revision identifier that the schema is now at,
-        for inclusion in the Bootstrap stage 3 completion log.
+        現在スキーマが到達している ``head`` リビジョン識別子。Bootstrap stage 3
+        完了ログに含めるために使う。
 
     Raises:
-        Exception: Alembic itself surfaces a wide variety of errors;
-            Bootstrap converts these to :class:`BakufuMigrationError`.
+        Exception: Alembic 自体は多様なエラーを表面化する。Bootstrap がこれらを
+            :class:`BakufuMigrationError` に変換する。
     """
     url = str(app_engine.url)
     migration_engine = create_migration_engine(url)

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/outbox/__init__.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/outbox/__init__.py
@@ -1,16 +1,16 @@
-"""Outbox dispatcher + handler registry skeleton.
+"""Outbox ディスパッチャ + ハンドラ レジストリ スケルトン。
 
-The dispatcher polls ``domain_event_outbox``, marks rows
-``DISPATCHING``, looks up the handler for the row's ``event_kind`` in
-:mod:`...handler_registry`, awaits the handler, and updates the row to
-``DISPATCHED`` (success) / ``PENDING`` with an incremented
-``attempt_count`` (failure) / ``DEAD_LETTER`` (after 5 failures).
+ディスパッチャは ``domain_event_outbox`` をポーリングし、行を ``DISPATCHING`` に
+マークし、行の ``event_kind`` に対応するハンドラを :mod:`...handler_registry` で
+ルックアップし、ハンドラを await して、行を ``DISPATCHED``（成功）/
+``attempt_count`` をインクリメントした ``PENDING``（失敗）/ ``DEAD_LETTER``
+（5 回失敗後）に更新する。
 
-Per Schneier 中等 3 (Confirmation K), this PR registers **zero**
-handlers — every Outbox row stays ``PENDING`` until subsequent
-``feature/{event-kind}-handler`` PRs land. The dispatcher emits a
-WARN at startup and on each polling cycle that finds pending rows
-with an empty registry, so operators notice the partial wiring.
+Schneier 中等 3（Confirmation K）に従い、本 PR は **ゼロ個** のハンドラを登録する。
+すべての Outbox 行は後続の ``feature/{event-kind}-handler`` PR が投入されるまで
+``PENDING`` のままとなる。ディスパッチャは起動時、およびレジストリが空のまま
+pending 行を見つけたポーリング サイクルごとに WARN を発火するため、オペレータは
+配線が部分的であることに気付ける。
 """
 
 from __future__ import annotations

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/outbox/dispatcher.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/outbox/dispatcher.py
@@ -1,20 +1,19 @@
-"""Outbox dispatcher (skeleton, §確定 K).
+"""Outbox ディスパッチャ（スケルトン、§確定 K）。
 
-The dispatcher is intentionally **skeleton-only** in this PR per
-Schneier 中等 3: handlers ship in subsequent
-``feature/{event-kind}-handler`` PRs. What this module *does*
-provide is:
+このディスパッチャは Schneier 中等 3 の方針により、本 PR では意図的に
+**スケルトンのみ** とする。実ハンドラは後続の ``feature/{event-kind}-handler``
+PR で導入される。本モジュールが *提供する* のは:
 
-* The polling loop structure (1-second tick, batch of 50, 5-minute
-  DISPATCHING-recovery, 5-attempt dead-letter cap).
-* The Confirmation K Fail Loud warnings — Bootstrap startup
-  diagnostic + per-cycle empty-registry WARN + 100-row backlog WARN.
-* A clean ``stop()`` path so Bootstrap LIFO cleanup can cancel the
-  background task.
+* ポーリング ループ構造（1 秒間隔、バッチ 50、5 分の DISPATCHING リカバリ、
+  5 回試行のデッドレター上限）。
+* Confirmation K Fail Loud 警告 — Bootstrap 起動時診断 + サイクル毎の
+  empty-registry WARN + 100 行バックログ WARN。
+* Bootstrap LIFO クリーンアップがバックグラウンドタスクをキャンセルできるよう
+  クリーンな ``stop()`` 経路。
 
-The actual SELECT / UPDATE SQL lands when handlers exist; here we keep
-the surface minimal so subsequent PRs only need to fill in the body
-of :meth:`_dispatch_one`.
+実 SELECT / UPDATE SQL はハンドラが存在するようになった時点で投入する。ここでは
+表面を最小限に保ち、後続 PR で :meth:`_dispatch_one` の本体を埋めるだけで済む
+ようにする。
 """
 
 from __future__ import annotations
@@ -31,7 +30,7 @@ from bakufu.infrastructure.persistence.sqlite.tables.outbox import OutboxRow
 
 logger = logging.getLogger(__name__)
 
-# Confirmation K — see ``outbox.md``.
+# Confirmation K — ``outbox.md`` を参照。
 DEFAULT_BATCH_SIZE: Final = 50
 DEFAULT_POLL_INTERVAL_SECONDS: Final = 1.0
 DEFAULT_DISPATCHING_RECOVERY_MINUTES: Final = 5
@@ -40,11 +39,11 @@ BACKLOG_WARN_THRESHOLD: Final = 100
 
 
 class OutboxDispatcher:
-    """Background dispatcher for ``domain_event_outbox`` rows.
+    """``domain_event_outbox`` 行のためのバックグラウンド ディスパッチャ。
 
-    Bootstrap stage 6 instantiates one of these and schedules
-    :meth:`run` as an asyncio task. Bootstrap LIFO cleanup
-    (Confirmation J) calls :meth:`stop` to break the loop on shutdown.
+    Bootstrap stage 6 がインスタンスを生成し :meth:`run` を asyncio タスクと
+    してスケジュールする。Bootstrap LIFO クリーンアップ（Confirmation J）は
+    シャットダウン時にループを抜けるため :meth:`stop` を呼ぶ。
     """
 
     def __init__(
@@ -62,34 +61,32 @@ class OutboxDispatcher:
         self._dispatching_recovery_minutes = dispatching_recovery_minutes
         self._max_attempts = max_attempts
         self._stop_event = asyncio.Event()
-        # Track whether we have already warned about an empty handler
-        # registry encountering pending rows; avoid spamming the log on
-        # every poll cycle (Confirmation K row 2).
+        # 空のハンドラ レジストリが pending 行を見つけたことを既に警告済みかどうか
+        # を追跡する。ポーリング サイクル毎にログが溢れるのを避ける（Confirmation K
+        # 行 2）。
         self._empty_registry_warned: bool = False
-        # Backlog WARN throttling. ``None`` means "never warned yet";
-        # the first triggering cycle warns immediately and stamps a
-        # real ``loop.time()`` value. The previous default of ``0.0``
-        # (BUG-PF-003) collided with the OS-monotonic clock at process
-        # start: ``loop.time() - 0.0`` was always huge, but on a fresh
-        # process re-entering the loop after restart the clock could
-        # roll under 300s and silently swallow the first 5 minutes of
-        # warnings.
+        # バックログ WARN のスロットリング。``None`` は「まだ警告していない」を意味し、
+        # 初回トリガで即座に警告して実際の ``loop.time()`` 値を記録する。以前の
+        # デフォルト ``0.0``（BUG-PF-003）は OS モノトニック クロックとプロセス開始時
+        # に衝突していた: ``loop.time() - 0.0`` は常に巨大値だが、再起動後にループへ
+        # 再入したばかりの新規プロセスではクロックが 300s を下回り、最初の 5 分間の
+        # 警告がサイレントに飲み込まれることがあった。
         self._backlog_last_warn_monotonic: float | None = None
 
     async def run(self) -> None:
-        """Polling loop. Call from ``asyncio.create_task`` in Bootstrap.
+        """ポーリング ループ。Bootstrap から ``asyncio.create_task`` で呼ぶ。
 
-        The loop is intentionally simple — no row processing yet
-        because no handlers are registered. Each tick still runs the
-        empty-registry / backlog Fail Loud checks so operators see
-        the same telemetry once handlers land.
+        ハンドラがまだ登録されていないため、ループは意図的に単純である — 行処理は
+        まだ行わない。それでも各 tick で empty-registry / backlog の Fail Loud
+        チェックは走るため、ハンドラが投入された後も同じテレメトリをオペレータが
+        確認できる。
         """
         while not self._stop_event.is_set():
             try:
                 await self._poll_once()
             except Exception:  # pragma: no cover — defensive
-                # The dispatcher must never die in the body of a poll.
-                # Log and continue; the next cycle retries.
+                # ディスパッチャはポーリング本体で死んではならない。ログを残し
+                # 継続する。次のサイクルでリトライされる。
                 logger.exception(
                     "[ERROR] Outbox dispatcher poll cycle raised; continuing to next cycle"
                 )
@@ -102,16 +99,15 @@ class OutboxDispatcher:
                 continue
 
     async def stop(self) -> None:
-        """Signal the polling loop to exit at the next iteration."""
+        """次のイテレーションで終了するようポーリング ループへシグナルを送る。"""
         self._stop_event.set()
 
     async def _poll_once(self) -> None:
-        """Single polling cycle: count pending rows + emit WARNs.
+        """単一のポーリング サイクル: pending 行をカウントし WARN を発火する。
 
-        Subsequent PRs extend this to actually process the batch via
-        :meth:`_dispatch_one`. This skeleton just exposes the count
-        so Confirmation K's startup / per-cycle / backlog warnings
-        fire on real data.
+        後続 PR ではここに :meth:`_dispatch_one` 経由のバッチ処理を追加する。
+        現スケルトンではカウントを露出するだけで、Confirmation K の起動 / サイクル毎
+        / バックログ警告が実データに対して発火するようにしている。
         """
         async with self._session_factory() as session:
             stmt = select(OutboxRow).where(OutboxRow.status == "PENDING")
@@ -121,7 +117,7 @@ class OutboxDispatcher:
         pending_count = len(pending)
         registry_size = handler_registry.size()
 
-        # Confirmation K row 2: empty registry + pending rows.
+        # Confirmation K 行 2: registry が空かつ pending 行がある場合。
         if pending_count > 0 and registry_size == 0:
             if not self._empty_registry_warned:
                 logger.warning(
@@ -130,11 +126,11 @@ class OutboxDispatcher:
                 )
                 self._empty_registry_warned = True
         else:
-            # Once a handler appears or the queue clears, allow the
-            # WARN to re-fire if the situation regresses.
+            # ハンドラが現れるかキューが解消したら、状況が悪化した際の WARN 再発火を
+            # 許可する。
             self._empty_registry_warned = False
 
-        # Confirmation K row 3: backlog threshold (>100 rows).
+        # Confirmation K 行 3: バックログ閾値（>100 行）。
         if pending_count > BACKLOG_WARN_THRESHOLD:
             now = asyncio.get_running_loop().time()
             five_minutes_seconds = 300.0

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/outbox/handler_registry.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/outbox/handler_registry.py
@@ -1,22 +1,19 @@
-"""Outbox event-kind → handler registry.
+"""Outbox event-kind → ハンドラ レジストリ。
 
-Each ``domain_event_outbox`` row carries an ``event_kind`` enum
-identifying the side effect the dispatcher should perform
-(DirectiveIssued → Task creation, TaskAssigned → WebSocket broadcast,
-ExternalReviewRequested → Discord notify, etc.). This module owns the
-mapping.
+各 ``domain_event_outbox`` 行は、ディスパッチャが実行すべき副作用を識別する
+``event_kind`` enum を持つ（DirectiveIssued → Task 作成、TaskAssigned →
+WebSocket ブロードキャスト、ExternalReviewRequested → Discord 通知 等）。
+本モジュールはそのマッピングを所有する。
 
-Contracts
----------
-* :func:`register` rejects re-registration. Use :func:`clear` in tests
-  to reset state — production code should never silently overwrite a
-  handler.
-* :func:`resolve` raises
-  :class:`bakufu.infrastructure.exceptions.HandlerNotRegisteredError`
-  when no handler is present. The dispatcher catches and re-marks the
-  row ``PENDING`` for the next cycle.
-* :func:`size` exposes the registered count for the Bootstrap
-  startup-WARN logic (Confirmation K).
+コントラクト
+------------
+* :func:`register` は再登録を拒否する。テストでは :func:`clear` を使って状態を
+  リセットする — 本番コードがハンドラをサイレントに上書きしてはならない。
+* :func:`resolve` はハンドラが存在しないとき
+  :class:`bakufu.infrastructure.exceptions.HandlerNotRegisteredError` を送出する。
+  ディスパッチャがこれを捕捉し、行を次サイクル用に ``PENDING`` に再マークする。
+* :func:`size` は登録数を Bootstrap 起動 WARN ロジック（Confirmation K）に
+  公開する。
 """
 
 from __future__ import annotations
@@ -25,19 +22,18 @@ from collections.abc import Awaitable, Callable
 
 from bakufu.infrastructure.exceptions import HandlerNotRegisteredError
 
-# Handlers receive a payload dict and return ``None`` (any persistence
-# side effect lands in the same Unit-of-Work as the dispatcher).
+# ハンドラはペイロード dict を受け取り ``None`` を返す（永続化の副作用は
+# ディスパッチャと同じ Unit-of-Work に収める）。
 type EventHandler = Callable[[dict[str, object]], Awaitable[None]]
 
 _handlers: dict[str, EventHandler] = {}
 
 
 def register(event_kind: str, handler: EventHandler) -> None:
-    """Bind ``event_kind`` to ``handler``. Raises if already bound.
+    """``event_kind`` を ``handler`` に紐付ける。既に紐付いていれば送出する。
 
-    Re-registration is rejected so two PRs cannot silently fight over
-    the same event_kind. Tests should call :func:`clear` between
-    cases.
+    再登録を拒否することで、2 つの PR が同一の event_kind をサイレントに奪い合うのを
+    防ぐ。テストではケース間で :func:`clear` を呼ぶこと。
     """
     if event_kind in _handlers:
         raise KeyError(
@@ -48,12 +44,11 @@ def register(event_kind: str, handler: EventHandler) -> None:
 
 
 def resolve(event_kind: str) -> EventHandler:
-    """Return the handler bound to ``event_kind`` or raise.
+    """``event_kind`` に紐付いたハンドラを返す。なければ送出する。
 
     Raises:
-        HandlerNotRegisteredError: when no handler is registered. The
-            dispatcher catches this and warns + re-marks the row
-            ``PENDING`` for the next cycle.
+        HandlerNotRegisteredError: ハンドラが登録されていないとき。ディスパッチャ
+            がこれを捕捉して警告し、行を次サイクル用に ``PENDING`` に再マークする。
     """
     handler = _handlers.get(event_kind)
     if handler is None:
@@ -62,12 +57,12 @@ def resolve(event_kind: str) -> EventHandler:
 
 
 def clear() -> None:
-    """Drop all registered handlers. Test-only helper."""
+    """登録済みハンドラを全て破棄する。テスト専用ヘルパ。"""
     _handlers.clear()
 
 
 def size() -> int:
-    """Return the registered handler count."""
+    """登録済みハンドラ数を返す。"""
     return len(_handlers)
 
 

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/pid_gc.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/pid_gc.py
@@ -1,25 +1,24 @@
-"""Bootstrap stage 4 orphan-process garbage collection (§確定 E).
+"""Bootstrap stage 4 のオーファン プロセス ガベージ コレクション（§確定 E）。
 
-The previous run of bakufu may have left subprocess (claude / codex /
-etc.) trees alive — a crash, a SIGKILL of the parent, an exotic OS
-state. This module sweeps :class:`PidRegistryRow` entries on startup,
-classifies each, and either DELETEs the row alone (the PID is gone or
-has been recycled by an unrelated process) or kills the descendants
-and DELETEs the row.
+bakufu の前回実行がサブプロセス（claude / codex 等）ツリーを生かしたままにする
+場合がある — クラッシュ、親プロセスの SIGKILL、OS の特殊な状態など。本モジュール
+は起動時に :class:`PidRegistryRow` エントリをスイープし、各行を分類して、行のみを
+DELETE するか（PID が消失している、または無関係なプロセスに再利用されている）、
+子孫プロセスを kill してから DELETE するかを決める。
 
-Classification logic
---------------------
-Each row carries the snapshot ``started_at`` from the original
-``psutil.Process.create_time()``. That timestamp is the **PID-collision
-guard**: if a different process happened to land on the same PID, its
-``create_time()`` will not match and we must not kill it.
+分類ロジック
+------------
+各行はオリジナルの ``psutil.Process.create_time()`` から取得したスナップショット
+``started_at`` を保持する。このタイムスタンプが **PID 衝突ガード** となる: 別の
+プロセスが同じ PID にたまたま入った場合、``create_time()`` が一致しないため
+kill してはならない。
 
-| psutil result                         | classification | action                       |
-|---------------------------------------|----------------|------------------------------|
-| ``NoSuchProcess``                     | ``absent``     | DELETE the row only          |
-| Process exists, ``create_time`` match | ``orphan_kill``| Kill descendants + DELETE    |
-| Process exists, ``create_time`` mismatch | ``protected``  | DELETE the row only (PID reused) |
-| ``AccessDenied``                       | (no class.)    | WARN, leave row for next GC  |
+| psutil 結果                            | 分類             | アクション                       |
+|----------------------------------------|------------------|----------------------------------|
+| ``NoSuchProcess``                      | ``absent``       | 行のみ DELETE                    |
+| プロセス存在 + ``create_time`` 一致    | ``orphan_kill``  | 子孫を kill + DELETE             |
+| プロセス存在 + ``create_time`` 不一致  | ``protected``    | 行のみ DELETE（PID 再利用）      |
+| ``AccessDenied``                       | （分類なし）     | WARN、行は次回 GC に残す         |
 """
 
 from __future__ import annotations
@@ -40,7 +39,7 @@ from bakufu.infrastructure.persistence.sqlite.tables.pid_registry import (
 
 logger = logging.getLogger(__name__)
 
-# Confirmation E: SIGTERM grace before SIGKILL.
+# Confirmation E: SIGKILL の前に与える SIGTERM 猶予。
 SIGTERM_GRACE_SECONDS: int = 5
 
 PidClassification = Literal["orphan_kill", "protected", "absent"]
@@ -49,16 +48,15 @@ PidClassification = Literal["orphan_kill", "protected", "absent"]
 async def run_startup_gc(
     session_factory: async_sessionmaker[AsyncSession],
 ) -> dict[str, int]:
-    """Sweep ``bakufu_pid_registry`` and reconcile against the OS.
+    """``bakufu_pid_registry`` をスイープして OS に対して整合性を取る。
 
     Args:
-        session_factory: AsyncSession factory used to read / DELETE
-            registry rows.
+        session_factory: registry 行の読み取り／DELETE に使用する AsyncSession
+            ファクトリ。
 
     Returns:
-        Counts dict with keys ``killed`` / ``protected`` / ``absent`` /
-        ``access_denied`` so Bootstrap can include them in the stage-4
-        completion log line.
+        ``killed`` / ``protected`` / ``absent`` / ``access_denied`` のキーを持つ
+        カウント辞書。Bootstrap が stage-4 完了ログに含められる。
     """
     counts = {"killed": 0, "protected": 0, "absent": 0, "access_denied": 0}
 
@@ -93,11 +91,11 @@ async def run_startup_gc(
 
 
 def _classify_row(pid: int, recorded_started_at: datetime) -> PidClassification:
-    """Compare the recorded ``started_at`` with the live process.
+    """記録された ``started_at`` と現在のプロセスを比較する。
 
     Raises:
-        psutil.AccessDenied: surfaces upward so the caller can WARN-log
-            the row and skip DELETE (next GC retries).
+        psutil.AccessDenied: 上位に伝播するため、呼び元は当該行を WARN ログに
+            残し DELETE をスキップできる（次回 GC で再試行）。
     """
     try:
         proc = psutil.Process(pid)
@@ -111,9 +109,9 @@ def _classify_row(pid: int, recorded_started_at: datetime) -> PidClassification:
     except psutil.AccessDenied:
         raise
 
-    # ``psutil.Process.create_time`` returns POSIX seconds; we stored a
-    # tz-aware datetime. Compare with millisecond tolerance to absorb
-    # rounding noise across psutil versions.
+    # ``psutil.Process.create_time`` は POSIX 秒を返す。一方こちらは tz-aware の
+    # datetime を保存している。psutil バージョン間の丸めノイズを吸収するため
+    # ミリ秒単位の許容で比較する。
     recorded_seconds = recorded_started_at.timestamp()
     if abs(live_create_time - recorded_seconds) > 0.001:
         return "protected"
@@ -121,11 +119,10 @@ def _classify_row(pid: int, recorded_started_at: datetime) -> PidClassification:
 
 
 def _kill_descendants(pid: int) -> None:
-    """SIGTERM all descendants → 5-second grace → SIGKILL stragglers.
+    """全子孫に SIGTERM → 5 秒待機 → 残存プロセスに SIGKILL。
 
-    Uses ``psutil.Process.children(recursive=True)`` so the entire
-    subtree (claude → codex → grandchildren) is reaped, not just the
-    direct child.
+    ``psutil.Process.children(recursive=True)`` を使い、サブツリー全体
+    （claude → codex → 孫プロセス）を刈り取る — 直接子のみではない。
     """
     try:
         proc = psutil.Process(pid)

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/repositories/__init__.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/repositories/__init__.py
@@ -1,16 +1,15 @@
-"""SQLite Repository adapters (one module per Aggregate).
+"""SQLite リポジトリ アダプタ（Aggregate ごとに 1 モジュール）。
 
-Each module exports a class that satisfies the matching
-:class:`typing.Protocol` defined in :mod:`bakufu.application.ports`.
-Empire (PR #25) is the first Repository PR; the same pattern applies
-to subsequent ``feature/{aggregate}-repository`` PRs:
+各モジュールは :mod:`bakufu.application.ports` で定義される対応する
+:class:`typing.Protocol` を満たすクラスをエクスポートする。Empire（PR #25）が
+最初のリポジトリ PR。同じパターンが後続の ``feature/{aggregate}-repository``
+PR に適用される:
 
-* ``__init__(session: AsyncSession)`` — keeps the caller-managed Tx
-  boundary (Repositories never call ``session.commit()`` /
-  ``session.rollback()``).
-* ``find_by_id`` / ``count`` / ``save`` are ``async def``.
-* Reference / child tables are updated via delete-then-insert
-  (§確定 B) inside the caller's transaction.
-* ``_to_row`` / ``_from_row`` are private and convert between domain
-  Aggregate Roots and ``dict`` payloads (§確定 C).
+* ``__init__(session: AsyncSession)`` — 呼び元管理の Tx 境界を保つ
+  （リポジトリは ``session.commit()`` / ``session.rollback()`` を呼ばない）。
+* ``find_by_id`` / ``count`` / ``save`` は ``async def``。
+* 関連／子テーブルは呼び元のトランザクション内で delete-then-insert
+  （§確定 B）により更新される。
+* ``_to_row`` / ``_from_row`` はプライベートで、ドメイン Aggregate Root と
+  ``dict`` ペイロード間を変換する（§確定 C）。
 """

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/repositories/agent_repository.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/repositories/agent_repository.py
@@ -1,40 +1,35 @@
-"""SQLite adapter for :class:`bakufu.application.ports.AgentRepository`.
+""":class:`bakufu.application.ports.AgentRepository` の SQLite アダプタ。
 
-Implements the §確定 B "delete-then-insert" save flow over three
-tables (``agents`` / ``agent_providers`` / ``agent_skills``):
+§確定 B の "delete-then-insert" 保存フローを 3 つのテーブル
+（``agents`` / ``agent_providers`` / ``agent_skills``）に対して実装する:
 
-1. ``agents`` UPSERT (id-conflict → name + role + persona +
-   archived update; ``prompt_body`` binds through
-   :class:`MaskedText` so any embedded API key / OAuth token /
-   GitHub PAT is redacted *before* it hits SQLite — Schneier 申し送り
-   #3 实適用, applied to the Agent path here).
+1. ``agents`` UPSERT（id 衝突時に name + role + persona + archived を更新。
+   ``prompt_body`` は :class:`MaskedText` 経由でバインドされるため、埋め込まれた
+   API キー / OAuth トークン / GitHub PAT は SQLite に到達する *前* に伏字化される —
+   Schneier 申し送り #3 を Agent 経路にも適用）。
 2. ``agent_providers`` DELETE WHERE agent_id = ?
-3. ``agent_providers`` bulk INSERT (one row per ProviderConfig).
+3. ``agent_providers`` 一括 INSERT（ProviderConfig ごとに 1 行）。
 4. ``agent_skills`` DELETE WHERE agent_id = ?
-5. ``agent_skills`` bulk INSERT (one row per SkillRef).
+5. ``agent_skills`` 一括 INSERT（SkillRef ごとに 1 行）。
 
-The repository **never** calls ``session.commit()`` /
-``session.rollback()``: the caller-side service runs
-``async with session.begin():`` so the five steps above stay in one
-transaction (§確定 B Tx 境界の責務分離).
+リポジトリは ``session.commit()`` / ``session.rollback()`` を **決して** 呼ばない。
+呼び元のサービスが ``async with session.begin():`` を実行することで上記 5 ステップ
+を 1 トランザクションに収める（§確定 B Tx 境界の責務分離）。
 
-``_to_row`` / ``_from_row`` are kept as private methods on the class
-so both directions live next to each other and tests don't accidentally
-acquire a public conversion API to depend on (§確定 C).
+``_to_row`` / ``_from_row`` はクラスのプライベートメソッドのまま保持し、双方向の
+変換が隣接して存在するようにする。これにより、テストが公開された変換 API を誤って
+取得して依存することを避ける（§確定 C）。
 
-Two Agent-specific contracts widen the empire / workflow repository
-template:
+empire / workflow リポジトリ テンプレートを Agent 固有に拡張する 2 つのコントラクト:
 
-* **§確定 F — :meth:`find_by_name`**: an extra Protocol method that
-  scopes the lookup with ``WHERE empire_id = :empire_id AND name =
-  :name LIMIT 1``. The implementation deliberately delegates to
-  :meth:`find_by_id` once the AgentId is known so the
-  ``_from_row`` conversion logic stays single-sourced.
-* **§確定 H — masked ``prompt_body`` is irreversible**: hydration
-  via :meth:`find_by_id` returns a Persona whose ``prompt_body`` is
-  the masked form (e.g. ``<REDACTED:ANTHROPIC_KEY>``). Detecting and
-  refusing to dispatch a masked prompt is the application-layer's
-  job, frozen as a follow-up under ``feature/llm-adapter``.
+* **§確定 F — :meth:`find_by_name`**: ``WHERE empire_id = :empire_id AND name =
+  :name LIMIT 1`` でルックアップをスコープする追加の Protocol メソッド。実装は意図的に
+  AgentId が判明し次第 :meth:`find_by_id` に委譲する — ``_from_row`` の変換ロジックを
+  単一情報源に保つため。
+* **§確定 H — 伏字化された ``prompt_body`` は不可逆**: :meth:`find_by_id` 経由の水和は、
+  ``prompt_body`` が伏字化された形（例 ``<REDACTED:ANTHROPIC_KEY>``）の Persona を返す。
+  伏字化されたプロンプトのディスパッチ拒否はアプリケーション層の責務であり、
+  ``feature/llm-adapter`` のフォローアップとして凍結されている。
 """
 
 from __future__ import annotations
@@ -62,31 +57,28 @@ from bakufu.infrastructure.persistence.sqlite.tables.agents import AgentRow
 
 
 class SqliteAgentRepository:
-    """SQLite implementation of :class:`AgentRepository`."""
+    """:class:`AgentRepository` の SQLite 実装。"""
 
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
 
     async def find_by_id(self, agent_id: AgentId) -> Agent | None:
-        """SELECT agent + side tables, hydrate via :meth:`_from_row`.
+        """agent と関連テーブルを SELECT し、:meth:`_from_row` で水和する。
 
-        Returns ``None`` when the agents row is absent. Side-table
-        SELECTs use ``ORDER BY provider_kind`` /
-        ``ORDER BY skill_id`` so the hydrated lists are deterministic
-        — empire-repository BUG-EMR-001 froze this contract; we apply
-        it from PR #1 here.
+        agents 行が存在しない場合は ``None`` を返す。関連テーブルの SELECT は
+        ``ORDER BY provider_kind`` / ``ORDER BY skill_id`` を使い、水和されたリスト
+        が決定的になるようにする — empire-repository BUG-EMR-001 が凍結したコントラクト
+        を本 PR の最初から適用する。
         """
         agent_stmt = select(AgentRow).where(AgentRow.id == agent_id)
         agent_row = (await self._session.execute(agent_stmt)).scalar_one_or_none()
         if agent_row is None:
             return None
 
-        # ORDER BY makes find_by_id deterministic. Without it SQLite
-        # returns rows in internal-scan order, which would break
-        # ``Agent == Agent`` round-trip equality (the Aggregate
-        # compares list-by-list). See basic-design + workflow-repo
-        # §BUG-EMR-001 — this PR adopts the resolved contract from
-        # day one.
+        # ORDER BY を付与することで find_by_id を決定的にする。これがないと SQLite は
+        # 内部スキャン順で行を返し、``Agent == Agent`` の往復等価性が壊れる
+        # （Aggregate はリスト同士で比較する）。basic-design および workflow-repo
+        # §BUG-EMR-001 を参照 — 本 PR では当初から決定の済んだコントラクトを採用する。
         provider_stmt = (
             select(AgentProviderRow)
             .where(AgentProviderRow.agent_id == agent_id)
@@ -104,32 +96,29 @@ class SqliteAgentRepository:
         return self._from_row(agent_row, provider_rows, skill_rows)
 
     async def count(self) -> int:
-        """``SELECT COUNT(*) FROM agents``.
+        """``SELECT COUNT(*) FROM agents``。
 
-        Implementation detail: SQLAlchemy's ``func.count()`` issues a
-        proper ``SELECT COUNT(*)`` so SQLite returns one scalar row
-        instead of streaming every PK back to Python. This is the
-        empire-repository §確定 D 補強 contract continued — Agent
-        provider / skill rows can hold hundreds of records once the
-        preset library lands, so the pattern matters.
+        実装詳細: SQLAlchemy の ``func.count()`` は適切な ``SELECT COUNT(*)`` を
+        発行するため、SQLite は全 PK を Python にストリームせずスカラー 1 行だけ返す。
+        これは empire-repository §確定 D 補強コントラクトの継続である — Agent の
+        provider / skill 行はプリセット ライブラリが入ると数百件を保持し得るため、
+        このパターンが効いてくる。
         """
         stmt = select(func.count()).select_from(AgentRow)
         return (await self._session.execute(stmt)).scalar_one()
 
     async def save(self, agent: Agent) -> None:
-        """Persist ``agent`` via the §確定 B five-step delete-then-insert.
+        """§確定 B の 5 ステップ delete-then-insert で ``agent`` を永続化する。
 
-        The caller is responsible for the surrounding
-        ``async with session.begin():`` block; failures inside any
-        step propagate untouched so the Unit-of-Work boundary in the
-        application service can rollback cleanly.
+        外側の ``async with session.begin():`` ブロックは呼び元の責任。各ステップ
+        内部の失敗はそのまま伝播するため、アプリケーション サービスの Unit-of-Work
+        境界はクリーンにロールバックできる。
         """
         agent_row, provider_rows, skill_rows = self._to_row(agent)
 
-        # Step 1: agents UPSERT (id PK, ON CONFLICT update name +
-        # role + Persona fields + archived). ``prompt_body`` binds
-        # through MaskedText so the masked form lands in the DB even
-        # on update.
+        # Step 1: agents UPSERT（id PK、ON CONFLICT で name + role + Persona フィールド
+        # + archived を更新）。``prompt_body`` は MaskedText 経由でバインドされるため、
+        # 更新時にも伏字化された形で DB に到達する。
         upsert_stmt = sqlite_insert(AgentRow).values(agent_row)
         upsert_stmt = upsert_stmt.on_conflict_do_update(
             index_elements=["id"],
@@ -145,33 +134,31 @@ class SqliteAgentRepository:
         )
         await self._session.execute(upsert_stmt)
 
-        # Step 2: agent_providers DELETE.
+        # Step 2: agent_providers DELETE。
         await self._session.execute(
             delete(AgentProviderRow).where(AgentProviderRow.agent_id == agent.id)
         )
 
-        # Step 3: agent_providers bulk INSERT (skip when no
-        # providers — though the Agent invariant requires at least
-        # one provider, the defensive empty-skip keeps behavior
-        # consistent with the empire / workflow templates).
+        # Step 3: agent_providers 一括 INSERT（providers が無い場合はスキップ —
+        # Agent 不変条件は最低 1 つの provider を要求するが、空チェックは empire /
+        # workflow テンプレートとの動作整合のために残す）。
         if provider_rows:
             await self._session.execute(insert(AgentProviderRow), provider_rows)
 
-        # Step 4: agent_skills DELETE.
+        # Step 4: agent_skills DELETE。
         await self._session.execute(delete(AgentSkillRow).where(AgentSkillRow.agent_id == agent.id))
 
-        # Step 5: agent_skills bulk INSERT (skill set may legitimately
-        # be empty — Agent allows zero skills).
+        # Step 5: agent_skills 一括 INSERT（skill 集合は正当に空となり得る —
+        # Agent はゼロ skill を許容する）。
         if skill_rows:
             await self._session.execute(insert(AgentSkillRow), skill_rows)
 
     async def find_by_name(self, empire_id: EmpireId, name: str) -> Agent | None:
-        """Hydrate the Agent named ``name`` inside ``empire_id`` (§確定 F).
+        """``empire_id`` 内の ``name`` という Agent を水和する（§確定 F）。
 
-        Two-stage flow: a lightweight ``SELECT id ... LIMIT 1`` to
-        locate the AgentId, then delegation to :meth:`find_by_id` so
-        the side-table SELECTs + ``_from_row`` conversion stay
-        single-sourced (§設計判断補足 "find_by_id 経由で復元する根拠").
+        2 段階フロー: 軽量な ``SELECT id ... LIMIT 1`` で AgentId を特定し、その後
+        :meth:`find_by_id` に委譲することで関連テーブルの SELECT と ``_from_row``
+        変換を単一情報源に保つ（§設計判断補足「find_by_id 経由で復元する根拠」）。
         """
         id_stmt = (
             select(AgentRow.id)
@@ -188,12 +175,11 @@ class SqliteAgentRepository:
         self,
         agent: Agent,
     ) -> tuple[dict[str, Any], list[dict[str, Any]], list[dict[str, Any]]]:
-        """Split ``agent`` into ``(agent_row, provider_rows, skill_rows)``.
+        """``agent`` を ``(agent_row, provider_rows, skill_rows)`` に分割する。
 
-        SQLAlchemy ``Row`` objects are intentionally avoided here so
-        the domain layer never gains an accidental dependency on the
-        SQLAlchemy type hierarchy. Each returned ``dict`` matches the
-        ``mapped_column`` names of the corresponding table verbatim.
+        ここでは SQLAlchemy の ``Row`` オブジェクトを意図的に使わない。これによって
+        ドメイン層が SQLAlchemy の型階層に偶発的に依存することを防ぐ。返却される
+        各 ``dict`` のキーは対応するテーブルの ``mapped_column`` 名と完全一致する。
         """
         agent_row: dict[str, Any] = {
             "id": agent.id,
@@ -202,9 +188,9 @@ class SqliteAgentRepository:
             "role": agent.role.value,
             "display_name": agent.persona.display_name,
             "archetype": agent.persona.archetype,
-            # MaskedText.process_bind_param will redact secrets from
-            # this string before json.dumps / VARCHAR storage —
-            # Schneier 申し送り #3 实適用.
+            # MaskedText.process_bind_param は json.dumps / VARCHAR ストレージに
+            # 到達する前にこの文字列からシークレットを伏字化する —
+            # Schneier 申し送り #3。
             "prompt_body": agent.persona.prompt_body,
             "archived": agent.archived,
         }
@@ -234,19 +220,17 @@ class SqliteAgentRepository:
         provider_rows: list[AgentProviderRow],
         skill_rows: list[AgentSkillRow],
     ) -> Agent:
-        """Hydrate an :class:`Agent` Aggregate Root from its three rows.
+        """3 つの行から :class:`Agent` Aggregate Root を水和する。
 
-        ``Agent.model_validate`` re-runs the post-validator so
-        Repository-side hydration goes through the same invariant
-        checks that ``AgentService.hire()`` does at construction
-        time. The contract (§確定 C) is "Repository hydration produces
-        a valid Agent or raises".
+        ``Agent.model_validate`` は post-validator を再実行するため、リポジトリ側
+        の水和も ``AgentService.hire()`` が構築時に走らせるのと同じ不変条件チェック
+        を通る。コントラクト（§確定 C）は「リポジトリ水和は妥当な Agent を生成するか
+        例外を送出する」。
 
-        §確定 H §不可逆性: ``persona.prompt_body`` carries the
-        already-masked text from disk. ``Persona`` accepts any string
-        within the length cap so the masked form constructs cleanly,
-        but the resulting Agent should not be dispatched to an LLM
-        without ``feature/llm-adapter``'s masked-prompt guard.
+        §確定 H §不可逆性: ``persona.prompt_body`` はディスクから既に伏字化された
+        テキストを保持する。``Persona`` は長さ上限内の任意の文字列を受理するため
+        伏字化された形でも構築は通るが、生成された Agent は ``feature/llm-adapter``
+        の masked-prompt ガード無しに LLM へディスパッチすべきではない。
         """
         persona = Persona(
             display_name=agent_row.display_name,

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/repositories/directive_repository.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/repositories/directive_repository.py
@@ -1,30 +1,29 @@
-"""SQLite adapter for :class:`bakufu.application.ports.DirectiveRepository`.
+""":class:`bakufu.application.ports.DirectiveRepository` の SQLite アダプタ。
 
-Implements the §確定 R1-B single-table UPSERT save flow over one table
-(``directives``):
+§確定 R1-B の単一テーブル UPSERT 保存フローを 1 つのテーブル（``directives``）
+に対して実装する:
 
-1. ``directives`` UPSERT (id-conflict → ``text`` + ``created_at`` +
-   ``task_id`` update; **``target_room_id`` is NOT updated** — ownership
-   of a Directive never changes after creation, §確定 R1-B);
-   ``text`` binds through :class:`MaskedText` so any embedded API key /
-   OAuth token / Discord webhook secret is redacted *before* it hits
-   SQLite — §確定 R1-E, §確定 R1-G 不可逆性凍結).
+1. ``directives`` UPSERT（id 衝突時に ``text`` + ``created_at`` + ``task_id`` を
+   更新。**``target_room_id`` は更新しない** — Directive の所有権は作成後に
+   変化しない、§確定 R1-B）。``text`` は :class:`MaskedText` 経由でバインドされる
+   ため、埋め込まれた API キー / OAuth トークン / Discord webhook シークレットは
+   SQLite に到達する *前* に伏字化される — §確定 R1-E、§確定 R1-G 不可逆性凍結。
 
-Directive is a flat aggregate with **no child tables**, so the
-empire-repository delete-then-insert pattern reduces to a single UPSERT
-step with no DELETE step (§確定 R1-B 子テーブルなし版).
+Directive は **子テーブルを持たない** フラットな Aggregate のため、
+empire-repository の delete-then-insert パターンは DELETE ステップ無しの単一
+UPSERT ステップに簡約される（§確定 R1-B 子テーブルなし版）。
 
-The repository **never** calls ``session.commit()`` / ``session.rollback()``:
-the caller-side service runs ``async with session.begin():`` so the UPSERT
-stays in one transaction (empire-repo §確定 B Tx 境界の責務分離).
+リポジトリは ``session.commit()`` / ``session.rollback()`` を **決して** 呼ばない。
+呼び元のサービスが ``async with session.begin():`` を実行することで UPSERT を 1
+トランザクションに収める（empire-repo §確定 B Tx 境界の責務分離）。
 
-``save(directive)`` uses the **standard 1-argument pattern** (§確定 R1-F):
-:class:`Directive` carries ``target_room_id`` as its own attribute, so the
-Repository reads it directly — the non-symmetric Room pattern is not needed.
+``save(directive)`` は **標準の 1 引数パターン**（§確定 R1-F）を使う:
+:class:`Directive` は ``target_room_id`` を自身の属性として保持するため、リポジトリ
+はそれを直接読む — 非対称な Room パターンは不要。
 
-``_to_row`` / ``_from_row`` are kept as private methods on the class so both
-conversion directions live next to each other and tests don't accidentally
-acquire a public conversion API to depend on (empire-repo §確定 C).
+``_to_row`` / ``_from_row`` はクラスのプライベートメソッドのまま保持し、双方向の
+変換が隣接して存在するようにする。これにより、テストが公開された変換 API を誤って
+取得して依存することを避ける（empire-repo §確定 C）。
 """
 
 from __future__ import annotations
@@ -41,16 +40,16 @@ from bakufu.infrastructure.persistence.sqlite.tables.directives import Directive
 
 
 class SqliteDirectiveRepository:
-    """SQLite implementation of :class:`DirectiveRepository`."""
+    """:class:`DirectiveRepository` の SQLite 実装。"""
 
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
 
     async def find_by_id(self, directive_id: DirectiveId) -> Directive | None:
-        """SELECT directive row, hydrate via :meth:`_from_row`.
+        """directive 行を SELECT し、:meth:`_from_row` で水和する。
 
-        Returns ``None`` when the directives row is absent. Directive is a
-        flat aggregate — no child-table SELECTs needed.
+        directives 行が存在しない場合は ``None`` を返す。Directive はフラットな
+        Aggregate — 子テーブル SELECT は不要。
         """
         stmt = select(DirectiveRow).where(DirectiveRow.id == directive_id)
         row = (await self._session.execute(stmt)).scalar_one_or_none()
@@ -59,35 +58,34 @@ class SqliteDirectiveRepository:
         return self._from_row(row)
 
     async def count(self) -> int:
-        """``SELECT COUNT(*) FROM directives``.
+        """``SELECT COUNT(*) FROM directives``。
 
-        Implementation detail: SQLAlchemy's ``func.count()`` issues a proper
-        ``SELECT COUNT(*)`` so SQLite returns one scalar row instead of
-        streaming every PK back to Python (empire-repo §確定 D 踏襲).
+        実装詳細: SQLAlchemy の ``func.count()`` は適切な ``SELECT COUNT(*)`` を
+        発行するため、SQLite は全 PK を Python にストリームせずスカラー 1 行だけ
+        返す（empire-repo §確定 D 踏襲）。
         """
         stmt = select(func.count()).select_from(DirectiveRow)
         return (await self._session.execute(stmt)).scalar_one()
 
     async def save(self, directive: Directive) -> None:
-        """Persist ``directive`` via the §確定 R1-B single-table UPSERT.
+        """§確定 R1-B の単一テーブル UPSERT で ``directive`` を永続化する。
 
-        ON CONFLICT (id) DO UPDATE sets ``text``, ``created_at``, and
-        ``task_id``. ``target_room_id`` is intentionally **not** updated —
-        a Directive's ownership (target room) never changes after creation.
+        ON CONFLICT (id) DO UPDATE は ``text``、``created_at``、``task_id`` を
+        セットする。``target_room_id`` は意図的に **更新しない** — Directive の
+        所有権（target room）は作成後に変化しない。
 
-        ``text`` binds through :class:`MaskedText` so the masked form lands
-        in the DB even on UPDATE (§確定 R1-E / R1-G).
+        ``text`` は :class:`MaskedText` 経由でバインドされるため、UPDATE 時にも
+        伏字化された形で DB に到達する（§確定 R1-E / R1-G）。
 
-        The caller is responsible for the surrounding
-        ``async with session.begin():`` block; failures propagate untouched
-        so the Unit-of-Work boundary in the application service can rollback
-        cleanly (empire-repo §確定 B 踏襲).
+        外側の ``async with session.begin():`` ブロックは呼び元の責任。失敗は
+        そのまま伝播するため、アプリケーション サービスの Unit-of-Work 境界は
+        クリーンにロールバックできる（empire-repo §確定 B 踏襲）。
         """
         row = self._to_row(directive)
 
-        # Single-step UPSERT: directives has no child tables (§確定 R1-B).
-        # target_room_id is excluded from the ON CONFLICT update set because
-        # ownership is immutable — a Directive always targets the same Room.
+        # 単一ステップ UPSERT: directives は子テーブルを持たない（§確定 R1-B）。
+        # target_room_id は ON CONFLICT 更新セットから除外する。所有権は不変 —
+        # Directive は常に同じ Room を対象とする。
         upsert_stmt = sqlite_insert(DirectiveRow).values(row)
         upsert_stmt = upsert_stmt.on_conflict_do_update(
             index_elements=["id"],
@@ -100,14 +98,14 @@ class SqliteDirectiveRepository:
         await self._session.execute(upsert_stmt)
 
     async def find_by_room(self, room_id: RoomId) -> list[Directive]:
-        """Return all Directives targeting ``room_id``, newest first.
+        """``room_id`` を対象とする全 Directive を新しい順で返す。
 
-        ORDER BY ``created_at DESC, id DESC`` (BUG-EMR-001 規約: composite
-        key for deterministic ordering). ``created_at`` alone is insufficient
-        when multiple Directives share the same timestamp; ``id`` (PK, UUID)
-        is the tiebreaker that makes the result fully deterministic (§確定 R1-D).
+        ORDER BY ``created_at DESC, id DESC``（BUG-EMR-001 規約: 決定的順序付け
+        のための複合キー）。``created_at`` 単独では複数 Directive が同じタイム
+        スタンプを共有する場合に不十分で、``id``（PK、UUID）が結果を完全に決定的
+        にする tiebreaker となる（§確定 R1-D）。
 
-        Returns ``[]`` when no Directives exist for the Room.
+        Room に Directive が無い場合は ``[]`` を返す。
         """
         stmt = (
             select(DirectiveRow)
@@ -119,15 +117,15 @@ class SqliteDirectiveRepository:
 
     # ---- private domain ↔ row converters (empire-repo §確定 C) -----------
     def _to_row(self, directive: Directive) -> dict[str, Any]:
-        """Convert ``directive`` to a ``directives`` table row dict.
+        """``directive`` を ``directives`` テーブル行 dict に変換する。
 
-        SQLAlchemy ``Row`` objects are avoided so the domain layer never
-        gains an accidental dependency on the SQLAlchemy type hierarchy. The
-        returned dict matches the ``mapped_column`` names verbatim.
+        ドメイン層が SQLAlchemy の型階層に偶発的に依存しないよう、SQLAlchemy
+        ``Row`` オブジェクトは使わない。返却される dict のキーは ``mapped_column``
+        名と完全一致する。
 
-        ``text`` is passed as the raw string — :class:`MaskedText`
-        ``process_bind_param`` applies the masking gate automatically when
-        SQLAlchemy resolves the bind parameter (§確定 R1-E 物理保証).
+        ``text`` は素の文字列として渡す — :class:`MaskedText`
+        ``process_bind_param`` が SQLAlchemy のバインド パラメータ解決時に
+        マスキング ゲートを自動適用する（§確定 R1-E 物理保証）。
         """
         return {
             "id": directive.id,
@@ -138,25 +136,23 @@ class SqliteDirectiveRepository:
         }
 
     def _from_row(self, row: DirectiveRow) -> Directive:
-        """Hydrate a :class:`Directive` Aggregate Root from its row.
+        """行から :class:`Directive` Aggregate Root を水和する。
 
-        ``Directive.model_validate`` re-runs the post-validator so
-        Repository-side hydration goes through the same invariant checks
-        that ``DirectiveService.issue()`` does at construction time. The
-        contract (empire §確定 C) is "Repository hydration produces a valid
-        Directive or raises".
+        ``Directive.model_validate`` は post-validator を再実行するため、リポジトリ
+        側の水和も ``DirectiveService.issue()`` が構築時に走らせるのと同じ不変条件
+        チェックを通る。コントラクト（empire §確定 C）は「リポジトリ水和は妥当な
+        Directive を生成するか例外を送出する」。
 
-        TypeDecorator-trust pattern (PR #48 v2 確立): :class:`UUIDStr`
-        returns ``UUID`` instances from ``process_result_value``, so
-        ``row.id`` / ``row.target_room_id`` / ``row.task_id`` are already
-        ``UUID`` (or ``None``). Direct attribute access without defensive
-        ``UUID(row.id)`` wrapping is correct and required (§確定 R1-G).
+        TypeDecorator-trust パターン（PR #48 v2 確立）: :class:`UUIDStr` は
+        ``process_result_value`` で ``UUID`` インスタンスを返すため、``row.id`` /
+        ``row.target_room_id`` / ``row.task_id`` は既に ``UUID``（または ``None``）。
+        防御的な ``UUID(row.id)`` ラッピング無しで属性を直接参照するのが正しく、
+        必須である（§確定 R1-G）。
 
-        §確定 R1-G §不可逆性: ``text`` carries the already-masked text from
-        disk. ``Directive`` accepts any string within the length cap so the
-        masked form constructs cleanly, but the resulting Directive should not
-        be dispatched to an LLM without ``feature/llm-adapter``'s
-        masked-prompt guard.
+        §確定 R1-G §不可逆性: ``text`` はディスクから既に伏字化されたテキストを
+        保持する。``Directive`` は長さ上限内の任意の文字列を受理するため伏字化
+        された形でも構築は通るが、生成された Directive は ``feature/llm-adapter``
+        の masked-prompt ガード無しに LLM へディスパッチすべきではない。
         """
         return Directive(
             id=row.id,

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/repositories/empire_repository.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/repositories/empire_repository.py
@@ -1,23 +1,22 @@
-"""SQLite adapter for :class:`bakufu.application.ports.EmpireRepository`.
+""":class:`bakufu.application.ports.EmpireRepository` の SQLite アダプタ。
 
-Implements the §確定 B "delete-then-insert" save flow:
+§確定 B の "delete-then-insert" 保存フローを実装する:
 
-1. ``empires`` UPSERT (id-conflict → name update)
+1. ``empires`` UPSERT（id 衝突時に name を更新）
 2. ``empire_room_refs`` DELETE WHERE empire_id = ?
-3. ``empire_room_refs`` bulk INSERT (one row per ``RoomRef``)
+3. ``empire_room_refs`` 一括 INSERT（``RoomRef`` ごとに 1 行）
 4. ``empire_agent_refs`` DELETE WHERE empire_id = ?
-5. ``empire_agent_refs`` bulk INSERT (one row per ``AgentRef``)
+5. ``empire_agent_refs`` 一括 INSERT（``AgentRef`` ごとに 1 行）
 
-The repository **never** calls ``session.commit()`` /
-``session.rollback()``: the caller-side service runs
-``async with session.begin():`` so the five steps above stay in one
-transaction (§確定 B Tx 境界の責務分離). This also lets a single
-service combine multiple Repositories in the same Unit-of-Work
-(``EmpireRepository.save`` + Outbox row append, etc.).
+リポジトリは ``session.commit()`` / ``session.rollback()`` を **決して** 呼ばない。
+呼び元のサービスが ``async with session.begin():`` を実行することで、上記 5 ステップ
+を 1 トランザクションに収める（§確定 B Tx 境界の責務分離）。これにより 1 つの
+サービスが同じ Unit-of-Work で複数のリポジトリを組み合わせられる
+（``EmpireRepository.save`` + Outbox 行追加など）。
 
-``_to_row`` / ``_from_row`` are kept as private methods on the class
-so both directions live next to each other and tests don't accidentally
-acquire a public conversion API to depend on (§確定 C).
+``_to_row`` / ``_from_row`` はクラスのプライベートメソッドのまま保持し、双方向の
+変換が隣接して存在するようにする。これにより、テストが公開された変換 API を誤って
+取得して依存することを避ける（§確定 C）。
 """
 
 from __future__ import annotations
@@ -46,32 +45,29 @@ from bakufu.infrastructure.persistence.sqlite.tables.empires import EmpireRow
 
 
 class SqliteEmpireRepository:
-    """SQLite implementation of :class:`EmpireRepository`."""
+    """:class:`EmpireRepository` の SQLite 実装。"""
 
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
 
     async def find_by_id(self, empire_id: EmpireId) -> Empire | None:
-        """SELECT empires + side tables, hydrate via :meth:`_from_row`.
+        """empires と関連テーブルを SELECT し、:meth:`_from_row` で水和する。
 
-        Returns ``None`` when the empires row is absent. The two side
-        SELECTs run sequentially to keep the SQL trivial; bulk Empires
-        will not exceed Confirmation C's ``len(rooms) ≤ 100`` cap, so
-        IN-clause batching is unnecessary for MVP.
+        empires 行が存在しない場合は ``None`` を返す。2 つの関連 SELECT は SQL を
+        単純に保つため逐次実行する。バルクの Empire は Confirmation C の
+        ``len(rooms) ≤ 100`` 上限を超えないため、MVP では IN 句バッチ化は不要。
         """
         empire_stmt = select(EmpireRow).where(EmpireRow.id == empire_id)
         empire_row = (await self._session.execute(empire_stmt)).scalar_one_or_none()
         if empire_row is None:
             return None
 
-        # BUG-EMR-001 fix: ORDER BY room_id / agent_id makes the
-        # hydrated list deterministic. Without it SQLite returns rows
-        # in internal-scan order, which broke ``Empire == Empire``
-        # round-trip equality (the Aggregate VO compares list-by-list).
-        # See docs/features/empire-repository/detailed-design.md
-        # §Known Issues for the design resolution; basic-design.md
-        # L127-128 froze ``ORDER BY room_id`` / ``ORDER BY agent_id``
-        # as the design contract.
+        # BUG-EMR-001 修正: ORDER BY room_id / agent_id により、水和されたリストを
+        # 決定的にする。これがないと SQLite は内部スキャン順で行を返し、
+        # ``Empire == Empire`` の往復等価性が壊れていた（Aggregate VO はリスト同士
+        # で比較する）。設計解決は docs/features/empire-repository/detailed-design.md
+        # §Known Issues を参照。basic-design.md L127-128 が ``ORDER BY room_id`` /
+        # ``ORDER BY agent_id`` を設計コントラクトとして凍結している。
         room_stmt = (
             select(EmpireRoomRefRow)
             .where(EmpireRoomRefRow.empire_id == empire_id)
@@ -89,12 +85,11 @@ class SqliteEmpireRepository:
         return self._from_row(empire_row, room_rows, agent_rows)
 
     async def find_all(self) -> list[Empire]:
-        """``SELECT * FROM empires`` with side-table hydration.
+        """``SELECT * FROM empires`` を関連テーブル水和込みで実行する。
 
-        Bakufu's Empire is a singleton (R1-5), so the result list is
-        0 or 1 element. The implementation fetches all ``empires`` rows
-        then hydrates each via :meth:`find_by_id` semantics, keeping
-        the hydration logic centralized.
+        bakufu の Empire はシングルトン（R1-5）であるため、結果リストは 0 または 1
+        要素になる。実装は全 ``empires`` 行を取得した後、:meth:`find_by_id` セマン
+        ティクスで各行を水和することで水和ロジックを集約する。
         """
         empire_stmt = select(EmpireRow)
         empire_rows = list((await self._session.execute(empire_stmt)).scalars().all())
@@ -121,35 +116,32 @@ class SqliteEmpireRepository:
         return result
 
     async def count(self) -> int:
-        """``SELECT COUNT(*) FROM empires``.
+        """``SELECT COUNT(*) FROM empires``。
 
-        ``EmpireService.create()`` consumes this to enforce the
-        singleton invariant (§確定 D); the Repository itself is silent
-        about whether ``count != 0`` is an error — that decision is
-        the application service's.
+        ``EmpireService.create()`` がこれを呼んでシングルトン不変条件を強制する
+        （§確定 D）。リポジトリ自体は ``count != 0`` がエラーかどうかについて
+        沈黙する — その判断はアプリケーション サービスのもの。
 
-        Implementation detail: SQLAlchemy's ``func.count()`` issues a
-        proper ``SELECT COUNT(*)`` so SQLite returns one scalar row
-        instead of streaming every PK back to Python. This matters as
-        a **template responsibility** for the six follow-up Repository
-        PRs (workflow / agent / room / directive / task /
-        external-review-gate) — Stage / Task tables can hold hundreds
-        of rows, so the pattern emitted here propagates downstream.
+        実装詳細: SQLAlchemy の ``func.count()`` は適切な ``SELECT COUNT(*)`` を
+        発行するため、SQLite は全 PK を Python にストリームせずスカラー 1 行だけ
+        返す。これは 6 つの後続リポジトリ PR（workflow / agent / room / directive
+        / task / external-review-gate）に対する **テンプレート責任** として重要
+        である — Stage / Task テーブルは数百行を保持し得るため、ここで提示する
+        パターンが下流に伝播する。
         """
         stmt = select(func.count()).select_from(EmpireRow)
         return (await self._session.execute(stmt)).scalar_one()
 
     async def save(self, empire: Empire) -> None:
-        """Persist ``empire`` via the §確定 B five-step delete-then-insert.
+        """§確定 B の 5 ステップ delete-then-insert で ``empire`` を永続化する。
 
-        The caller is responsible for the surrounding
-        ``async with session.begin():`` block; failures inside any
-        step propagate untouched so the Unit-of-Work boundary in the
-        application service can rollback cleanly.
+        外側の ``async with session.begin():`` ブロックは呼び元の責任。各ステップ
+        内部の失敗はそのまま伝播するため、アプリケーション サービスの Unit-of-Work
+        境界はクリーンにロールバックできる。
         """
         empire_row, room_refs, agent_refs = self._to_row(empire)
 
-        # Step 1: empires UPSERT (id PK, ON CONFLICT update name).
+        # Step 1: empires UPSERT（id PK、ON CONFLICT で name を更新）。
         upsert_stmt = sqlite_insert(EmpireRow).values(empire_row)
         upsert_stmt = upsert_stmt.on_conflict_do_update(
             index_elements=["id"],
@@ -160,21 +152,21 @@ class SqliteEmpireRepository:
         )
         await self._session.execute(upsert_stmt)
 
-        # Step 2: empire_room_refs DELETE.
+        # Step 2: empire_room_refs DELETE。
         await self._session.execute(
             delete(EmpireRoomRefRow).where(EmpireRoomRefRow.empire_id == empire.id)
         )
 
-        # Step 3: empire_room_refs bulk INSERT (skip when no rooms).
+        # Step 3: empire_room_refs 一括 INSERT（rooms が無い場合はスキップ）。
         if room_refs:
             await self._session.execute(insert(EmpireRoomRefRow), room_refs)
 
-        # Step 4: empire_agent_refs DELETE.
+        # Step 4: empire_agent_refs DELETE。
         await self._session.execute(
             delete(EmpireAgentRefRow).where(EmpireAgentRefRow.empire_id == empire.id)
         )
 
-        # Step 5: empire_agent_refs bulk INSERT (skip when no agents).
+        # Step 5: empire_agent_refs 一括 INSERT（agents が無い場合はスキップ）。
         if agent_refs:
             await self._session.execute(insert(EmpireAgentRefRow), agent_refs)
 
@@ -183,12 +175,11 @@ class SqliteEmpireRepository:
         self,
         empire: Empire,
     ) -> tuple[dict[str, Any], list[dict[str, Any]], list[dict[str, Any]]]:
-        """Split ``empire`` into ``(empires_row, room_refs, agent_refs)``.
+        """``empire`` を ``(empires_row, room_refs, agent_refs)`` に分割する。
 
-        The three return values match the three tables that
-        :meth:`save` writes. SQLAlchemy ``Row`` objects are
-        intentionally avoided here so the domain layer never gains an
-        accidental dependency on the SQLAlchemy type hierarchy.
+        3 つの返り値は :meth:`save` が書き込む 3 つのテーブルに対応する。SQLAlchemy
+        ``Row`` オブジェクトは意図的に使わない — ドメイン層が SQLAlchemy の型階層に
+        偶発的に依存することを防ぐため。
         """
         empire_row: dict[str, Any] = {
             "id": empire.id,
@@ -221,13 +212,12 @@ class SqliteEmpireRepository:
         room_rows: list[EmpireRoomRefRow],
         agent_rows: list[EmpireAgentRefRow],
     ) -> Empire:
-        """Hydrate an :class:`Empire` Aggregate Root from its three rows.
+        """3 つの行から :class:`Empire` Aggregate Root を水和する。
 
-        ``Empire.model_validate`` re-runs the post-validator so
-        Repository-side hydration goes through the same invariant
-        checks that ``EmpireService.create()`` does at construction
-        time. The contract (§確定 C) is "Repository hydration produces
-        a valid Empire or raises".
+        ``Empire.model_validate`` は post-validator を再実行するため、リポジトリ側
+        の水和も ``EmpireService.create()`` が構築時に走らせるのと同じ不変条件
+        チェックを通る。コントラクト（§確定 C）は「リポジトリ水和は妥当な Empire
+        を生成するか例外を送出する」。
         """
         rooms = [
             RoomRef(
@@ -255,12 +245,11 @@ class SqliteEmpireRepository:
 
 
 def _uuid(value: UUID | str) -> UUID:
-    """Coerce a row value to :class:`uuid.UUID`.
+    """行の値を :class:`uuid.UUID` に強制変換する。
 
-    SQLAlchemy's UUIDStr TypeDecorator already returns ``UUID``
-    instances on ``process_result_value``, but defensive coercion lets
-    raw-SQL hydration paths route through the same code without an
-    extra ``isinstance`` ladder at every call site.
+    SQLAlchemy の UUIDStr TypeDecorator は ``process_result_value`` で既に ``UUID``
+    インスタンスを返すが、防御的な強制変換により、raw SQL 経路の水和も同じコードを
+    通せる — 各呼び出し箇所で ``isinstance`` の階段を書かずに済む。
     """
     if isinstance(value, UUID):
         return value

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/repositories/external_review_gate_repository.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/repositories/external_review_gate_repository.py
@@ -1,46 +1,43 @@
-"""SQLite adapter for :class:`bakufu.application.ports.ExternalReviewGateRepository`.
+""":class:`bakufu.application.ports.ExternalReviewGateRepository` の SQLite アダプタ。
 
-Implements the §確定 R1-B 5-step save flow over three tables
-(``external_review_gates`` / ``external_review_gate_attachments`` /
-``external_review_audit_entries``):
+§確定 R1-B の 5 ステップ保存フローを 3 つのテーブル
+（``external_review_gates`` / ``external_review_gate_attachments`` /
+``external_review_audit_entries``）に対して実装する:
 
 1. ``DELETE FROM external_review_gate_attachments WHERE gate_id = :id`` —
-   no CASCADE parent; direct DELETE. New Gates produce 0 rows (no-op).
+   CASCADE 親無し、直接 DELETE。新規 Gate では 0 行（no-op）。
 2. ``DELETE FROM external_review_audit_entries WHERE gate_id = :id`` —
-   same. Direct DELETE, no CASCADE parent.
-3. ``external_review_gates`` UPSERT (id-conflict → mutable fields update;
-   ``task_id``, ``stage_id``, ``reviewer_id``, ``created_at``, and all
-   ``snapshot_*`` columns are intentionally **not** updated — Gate origin,
-   reviewer assignment, and deliverable snapshot are immutable after
-   creation).
-4. ``INSERT INTO external_review_gate_attachments`` — one row per
-   :class:`Attachment` in ``gate.deliverable_snapshot.attachments``. A
-   fresh ``uuid4()`` PK is generated for each row on every save
-   (DELETE-then-INSERT pattern guarantees no PK collision). Business key
-   remains ``UNIQUE(gate_id, sha256)``.
-5. ``INSERT INTO external_review_audit_entries`` — one row per
-   :class:`AuditEntry` in ``gate.audit_trail``. PKs come directly from
-   ``AuditEntry.id`` (domain-assigned UUIDs, not regenerated).
+   同様。直接 DELETE、CASCADE 親無し。
+3. ``external_review_gates`` UPSERT（id 衝突時に変更可能フィールドを更新。
+   ``task_id``、``stage_id``、``reviewer_id``、``created_at``、および全 ``snapshot_*``
+   カラムは意図的に **更新しない** — Gate の起源、レビュアー アサイン、成果物スナップ
+   ショットは作成後に不変）。
+4. ``INSERT INTO external_review_gate_attachments`` —
+   ``gate.deliverable_snapshot.attachments`` の :class:`Attachment` ごとに 1 行。
+   保存ごとに各行で新しい ``uuid4()`` PK を生成する（DELETE-then-INSERT パターンが
+   PK 衝突しないことを保証する）。ビジネス キーは引き続き ``UNIQUE(gate_id, sha256)``。
+5. ``INSERT INTO external_review_audit_entries`` — ``gate.audit_trail`` の
+   :class:`AuditEntry` ごとに 1 行。PK は ``AuditEntry.id`` から直接取得する
+   （ドメイン側で割り当てられた UUID、再生成しない）。
 
-The repository **never** calls ``session.commit()`` / ``session.rollback()``:
-the caller-side service runs ``async with session.begin():`` so all 5 steps
-stay in one transaction (empire-repo §確定 B Tx 境界の責務分離).
+リポジトリは ``session.commit()`` / ``session.rollback()`` を **決して** 呼ばない。
+呼び元のサービスが ``async with session.begin():`` を実行することで、5 ステップ全てを
+1 トランザクションに収める（empire-repo §確定 B Tx 境界の責務分離）。
 
-``save(gate)`` uses the **standard 1-argument pattern** (§確定 R1-F):
-:class:`ExternalReviewGate` carries all own attributes so the Repository
-reads them directly.
+``save(gate)`` は **標準の 1 引数パターン**（§確定 R1-F）を使う:
+:class:`ExternalReviewGate` は全ての必要な属性を自身に保持するため、リポジトリは
+それらを直接読む。
 
-``_to_rows`` / ``_from_rows`` are kept as private methods on the class so
-both conversion directions live next to each other and tests don't
-accidentally acquire a public conversion API to depend on (empire-repo
-§確定 C).
+``_to_rows`` / ``_from_rows`` はクラスのプライベートメソッドのまま保持し、双方向の
+変換が隣接して存在するようにする。これにより、テストが公開された変換 API を誤って
+取得して依存することを避ける（empire-repo §確定 C）。
 
-TypeDecorator-trust pattern (§確定 R1-A): :class:`UUIDStr` returns
-``UUID`` instances from ``process_result_value``, so ``row.id`` etc. are
-already ``UUID``. Direct attribute access without defensive ``UUID(row.id)``
-wrapping is correct and required. :class:`MaskedText` returns the already-
-masked string on SELECT; raw domain strings are passed on INSERT and
-``process_bind_param`` applies the masking gate automatically.
+TypeDecorator-trust パターン（§確定 R1-A）: :class:`UUIDStr` は
+``process_result_value`` で ``UUID`` インスタンスを返すため、``row.id`` 等は
+すでに ``UUID`` である。防御的な ``UUID(row.id)`` ラッピング無しで属性を直接参照する
+のが正しく、必須である。:class:`MaskedText` は SELECT 時に伏字化済みの文字列を返し、
+INSERT 時には素のドメイン文字列が渡され、``process_bind_param`` がマスキング ゲート
+を自動適用する。
 """
 
 from __future__ import annotations
@@ -75,17 +72,16 @@ from bakufu.infrastructure.persistence.sqlite.tables.external_review_gates impor
 
 
 class SqliteExternalReviewGateRepository:
-    """SQLite implementation of :class:`ExternalReviewGateRepository`."""
+    """:class:`ExternalReviewGateRepository` の SQLite 実装。"""
 
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
 
     async def find_by_id(self, gate_id: GateId) -> ExternalReviewGate | None:
-        """SELECT gate row + 2 child tables, hydrate via :meth:`_from_rows`.
+        """gate 行と 2 つの子テーブルを SELECT し、:meth:`_from_rows` で水和する。
 
-        Returns ``None`` when the gate row is absent. On success, both
-        child tables are queried with their §確定 R1-H ORDER BY clauses so
-        the hydrated Aggregate is deterministic.
+        gate 行が存在しない場合は ``None`` を返す。成功時は §確定 R1-H の ORDER BY
+        句で 2 つの子テーブル全てを問い合わせるため、水和された Aggregate は決定的になる。
         """
         gate_row = (
             await self._session.execute(
@@ -97,43 +93,42 @@ class SqliteExternalReviewGateRepository:
         return await self._hydrate_row(gate_row)
 
     async def count(self) -> int:
-        """``SELECT COUNT(*) FROM external_review_gates``.
+        """``SELECT COUNT(*) FROM external_review_gates``。
 
-        SQLAlchemy's ``func.count()`` issues a proper ``SELECT COUNT(*)``
-        so SQLite returns one scalar row instead of streaming every PK back
-        to Python (empire-repo §確定 D 踏襲).
+        SQLAlchemy の ``func.count()`` は適切な ``SELECT COUNT(*)`` を発行するため、
+        SQLite は全 PK を Python にストリームせずスカラー 1 行だけ返す
+        （empire-repo §確定 D 踏襲）。
         """
         return (
             await self._session.execute(select(func.count()).select_from(ExternalReviewGateRow))
         ).scalar_one()
 
     async def save(self, gate: ExternalReviewGate) -> None:
-        """Persist ``gate`` via the §確定 R1-B 5-step delete-then-insert.
+        """§確定 R1-B の 5 ステップ delete-then-insert で ``gate`` を永続化する。
 
-        The caller is responsible for the surrounding
-        ``async with session.begin():`` block; failures propagate untouched
-        so the Unit-of-Work boundary in the application service can rollback
-        cleanly (empire-repo §確定 B 踏襲).
+        外側の ``async with session.begin():`` ブロックは呼び元の責任。失敗はそのまま
+        伝播するため、アプリケーション サービスの Unit-of-Work 境界はクリーンに
+        ロールバックできる（empire-repo §確定 B 踏襲）。
         """
         gate_row, attach_rows, audit_rows = self._to_rows(gate)
 
-        # Step 1: DELETE external_review_gate_attachments (no CASCADE, direct).
+        # Step 1: DELETE external_review_gate_attachments（CASCADE 無し、直接）。
         await self._session.execute(
             delete(ExternalReviewGateAttachmentRow).where(
                 ExternalReviewGateAttachmentRow.gate_id == gate.id
             )
         )
 
-        # Step 2: DELETE external_review_audit_entries (no CASCADE, direct).
+        # Step 2: DELETE external_review_audit_entries（CASCADE 無し、直接）。
         await self._session.execute(
             delete(ExternalReviewAuditEntryRow).where(
                 ExternalReviewAuditEntryRow.gate_id == gate.id
             )
         )
 
-        # Step 3: external_review_gates UPSERT.
-        # Immutable fields excluded from DO UPDATE — Gate origin, reviewer
-        # assignment, and deliverable snapshot never change after creation.
+        # Step 3: external_review_gates UPSERT。
+        # 不変フィールドは DO UPDATE から除外 — Gate の起源、レビュアー アサイン、
+        # 成果物スナップショットは作成後に変化しない。
         upsert_stmt = sqlite_insert(ExternalReviewGateRow).values(gate_row)
         upsert_stmt = upsert_stmt.on_conflict_do_update(
             index_elements=["id"],
@@ -145,20 +140,20 @@ class SqliteExternalReviewGateRepository:
         )
         await self._session.execute(upsert_stmt)
 
-        # Step 4: INSERT external_review_gate_attachments.
+        # Step 4: INSERT external_review_gate_attachments。
         if attach_rows:
             await self._session.execute(insert(ExternalReviewGateAttachmentRow), attach_rows)
 
-        # Step 5: INSERT external_review_audit_entries.
+        # Step 5: INSERT external_review_audit_entries。
         if audit_rows:
             await self._session.execute(insert(ExternalReviewAuditEntryRow), audit_rows)
 
     async def find_pending_by_reviewer(self, reviewer_id: OwnerId) -> list[ExternalReviewGate]:
-        """Return all PENDING Gates for ``reviewer_id`` ordered ``created_at DESC, id DESC``.
+        """``reviewer_id`` の全 PENDING Gate を ``created_at DESC, id DESC`` 順で返す。
 
-        The composite INDEX ``ix_external_review_gates_reviewer_decision``
-        on ``(reviewer_id, decision)`` covers the WHERE filter (§確定 R1-K).
-        Returns ``[]`` when no PENDING Gates exist for the given reviewer.
+        ``(reviewer_id, decision)`` 上の複合 INDEX
+        ``ix_external_review_gates_reviewer_decision`` が WHERE フィルタをカバーする
+        （§確定 R1-K）。指定レビュアーの PENDING Gate が無い場合は ``[]`` を返す。
         """
         gate_rows = list(
             (
@@ -186,12 +181,12 @@ class SqliteExternalReviewGateRepository:
         return results
 
     async def find_by_task_id(self, task_id: TaskId) -> list[ExternalReviewGate]:
-        """Return all Gates for ``task_id`` ordered ``created_at ASC, id ASC``.
+        """``task_id`` の全 Gate を ``created_at ASC, id ASC`` 順で返す。
 
-        The composite INDEX ``ix_external_review_gates_task_id_created``
-        on ``(task_id, created_at)`` covers the WHERE + ORDER BY in one
-        B-tree scan (§確定 R1-K). Returns ``[]`` when no Gates exist for
-        the given Task.
+        ``(task_id, created_at)`` 上の複合 INDEX
+        ``ix_external_review_gates_task_id_created`` は WHERE と ORDER BY の両方を
+        1 回の B-tree スキャンでカバーする（§確定 R1-K）。指定 Task の Gate が無い場合
+        は ``[]`` を返す。
         """
         gate_rows = list(
             (
@@ -216,11 +211,10 @@ class SqliteExternalReviewGateRepository:
         return results
 
     async def count_by_decision(self, decision: ReviewDecision) -> int:
-        """``SELECT COUNT(*) FROM external_review_gates WHERE decision = :decision``.
+        """``SELECT COUNT(*) FROM external_review_gates WHERE decision = :decision``。
 
-        The INDEX ``ix_external_review_gates_decision`` on ``(decision)``
-        accelerates this WHERE filter (§確定 R1-K).
-        Returns 0 when no Gates exist with the given decision.
+        ``(decision)`` 上の INDEX ``ix_external_review_gates_decision`` がこの WHERE
+        フィルタを高速化する（§確定 R1-K）。指定 decision の Gate が無い場合は 0 を返す。
         """
         return (
             await self._session.execute(
@@ -233,12 +227,12 @@ class SqliteExternalReviewGateRepository:
     # ---- private domain ↔ row converters (empire-repo §確定 C) -----------
 
     async def _hydrate_row(self, gate_row: ExternalReviewGateRow) -> ExternalReviewGate:
-        """Fetch child tables for an already-loaded gate row and reconstruct.
+        """既にロード済みの gate 行に対する子テーブルを取得して再構築する。
 
-        Shared by :meth:`find_by_id`, :meth:`find_pending_by_reviewer`, and
-        :meth:`find_by_task_id` to avoid redundant root-table re-fetches.
+        :meth:`find_by_id`、:meth:`find_pending_by_reviewer`、:meth:`find_by_task_id`
+        で共有し、ルート テーブルの冗長な再取得を避ける。
         """
-        # §確定 R1-H: ORDER BY sha256 ASC (UNIQUE per gate scope, deterministic).
+        # §確定 R1-H: ORDER BY sha256 ASC（gate スコープで UNIQUE で決定的）。
         attach_rows = list(
             (
                 await self._session.execute(
@@ -251,8 +245,8 @@ class SqliteExternalReviewGateRepository:
             .all()
         )
 
-        # §確定 R1-H: ORDER BY occurred_at ASC, id ASC (append-only audit trail
-        # must reconstruct in temporal order; id breaks timestamp ties).
+        # §確定 R1-H: ORDER BY occurred_at ASC, id ASC（追記専用の監査証跡は時系列順で
+        # 再構築する必要があり、id がタイムスタンプ重複の決め手となる）。
         audit_rows = list(
             (
                 await self._session.execute(
@@ -278,29 +272,25 @@ class SqliteExternalReviewGateRepository:
         list[dict[str, Any]],
         list[dict[str, Any]],
     ]:
-        """Convert ``gate`` to ``(gate_row, attach_rows, audit_rows)``.
+        """``gate`` を ``(gate_row, attach_rows, audit_rows)`` に変換する。
 
-        SQLAlchemy ``Row`` objects are avoided so the domain layer never
-        gains an accidental dependency on the SQLAlchemy type hierarchy.
+        ドメイン層が SQLAlchemy の型階層に偶発的に依存しないよう、SQLAlchemy ``Row``
+        オブジェクトは使わない。
 
-        TypeDecorator-trust (§確定 R1-A): raw domain values are passed
-        directly; ``UUIDStr`` / ``MaskedText`` / ``UTCDateTime``
-        TypeDecorators perform all conversions at bind-parameter time.
-        ``feedback_text``, ``snapshot_body_markdown``, and ``comment`` are
-        passed as plain strings — ``MaskedText.process_bind_param`` applies
-        the masking gate automatically without manual
-        ``MaskingGateway.mask()`` calls.
+        TypeDecorator-trust（§確定 R1-A）: 生のドメイン値を直接渡す。``UUIDStr`` /
+        ``MaskedText`` / ``UTCDateTime`` の TypeDecorator がバインド パラメータ時点で
+        全ての変換を行う。``feedback_text``、``snapshot_body_markdown``、``comment``
+        は素の文字列として渡す — ``MaskedText.process_bind_param`` が手動の
+        ``MaskingGateway.mask()`` 呼び出し無しに自動的にマスキング ゲートを適用する。
 
-        Attachment PKs: ``external_review_gate_attachments.id`` has no
-        domain-level identity (the business key is ``UNIQUE(gate_id, sha256)``).
-        A fresh ``uuid4()`` is generated for each attachment row on every
-        save. Because step 1 DELETE-then-step 4 INSERT, there is never a PK
-        collision.
+        Attachment の PK: ``external_review_gate_attachments.id`` はドメインレベルの
+        アイデンティティを持たない（ビジネス キーは ``UNIQUE(gate_id, sha256)``）。
+        保存ごとに各 attachment 行で新しい ``uuid4()`` を生成する。step 1 の DELETE
+        と step 4 の INSERT により PK 衝突は起きない。
 
-        Audit entry PKs: ``external_review_audit_entries.id`` is taken
-        directly from ``AuditEntry.id`` (domain-assigned UUID). The DELETE-
-        then-INSERT flow in steps 2+5 guarantees no PK collision even as the
-        trail grows.
+        Audit entry の PK: ``external_review_audit_entries.id`` は ``AuditEntry.id``
+        から直接取得（ドメイン側で割り当てられた UUID）。step 2+5 の DELETE-then-INSERT
+        フローにより、証跡が伸びても PK 衝突は起きない。
         """
         gate_row: dict[str, Any] = {
             "id": gate.id,
@@ -308,11 +298,11 @@ class SqliteExternalReviewGateRepository:
             "stage_id": gate.stage_id,
             "reviewer_id": gate.reviewer_id,
             "decision": gate.decision.value,
-            # MaskedText.process_bind_param redacts secrets at bind time.
+            # MaskedText.process_bind_param がバインド時にシークレットを伏字化する。
             "feedback_text": gate.feedback_text,
-            # Inline snapshot copy — immutable after construction (§確定 D).
+            # インラインのスナップショット コピー — 構築後に不変（§確定 D）。
             "snapshot_stage_id": gate.deliverable_snapshot.stage_id,
-            # MaskedText.process_bind_param redacts secrets at bind time.
+            # MaskedText.process_bind_param がバインド時にシークレットを伏字化する。
             "snapshot_body_markdown": gate.deliverable_snapshot.body_markdown,
             "snapshot_committed_by": gate.deliverable_snapshot.committed_by,
             "snapshot_committed_at": gate.deliverable_snapshot.committed_at,
@@ -322,7 +312,7 @@ class SqliteExternalReviewGateRepository:
 
         attach_rows: list[dict[str, Any]] = [
             {
-                # Fresh UUID PK — business key is UNIQUE(gate_id, sha256).
+                # 新規 UUID PK — ビジネス キーは UNIQUE(gate_id, sha256)。
                 "id": _uuid.uuid4(),
                 "gate_id": gate.id,
                 "sha256": attachment.sha256,
@@ -335,12 +325,12 @@ class SqliteExternalReviewGateRepository:
 
         audit_rows: list[dict[str, Any]] = [
             {
-                # AuditEntry.id is domain-assigned — preserve it verbatim.
+                # AuditEntry.id はドメイン側で割り当てられた値 — そのまま保持する。
                 "id": entry.id,
                 "gate_id": gate.id,
                 "actor_id": entry.actor_id,
                 "action": entry.action.value,
-                # MaskedText.process_bind_param redacts secrets at bind time.
+                # MaskedText.process_bind_param がバインド時にシークレットを伏字化する。
                 "comment": entry.comment,
                 "occurred_at": entry.occurred_at,
             }
@@ -355,26 +345,24 @@ class SqliteExternalReviewGateRepository:
         attach_rows: list[ExternalReviewGateAttachmentRow],
         audit_rows: list[ExternalReviewAuditEntryRow],
     ) -> ExternalReviewGate:
-        """Hydrate an :class:`ExternalReviewGate` from its row types.
+        """行型から :class:`ExternalReviewGate` を水和する。
 
-        ``ExternalReviewGate(...)`` direct construction re-runs the
-        post-validator so Repository-side hydration goes through the same
-        invariant checks that ``GateService.create()`` does at construction
-        time (empire §確定 C contract: "Repository hydration produces a valid
-        Gate or raises").
+        ``ExternalReviewGate(...)`` の直接構築は post-validator を再実行するため、
+        リポジトリ側の水和も ``GateService.create()`` が構築時に走らせるのと同じ
+        不変条件チェックを通る（empire §確定 C コントラクト「リポジトリ水和は妥当な
+        Gate を生成するか例外を送出する」）。
 
-        TypeDecorator-trust (§確定 R1-A): ``UUIDStr`` returns ``UUID``
-        instances from ``process_result_value``; ``UTCDateTime`` returns
-        tz-aware ``datetime``; ``MaskedText`` returns the already-masked
-        string. No defensive wrapping (e.g. ``UUID(row.id)``) needed.
+        TypeDecorator-trust（§確定 R1-A）: ``UUIDStr`` は ``process_result_value`` で
+        ``UUID`` インスタンスを返し、``UTCDateTime`` は tz-aware ``datetime`` を返し、
+        ``MaskedText`` は伏字化済みの文字列を返す。``UUID(row.id)`` のような防御的
+        ラッピングは不要。
 
-        §確定 R1-J §不可逆性: ``feedback_text``, ``snapshot_body_markdown``,
-        and ``comment`` carry the already-masked text from disk. All fields
-        accept any string within their length caps so the masked form
-        constructs cleanly.
+        §確定 R1-J §不可逆性: ``feedback_text``、``snapshot_body_markdown``、
+        ``comment`` はディスクから既に伏字化されたテキストを保持する。全フィールドは
+        長さ上限内の任意の文字列を受理するため、伏字化された形でも構築は通る。
         """
-        # §確定 R1-C: reconstruct deliverable_snapshot from gate_row scalars
-        # + attach_rows (attach_rows already sorted sha256 ASC by caller).
+        # §確定 R1-C: gate_row のスカラと attach_rows から deliverable_snapshot を
+        # 再構築する（attach_rows は呼び元側で sha256 ASC でソート済み）。
         attachments = [
             Attachment(
                 sha256=a.sha256,
@@ -392,10 +380,10 @@ class SqliteExternalReviewGateRepository:
             committed_at=gate_row.snapshot_committed_at,
         )
 
-        # §確定 R1-C: reconstruct audit_trail from audit_rows (already sorted
-        # occurred_at ASC, id ASC by caller — matches append-only domain order).
-        # TypeDecorator-trust (§確定 R1-A): UUIDStr.process_result_value
-        # already returns UUID instances — no defensive wrapping needed.
+        # §確定 R1-C: audit_rows から audit_trail を再構築する（呼び元側で
+        # occurred_at ASC, id ASC でソート済み — 追記専用ドメイン順と一致）。
+        # TypeDecorator-trust（§確定 R1-A）: UUIDStr.process_result_value は
+        # 既に UUID インスタンスを返す — 防御的ラッピング不要。
         audit_trail: list[AuditEntry] = [
             AuditEntry(
                 id=r.id,

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/repositories/room_repository.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/repositories/room_repository.py
@@ -1,32 +1,31 @@
-"""SQLite adapter for :class:`bakufu.application.ports.RoomRepository`.
+""":class:`bakufu.application.ports.RoomRepository` の SQLite アダプタ。
 
-Implements the §確定 R1-B three-step save flow over two tables
-(``rooms`` / ``room_members``):
+§確定 R1-B の 3 ステップ保存フローを 2 つのテーブル（``rooms`` / ``room_members``）
+に対して実装する:
 
-1. ``rooms`` UPSERT (id-conflict → workflow_id + name + description +
-   prompt_kit_prefix_markdown + archived update; ``prompt_kit_prefix_markdown``
-   binds through :class:`MaskedText` so any embedded API key / OAuth token /
-   Discord webhook secret is redacted *before* it hits SQLite — room §確定 G
-   实適用, §確定 R1-J 不可逆性凍結).
+1. ``rooms`` UPSERT（id 衝突時に workflow_id + name + description +
+   prompt_kit_prefix_markdown + archived を更新。``prompt_kit_prefix_markdown``
+   は :class:`MaskedText` 経由でバインドされるため、埋め込まれた API キー /
+   OAuth トークン / Discord webhook シークレットは SQLite に到達する *前* に
+   伏字化される — room §確定 G、§確定 R1-J 不可逆性凍結）。
 2. ``room_members`` DELETE WHERE room_id = ?
-3. ``room_members`` bulk INSERT (one row per AgentMembership).
+3. ``room_members`` 一括 INSERT（AgentMembership ごとに 1 行）。
 
-The repository **never** calls ``session.commit()`` / ``session.rollback()``:
-the caller-side service runs ``async with session.begin():`` so the three
-steps above stay in one transaction (empire-repo §確定 B Tx 境界の責務分離).
+リポジトリは ``session.commit()`` / ``session.rollback()`` を **決して** 呼ばない。
+呼び元のサービスが ``async with session.begin():`` を実行することで、上記 3 ステップ
+を 1 トランザクションに収める（empire-repo §確定 B Tx 境界の責務分離）。
 
-``save`` takes an explicit ``empire_id`` argument because :class:`Room`
-Aggregate holds no ``empire_id`` attribute — ownership is expressed via
-``Empire.rooms: list[RoomRef]``. The calling service always has ``empire_id``
-in scope (§確定 R1-H).
+``save`` は明示的な ``empire_id`` 引数を取る。:class:`Room` Aggregate には
+``empire_id`` 属性が無く、所有関係は ``Empire.rooms: list[RoomRef]`` で表現される
+ため。呼び元サービスは常に ``empire_id`` をスコープに持つ（§確定 R1-H）。
 
-``_to_row`` / ``_from_row`` are kept as private methods on the class so both
-conversion directions live next to each other and tests don't accidentally
-acquire a public conversion API to depend on (empire-repo §確定 C).
+``_to_row`` / ``_from_row`` はクラスのプライベートメソッドのまま保持し、双方向の
+変換が隣接して存在するようにする。これにより、テストが公開された変換 API を誤って
+取得して依存することを避ける（empire-repo §確定 C）。
 
-``find_by_name`` delegates to ``find_by_id`` once the RoomId is known so the
-child-table SELECTs and ``_from_row`` conversion stay single-sourced
-(agent §R1-C テンプレート継承, §確定 R1-F).
+``find_by_name`` は RoomId が判明し次第 ``find_by_id`` に委譲することで、子テーブル
+SELECT と ``_from_row`` 変換を単一情報源に保つ（agent §R1-C テンプレート継承、
+§確定 R1-F）。
 """
 
 from __future__ import annotations
@@ -45,29 +44,28 @@ from bakufu.infrastructure.persistence.sqlite.tables.rooms import RoomRow
 
 
 class SqliteRoomRepository:
-    """SQLite implementation of :class:`RoomRepository`."""
+    """:class:`RoomRepository` の SQLite 実装。"""
 
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
 
     async def find_by_id(self, room_id: RoomId) -> Room | None:
-        """SELECT room + room_members, hydrate via :meth:`_from_row`.
+        """room と room_members を SELECT し、:meth:`_from_row` で水和する。
 
-        Returns ``None`` when the rooms row is absent. The room_members
-        SELECT uses ``ORDER BY agent_id, role`` (composite key ascending)
-        so the hydrated member list is deterministic — empire-repository
-        BUG-EMR-001 froze this contract; we apply it from day one here.
+        rooms 行が存在しない場合は ``None`` を返す。room_members の SELECT は
+        ``ORDER BY agent_id, role``（複合キー昇順）を使い、水和されたメンバ リスト
+        が決定的になるようにする — empire-repository BUG-EMR-001 が凍結したコント
+        ラクトを当初から適用する。
         """
         room_stmt = select(RoomRow).where(RoomRow.id == room_id)
         room_row = (await self._session.execute(room_stmt)).scalar_one_or_none()
         if room_row is None:
             return None
 
-        # ORDER BY makes find_by_id deterministic. Without it SQLite returns
-        # rows in internal-scan order, which would break ``Room == Room``
-        # round-trip equality (the Aggregate compares list-by-list).
-        # See empire-repo BUG-EMR-001 — this PR adopts the resolved contract
-        # from day one.
+        # ORDER BY を付与することで find_by_id を決定的にする。これがないと SQLite は
+        # 内部スキャン順で行を返し、``Room == Room`` の往復等価性が壊れる
+        # （Aggregate はリスト同士で比較する）。empire-repo BUG-EMR-001 を参照 —
+        # 本 PR では当初から決定の済んだコントラクトを採用する。
         member_stmt = (
             select(RoomMemberRow)
             .where(RoomMemberRow.room_id == room_id)
@@ -78,30 +76,29 @@ class SqliteRoomRepository:
         return self._from_row(room_row, member_rows)
 
     async def count(self) -> int:
-        """``SELECT COUNT(*) FROM rooms``.
+        """``SELECT COUNT(*) FROM rooms``。
 
-        Implementation detail: SQLAlchemy's ``func.count()`` issues a
-        proper ``SELECT COUNT(*)`` so SQLite returns one scalar row instead
-        of streaming every PK back to Python (empire-repo §確定 D 踏襲).
+        実装詳細: SQLAlchemy の ``func.count()`` は適切な ``SELECT COUNT(*)`` を
+        発行するため、SQLite は全 PK を Python にストリームせずスカラー 1 行だけ
+        返す（empire-repo §確定 D 踏襲）。
         """
         stmt = select(func.count()).select_from(RoomRow)
         return (await self._session.execute(stmt)).scalar_one()
 
     async def save(self, room: Room, empire_id: EmpireId) -> None:
-        """Persist ``room`` via the §確定 R1-B three-step delete-then-insert.
+        """§確定 R1-B の 3 ステップ delete-then-insert で ``room`` を永続化する。
 
-        ``empire_id`` is an explicit argument because :class:`Room` holds no
-        ``empire_id`` attribute (§確定 R1-H). The caller is responsible for
-        the surrounding ``async with session.begin():`` block; failures inside
-        any step propagate untouched so the Unit-of-Work boundary in the
-        application service can rollback cleanly.
+        :class:`Room` には ``empire_id`` 属性が無いため（§確定 R1-H）、``empire_id``
+        を明示引数とする。外側の ``async with session.begin():`` ブロックは呼び元の
+        責任。各ステップ内部の失敗はそのまま伝播するため、アプリケーション サービス
+        の Unit-of-Work 境界はクリーンにロールバックできる。
         """
         room_row, member_rows = self._to_row(room, empire_id)
 
-        # Step 1: rooms UPSERT (id PK, ON CONFLICT update workflow_id + name
-        # + description + prompt_kit_prefix_markdown + archived).
-        # ``prompt_kit_prefix_markdown`` binds through MaskedText so the
-        # masked form lands in DB even on update (§確定 R1-J).
+        # Step 1: rooms UPSERT（id PK、ON CONFLICT で workflow_id + name +
+        # description + prompt_kit_prefix_markdown + archived を更新）。
+        # ``prompt_kit_prefix_markdown`` は MaskedText 経由でバインドされるため、
+        # 更新時にも伏字化された形で DB に到達する（§確定 R1-J）。
         upsert_stmt = sqlite_insert(RoomRow).values(room_row)
         upsert_stmt = upsert_stmt.on_conflict_do_update(
             index_elements=["id"],
@@ -115,21 +112,21 @@ class SqliteRoomRepository:
         )
         await self._session.execute(upsert_stmt)
 
-        # Step 2: room_members DELETE.
+        # Step 2: room_members DELETE。
         await self._session.execute(delete(RoomMemberRow).where(RoomMemberRow.room_id == room.id))
 
-        # Step 3: room_members bulk INSERT (skip when no members — a newly
-        # created room may legitimately have zero members).
+        # Step 3: room_members 一括 INSERT（メンバが無い場合はスキップ —
+        # 新規作成された room はメンバ 0 で正当に存在し得る）。
         if member_rows:
             await self._session.execute(insert(RoomMemberRow), member_rows)
 
     async def find_by_name(self, empire_id: EmpireId, name: str) -> Room | None:
-        """Hydrate the Room named ``name`` inside ``empire_id`` (§確定 R1-F).
+        """``empire_id`` 内の ``name`` という Room を水和する（§確定 R1-F）。
 
-        Two-stage flow: a lightweight ``SELECT id ... LIMIT 1`` locates the
-        RoomId via ``INDEX(empire_id, name)``, then delegation to
-        :meth:`find_by_id` so the child-table SELECTs and ``_from_row``
-        conversion stay single-sourced (agent §R1-C テンプレート継承).
+        2 段階フロー: 軽量な ``SELECT id ... LIMIT 1`` で ``INDEX(empire_id, name)``
+        を介して RoomId を特定し、その後 :meth:`find_by_id` に委譲することで、
+        子テーブル SELECT と ``_from_row`` 変換を単一情報源に保つ
+        （agent §R1-C テンプレート継承）。
         """
         id_stmt = (
             select(RoomRow.id).where(RoomRow.empire_id == empire_id, RoomRow.name == name).limit(1)
@@ -145,14 +142,14 @@ class SqliteRoomRepository:
         room: Room,
         empire_id: EmpireId,
     ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
-        """Split ``room`` into ``(room_row, member_rows)``.
+        """``room`` を ``(room_row, member_rows)`` に分割する。
 
-        SQLAlchemy ``Row`` objects are avoided so the domain layer never
-        gains an accidental dependency on the SQLAlchemy type hierarchy. Each
-        returned ``dict`` matches the ``mapped_column`` names verbatim.
+        ドメイン層が SQLAlchemy の型階層に偶発的に依存しないよう、SQLAlchemy ``Row``
+        オブジェクトは使わない。返却される各 ``dict`` のキーは ``mapped_column``
+        名と完全一致する。
 
-        ``empire_id`` is passed explicitly because :class:`Room` holds no
-        ``empire_id`` attribute (§確定 R1-H).
+        :class:`Room` には ``empire_id`` 属性が無いため、``empire_id`` を明示的に
+        渡す（§確定 R1-H）。
         """
         room_row: dict[str, Any] = {
             "id": room.id,
@@ -160,8 +157,8 @@ class SqliteRoomRepository:
             "workflow_id": room.workflow_id,
             "name": room.name,
             "description": room.description,
-            # MaskedText.process_bind_param will redact secrets from this
-            # string before VARCHAR storage — room §確定 G 実適用.
+            # MaskedText.process_bind_param が VARCHAR ストレージに到達する前に
+            # この文字列からシークレットを伏字化する — room §確定 G 実適用。
             "prompt_kit_prefix_markdown": room.prompt_kit.prefix_markdown,
             "archived": room.archived,
         }
@@ -181,20 +178,20 @@ class SqliteRoomRepository:
         room_row: RoomRow,
         member_rows: list[RoomMemberRow],
     ) -> Room:
-        """Hydrate a :class:`Room` Aggregate Root from its two row types.
+        """2 つの行型から :class:`Room` Aggregate Root を水和する。
 
-        ``Room.model_validate`` re-runs the post-validator so Repository-side
-        hydration goes through the same invariant checks that
-        ``RoomService.establish_room()`` does at construction time.
+        ``Room.model_validate`` は post-validator を再実行するため、リポジトリ側の
+        水和も ``RoomService.establish_room()`` が構築時に走らせるのと同じ不変条件
+        チェックを通る。
 
-        §確定 R1-J §不可逆性: ``prompt_kit.prefix_markdown`` carries the
-        already-masked text from disk. ``PromptKit`` accepts any string within
-        the length cap so the masked form constructs cleanly, but the resulting
-        Room should not be dispatched to an LLM without
-        ``feature/llm-adapter``'s masked-prompt guard.
+        §確定 R1-J §不可逆性: ``prompt_kit.prefix_markdown`` はディスクから既に
+        伏字化されたテキストを保持する。``PromptKit`` は長さ上限内の任意の文字列を
+        受理するため伏字化された形でも構築は通るが、生成された Room は
+        ``feature/llm-adapter`` の masked-prompt ガード無しに LLM へディスパッチ
+        すべきではない。
 
-        ``empire_id`` is **not** restored onto :class:`Room` — the Aggregate
-        holds no ``empire_id`` attribute (§確定 R1-H).
+        ``empire_id`` は :class:`Room` 上に **復元しない** — Aggregate には
+        ``empire_id`` 属性が無い（§確定 R1-H）。
         """
         members = [
             AgentMembership(

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/repositories/task_repository.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/repositories/task_repository.py
@@ -1,48 +1,44 @@
-"""SQLite adapter for :class:`bakufu.application.ports.TaskRepository`.
+""":class:`bakufu.application.ports.TaskRepository` の SQLite アダプタ。
 
-Implements the §確定 R1-B 6-step save flow over four tables
-(``tasks`` / ``task_assigned_agents`` / ``deliverables`` /
-``deliverable_attachments``):
+§確定 R1-B の 6 ステップ保存フローを 4 つのテーブル
+（``tasks`` / ``task_assigned_agents`` / ``deliverables`` /
+``deliverable_attachments``）に対して実装する:
 
-1. ``DELETE FROM deliverables WHERE task_id = :id`` — CASCADE removes
-   ``deliverable_attachments`` automatically.
-2. ``DELETE FROM task_assigned_agents WHERE task_id = :id`` — no CASCADE,
-   direct DELETE.
-3. ``tasks`` UPSERT (id-conflict → ``current_stage_id`` + ``status`` +
-   ``last_error`` + ``updated_at`` update; ``room_id``, ``directive_id``,
-   and ``created_at`` are intentionally **not** updated — Task ownership
-   and origin never change after creation).
-4. ``INSERT INTO task_assigned_agents`` — one row per AgentId with
-   ``order_index`` = list position (0-indexed).
-5. ``INSERT INTO deliverables`` — one row per Deliverable in
-   ``task.deliverables.values()``. A fresh ``uuid4()`` PK is generated for
-   each row on every save (DELETE-then-INSERT pattern guarantees no PK
-   collision).
-6. ``INSERT INTO deliverable_attachments`` — one row per Attachment per
-   Deliverable, linked via the ``deliverable_id`` FK generated in step 5.
+1. ``DELETE FROM deliverables WHERE task_id = :id`` — CASCADE で
+   ``deliverable_attachments`` も自動削除される。
+2. ``DELETE FROM task_assigned_agents WHERE task_id = :id`` — CASCADE 無し、直接 DELETE。
+3. ``tasks`` UPSERT（id 衝突時に ``current_stage_id`` + ``status`` + ``last_error``
+   + ``updated_at`` を更新。``room_id``、``directive_id``、``created_at`` は意図的に
+   **更新しない** — Task の所有権と起源は作成後に変化しない）。
+4. ``INSERT INTO task_assigned_agents`` — AgentId ごとに 1 行、``order_index`` は
+   リスト位置（0 始まり）。
+5. ``INSERT INTO deliverables`` — ``task.deliverables.values()`` の Deliverable
+   ごとに 1 行。保存ごとに各行で新しい ``uuid4()`` PK を生成する（DELETE-then-INSERT
+   パターンが PK 衝突しないことを保証する）。
+6. ``INSERT INTO deliverable_attachments`` — Deliverable ごとの Attachment 1 つに対し
+   1 行。step 5 で生成した ``deliverable_id`` FK でリンクされる。
 
-``conversations`` / ``conversation_messages`` tables are excluded from this
-flow (§BUG-TR-002 凍結済み): Task Aggregate currently has no
-``conversations`` attribute. These tables will be added in the future PR
-that introduces ``Task.conversations: list[Conversation]``.
+``conversations`` / ``conversation_messages`` テーブルはこのフローから除外
+（§BUG-TR-002 凍結済み）: Task Aggregate には現状 ``conversations`` 属性が無い。
+これらのテーブルは ``Task.conversations: list[Conversation]`` を導入する将来 PR
+で追加される。
 
-The repository **never** calls ``session.commit()`` / ``session.rollback()``:
-the caller-side service runs ``async with session.begin():`` so all 6 steps
-stay in one transaction (empire-repo §確定 B Tx 境界の責務分離).
+リポジトリは ``session.commit()`` / ``session.rollback()`` を **決して** 呼ばない。
+呼び元のサービスが ``async with session.begin():`` を実行することで、6 ステップ全てを
+1 トランザクションに収める（empire-repo §確定 B Tx 境界の責務分離）。
 
-``save(task)`` uses the **standard 1-argument pattern** (§確定 R1-F):
-:class:`Task` carries ``room_id`` and ``directive_id`` as own attributes,
-so the Repository reads them directly.
+``save(task)`` は **標準の 1 引数パターン**（§確定 R1-F）を使う:
+:class:`Task` は ``room_id`` と ``directive_id`` を自身の属性として保持するため、
+リポジトリはそれらを直接読む。
 
-``_to_rows`` / ``_from_rows`` are kept as private methods on the class so
-both conversion directions live next to each other and tests don't
-accidentally acquire a public conversion API to depend on (empire-repo
-§確定 C).
+``_to_rows`` / ``_from_rows`` はクラスのプライベートメソッドのまま保持し、双方向の
+変換が隣接して存在するようにする。これにより、テストが公開された変換 API を誤って
+取得して依存することを避ける（empire-repo §確定 C）。
 
-TypeDecorator-trust pattern (PR #48 v2 確立): :class:`UUIDStr` returns
-``UUID`` instances from ``process_result_value``, so ``row.id`` etc. are
-already ``UUID``. Direct attribute access without defensive ``UUID(row.id)``
-wrapping is correct and required (§確定 R1-A).
+TypeDecorator-trust パターン（PR #48 v2 で確立）: :class:`UUIDStr` は
+``process_result_value`` で ``UUID`` インスタンスを返すため、``row.id`` 等は
+すでに ``UUID`` である。防御的な ``UUID(row.id)`` ラッピング無しで属性を直接
+参照するのが正しく、必須である（§確定 R1-A）。
 """
 
 from __future__ import annotations
@@ -75,17 +71,16 @@ from bakufu.infrastructure.persistence.sqlite.tables.tasks import TaskRow
 
 
 class SqliteTaskRepository:
-    """SQLite implementation of :class:`TaskRepository`."""
+    """:class:`TaskRepository` の SQLite 実装。"""
 
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
 
     async def find_by_id(self, task_id: TaskId) -> Task | None:
-        """SELECT tasks row + 3 child tables, hydrate via :meth:`_from_rows`.
+        """tasks 行と 3 つの子テーブルを SELECT し、:meth:`_from_rows` で水和する。
 
-        Returns ``None`` when the tasks row is absent. On success, all three
-        child tables are queried with their §確定 R1-H ORDER BY clauses so
-        the hydrated Aggregate is deterministic.
+        tasks 行が存在しない場合は ``None`` を返す。成功時は §確定 R1-H の ORDER BY
+        句で 3 つの子テーブル全てを問い合わせるため、水和された Aggregate は決定的になる。
         """
         task_row = (
             await self._session.execute(select(TaskRow).where(TaskRow.id == task_id))
@@ -93,8 +88,8 @@ class SqliteTaskRepository:
         if task_row is None:
             return None
 
-        # §確定 R1-H: ORDER BY order_index ASC preserves assigned-agent list
-        # order from the Aggregate's ``assigned_agent_ids``.
+        # §確定 R1-H: ORDER BY order_index ASC により、Aggregate の
+        # ``assigned_agent_ids`` から得たアサイン エージェント リスト順を保つ。
         agent_rows = list(
             (
                 await self._session.execute(
@@ -107,7 +102,7 @@ class SqliteTaskRepository:
             .all()
         )
 
-        # §確定 R1-H: ORDER BY stage_id ASC (UNIQUE per task, deterministic).
+        # §確定 R1-H: ORDER BY stage_id ASC（task ごとに UNIQUE で決定的）。
         deliv_rows = list(
             (
                 await self._session.execute(
@@ -120,8 +115,8 @@ class SqliteTaskRepository:
             .all()
         )
 
-        # §確定 R1-H: fetch all attachments in one query, group by deliverable_id.
-        # ORDER BY sha256 ASC (UNIQUE per deliverable scope, deterministic).
+        # §確定 R1-H: 全 attachment を 1 クエリで取得し、deliverable_id でグルーピング。
+        # ORDER BY sha256 ASC（deliverable スコープで UNIQUE で決定的）。
         attach_rows_by_deliv: dict[UUID, list[DeliverableAttachmentRow]] = {}
         if deliv_rows:
             deliv_ids = [r.id for r in deliv_rows]
@@ -137,35 +132,34 @@ class SqliteTaskRepository:
         return self._from_rows(task_row, agent_rows, deliv_rows, attach_rows_by_deliv)
 
     async def count(self) -> int:
-        """``SELECT COUNT(*) FROM tasks``.
+        """``SELECT COUNT(*) FROM tasks``。
 
-        SQLAlchemy's ``func.count()`` issues a proper ``SELECT COUNT(*)``
-        so SQLite returns one scalar row instead of streaming every PK back
-        to Python (empire-repo §確定 D 踏襲).
+        SQLAlchemy の ``func.count()`` は適切な ``SELECT COUNT(*)`` を発行するため、
+        SQLite は全 PK を Python にストリームせずスカラー 1 行だけ返す
+        （empire-repo §確定 D 踏襲）。
         """
         return (await self._session.execute(select(func.count()).select_from(TaskRow))).scalar_one()
 
     async def save(self, task: Task) -> None:
-        """Persist ``task`` via the §確定 R1-B 6-step delete-then-insert.
+        """§確定 R1-B の 6 ステップ delete-then-insert で ``task`` を永続化する。
 
-        The caller is responsible for the surrounding
-        ``async with session.begin():`` block; failures propagate untouched
-        so the Unit-of-Work boundary in the application service can rollback
-        cleanly (empire-repo §確定 B 踏襲).
+        外側の ``async with session.begin():`` ブロックは呼び元の責任。失敗はそのまま
+        伝播するため、アプリケーション サービスの Unit-of-Work 境界はクリーンに
+        ロールバックできる（empire-repo §確定 B 踏襲）。
         """
         task_row, agent_rows, deliv_rows, attach_rows = self._to_rows(task)
 
-        # Step 1: DELETE deliverables — CASCADE removes deliverable_attachments.
+        # Step 1: DELETE deliverables — CASCADE で deliverable_attachments も削除。
         await self._session.execute(delete(DeliverableRow).where(DeliverableRow.task_id == task.id))
 
-        # Step 2: DELETE task_assigned_agents (no CASCADE, direct DELETE).
+        # Step 2: DELETE task_assigned_agents（CASCADE 無し、直接 DELETE）。
         await self._session.execute(
             delete(TaskAssignedAgentRow).where(TaskAssignedAgentRow.task_id == task.id)
         )
 
-        # Step 3: tasks UPSERT.
-        # room_id / directive_id / created_at are excluded from DO UPDATE —
-        # Task ownership and origin are immutable after creation.
+        # Step 3: tasks UPSERT。
+        # room_id / directive_id / created_at は DO UPDATE から除外 — Task の所有権と
+        # 起源は作成後に不変。
         upsert_stmt = sqlite_insert(TaskRow).values(task_row)
         upsert_stmt = upsert_stmt.on_conflict_do_update(
             index_elements=["id"],
@@ -178,24 +172,24 @@ class SqliteTaskRepository:
         )
         await self._session.execute(upsert_stmt)
 
-        # Step 4: INSERT task_assigned_agents.
+        # Step 4: INSERT task_assigned_agents。
         if agent_rows:
             await self._session.execute(insert(TaskAssignedAgentRow), agent_rows)
 
-        # Step 5: INSERT deliverables.
+        # Step 5: INSERT deliverables。
         if deliv_rows:
             await self._session.execute(insert(DeliverableRow), deliv_rows)
 
-        # Step 6: INSERT deliverable_attachments.
+        # Step 6: INSERT deliverable_attachments。
         if attach_rows:
             await self._session.execute(insert(DeliverableAttachmentRow), attach_rows)
 
     async def count_by_status(self, status: TaskStatus) -> int:
-        """``SELECT COUNT(*) FROM tasks WHERE status = :status``.
+        """``SELECT COUNT(*) FROM tasks WHERE status = :status``。
 
-        The composite INDEX ``ix_tasks_status_updated_id`` prefix on
-        ``(status)`` accelerates this WHERE filter (§確定 R1-K).
-        Returns 0 when no Tasks exist with the given status.
+        複合 INDEX ``ix_tasks_status_updated_id`` の ``(status)`` プレフィックスが
+        この WHERE フィルタを高速化する（§確定 R1-K）。指定 status の Task が
+        存在しない場合は 0 を返す。
         """
         return (
             await self._session.execute(
@@ -204,10 +198,10 @@ class SqliteTaskRepository:
         ).scalar_one()
 
     async def count_by_room(self, room_id: RoomId) -> int:
-        """``SELECT COUNT(*) FROM tasks WHERE room_id = :room_id``.
+        """``SELECT COUNT(*) FROM tasks WHERE room_id = :room_id``。
 
-        The INDEX ``ix_tasks_room_id`` accelerates this WHERE filter
-        (§確定 R1-K). Returns 0 when no Tasks exist for the given Room.
+        INDEX ``ix_tasks_room_id`` がこの WHERE フィルタを高速化する（§確定 R1-K）。
+        指定 Room の Task が存在しない場合は 0 を返す。
         """
         return (
             await self._session.execute(
@@ -216,15 +210,14 @@ class SqliteTaskRepository:
         ).scalar_one()
 
     async def find_blocked(self) -> list[Task]:
-        """Return all BLOCKED Tasks ordered by ``updated_at DESC, id DESC``.
+        """``updated_at DESC, id DESC`` 順で全 BLOCKED Task を返す。
 
-        The composite INDEX ``ix_tasks_status_updated_id`` on
-        ``(status, updated_at, id)`` covers both the WHERE filter and the
-        ORDER BY in a single B-tree scan (§確定 R1-K). For each BLOCKED
-        TaskRow, child tables are fetched individually — the same pattern
-        as :meth:`find_by_id`.
+        ``(status, updated_at, id)`` 上の複合 INDEX ``ix_tasks_status_updated_id``
+        は WHERE フィルタと ORDER BY の両方を 1 回の B-tree スキャンでカバーする
+        （§確定 R1-K）。各 BLOCKED TaskRow について子テーブルを個別に取得する —
+        :meth:`find_by_id` と同じパターン。
 
-        Returns ``[]`` when no BLOCKED Tasks exist.
+        BLOCKED Task が存在しない場合は ``[]`` を返す。
         """
         task_rows = list(
             (
@@ -258,28 +251,25 @@ class SqliteTaskRepository:
         list[dict[str, Any]],
         list[dict[str, Any]],
     ]:
-        """Convert ``task`` to ``(task_row, agent_rows, deliv_rows, attach_rows)``.
+        """``task`` を ``(task_row, agent_rows, deliv_rows, attach_rows)`` に変換する。
 
-        SQLAlchemy ``Row`` objects are avoided so the domain layer never
-        gains an accidental dependency on the SQLAlchemy type hierarchy.
+        ドメイン層が SQLAlchemy の型階層に偶発的に依存しないよう、SQLAlchemy ``Row``
+        オブジェクトは使わない。
 
-        TypeDecorator-trust (§確定 R1-A): raw domain values are passed
-        directly; ``UUIDStr`` / ``MaskedText`` / ``UTCDateTime``
-        TypeDecorators perform all conversions at bind-parameter time.
-        ``last_error`` and ``body_markdown`` are passed as plain strings —
-        ``MaskedText.process_bind_param`` applies the masking gate
-        automatically without manual ``MaskingGateway.mask()`` calls.
+        TypeDecorator-trust（§確定 R1-A）: 生のドメイン値を直接渡す。``UUIDStr`` /
+        ``MaskedText`` / ``UTCDateTime`` の TypeDecorator がバインド パラメータ時点で
+        全ての変換を行う。``last_error`` と ``body_markdown`` は素の文字列として渡す
+        — ``MaskedText.process_bind_param`` が手動の ``MaskingGateway.mask()`` 呼び
+        出し無しに自動的にマスキング ゲートを適用する。
 
-        Deliverable PKs: ``deliverables.id`` has no domain-level identity
-        (the Aggregate identifies Deliverables by ``stage_id``). A fresh
-        ``uuid4()`` is generated for each deliverable row on every save.
-        Because steps 1→5 are DELETE-then-INSERT, there is never a PK
-        collision. The same fresh UUID is used as ``deliverable_id`` in the
-        corresponding attachment rows built in the same call.
+        Deliverable の PK: ``deliverables.id`` はドメインレベルのアイデンティティを
+        持たない（Aggregate は Deliverable を ``stage_id`` で識別する）。保存ごとに
+        各 deliverable 行で新しい ``uuid4()`` を生成する。step 1→5 が
+        DELETE-then-INSERT のため PK 衝突は起きない。同じ呼び出しで構築される対応する
+        attachment 行の ``deliverable_id`` には同じ新規 UUID が使われる。
 
-        ``conversations`` / ``conversation_messages`` rows are excluded
-        (§BUG-TR-002 凍結済み): Task domain currently has no ``conversations``
-        attribute.
+        ``conversations`` / ``conversation_messages`` 行は除外（§BUG-TR-002 凍結済み）:
+        Task ドメインには現状 ``conversations`` 属性が無い。
         """
         task_row: dict[str, Any] = {
             "id": task.id,
@@ -287,7 +277,7 @@ class SqliteTaskRepository:
             "directive_id": task.directive_id,
             "current_stage_id": task.current_stage_id,
             "status": task.status.value,
-            # MaskedText.process_bind_param redacts secrets at bind time.
+            # MaskedText.process_bind_param がバインド時にシークレットを伏字化する。
             "last_error": task.last_error,
             "created_at": task.created_at,
             "updated_at": task.updated_at,
@@ -306,16 +296,16 @@ class SqliteTaskRepository:
         attach_rows: list[dict[str, Any]] = []
 
         for deliverable in task.deliverables.values():
-            # Fresh UUID for this deliverable's PK.  The same UUID is
-            # used below as ``deliverable_id`` in all attachment rows for
-            # this deliverable — linking them within this save() call.
+            # 当該 deliverable の PK 用に新規 UUID を生成。同じ UUID をこの deliverable
+            # に属する全 attachment 行の ``deliverable_id`` に再利用する — この save()
+            # 呼び出し内でリンクを成立させる。
             deliv_pk = _uuid.uuid4()
             deliv_rows.append(
                 {
                     "id": deliv_pk,
                     "task_id": task.id,
                     "stage_id": deliverable.stage_id,
-                    # MaskedText.process_bind_param redacts secrets at bind time.
+                    # MaskedText.process_bind_param がバインド時にシークレットを伏字化する。
                     "body_markdown": deliverable.body_markdown,
                     "committed_by": deliverable.committed_by,
                     "committed_at": deliverable.committed_at,
@@ -342,30 +332,28 @@ class SqliteTaskRepository:
         deliv_rows: list[DeliverableRow],
         attach_rows_by_deliv: dict[UUID, list[DeliverableAttachmentRow]],
     ) -> Task:
-        """Hydrate a :class:`Task` Aggregate Root from its row types.
+        """行型から :class:`Task` Aggregate Root を水和する。
 
-        ``Task.model_validate`` / direct construction re-runs the
-        post-validator so Repository-side hydration goes through the same
-        invariant checks that ``TaskService.create()`` does at construction
-        time (empire §確定 C contract: "Repository hydration produces a valid
-        Task or raises").
+        ``Task.model_validate`` / 直接構築は post-validator を再実行するため、リポジトリ
+        側の水和も ``TaskService.create()`` が構築時に走らせるのと同じ不変条件チェック
+        を通る（empire §確定 C コントラクト「リポジトリ水和は妥当な Task を生成するか
+        例外を送出する」）。
 
-        TypeDecorator-trust (§確定 R1-A): ``UUIDStr`` returns ``UUID``
-        instances from ``process_result_value``; ``UTCDateTime`` returns
-        tz-aware ``datetime``; ``MaskedText`` returns the already-masked
-        string. No defensive wrapping (e.g. ``UUID(row.id)``) needed.
+        TypeDecorator-trust（§確定 R1-A）: ``UUIDStr`` は ``process_result_value`` で
+        ``UUID`` インスタンスを返し、``UTCDateTime`` は tz-aware ``datetime`` を返し、
+        ``MaskedText`` は伏字化済みの文字列を返す。``UUID(row.id)`` のような防御的
+        ラッピングは不要。
 
-        §確定 R1-J §不可逆性: ``last_error`` and deliverable
-        ``body_markdown`` carry the already-masked text from disk. Both
-        fields accept any string within the length cap so the masked form
-        constructs cleanly; LLM-facing dispatch must apply its own
-        masked-prompt guard (``feature/llm-adapter`` scope).
+        §確定 R1-J §不可逆性: ``last_error`` と deliverable の ``body_markdown`` は
+        ディスクから既に伏字化されたテキストを保持する。両フィールドは長さ上限内の
+        任意の文字列を受理するため伏字化された形でも構築は通る。LLM へのディスパッチ
+        は独自の masked-prompt ガードを適用する必要がある（``feature/llm-adapter`` 範囲）。
         """
-        # §確定 R1-H: agent_rows already sorted order_index ASC by the caller.
+        # §確定 R1-H: agent_rows は呼び元側で order_index ASC でソート済み。
         assigned_agent_ids = [row.agent_id for row in agent_rows]
 
-        # §確定 R1-J: reconstruct deliverables dict keyed by StageId.
-        # deliv_rows already sorted stage_id ASC by the caller.
+        # §確定 R1-J: StageId をキーとした deliverables 辞書を再構築する。
+        # deliv_rows は呼び元側で stage_id ASC でソート済み。
         deliverables: dict[StageId, Deliverable] = {}
         for deliv_row in deliv_rows:
             stage_id: StageId = deliv_row.stage_id

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/repositories/workflow_repository.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/repositories/workflow_repository.py
@@ -1,51 +1,47 @@
-"""SQLite adapter for :class:`bakufu.application.ports.WorkflowRepository`.
+""":class:`bakufu.application.ports.WorkflowRepository` の SQLite アダプタ。
 
-Implements the §確定 B "delete-then-insert" save flow over three
-tables (``workflows`` / ``workflow_stages`` / ``workflow_transitions``):
+§確定 B の "delete-then-insert" 保存フローを 3 つのテーブル
+（``workflows`` / ``workflow_stages`` / ``workflow_transitions``）に対して実装する:
 
-1. ``workflows`` UPSERT (id-conflict → name + entry_stage_id update)
+1. ``workflows`` UPSERT（id 衝突時に name + entry_stage_id を更新）
 2. ``workflow_stages`` DELETE WHERE workflow_id = ?
-3. ``workflow_stages`` bulk INSERT (one row per Stage; ``notify_channels_json``
-   binds through :class:`MaskedJSONEncoded` so Discord webhook tokens are
-   redacted *before* the JSON hits disk — Schneier 申し送り #6 multilayer
-   defense, applied to the Workflow path here).
+3. ``workflow_stages`` 一括 INSERT（Stage ごとに 1 行。``notify_channels_json`` は
+   :class:`MaskedJSONEncoded` 経由でバインドされるため、Discord の Webhook トークンは
+   JSON が ディスクに到達する *前* に伏字化される — Schneier 申し送り #6 多層防御を
+   Workflow 経路にも適用）。
 4. ``workflow_transitions`` DELETE WHERE workflow_id = ?
-5. ``workflow_transitions`` bulk INSERT (one row per Transition).
+5. ``workflow_transitions`` 一括 INSERT（Transition ごとに 1 行）。
 
-The repository **never** calls ``session.commit()`` /
-``session.rollback()``: the caller-side service runs
-``async with session.begin():`` so the five steps above stay in one
-transaction (§確定 B Tx 境界の責務分離). Same Unit-of-Work pattern as
-:class:`SqliteEmpireRepository`.
+リポジトリは ``session.commit()`` / ``session.rollback()`` を **決して** 呼ばない。
+呼び元のサービスが ``async with session.begin():`` を実行することで、上記 5 ステップ
+を 1 トランザクションに収める（§確定 B Tx 境界の責務分離）。
+:class:`SqliteEmpireRepository` と同じ Unit-of-Work パターン。
 
-``_to_row`` / ``_from_row`` are kept as private methods on the class
-so both directions live next to each other and tests don't accidentally
-acquire a public conversion API to depend on (§確定 C). The two
-helpers also encapsulate the four format choices frozen in §確定 G〜J:
+``_to_row`` / ``_from_row`` はクラスのプライベートメソッドのまま保持し、双方向の
+変換が隣接して存在するようにする。これにより、テストが公開された変換 API を誤って
+取得して依存することを避ける（§確定 C）。2 つのヘルパは §確定 G〜J で凍結された
+4 つのフォーマット選択もカプセル化する:
 
-* ``roles_csv`` — sorted-CSV serialization of ``frozenset[Role]``
-  (§確定 G). Sorting is **mandatory** so frozenset's
-  implementation-dependent iteration order does not produce
-  delete-then-insert diff noise across runs.
-* ``notify_channels_json`` — :class:`MaskedJSONEncoded` (§確定 H). The
-  underlying TypeDecorator does the masking; ``_to_row`` only feeds
-  it ``list[dict]`` produced by ``NotifyChannel.model_dump(mode='json')``
-  (which itself masks through the VO's ``when_used='json'`` serializer
-  — defense-in-depth).
-* ``completion_policy_json`` — plain :class:`JSONEncoded` (§確定 I).
-  CompletionPolicy carries no Schneier #6 secret category, so
-  ``MaskedJSONEncoded`` would be over-masking; the CI Layer 2 arch
-  test pins the un-masked TypeDecorator.
-* ``workflows.entry_stage_id`` — no DB-level FK (§確定 J); Aggregate
-  invariant ``_validate_entry_in_stages`` guards it.
+* ``roles_csv`` — ``frozenset[Role]`` のソート CSV シリアライズ（§確定 G）。
+  ソートは **必須**。frozenset の実装依存な反復順により、実行ごとに
+  delete-then-insert の差分ノイズが発生するのを防ぐ。
+* ``notify_channels_json`` — :class:`MaskedJSONEncoded`（§確定 H）。基底の
+  TypeDecorator が伏字化を行う。``_to_row`` は ``NotifyChannel.model_dump(mode='json')``
+  が生成した ``list[dict]`` を渡すだけ（VO の ``when_used='json'`` シリアライザ
+  自体も伏字化を行う — 多層防御）。
+* ``completion_policy_json`` — 通常の :class:`JSONEncoded`（§確定 I）。
+  CompletionPolicy は Schneier #6 のシークレット カテゴリを持たないため、
+  ``MaskedJSONEncoded`` だと過剰マスキングになる。CI の Layer 2 アーキテクチャ
+  テストが非マスキング TypeDecorator を固定する。
+* ``workflows.entry_stage_id`` — DB レベルの FK は持たない（§確定 J）。
+  Aggregate 不変条件 ``_validate_entry_in_stages`` が責任を持つ。
 
-``_from_row`` runs ``Workflow.model_validate(...)`` so the same
-invariants the application layer enforces at construction time fire
-on rehydration too. ``find_by_id`` may therefore raise
-``pydantic.ValidationError`` when a saved Workflow contained
-``EXTERNAL_REVIEW`` stages whose notify URLs were masked at save time
-(§確定 H §不可逆性): the application layer catches and surfaces a
-"webhook re-registration required" error to the operator.
+``_from_row`` は ``Workflow.model_validate(...)`` を実行する。これにより、
+アプリケーション層が構築時に強制する不変条件と同じものが、再水和（rehydration）時
+にも発火する。したがって ``find_by_id`` は、保存時に Notify URL が伏字化された
+``EXTERNAL_REVIEW`` ステージを含む Workflow を読み込んだ際に ``pydantic.ValidationError``
+を送出する可能性がある（§確定 H §不可逆性）。アプリケーション層がこれを捕捉し、
+オペレータに「Webhook の再登録が必要」エラーとして表面化する。
 """
 
 from __future__ import annotations
@@ -76,31 +72,29 @@ from bakufu.infrastructure.persistence.sqlite.tables.workflows import WorkflowRo
 
 
 class SqliteWorkflowRepository:
-    """SQLite implementation of :class:`WorkflowRepository`."""
+    """:class:`WorkflowRepository` の SQLite 実装。"""
 
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
 
     async def find_by_id(self, workflow_id: WorkflowId) -> Workflow | None:
-        """SELECT workflow + side tables, hydrate via :meth:`_from_row`.
+        """workflow と関連テーブルを SELECT し、:meth:`_from_row` で水和する。
 
-        Returns ``None`` when the workflows row is absent. Side-table
-        SELECTs use ``ORDER BY stage_id`` / ``ORDER BY transition_id``
-        so the hydrated lists are deterministic — empire-repository
-        BUG-EMR-001 froze this contract; we apply it from PR #1 here.
+        workflows 行が存在しない場合は ``None`` を返す。関連テーブルの SELECT は
+        ``ORDER BY stage_id`` / ``ORDER BY transition_id`` を使い、水和されたリスト
+        が決定的になるようにする — empire-repository BUG-EMR-001 が凍結したコントラクト
+        を本 PR の最初から適用する。
         """
         workflow_stmt = select(WorkflowRow).where(WorkflowRow.id == workflow_id)
         workflow_row = (await self._session.execute(workflow_stmt)).scalar_one_or_none()
         if workflow_row is None:
             return None
 
-        # ORDER BY makes find_by_id deterministic. Without it SQLite
-        # returns rows in internal-scan order, which would break
-        # ``Workflow == Workflow`` round-trip equality (the Aggregate
-        # compares list-by-list). See basic-design §ユースケース 2 +
-        # docs/features/empire-repository/detailed-design.md §Known
-        # Issues §BUG-EMR-001 — this PR adopts the resolved contract
-        # from day one.
+        # ORDER BY を付与することで find_by_id を決定的にする。これがないと SQLite は
+        # 内部スキャン順で行を返し、``Workflow == Workflow`` の往復等価性が壊れる
+        # （Aggregate はリスト同士で比較する）。basic-design §ユースケース 2 と
+        # docs/features/empire-repository/detailed-design.md §Known Issues §BUG-EMR-001
+        # 参照 — 本 PR では当初から決定の済んだコントラクトを採用する。
         stage_stmt = (
             select(WorkflowStageRow)
             .where(WorkflowStageRow.workflow_id == workflow_id)
@@ -118,31 +112,29 @@ class SqliteWorkflowRepository:
         return self._from_row(workflow_row, stage_rows, transition_rows)
 
     async def count(self) -> int:
-        """``SELECT COUNT(*) FROM workflows``.
+        """``SELECT COUNT(*) FROM workflows``。
 
-        Implementation detail: SQLAlchemy's ``func.count()`` issues a
-        proper ``SELECT COUNT(*)`` so SQLite returns one scalar row
-        instead of streaming every PK back to Python. This is the
-        empire-repository §確定 D 補強 contract continued — Stage /
-        Transition / Workflow tables can hold hundreds of rows
-        once preset libraries land, so the pattern matters.
+        実装詳細: SQLAlchemy の ``func.count()`` は適切な ``SELECT COUNT(*)`` を
+        発行するため、SQLite は全 PK を Python にストリームせずスカラー 1 行だけ
+        返す。これは empire-repository §確定 D 補強コントラクトの継続である —
+        Stage / Transition / Workflow テーブルはプリセット ライブラリが入ると
+        数百行を保持し得るため、このパターンが効いてくる。
         """
         stmt = select(func.count()).select_from(WorkflowRow)
         return (await self._session.execute(stmt)).scalar_one()
 
     async def save(self, workflow: Workflow) -> None:
-        """Persist ``workflow`` via the §確定 B five-step delete-then-insert.
+        """§確定 B の 5 ステップ delete-then-insert で ``workflow`` を永続化する。
 
-        The caller is responsible for the surrounding
-        ``async with session.begin():`` block; failures inside any
-        step propagate untouched so the Unit-of-Work boundary in the
-        application service can rollback cleanly.
+        外側の ``async with session.begin():`` ブロックは呼び元の責任。各ステップ
+        内部の失敗はそのまま伝播するため、アプリケーション サービスの Unit-of-Work
+        境界はクリーンにロールバックできる。
         """
         workflow_row, stage_rows, transition_rows = self._to_row(workflow)
 
-        # Step 1: workflows UPSERT (id PK, ON CONFLICT update name +
-        # entry_stage_id). entry_stage_id can change when the
-        # operator inserts a new entry stage at the head of the DAG.
+        # Step 1: workflows UPSERT（id PK、ON CONFLICT で name + entry_stage_id を更新）。
+        # entry_stage_id は、オペレータが DAG の先頭に新しい entry stage を挿入する
+        # 際に変化し得る。
         upsert_stmt = sqlite_insert(WorkflowRow).values(workflow_row)
         upsert_stmt = upsert_stmt.on_conflict_do_update(
             index_elements=["id"],
@@ -153,25 +145,24 @@ class SqliteWorkflowRepository:
         )
         await self._session.execute(upsert_stmt)
 
-        # Step 2: workflow_stages DELETE.
+        # Step 2: workflow_stages DELETE。
         await self._session.execute(
             delete(WorkflowStageRow).where(WorkflowStageRow.workflow_id == workflow.id)
         )
 
-        # Step 3: workflow_stages bulk INSERT (skip when no stages —
-        # though Workflow's capacity validator forbids zero-length
-        # stages, defensive empty-skip keeps the behavior consistent
-        # with the Empire template).
+        # Step 3: workflow_stages 一括 INSERT（stages が無い場合はスキップ —
+        # Workflow のキャパシティ バリデータは長さ 0 を禁止しているが、空チェックは
+        # Empire テンプレートとの動作整合のために残す）。
         if stage_rows:
             await self._session.execute(insert(WorkflowStageRow), stage_rows)
 
-        # Step 4: workflow_transitions DELETE.
+        # Step 4: workflow_transitions DELETE。
         await self._session.execute(
             delete(WorkflowTransitionRow).where(WorkflowTransitionRow.workflow_id == workflow.id)
         )
 
-        # Step 5: workflow_transitions bulk INSERT (skip when no
-        # transitions — a single-stage Workflow is valid).
+        # Step 5: workflow_transitions 一括 INSERT（transitions が無い場合はスキップ —
+        # 単一ステージの Workflow は有効）。
         if transition_rows:
             await self._session.execute(insert(WorkflowTransitionRow), transition_rows)
 
@@ -180,12 +171,11 @@ class SqliteWorkflowRepository:
         self,
         workflow: Workflow,
     ) -> tuple[dict[str, Any], list[dict[str, Any]], list[dict[str, Any]]]:
-        """Split ``workflow`` into ``(workflow_row, stage_rows, transition_rows)``.
+        """``workflow`` を ``(workflow_row, stage_rows, transition_rows)`` に分割する。
 
-        SQLAlchemy ``Row`` objects are intentionally avoided here so
-        the domain layer never gains an accidental dependency on the
-        SQLAlchemy type hierarchy. Each returned ``dict`` matches the
-        ``mapped_column`` names of the corresponding table verbatim.
+        ここでは SQLAlchemy の ``Row`` オブジェクトを意図的に使わない。これによって
+        ドメイン層が SQLAlchemy の型階層に偶発的に依存することを防ぐ。返却される
+        各 ``dict`` のキーは対応するテーブルの ``mapped_column`` 名と完全一致する。
         """
         workflow_row: dict[str, Any] = {
             "id": workflow.id,
@@ -198,20 +188,17 @@ class SqliteWorkflowRepository:
                 "stage_id": stage.id,
                 "name": stage.name,
                 "kind": stage.kind.value,
-                # §確定 G: sorted CSV. ``sorted(..., key=str)`` keeps
-                # the byte-equality contract no matter how Python
-                # frozenset chooses to iterate.
+                # §確定 G: ソート済み CSV。``sorted(..., key=str)`` により Python の
+                # frozenset がどんな順序で反復しようとバイト等価性のコントラクトを保つ。
                 "roles_csv": ",".join(sorted(role.value for role in stage.required_role)),
                 "deliverable_template": stage.deliverable_template,
-                # §確定 I: plain JSONEncoded. ``model_dump(mode='json')``
-                # returns ``{'kind': ..., 'description': ...}``.
+                # §確定 I: 通常の JSONEncoded。``model_dump(mode='json')`` は
+                # ``{'kind': ..., 'description': ...}`` を返す。
                 "completion_policy_json": stage.completion_policy.model_dump(mode="json"),
-                # §確定 H: list[dict] with masked targets. The column
-                # type :class:`MaskedJSONEncoded` re-runs ``mask_in``
-                # on the bound value so even a hypothetical raw URL
-                # leaking past ``when_used='json'`` would be redacted
-                # by the gateway before ``json.dumps`` (BUG-PF-001
-                # twin defense).
+                # §確定 H: 伏字化されたターゲットを含む list[dict]。カラム型
+                # :class:`MaskedJSONEncoded` がバインド値に対して再度 ``mask_in`` を
+                # 実行するため、仮に ``when_used='json'`` を素通りした生 URL があっても
+                # ``json.dumps`` の前にゲートウェイで伏字化される（BUG-PF-001 双子防御）。
                 "notify_channels_json": [
                     channel.model_dump(mode="json") for channel in stage.notify_channels
                 ],
@@ -237,15 +224,14 @@ class SqliteWorkflowRepository:
         stage_rows: list[WorkflowStageRow],
         transition_rows: list[WorkflowTransitionRow],
     ) -> Workflow:
-        """Hydrate a :class:`Workflow` Aggregate Root from its three rows.
+        """3 つの行から :class:`Workflow` Aggregate Root を水和する。
 
-        ``Workflow.model_validate`` re-runs the post-validator so
-        Repository-side hydration goes through the same invariant
-        checks the application service runs at construction time
-        (Empire §確定 C). Hydration of a Workflow whose
-        ``EXTERNAL_REVIEW`` stages had notify channels will raise
-        ``pydantic.ValidationError`` because the persisted target was
-        masked — that is the design contract per §確定 H §不可逆性.
+        ``Workflow.model_validate`` は post-validator を再実行するため、リポジトリ
+        側の水和もアプリケーション サービスが構築時に走らせるのと同じ不変条件
+        チェックを通る（Empire §確定 C）。``EXTERNAL_REVIEW`` ステージの notify
+        channels を持つ Workflow の水和は ``pydantic.ValidationError`` を送出する —
+        永続化されたターゲットが伏字化されているため。これは §確定 H §不可逆性
+        による設計上のコントラクト。
         """
         stages = [self._stage_from_row(row) for row in stage_rows]
         transitions = [self._transition_from_row(row) for row in transition_rows]
@@ -259,18 +245,17 @@ class SqliteWorkflowRepository:
 
     @staticmethod
     def _stage_from_row(row: WorkflowStageRow) -> Stage:
-        """Hydrate one ``Stage`` from its persisted row."""
-        # §確定 G: split CSV → set comprehension → frozenset. An empty
-        # ``required_role`` is impossible because the storage column
-        # is NOT NULL and Workflow capacity invariants reject it on
-        # save. If a malformed row sneaks past, ``Role(s)`` raises
-        # ``ValueError`` and the Aggregate's StageInvariantViolation
-        # path takes over downstream (Fail-Fast).
+        """永続化された行から ``Stage`` を 1 つ水和する。"""
+        # §確定 G: CSV を split → 集合内包 → frozenset。``required_role`` が空に
+        # なることはない（保存カラムが NOT NULL であり、Workflow キャパシティ
+        # 不変条件が保存時に拒否する）。万一壊れた行をすり抜けた場合、``Role(s)``
+        # が ``ValueError`` を送出し、Aggregate の StageInvariantViolation 経路が
+        # ダウンストリームで引き継ぐ（Fail-Fast）。
         roles = frozenset(Role(token) for token in row.roles_csv.split(","))
         completion_policy = CompletionPolicy.model_validate(row.completion_policy_json)
-        # §確定 H §不可逆性: NotifyChannel.model_validate may raise
-        # because the persisted ``target`` field was masked at save
-        # time. The exception escapes find_by_id deliberately.
+        # §確定 H §不可逆性: NotifyChannel.model_validate は、保存時に ``target``
+        # フィールドが伏字化されているため例外を送出することがある。例外が
+        # find_by_id から漏れ出るのは意図的。
         notify_payloads = cast(
             "list[dict[str, Any]]",
             row.notify_channels_json or [],
@@ -288,7 +273,7 @@ class SqliteWorkflowRepository:
 
     @staticmethod
     def _transition_from_row(row: WorkflowTransitionRow) -> Transition:
-        """Hydrate one ``Transition`` from its persisted row."""
+        """永続化された行から ``Transition`` を 1 つ水和する。"""
         return Transition(
             id=_uuid(row.transition_id),
             from_stage_id=_uuid(row.from_stage_id),
@@ -299,12 +284,11 @@ class SqliteWorkflowRepository:
 
 
 def _uuid(value: UUID | str) -> UUID:
-    """Coerce a row value to :class:`uuid.UUID`.
+    """行の値を :class:`uuid.UUID` に強制変換する。
 
-    SQLAlchemy's UUIDStr TypeDecorator already returns ``UUID``
-    instances on ``process_result_value``, but defensive coercion lets
-    raw-SQL hydration paths route through the same code without an
-    extra ``isinstance`` ladder at every call site.
+    SQLAlchemy の UUIDStr TypeDecorator は ``process_result_value`` で既に ``UUID``
+    インスタンスを返すが、防御的な強制変換により、raw SQL 経路の水和も同じコードを
+    通せる — 各呼び出し箇所で ``isinstance`` の階段を書かずに済む。
     """
     if isinstance(value, UUID):
         return value

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/session.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/session.py
@@ -1,11 +1,10 @@
-"""``async_sessionmaker`` factory (Unit-of-Work boundary).
+"""``async_sessionmaker`` ファクトリ（Unit-of-Work 境界）。
 
-Aggregate Repositories obtain an :class:`AsyncSession` from the
-factory created here; each ``async with session.begin():`` block
-encloses one Unit-of-Work. Sessions are configured for explicit
-flushing (``autoflush=False``) so listener-driven masking applies
-exactly once per row write — auto-flushing inside read queries would
-add ambiguity nobody wants.
+Aggregate リポジトリはここで作成されたファクトリから :class:`AsyncSession`
+を取得する。各 ``async with session.begin():`` ブロックが 1 Unit-of-Work を
+構成する。セッションは明示フラッシュ（``autoflush=False``）に設定する。
+これによりリスナ駆動のマスキングが行書き込みごとに正確に 1 回適用される —
+read クエリ内部で自動フラッシュすると誰も望まない曖昧さが生じる。
 """
 
 from __future__ import annotations
@@ -16,15 +15,15 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 def make_session_factory(
     engine: AsyncEngine,
 ) -> async_sessionmaker[AsyncSession]:
-    """Build the session factory for ``engine``.
+    """``engine`` 用のセッション ファクトリを構築する。
 
     Args:
-        engine: Application-level engine from
-            :func:`bakufu.infrastructure.persistence.sqlite.engine.create_engine`.
+        engine: :func:`bakufu.infrastructure.persistence.sqlite.engine.create_engine`
+            から得るアプリケーション レベルのエンジン。
 
-    The factory is async, ``expire_on_commit=False`` (so domain objects
-    survive across commit boundaries), and ``autoflush=False`` (so
-    masking listeners are predictable).
+    ファクトリは async で、``expire_on_commit=False``（コミット境界を跨いでも
+    ドメイン オブジェクトが生き続けるよう）、``autoflush=False``（マスキング
+    リスナが予測可能になるよう）。
     """
     return async_sessionmaker(
         engine,

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/tables/__init__.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/tables/__init__.py
@@ -1,121 +1,111 @@
-"""Cross-cutting + Aggregate-specific tables.
+"""横断的および Aggregate 固有のテーブル群。
 
-Cross-cutting (M2 persistence-foundation, PR #23):
+横断的（M2 persistence-foundation、PR #23）:
 
-* :mod:`...tables.audit_log` — Admin CLI audit trail (DELETE-rejecting).
-* :mod:`...tables.pid_registry` — bakufu_pid_registry (orphan-process GC).
-* :mod:`...tables.outbox` — domain_event_outbox (Outbox pattern).
+* :mod:`...tables.audit_log` — Admin CLI 監査証跡（DELETE 拒否）。
+* :mod:`...tables.pid_registry` — bakufu_pid_registry（オーファン プロセス GC）。
+* :mod:`...tables.outbox` — domain_event_outbox（Outbox パターン）。
 
-Empire Aggregate (PR #25):
+Empire Aggregate（PR #25）:
 
-* :mod:`...tables.empires` — Empire root row.
-* :mod:`...tables.empire_room_refs` — RoomRef collection.
-* :mod:`...tables.empire_agent_refs` — AgentRef collection.
+* :mod:`...tables.empires` — Empire ルート行。
+* :mod:`...tables.empire_room_refs` — RoomRef コレクション。
+* :mod:`...tables.empire_agent_refs` — AgentRef コレクション。
 
-Workflow Aggregate (PR #31):
+Workflow Aggregate（PR #31）:
 
-* :mod:`...tables.workflows` — Workflow root row (entry_stage_id has
-  no DB-level FK; the Aggregate invariant guards it instead).
-* :mod:`...tables.workflow_stages` — Stage child rows. The
-  ``notify_channels_json`` column is the **first** ``MaskedJSONEncoded``
-  column outside ``audit_log`` / ``domain_event_outbox`` and is
-  registered with the CI three-layer defense's *positive* contract.
-* :mod:`...tables.workflow_transitions` — Transition child rows
-  (no-mask).
+* :mod:`...tables.workflows` — Workflow ルート行（entry_stage_id は DB レベル
+  FK を持たず、Aggregate 不変条件が代わりにガードする）。
+* :mod:`...tables.workflow_stages` — Stage 子行。``notify_channels_json`` カラム
+  は ``audit_log`` / ``domain_event_outbox`` の外で **最初の** ``MaskedJSONEncoded``
+  カラムであり、CI 3 層防御の *positive* コントラクトに登録されている。
+* :mod:`...tables.workflow_transitions` — Transition 子行（マスク無し）。
 
-Agent Aggregate (PR #32):
+Agent Aggregate（PR #32）:
 
-* :mod:`...tables.agents` — Agent root row. The ``prompt_body``
-  column is the **first** ``MaskedText`` Repository application of
-  Schneier 申し送り #3 (PR #23 hook → PR #32 wire-up); the table is
-  registered with the CI three-layer defense's *partial-mask*
-  contract pinning exactly one masked column.
-* :mod:`...tables.agent_providers` — ProviderConfig child rows.
-  Carries a partial unique index ``WHERE is_default = 1`` for the
-  Defense-in-Depth "exactly one default provider per Agent" floor.
-* :mod:`...tables.agent_skills` — SkillRef child rows (no-mask).
+* :mod:`...tables.agents` — Agent ルート行。``prompt_body`` カラムは
+  Schneier 申し送り #3 を **最初に** リポジトリ適用した ``MaskedText``（PR #23
+  フック → PR #32 配線）。本テーブルは CI 3 層防御の *partial-mask* コントラクト
+  に登録され、マスク対象カラムを厳密に 1 つ固定する。
+* :mod:`...tables.agent_providers` — ProviderConfig 子行。
+  「Agent ごとに default プロバイダはちょうど 1 つ」の多層防御として
+  ``WHERE is_default = 1`` の部分一意インデックスを持つ。
+* :mod:`...tables.agent_skills` — SkillRef 子行（マスク無し）。
 
-Room Aggregate (PR #33):
+Room Aggregate（PR #33）:
 
-* :mod:`...tables.rooms` — Room root row. The
-  ``prompt_kit_prefix_markdown`` column is ``MaskedText`` (room
-  §確定 G 実適用); the table is registered with the CI three-layer
-  defense's *partial-mask* contract pinning exactly one masked column.
-  ``empire_room_refs.room_id → rooms.id`` FK is closed in Alembic
-  0005 (BUG-EMR-001 closure).
-* :mod:`...tables.room_members` — AgentMembership child rows (no-mask).
-  Composite PK + explicit ``UniqueConstraint`` for §確定 R1-D
-  Defense-in-Depth; ``agent_id`` intentionally has no FK onto
-  ``agents.id`` (application-layer responsibility).
+* :mod:`...tables.rooms` — Room ルート行。``prompt_kit_prefix_markdown`` カラムは
+  ``MaskedText``（room §確定 G 実適用）。本テーブルは CI 3 層防御の
+  *partial-mask* コントラクトに登録され、マスク対象カラムを厳密に 1 つ固定する。
+  ``empire_room_refs.room_id → rooms.id`` FK は Alembic 0005 で確定する
+  （BUG-EMR-001 closure）。
+* :mod:`...tables.room_members` — AgentMembership 子行（マスク無し）。
+  §確定 R1-D 多層防御のため複合 PK + 明示的 ``UniqueConstraint``。``agent_id`` は
+  意図的に ``agents.id`` への FK を持たない（アプリケーション層の責務）。
 
-Directive Aggregate (PR #34):
+Directive Aggregate（PR #34）:
 
-* :mod:`...tables.directives` — Directive root row. The ``text`` column
-  is ``MaskedText`` (§確定 R1-E 実適用); the table is registered with
-  the CI three-layer defense's *partial-mask* contract pinning exactly
-  one masked column. ``directives.task_id → tasks.id`` FK closed in
-  Alembic 0007 (BUG-DRR-001 closure).
+* :mod:`...tables.directives` — Directive ルート行。``text`` カラムは ``MaskedText``
+  （§確定 R1-E 実適用）。本テーブルは CI 3 層防御の *partial-mask* コントラクト
+  に登録され、マスク対象カラムを厳密に 1 つ固定する。
+  ``directives.task_id → tasks.id`` FK は Alembic 0007 で確定する
+  （BUG-DRR-001 closure）。
 
-Task Aggregate (PR #35):
+Task Aggregate（PR #35）:
 
-* :mod:`...tables.tasks` — Task root row. The ``last_error`` column is
-  ``MaskedText`` (§確定 R1-E 実適用); the table is registered with the
-  CI three-layer defense's *partial-mask* contract pinning exactly one
-  masked column. Two indexes: ``ix_tasks_room_id`` (single-column) and
-  ``ix_tasks_status_updated_id`` (composite, §確定 R1-K).
-* :mod:`...tables.task_assigned_agents` — AgentId list child rows.
-  Composite PK ``(task_id, agent_id)`` + explicit ``UniqueConstraint``
-  for Defense-in-Depth. ``agent_id`` intentionally has no FK onto
-  ``agents.id`` (§設計決定 TR-001).
-* :mod:`...tables.deliverables` — Deliverable child rows. ``body_markdown``
-  is ``MaskedText`` (§確定 R1-E 実適用); registered with CI three-layer
-  defense *partial-mask* contract. ``UNIQUE(task_id, stage_id)`` mirrors
-  the Aggregate's ``deliverables: dict[StageId, Deliverable]`` invariant.
-* :mod:`...tables.deliverable_attachments` — Attachment metadata child rows
-  (no-mask). Metadata only — physical file bytes are ``feature/attachment-
-  storage`` scope (§確定 R1-I).
+* :mod:`...tables.tasks` — Task ルート行。``last_error`` カラムは ``MaskedText``
+  （§確定 R1-E 実適用）。本テーブルは CI 3 層防御の *partial-mask* コントラクト
+  に登録され、マスク対象カラムを厳密に 1 つ固定する。インデックスは 2 つ:
+  ``ix_tasks_room_id``（単一カラム）と ``ix_tasks_status_updated_id``（複合、
+  §確定 R1-K）。
+* :mod:`...tables.task_assigned_agents` — AgentId リスト子行。
+  多層防御のため複合 PK ``(task_id, agent_id)`` + 明示的 ``UniqueConstraint``。
+  ``agent_id`` は意図的に ``agents.id`` への FK を持たない（§設計決定 TR-001）。
+* :mod:`...tables.deliverables` — Deliverable 子行。``body_markdown`` は
+  ``MaskedText``（§確定 R1-E 実適用）。CI 3 層防御の *partial-mask* コントラクト
+  に登録される。``UNIQUE(task_id, stage_id)`` は Aggregate の
+  ``deliverables: dict[StageId, Deliverable]`` 不変条件をミラーする。
+* :mod:`...tables.deliverable_attachments` — Attachment メタデータ子行（マスク
+  無し）。メタデータのみ — 物理ファイル バイトは ``feature/attachment-storage``
+  の範囲（§確定 R1-I）。
 
-ExternalReviewGate Aggregate (PR #36):
+ExternalReviewGate Aggregate（PR #36）:
 
-* :mod:`...tables.external_review_gates` — Gate root row. Two masked
-  columns: ``feedback_text`` (MaskedText, §設計決定 ERGR-002) and
-  ``snapshot_body_markdown`` (MaskedText, §確定 R1-E 実適用); both are
-  registered with the CI three-layer defense's *partial-mask* contract.
-  Three indexes (§確定 R1-K): ``ix_external_review_gates_task_id_created``
-  (composite), ``ix_external_review_gates_reviewer_decision`` (composite),
-  ``ix_external_review_gates_decision`` (single-column).
-* :mod:`...tables.external_review_gate_attachments` — snapshot Attachment
-  metadata child rows (no-mask). Business key ``UNIQUE(gate_id, sha256)``;
-  PK is save-internal (uuid4() regenerated on each save).
-* :mod:`...tables.external_review_audit_entries` — AuditEntry child rows.
-  ``comment`` is ``MaskedText`` (§確定 R1-E 実適用); registered with CI
-  three-layer defense *partial-mask* contract pinning exactly one masked
-  column. PK is domain-assigned (AuditEntry.id, not regenerated).
+* :mod:`...tables.external_review_gates` — Gate ルート行。マスク対象カラムは
+  2 つ: ``feedback_text``（MaskedText、§設計決定 ERGR-002）と
+  ``snapshot_body_markdown``（MaskedText、§確定 R1-E 実適用）。両者とも CI 3 層
+  防御の *partial-mask* コントラクトに登録される。インデックスは 3 つ
+  （§確定 R1-K）: ``ix_external_review_gates_task_id_created``（複合）、
+  ``ix_external_review_gates_reviewer_decision``（複合）、
+  ``ix_external_review_gates_decision``（単一カラム）。
+* :mod:`...tables.external_review_gate_attachments` — スナップショット Attachment
+  メタデータ子行（マスク無し）。ビジネス キー ``UNIQUE(gate_id, sha256)``。
+  PK は保存内部（save() ごとに uuid4() を再生成）。
+* :mod:`...tables.external_review_audit_entries` — AuditEntry 子行。``comment``
+  は ``MaskedText``（§確定 R1-E 実適用）。CI 3 層防御の *partial-mask* コントラクト
+  に登録され、マスク対象カラムを厳密に 1 つ固定する。PK はドメイン側で割り当てられた
+  値（AuditEntry.id、再生成しない）。
 
-Note: ``conversations`` / ``conversation_messages`` tables are excluded
-(§BUG-TR-002 凍結済み). They will be registered here when Task domain gains
-a ``conversations: list[Conversation]`` attribute.
+注意: ``conversations`` / ``conversation_messages`` テーブルは除外
+（§BUG-TR-002 凍結済み）。Task ドメインが ``conversations: list[Conversation]``
+属性を獲得した時点でここに登録される。
 
-Secret-bearing tables declare their columns with
-:class:`MaskedJSONEncoded` / :class:`MaskedText` TypeDecorators
-(defined in :mod:`bakufu.infrastructure.persistence.sqlite.base`) that
-route values through the masking gateway via
-``process_bind_param``. The TypeDecorators activate on bind-parameter
-resolution so Core ``insert(table).values(...)`` and ORM
-``Session.add()`` both fire — see
-``docs/features/persistence-foundation/requirements-analysis.md``
-§確定 R1-D for the technical rationale (旧 ``before_insert`` /
-``before_update`` event-listener approach was reverse-rejected after
-PR #23 BUG-PF-001 proved that listeners do not fire for Core
-``insert(table).values({...})``).
+シークレット保持テーブルは :class:`MaskedJSONEncoded` / :class:`MaskedText` の
+TypeDecorator（:mod:`bakufu.infrastructure.persistence.sqlite.base` で定義）で
+カラムを宣言する。これらの TypeDecorator は ``process_bind_param`` 経由で値を
+マスキング ゲートウェイに通す。バインド パラメータ解決時に発火するため、Core
+``insert(table).values(...)`` と ORM ``Session.add()`` の両方で発動する —
+技術的根拠は ``docs/features/persistence-foundation/requirements-analysis.md``
+§確定 R1-D を参照（旧 ``before_insert`` / ``before_update`` イベント リスナ
+方式は、PR #23 BUG-PF-001 でリスナが Core ``insert(table).values({...})`` で
+発火しないことが判明し reverse-rejected された）。
 
-Empire tables carry **no** secret-bearing columns; the explicit
-absence is registered with the CI three-layer defense
-(grep guard + arch test + storage.md §逆引き表) so a future PR cannot
-silently swap a column to a secret-bearing semantic. The Workflow
-``workflows`` / ``workflow_transitions`` tables follow the same
-no-mask pattern; only ``workflow_stages.notify_channels_json`` is
-secret-bearing on the Workflow side.
+Empire テーブルはシークレット保持カラムを **持たない**。明示的な不在は CI 3 層
+防御（grep ガード + アーキ テスト + storage.md §逆引き表）に登録され、将来の
+PR がカラムをサイレントにシークレット保持の意味へ置き換えることはできない。
+Workflow ``workflows`` / ``workflow_transitions`` テーブルは同じノー マスク
+パターンに従う。Workflow 側でシークレット保持なのは
+``workflow_stages.notify_channels_json`` のみ。
 """
 
 from __future__ import annotations

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/tables/agent_providers.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/tables/agent_providers.py
@@ -1,27 +1,23 @@
-"""``agent_providers`` table — Agent ↔ ProviderConfig child rows.
+"""``agent_providers`` テーブル — Agent ↔ ProviderConfig 子行。
 
-Stores :class:`bakufu.domain.agent.value_objects.ProviderConfig` values
-as a side table of the Agent aggregate. ``ON DELETE CASCADE`` purges
-provider rows when the parent Agent is deleted; UNIQUE(agent_id,
-provider_kind) mirrors the
-``_validate_provider_kind_unique`` aggregate invariant at the row
-level.
+:class:`bakufu.domain.agent.value_objects.ProviderConfig` の値を Agent Aggregate
+の関連テーブルとして保存する。``ON DELETE CASCADE`` は親 Agent 削除時に provider
+行を消去する。UNIQUE(agent_id, provider_kind) は ``_validate_provider_kind_unique``
+Aggregate 不変条件を行レベルでミラーする。
 
-The interesting constraint is the **partial unique index**
-``WHERE is_default = 1`` — see
-``docs/features/agent-repository/detailed-design.md`` §確定 G. This
-gives the "exactly one default provider per Agent" invariant a
-**Defense-in-Depth** floor: the Aggregate-level helper
-``_validate_default_provider_count`` already enforces it, but if a
-future PR introduces a corrupted SQL path (raw INSERT, hand-rolled
-migration) the DB still refuses to host two ``is_default=1`` rows on
-the same Agent. SQLite ships partial indexes natively
-(https://www.sqlite.org/partialindex.html); the same construct ports
-to PostgreSQL with identical syntax.
+興味深い制約は **部分一意インデックス** ``WHERE is_default = 1`` —
+``docs/features/agent-repository/detailed-design.md`` §確定 G を参照。これにより
+「Agent ごとに default プロバイダはちょうど 1 つ」不変条件に **多層防御** の基盤
+が与えられる: Aggregate レベルのヘルパ ``_validate_default_provider_count`` が
+既に強制しているが、将来の PR が破損 SQL 経路（raw INSERT、手書きマイグレーション）
+を導入しても、DB は同じ Agent 上で 2 つの ``is_default=1`` 行をホストすることを
+拒否し続ける。SQLite は部分インデックスを標準で提供する
+（https://www.sqlite.org/partialindex.html）。同じ構文は PostgreSQL にも完全に
+ポートできる。
 
-No ``Masked*`` TypeDecorator on any column. ``provider_kind`` is an
-enum string, ``model`` is an LLM model identifier with no secret
-semantics, and ``is_default`` is a boolean flag.
+どのカラムにも ``Masked*`` TypeDecorator は付けない。``provider_kind`` は enum
+文字列、``model`` はシークレット意味を持たない LLM モデル識別子、``is_default``
+は真偽フラグ。
 """
 
 from __future__ import annotations
@@ -35,7 +31,7 @@ from bakufu.infrastructure.persistence.sqlite.base import Base, UUIDStr
 
 
 class AgentProviderRow(Base):
-    """ORM mapping for the ``agent_providers`` table."""
+    """``agent_providers`` テーブルの ORM マッピング。"""
 
     __tablename__ = "agent_providers"
 
@@ -55,10 +51,10 @@ class AgentProviderRow(Base):
             "provider_kind",
             name="uq_agent_providers_pair",
         ),
-        # Partial unique index — at most one row per agent_id may have
-        # ``is_default = 1``. SQLite / PostgreSQL syntax is the same.
-        # detailed-design §確定 G: Defense-in-Depth alongside the
-        # Aggregate-level ``_validate_default_provider_count`` check.
+        # 部分一意インデックス — 1 つの agent_id に対し ``is_default = 1`` の行は
+        # 最大 1 つ。SQLite / PostgreSQL の構文は同一。詳細設計 §確定 G:
+        # Aggregate レベルの ``_validate_default_provider_count`` チェックと並ぶ
+        # 多層防御。
         Index(
             "uq_agent_providers_default",
             "agent_id",

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/tables/agent_skills.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/tables/agent_skills.py
@@ -1,22 +1,20 @@
-"""``agent_skills`` table — Agent ↔ SkillRef child rows.
+"""``agent_skills`` テーブル — Agent ↔ SkillRef 子行。
 
-Stores :class:`bakufu.domain.agent.value_objects.SkillRef` values as
-a side table of the Agent aggregate. ``ON DELETE CASCADE`` purges
-skill rows when the parent Agent is deleted; UNIQUE(agent_id,
-skill_id) mirrors the ``_validate_skill_id_unique`` aggregate
-invariant at the row level.
+:class:`bakufu.domain.agent.value_objects.SkillRef` の値を Agent Aggregate の
+関連テーブルとして保存する。``ON DELETE CASCADE`` は親 Agent 削除時に skill 行を
+消去する。UNIQUE(agent_id, skill_id) は ``_validate_skill_id_unique`` Aggregate
+不変条件を行レベルでミラーする。
 
-``path`` is stored as a plain ``String(500)`` — the H1〜H10
-traversal-defense pipeline runs at VO construction time
-(:func:`bakufu.domain.agent.path_validators._validate_skill_path`) so
-hydration through :meth:`SqliteAgentRepository.find_by_id` re-runs
-the validators automatically when ``SkillRef.model_validate`` is
-called inside ``_from_row``. The Repository never re-checks the
-contract directly.
+``path`` は通常の ``String(500)`` として保存する — H1〜H10 トラバーサル防御
+パイプラインは VO 構築時に走る
+（:func:`bakufu.domain.agent.path_validators._validate_skill_path`）ため、
+:meth:`SqliteAgentRepository.find_by_id` 経由の水和では ``_from_row`` 内部の
+``SkillRef.model_validate`` 呼び出しがバリデータを自動的に再実行する。
+リポジトリは直接コントラクトを再チェックすることはない。
 
-No ``Masked*`` TypeDecorator on any column. Skill names / paths /
-ids are operational metadata with no secret semantics; the CI
-three-layer defense's *no-mask* contract registers this table.
+どのカラムにも ``Masked*`` TypeDecorator は付けない。Skill 名 / パス / id は
+シークレット意味を持たない運用メタデータ。CI 3 層防御の *no-mask* コントラクト
+が本テーブルを登録する。
 """
 
 from __future__ import annotations
@@ -30,7 +28,7 @@ from bakufu.infrastructure.persistence.sqlite.base import Base, UUIDStr
 
 
 class AgentSkillRow(Base):
-    """ORM mapping for the ``agent_skills`` table."""
+    """``agent_skills`` テーブルの ORM マッピング。"""
 
     __tablename__ = "agent_skills"
 

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/tables/agents.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/tables/agents.py
@@ -1,40 +1,34 @@
-"""``agents`` table — Agent Aggregate root row.
+"""``agents`` テーブル — Agent Aggregate ルート行。
 
-Holds the eight scalar columns of the Agent aggregate. The two side
-collections (``providers`` / ``skills``) live in
-:mod:`...tables.agent_providers` / :mod:`...tables.agent_skills` so
-the row width stays bounded and CASCADE targets are obvious.
+Agent Aggregate の 8 個のスカラー カラムを保持する。2 つの関連コレクション
+（``providers`` / ``skills``）は :mod:`...tables.agent_providers` /
+:mod:`...tables.agent_skills` に置き、行幅を抑え CASCADE 対象を明確にする。
 
-``empire_id`` carries an ``ON DELETE CASCADE`` foreign key onto
-``empires.id`` — when an Empire is removed, its hired Agents go with
-it. The Agent aggregate root holds the matching ``empire_id`` field
-(see ``backend/src/bakufu/domain/agent/agent.py``) so
-``SqliteAgentRepository.save()`` can populate this column without
-asking the caller for it.
+``empire_id`` は ``empires.id`` への ``ON DELETE CASCADE`` 外部キーを持つ —
+Empire が削除されると雇用された Agent も一緒に削除される。Agent Aggregate ルート
+は対応する ``empire_id`` フィールドを保持する（``backend/src/bakufu/domain/agent/
+agent.py`` 参照）ため、``SqliteAgentRepository.save()`` は呼び元に問い合わせず
+このカラムを埋められる。
 
-``name`` is intentionally **not** declared UNIQUE at the DB level. The
-"name unique within an Empire" invariant is enforced by the
-application layer via :meth:`AgentRepository.find_by_name` (per
-``docs/features/agent-repository/detailed-design.md`` §設計判断補足
-"なぜ agents.name に DB UNIQUE を張らないか") so MSG-AG-NNN wording
-stays in the application layer's voice rather than being preempted by
-``IntegrityError``.
+``name`` は意図的に DB レベルで UNIQUE として **宣言しない**。「Empire 内で名前
+一意」の不変条件は :meth:`AgentRepository.find_by_name` 経由でアプリケーション層
+が強制する（``docs/features/agent-repository/detailed-design.md`` §設計判断補足
+「なぜ agents.name に DB UNIQUE を張らないか」を参照）。これにより、
+``IntegrityError`` に先取りされず、MSG-AG-NNN 文言がアプリケーション層の声で出る。
 
-Per-column secret-handling (§確定 H + Schneier 申し送り #3 实適用):
+カラム別シークレット ハンドリング（§確定 H + Schneier 申し送り #3 实適用）:
 
-* ``prompt_body`` is a :class:`MaskedText` column. ``MaskingGateway``
-  replaces API key / OAuth token / GitHub PAT etc. fragments with
-  ``<REDACTED:*>`` *before* the row hits SQLite, so neither raw SQL
-  inspection nor backups can leak a CEO-pasted secret. **The
-  irreversibility** of ``MaskingGateway`` means a round-trip through
-  :class:`SqliteAgentRepository.find_by_id` returns a Persona whose
-  ``prompt_body`` is the masked form (§確定 H 不可逆性凍結) —
-  ``feature/llm-adapter`` carries the responsibility of detecting
-  ``<REDACTED:*>`` markers before dispatching the prompt.
-* No other column on this table is masked. The CI three-layer
-  defense's *partial-mask* contract pins exactly one masked column
-  here so a future PR cannot silently widen the masking surface
-  (or inadvertently revert ``prompt_body`` to plain :class:`Text`).
+* ``prompt_body`` は :class:`MaskedText` カラム。``MaskingGateway`` が API キー /
+  OAuth トークン / GitHub PAT 等の断片を、行が SQLite に到達する *前* に
+  ``<REDACTED:*>`` に置換する。これにより raw SQL 検査やバックアップでも CEO が
+  貼り付けたシークレットが漏洩しない。``MaskingGateway`` の **不可逆性** により、
+  :class:`SqliteAgentRepository.find_by_id` 経由の往復は ``prompt_body`` が伏字化
+  された形の Persona を返す（§確定 H 不可逆性凍結） — プロンプト ディスパッチ前に
+  ``<REDACTED:*>`` マーカーを検出する責務は ``feature/llm-adapter`` に置かれる。
+* このテーブルの他カラムはマスクされない。CI 3 層防御の *partial-mask* コントラクト
+  はマスク カラム数を厳密に 1 つに固定するため、将来の PR がマスキング表面を
+  サイレントに広げる（あるいは ``prompt_body`` を素の :class:`Text` に戻す）こと
+  はできない。
 """
 
 from __future__ import annotations
@@ -52,7 +46,7 @@ from bakufu.infrastructure.persistence.sqlite.base import (
 
 
 class AgentRow(Base):
-    """ORM mapping for the ``agents`` table."""
+    """``agents`` テーブルの ORM マッピング。"""
 
     __tablename__ = "agents"
 

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/tables/audit_log.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/tables/audit_log.py
@@ -1,16 +1,15 @@
-"""``audit_log`` table (append-only Admin CLI audit trail).
+"""``audit_log`` テーブル（追記専用 Admin CLI 監査証跡）。
 
-The DDL-level append-only contract (DELETE rejected, UPDATE limited
-to NULL → value transitions on ``result`` / ``error_text``) is enforced
-by the SQLite triggers from the initial Alembic revision; see
-``alembic/versions/0001_init_audit_pid_outbox.py``. Secret-column
-masking is enforced via :class:`MaskedJSONEncoded` /
-:class:`MaskedText` TypeDecorators in
-:mod:`bakufu.infrastructure.persistence.sqlite.base`. Their
-``process_bind_param`` hooks fire for both ORM ``Session.add()`` and
-Core ``insert(table).values(...)`` paths (BUG-PF-001 fix; see
-``docs/features/persistence-foundation/requirements-analysis.md``
-§確定 R1-D for the design rationale).
+DDL レベルの追記専用コントラクト（DELETE は拒否、UPDATE は ``result`` /
+``error_text`` の NULL → 値遷移に限定）は最初の Alembic リビジョン由来の
+SQLite トリガで強制する。``alembic/versions/0001_init_audit_pid_outbox.py``
+を参照。シークレット カラムのマスキングは
+:mod:`bakufu.infrastructure.persistence.sqlite.base` の :class:`MaskedJSONEncoded` /
+:class:`MaskedText` TypeDecorator で強制する。それらの ``process_bind_param``
+フックは ORM ``Session.add()`` と Core ``insert(table).values(...)`` の両経路で
+発火する（BUG-PF-001 修正、設計根拠は
+``docs/features/persistence-foundation/requirements-analysis.md`` §確定 R1-D
+を参照）。
 """
 
 from __future__ import annotations
@@ -32,12 +31,12 @@ from bakufu.infrastructure.persistence.sqlite.base import (
 
 
 class AuditLogRow(Base):
-    """ORM mapping for the append-only ``audit_log`` table.
+    """追記専用 ``audit_log`` テーブルの ORM マッピング。
 
-    ``args_json`` and ``error_text`` use the ``Masked*`` column types
-    so every bind value passes through the masking gateway regardless
-    of whether the row arrives via ORM ``Session.add`` or Core
-    ``session.execute(insert(...).values(...))`` (BUG-PF-001 fix).
+    ``args_json`` と ``error_text`` は ``Masked*`` カラム型を使うため、行が ORM
+    ``Session.add`` 経由で到達するか Core
+    ``session.execute(insert(...).values(...))`` 経由で到達するかに関わらず、
+    全バインド値がマスキング ゲートウェイを通る（BUG-PF-001 修正）。
     """
 
     __tablename__ = "audit_log"

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/tables/deliverable_attachments.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/tables/deliverable_attachments.py
@@ -1,22 +1,20 @@
-"""``deliverable_attachments`` table — Attachment metadata for Deliverables.
+"""``deliverable_attachments`` テーブル — Deliverable 用 Attachment メタデータ。
 
-Each row represents one file attachment associated with a Deliverable. Only
-the metadata (sha256 hash, filename, MIME type, size) is stored here; the
-physical file bytes are managed by the separate ``feature/attachment-storage``
-feature (§確定 R1-I metadata-only scope).
+各行は Deliverable に紐づく 1 つのファイル添付を表す。ここに保存されるのは
+メタデータ（sha256 ハッシュ、ファイル名、MIME タイプ、サイズ）のみで、物理
+ファイル バイトは別の ``feature/attachment-storage`` 機能が管理する
+（§確定 R1-I メタデータのみの範囲）。
 
-``deliverable_id`` carries an ``ON DELETE CASCADE`` foreign key onto
-``deliverables.id`` — when a Deliverable is removed all its attachment
-metadata rows go with it.
+``deliverable_id`` は ``deliverables.id`` への ``ON DELETE CASCADE`` 外部キーを持つ
+— Deliverable が削除されると、その attachment メタデータ行も一緒に削除される。
 
-``UNIQUE(deliverable_id, sha256)`` prevents duplicate attachment entries for
-the same file content within a single Deliverable. The sha256 hex string also
-provides a deterministic ``ORDER BY sha256 ASC`` sort anchor so repository
-hydration reconstructs attachment lists in stable order (§確定 R1-H).
+``UNIQUE(deliverable_id, sha256)`` は単一 Deliverable 内で同じファイル コンテンツ
+の重複エントリを防ぐ。sha256 hex 文字列は決定的な ``ORDER BY sha256 ASC`` ソート
+アンカーも提供するため、リポジトリ水和は attachment リストを安定順で再構築する
+（§確定 R1-H）。
 
-All four metadata columns are validated by the domain-layer
-:class:`bakufu.domain.value_objects.Attachment` VO before reaching the
-Repository, so DB-level constraints are Defense-in-Depth only.
+4 つのメタデータ カラムは全てドメイン層の :class:`bakufu.domain.value_objects.Attachment`
+VO がリポジトリに到達する前に検証する。よって DB レベル制約は多層防御のみが目的。
 """
 
 from __future__ import annotations
@@ -30,7 +28,7 @@ from bakufu.infrastructure.persistence.sqlite.base import Base, UUIDStr
 
 
 class DeliverableAttachmentRow(Base):
-    """ORM mapping for the ``deliverable_attachments`` table."""
+    """``deliverable_attachments`` テーブルの ORM マッピング。"""
 
     __tablename__ = "deliverable_attachments"
 
@@ -40,16 +38,16 @@ class DeliverableAttachmentRow(Base):
         ForeignKey("deliverables.id", ondelete="CASCADE"),
         nullable=False,
     )
-    # sha256: 64-character lowercase hex; validated by Attachment VO.
+    # sha256: 64 文字の小文字 hex。Attachment VO で検証される。
     sha256: Mapped[str] = mapped_column(String(64), nullable=False)
     filename: Mapped[str] = mapped_column(String(255), nullable=False)
     mime_type: Mapped[str] = mapped_column(String(128), nullable=False)
     size_bytes: Mapped[int] = mapped_column(Integer, nullable=False)
 
     __table_args__ = (
-        # UNIQUE(deliverable_id, sha256): prevents duplicate file content
-        # within one Deliverable. Also provides stable ORDER BY sha256 ASC
-        # sort for deterministic hydration (§確定 R1-H).
+        # UNIQUE(deliverable_id, sha256): 単一 Deliverable 内の重複ファイル
+        # コンテンツを防ぐ。決定的水和のため安定した ORDER BY sha256 ASC ソート
+        # も提供する（§確定 R1-H）。
         UniqueConstraint("deliverable_id", "sha256", name="uq_deliverable_attachments_sha256"),
     )
 

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/tables/deliverables.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/tables/deliverables.py
@@ -1,25 +1,25 @@
-"""``deliverables`` table — Deliverable child rows for Task Aggregate.
+"""``deliverables`` テーブル — Task Aggregate 用の Deliverable 子行。
 
-Each row represents one per-Stage deliverable snapshot. The Task Aggregate
-keeps ``deliverables: dict[StageId, Deliverable]`` so only the latest commit
-for a given Stage survives (dict key uniqueness). The ``UNIQUE(task_id,
-stage_id)`` constraint enforces the same invariant at the database level.
+各行は Stage ごとの成果物スナップショット 1 件を表す。Task Aggregate は
+``deliverables: dict[StageId, Deliverable]`` を保持するため、与えられた Stage に
+ついては最新コミットだけが残る（dict キーの一意性）。``UNIQUE(task_id, stage_id)``
+制約はこの不変条件をデータベース レベルでも強制する。
 
-``task_id`` carries an ``ON DELETE CASCADE`` foreign key onto ``tasks.id``.
-``deliverable_attachments`` rows are removed transitively via the
-``deliverables.id → deliverable_attachments.deliverable_id CASCADE`` chain.
+``task_id`` は ``tasks.id`` への ``ON DELETE CASCADE`` 外部キーを持つ。
+``deliverable_attachments`` 行は
+``deliverables.id → deliverable_attachments.deliverable_id`` の CASCADE 連鎖により
+推移的に削除される。
 
-``stage_id`` intentionally has **no FK** onto ``workflow_stages.id`` — same
-Aggregate boundary rationale as ``tasks.current_stage_id`` (§確定 R1-G).
+``stage_id`` は ``workflow_stages.id`` への FK を意図的に **持たない** —
+``tasks.current_stage_id`` と同じ Aggregate 境界の理由（§確定 R1-G）。
 
-``committed_by`` intentionally has **no FK** onto ``agents.id`` — same
-Aggregate boundary rationale as ``task_assigned_agents.agent_id``
-(§設計決定 TR-001).
+``committed_by`` は ``agents.id`` への FK を意図的に **持たない** —
+``task_assigned_agents.agent_id`` と同じ Aggregate 境界の理由（§設計決定 TR-001）。
 
-``body_markdown`` is a :class:`MaskedText` column (§確定 R1-E). Agent output
-submitted as a deliverable may contain embedded API keys / auth tokens.
-The masking gateway replaces them with ``<REDACTED:*>`` *before* the row hits
-SQLite (irreversible masking, §確定 R1-G 不可逆性凍結).
+``body_markdown`` は :class:`MaskedText` カラム（§確定 R1-E）。成果物として提出
+されるエージェント出力には埋め込まれた API キー / 認証トークンが含まれ得る。
+マスキング ゲートウェイが、行が SQLite に到達する *前* にそれらを ``<REDACTED:*>``
+に置換する（不可逆伏字化、§確定 R1-G 不可逆性凍結）。
 """
 
 from __future__ import annotations
@@ -39,7 +39,7 @@ from bakufu.infrastructure.persistence.sqlite.base import (
 
 
 class DeliverableRow(Base):
-    """ORM mapping for the ``deliverables`` table."""
+    """``deliverables`` テーブルの ORM マッピング。"""
 
     __tablename__ = "deliverables"
 
@@ -49,23 +49,23 @@ class DeliverableRow(Base):
         ForeignKey("tasks.id", ondelete="CASCADE"),
         nullable=False,
     )
-    # stage_id: intentionally NO FK onto workflow_stages.id.
-    # Aggregate boundary: Workflow and Task are independent Aggregates;
-    # Stage deletion must not cascade-delete deliverables (§確定 R1-G).
+    # stage_id: workflow_stages.id への FK は意図的に持たない。
+    # Aggregate 境界: Workflow と Task は独立した Aggregate であり、Stage 削除を
+    # deliverables に CASCADE 伝播させてはならない（§確定 R1-G）。
     stage_id: Mapped[UUID] = mapped_column(UUIDStr, nullable=False)
-    # body_markdown: MaskedText — Agent-submitted output may contain secrets.
-    # MaskedText.process_bind_param redacts before SQLite storage (§確定 R1-E).
+    # body_markdown: MaskedText — エージェント提出出力はシークレットを含み得る。
+    # MaskedText.process_bind_param が SQLite 格納前に伏字化する（§確定 R1-E）。
     body_markdown: Mapped[str] = mapped_column(MaskedText, nullable=False)
-    # committed_by: intentionally NO FK onto agents.id.
-    # Aggregate boundary (§設計決定 TR-001, room_members.agent_id 前例同方針).
+    # committed_by: agents.id への FK は意図的に持たない。
+    # Aggregate 境界（§設計決定 TR-001、room_members.agent_id 先例と同方針）。
     committed_by: Mapped[UUID] = mapped_column(UUIDStr, nullable=False)
     committed_at: Mapped[datetime] = mapped_column(UTCDateTime, nullable=False)
 
     __table_args__ = (
-        # UNIQUE(task_id, stage_id): mirrors the Aggregate's
-        # ``deliverables: dict[StageId, Deliverable]`` key-uniqueness invariant
-        # at the DB level. Also ensures the save() §確定 R1-B step-1 DELETE +
-        # step-8 INSERT pattern never hits a UNIQUE violation.
+        # UNIQUE(task_id, stage_id): Aggregate の
+        # ``deliverables: dict[StageId, Deliverable]`` キー一意性不変条件を
+        # DB レベルでミラーする。また、save() §確定 R1-B の step-1 DELETE +
+        # step-8 INSERT パターンが UNIQUE 違反に遭遇しないことも保証する。
         UniqueConstraint("task_id", "stage_id", name="uq_deliverables_task_stage"),
     )
 

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/tables/directives.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/tables/directives.py
@@ -1,22 +1,21 @@
-"""``directives`` table — Directive Aggregate root row.
+"""``directives`` テーブル — Directive Aggregate ルート行。
 
-Holds the five scalar columns of the Directive aggregate. Directive is a
-flat aggregate with no child tables — every attribute maps to a single row
-in this table.
+Directive Aggregate の 5 個のスカラー カラムを保持する。Directive は子テーブルを
+持たないフラットな Aggregate である — 全属性がこのテーブルの 1 行にマップされる。
 
-``target_room_id`` carries an ``ON DELETE CASCADE`` foreign key onto
-``rooms.id`` — when a Room is removed, its associated Directives go with it.
+``target_room_id`` は ``rooms.id`` への ``ON DELETE CASCADE`` 外部キーを持つ —
+Room が削除されると関連 Directive も一緒に削除される。
 
-``task_id`` is nullable and carries **no FK** at this migration level.
-``tasks.id`` does not exist yet; the FK closure is deferred to the
-task-repository PR via ``op.batch_alter_table('directives', recreate='always')``
-(§BUG-DRR-001 申し送り, same pattern as BUG-EMR-001 in 0005_room_aggregate).
+``task_id`` は nullable で、このマイグレーション レベルでは **FK を持たない**。
+``tasks.id`` がまだ存在しないため。FK の確定は task-repository PR で
+``op.batch_alter_table('directives', recreate='always')`` により延期される
+（§BUG-DRR-001 申し送り、0005_room_aggregate の BUG-EMR-001 と同パターン）。
 
-``text`` is a :class:`MaskedText` column (§確定 R1-E). ``MaskingGateway``
-replaces embedded API keys / OAuth tokens / Discord webhook secrets etc. with
-``<REDACTED:*>`` *before* the row hits SQLite — preventing DB-dump / SQL-log
-secret leaks. The masking is irreversible; see
-:mod:`...repositories.directive_repository` for the full contract.
+``text`` は :class:`MaskedText` カラム（§確定 R1-E）。``MaskingGateway`` が、行が
+SQLite に到達する *前* に埋め込まれた API キー / OAuth トークン / Discord webhook
+シークレット等を ``<REDACTED:*>`` に置換する — DB ダンプ / SQL ログからのシークレット
+漏洩を防ぐ。マスキングは不可逆。完全なコントラクトは
+:mod:`...repositories.directive_repository` を参照。
 """
 
 from __future__ import annotations
@@ -36,7 +35,7 @@ from bakufu.infrastructure.persistence.sqlite.base import (
 
 
 class DirectiveRow(Base):
-    """ORM mapping for the ``directives`` table."""
+    """``directives`` テーブルの ORM マッピング。"""
 
     __tablename__ = "directives"
 
@@ -48,16 +47,16 @@ class DirectiveRow(Base):
         nullable=False,
     )
     created_at: Mapped[datetime] = mapped_column(UTCDateTime, nullable=False)
-    # task_id intentionally has NO FK onto tasks.id — tasks table does not
-    # exist at this migration level. FK closure is deferred to the
-    # task-repository PR (§BUG-DRR-001 / BUG-EMR-001 pattern).
+    # task_id は tasks.id への FK を意図的に持たない — このマイグレーション レベル
+    # では tasks テーブルがまだ存在しない。FK の確定は task-repository PR で延期
+    # される（§BUG-DRR-001 / BUG-EMR-001 パターン）。
     task_id: Mapped[UUID | None] = mapped_column(UUIDStr, nullable=True)
 
     __table_args__ = (
-        # §確定 R1-D: composite index for Room-scoped find_by_room lookup.
-        # Left-prefix optimises ``WHERE target_room_id = ?`` and the full
-        # ``WHERE target_room_id = ? ORDER BY created_at DESC`` query shape.
-        # ``id`` (PK) acts as tiebreaker in-engine; no additional index needed.
+        # §確定 R1-D: Room スコープの find_by_room ルックアップ用の複合インデックス。
+        # 左プレフィックスが ``WHERE target_room_id = ?`` を最適化し、完全な
+        # ``WHERE target_room_id = ? ORDER BY created_at DESC`` クエリ形状にも
+        # 効く。``id``（PK）はエンジン内で同点決着に使われる — 追加インデックス不要。
         Index("ix_directives_target_room_id_created_at", "target_room_id", "created_at"),
     )
 

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/tables/empire_agent_refs.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/tables/empire_agent_refs.py
@@ -1,18 +1,17 @@
-"""``empire_agent_refs`` table — Empire ↔ Agent relationship rows.
+"""``empire_agent_refs`` テーブル — Empire ↔ Agent 関係行。
 
-Stores :class:`bakufu.domain.value_objects.AgentRef` values. As with
-``empire_room_refs``, ``agent_id`` is intentionally not a foreign key
-onto ``agents.id`` because the ``agents`` table arrives in
-``feature/agent-repository`` (separate PR); that PR adds the FK via
-``op.create_foreign_key(...)``.
+:class:`bakufu.domain.value_objects.AgentRef` の値を保存する。``empire_room_refs``
+と同様、``agent_id`` は ``agents.id`` への外部キーを意図的に持たない。``agents``
+テーブルは ``feature/agent-repository``（別 PR）で投入されるため。その PR が
+``op.create_foreign_key(...)`` で FK を追加する。
 
-Cascade: deleting an Empire row purges its agent refs.
-``UNIQUE(empire_id, agent_id)`` mirrors the aggregate-level
-duplicate-agent invariant.
+カスケード: Empire 行を削除するとその agent 参照も一緒に削除される。
+``UNIQUE(empire_id, agent_id)`` は Aggregate レベルの重複エージェント不変条件を
+ミラーする。
 
-No ``Masked*`` TypeDecorator: ``role`` is an enum string and ``name``
-is bounded to 40 chars; neither is a secret-bearing column per
-storage.md §逆引き表.
+``Masked*`` TypeDecorator は付けない: ``role`` は enum 文字列、``name`` は 40 文字
+で境界づけられる。どちらも storage.md §逆引き表 のシークレット保持カラムには
+該当しない。
 """
 
 from __future__ import annotations
@@ -26,7 +25,7 @@ from bakufu.infrastructure.persistence.sqlite.base import Base, UUIDStr
 
 
 class EmpireAgentRefRow(Base):
-    """ORM mapping for the ``empire_agent_refs`` table."""
+    """``empire_agent_refs`` テーブルの ORM マッピング。"""
 
     __tablename__ = "empire_agent_refs"
 

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/tables/empire_room_refs.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/tables/empire_room_refs.py
@@ -1,19 +1,17 @@
-"""``empire_room_refs`` table — Empire ↔ Room relationship rows.
+"""``empire_room_refs`` テーブル — Empire ↔ Room 関係行。
 
-Stores :class:`bakufu.domain.value_objects.RoomRef` values as a side
-table of the Empire Aggregate. ``room_id`` is **intentionally not** a
-foreign key onto ``rooms.id`` because the ``rooms`` table arrives in
-``feature/room-repository`` (separate PR). The future migration adds
-the FK constraint via ``op.create_foreign_key(...)`` once the target
-exists.
+:class:`bakufu.domain.value_objects.RoomRef` の値を Empire Aggregate の関連
+テーブルとして保存する。``room_id`` は ``rooms.id`` への外部キーを **意図的に
+持たない**。``rooms`` テーブルは ``feature/room-repository``（別 PR）で投入される
+ため。将来のマイグレーションが対象テーブル存在後に
+``op.create_foreign_key(...)`` 経由で FK 制約を追加する。
 
-Cascade: when an Empire row is deleted, its room-ref rows go with it
-(``ON DELETE CASCADE``). The ``UNIQUE(empire_id, room_id)`` index is
-the row-level uniqueness contract that mirrors the Aggregate Root's
-``Empire`` invariant on ``rooms``.
+カスケード: Empire 行を削除すると、その room 参照行も一緒に削除される
+（``ON DELETE CASCADE``）。``UNIQUE(empire_id, room_id)`` インデックスは Aggregate
+Root の ``Empire`` の ``rooms`` 不変条件をミラーする行レベル一意性コントラクト。
 
-No ``Masked*`` TypeDecorator: see :mod:`...tables.empires` and the
-storage.md §逆引き表 explicit "no masking targets" entry.
+``Masked*`` TypeDecorator は付けない: :mod:`...tables.empires` および storage.md
+§逆引き表 の明示的な「マスキング対象なし」エントリを参照。
 """
 
 from __future__ import annotations
@@ -27,7 +25,7 @@ from bakufu.infrastructure.persistence.sqlite.base import Base, UUIDStr
 
 
 class EmpireRoomRefRow(Base):
-    """ORM mapping for the ``empire_room_refs`` table."""
+    """``empire_room_refs`` テーブルの ORM マッピング。"""
 
     __tablename__ = "empire_room_refs"
 

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/tables/empires.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/tables/empires.py
@@ -1,17 +1,15 @@
-"""``empires`` table — Empire Aggregate root row.
+"""``empires`` テーブル — Empire Aggregate ルート行。
 
-The Empire holds two scalar columns (``id`` / ``name``); reference
-collections (``rooms`` / ``agents``) live in the side tables
-:mod:`...tables.empire_room_refs` /
-:mod:`...tables.empire_agent_refs` to keep the row width bounded and
-the foreign-key cascade target obvious.
+Empire は 2 個のスカラー カラム（``id`` / ``name``）を保持する。参照コレクション
+（``rooms`` / ``agents``）は :mod:`...tables.empire_room_refs` /
+:mod:`...tables.empire_agent_refs` の関連テーブルに置き、行幅を抑え外部キー
+カスケード対象を明確にする。
 
-No ``Masked*`` TypeDecorator on any column: per
-``docs/design/domain-model/storage.md`` §逆引き表 the Empire
-schema carries no secret-bearing values. The CI three-layer defense
-(grep guard + arch test + reverse-lookup table) registers this
-explicit absence so a future PR cannot silently swap a column to a
-secret-bearing semantic.
+どのカラムにも ``Masked*`` TypeDecorator は付けない:
+``docs/design/domain-model/storage.md`` §逆引き表 によれば、Empire スキーマは
+シークレットを保持する値を持たない。CI 3 層防御（grep ガード + アーキ テスト
++ 逆引き表）はこの明示的な不在を登録するため、将来の PR がカラムをサイレントに
+シークレット保持の意味へ置き換えることはできない。
 """
 
 from __future__ import annotations
@@ -25,7 +23,7 @@ from bakufu.infrastructure.persistence.sqlite.base import Base, UUIDStr
 
 
 class EmpireRow(Base):
-    """ORM mapping for the ``empires`` table."""
+    """``empires`` テーブルの ORM マッピング。"""
 
     __tablename__ = "empires"
 

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/tables/external_review_audit_entries.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/tables/external_review_audit_entries.py
@@ -1,26 +1,24 @@
-"""``external_review_audit_entries`` table — AuditEntry child rows.
+"""``external_review_audit_entries`` テーブル — AuditEntry 子行。
 
-Stores the append-only audit trail for each :class:`ExternalReviewGate`.
-Every ``approve`` / ``reject`` / ``cancel`` / ``record_view`` call on the
-domain Gate appends exactly one :class:`AuditEntry`; the Repository persists
-all entries on each ``save()`` via the §確定 R1-B DELETE-then-INSERT flow.
+各 :class:`ExternalReviewGate` の追記専用監査証跡を保存する。ドメイン Gate に対する
+``approve`` / ``reject`` / ``cancel`` / ``record_view`` 呼び出しは厳密に 1 つの
+:class:`AuditEntry` を追記する。リポジトリは §確定 R1-B の DELETE-then-INSERT
+フローにより ``save()`` のたびに全エントリを永続化する。
 
-``gate_id`` carries an ``ON DELETE CASCADE`` foreign key onto
-``external_review_gates.id`` — when a Gate is removed, its audit entries
-go with it.
+``gate_id`` は ``external_review_gates.id`` への ``ON DELETE CASCADE`` 外部キーを
+持つ — Gate が削除されると監査エントリも一緒に削除される。
 
-``actor_id`` intentionally has **no FK** — Owner Aggregate is not yet
-implemented in M2 scope (§設計決定 ERGR-001). Reference integrity is the
-application layer's responsibility (``GateService``).
+``actor_id`` は意図的に **FK を持たない** — Owner Aggregate は M2 範囲では未実装
+（§設計決定 ERGR-001）。参照整合性はアプリケーション層（``GateService``）の責務。
 
-``id`` is taken directly from :class:`AuditEntry.id` (domain-assigned UUID),
-**not** regenerated on save. Unlike attachment rows (which use save-internal
-PKs), audit entries carry their own stable identity so the Repository can
-reconstruct the exact :class:`AuditEntry` instances the domain produced.
+``id`` は :class:`AuditEntry.id`（ドメイン側で割り当てられた UUID）から直接取得し、
+保存時に **再生成しない**。attachment 行（保存内部の PK を使う）とは異なり、監査
+エントリは独自の安定 ID を持つため、リポジトリはドメインが生成した
+:class:`AuditEntry` インスタンスを正確に再構築できる。
 
-**masking 対象カラム**: ``comment`` (MaskedText) — CEO-authored free-form
-text in the same input path as ``feedback_text``; can carry webhook URLs /
-API keys (§確定 R1-E 3-column CI defense).
+**マスキング対象カラム**: ``comment``（MaskedText） — ``feedback_text`` と同じ入力
+経路を持つ CEO 著作の自由形式テキスト。webhook URL / API キーを持ち得る
+（§確定 R1-E、3-column CI 防御）。
 """
 
 from __future__ import annotations
@@ -40,24 +38,24 @@ from bakufu.infrastructure.persistence.sqlite.base import (
 
 
 class ExternalReviewAuditEntryRow(Base):
-    """ORM mapping for the ``external_review_audit_entries`` table."""
+    """``external_review_audit_entries`` テーブルの ORM マッピング。"""
 
     __tablename__ = "external_review_audit_entries"
 
-    # id: taken directly from AuditEntry.id (domain UUID, NOT regenerated).
+    # id: AuditEntry.id から直接取得（ドメイン UUID、再生成しない）。
     id: Mapped[UUID] = mapped_column(UUIDStr, primary_key=True)
     gate_id: Mapped[UUID] = mapped_column(
         UUIDStr,
         ForeignKey("external_review_gates.id", ondelete="CASCADE"),
         nullable=False,
     )
-    # actor_id: intentionally NO FK onto owners/agents — Owner Aggregate not
-    # yet implemented (§設計決定 ERGR-001). GateService validates existence.
+    # actor_id: owners / agents への FK は意図的に持たない — Owner Aggregate は
+    # 未実装（§設計決定 ERGR-001）。GateService が存在性を検証する。
     actor_id: Mapped[UUID] = mapped_column(UUIDStr, nullable=False)
     action: Mapped[str] = mapped_column(String(32), nullable=False)
-    # comment: MaskedText — CEO-authored text in approve/reject/cancel/view
-    # input path; can carry webhook URLs / API keys (§確定 R1-E). NOT NULL:
-    # AuditEntry.comment defaults to "" on VIEWED entries.
+    # comment: MaskedText — approve/reject/cancel/view 入力経路を通る CEO 著作
+    # テキスト。webhook URL / API キーを持ち得る（§確定 R1-E）。NOT NULL:
+    # AuditEntry.comment は VIEWED エントリでは "" がデフォルト。
     comment: Mapped[str] = mapped_column(MaskedText, nullable=False)
     occurred_at: Mapped[datetime] = mapped_column(UTCDateTime, nullable=False)
 

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/tables/external_review_gate_attachments.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/tables/external_review_gate_attachments.py
@@ -1,22 +1,20 @@
-"""``external_review_gate_attachments`` table — snapshot Attachment child rows.
+"""``external_review_gate_attachments`` テーブル — スナップショット Attachment 子行。
 
-Stores per-attachment metadata for the ``deliverable_snapshot`` inline copy
-inside each :class:`ExternalReviewGate`. Physical file bytes are out of scope
-for this feature (``feature/attachment-storage``).
+各 :class:`ExternalReviewGate` 内の ``deliverable_snapshot`` インライン コピー用
+の attachment ごとのメタデータを保存する。物理ファイル バイトは本機能の範囲外
+（``feature/attachment-storage`` の責務）。
 
-``gate_id`` carries an ``ON DELETE CASCADE`` foreign key onto
-``external_review_gates.id`` — when a Gate is removed, its snapshot
-attachment rows go with it.
+``gate_id`` は ``external_review_gates.id`` への ``ON DELETE CASCADE`` 外部キーを
+持つ — Gate が削除されるとそのスナップショット attachment 行も一緒に削除される。
 
-``id`` is a **save-internal** primary key regenerated via ``uuid4()`` on
-every :meth:`SqliteExternalReviewGateRepository.save` call (DELETE-then-INSERT
-pattern). External code must not reference this PK; the business key is
-``UNIQUE(gate_id, sha256)``.
+``id`` は :meth:`SqliteExternalReviewGateRepository.save` 呼び出しごとに ``uuid4()``
+で再生成される **保存内部** の主キー（DELETE-then-INSERT パターン）。外部コードは
+この PK を参照してはならない。ビジネス キーは ``UNIQUE(gate_id, sha256)``。
 
-**masking 対象カラム**: なし (全カラム masking 対象外)。Attachment metadata
-(sha256 / filename / mime_type / size_bytes) carries no Schneier #6 secret
-semantics; the content hash identifies a file but reveals nothing about its
-contents.
+**マスキング対象カラム**: なし（全カラム マスキング対象外）。Attachment メタ
+データ（sha256 / filename / mime_type / size_bytes）は Schneier #6 のシークレット
+意味を持たない。コンテンツ ハッシュはファイルを識別するが、その内容については
+何も明かさない。
 """
 
 from __future__ import annotations
@@ -30,27 +28,27 @@ from bakufu.infrastructure.persistence.sqlite.base import Base, UUIDStr
 
 
 class ExternalReviewGateAttachmentRow(Base):
-    """ORM mapping for the ``external_review_gate_attachments`` table."""
+    """``external_review_gate_attachments`` テーブルの ORM マッピング。"""
 
     __tablename__ = "external_review_gate_attachments"
 
-    # id: internal PK regenerated on each save(); external code must use
-    # UNIQUE(gate_id, sha256) as the business key (§確定 R1-B).
+    # id: save() ごとに再生成される内部 PK。外部コードは UNIQUE(gate_id, sha256) を
+    # ビジネス キーとして使うこと（§確定 R1-B）。
     id: Mapped[UUID] = mapped_column(UUIDStr, primary_key=True)
     gate_id: Mapped[UUID] = mapped_column(
         UUIDStr,
         ForeignKey("external_review_gates.id", ondelete="CASCADE"),
         nullable=False,
     )
-    # sha256: 64-char lowercase hex; validated by Attachment VO.
+    # sha256: 64 文字小文字 hex。Attachment VO で検証される。
     sha256: Mapped[str] = mapped_column(String(64), nullable=False)
     filename: Mapped[str] = mapped_column(String(255), nullable=False)
     mime_type: Mapped[str] = mapped_column(String(128), nullable=False)
     size_bytes: Mapped[int] = mapped_column(Integer, nullable=False)
 
     __table_args__ = (
-        # UNIQUE(gate_id, sha256): prevents duplicate content within one Gate;
-        # sha256 provides deterministic ORDER BY anchor (§確定 R1-H).
+        # UNIQUE(gate_id, sha256): 1 つの Gate 内のコンテンツ重複を防ぐ。
+        # sha256 は決定的な ORDER BY アンカーを提供する（§確定 R1-H）。
         UniqueConstraint("gate_id", "sha256", name="uq_erg_attachments_gate_sha256"),
     )
 

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/tables/external_review_gates.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/tables/external_review_gates.py
@@ -1,39 +1,38 @@
-"""``external_review_gates`` table — ExternalReviewGate Aggregate root row.
+"""``external_review_gates`` テーブル — ExternalReviewGate Aggregate ルート行。
 
-Holds all twelve scalar columns of the ExternalReviewGate aggregate root,
-including the inline ``deliverable_snapshot`` copy (four columns prefixed
-``snapshot_``). Child collections (attachments / audit entries) live in
-companion modules so the root row width stays bounded and CASCADE targets
-are obvious.
+ExternalReviewGate Aggregate ルートの 12 個全てのスカラー カラム（``snapshot_``
+プレフィックスを持つ 4 カラムからなるインライン ``deliverable_snapshot`` コピー
+を含む）を保持する。子コレクション（attachments / 監査エントリ）はコンパニオン
+モジュールに置き、ルート行の幅を抑え CASCADE 対象を明確にする。
 
-``task_id`` carries an ``ON DELETE CASCADE`` foreign key onto ``tasks.id`` —
-when a Task is removed, its associated Gates go with it.
+``task_id`` は ``tasks.id`` に対する ``ON DELETE CASCADE`` 外部キーを持つ —
+Task が削除されると関連する Gate も一緒に削除される。
 
-``stage_id`` and ``reviewer_id`` and ``snapshot_committed_by`` intentionally
-have **no FK** (§設計決定 ERGR-001):
-- ``stage_id``: Workflow Aggregate boundary; Gate must not depend on
-  workflow_stages directly.
-- ``reviewer_id``: Owner Aggregate not yet implemented (M2 scope).
-- ``snapshot_committed_by``: Agent deletion with CASCADE would destroy the
-  audit-frozen snapshot (task-repository §設計決定 TR-001 同論理).
+``stage_id``、``reviewer_id``、``snapshot_committed_by`` は意図的に **FK を持たない**
+（§設計決定 ERGR-001）:
+- ``stage_id``: Workflow Aggregate 境界。Gate は workflow_stages に直接依存して
+  はならない。
+- ``reviewer_id``: Owner Aggregate は未実装（M2 範囲）。
+- ``snapshot_committed_by``: Agent 削除に CASCADE が伴うと監査凍結された
+  スナップショットを破壊してしまう（task-repository §設計決定 TR-001 と同論理）。
 
-Two masking columns (§設計決定 ERGR-002, §確定 R1-E, 3-column CI defense):
+2 つのマスキング カラム（§設計決定 ERGR-002、§確定 R1-E、3-column CI 防御）:
 
-* ``feedback_text`` — MaskedText: CEO-authored review comment; ``approve`` /
-  ``reject`` / ``cancel`` input paths can carry webhook URLs / API keys.
-* ``snapshot_body_markdown`` — MaskedText: Agent-authored deliverable body;
-  LLM output may contain API keys / auth tokens embedded in code blocks.
+* ``feedback_text`` — MaskedText: CEO が書くレビュー コメント。``approve`` /
+  ``reject`` / ``cancel`` の入力経路は Webhook URL / API キーを持ち得る。
+* ``snapshot_body_markdown`` — MaskedText: Agent が書く成果物本体。LLM 出力には
+  コード ブロック内に API キー / 認証トークンが埋め込まれることがある。
 
-Three indexes (§確定 R1-K):
+3 つのインデックス（§確定 R1-K）:
 
-* ``ix_external_review_gates_task_id_created`` — composite ``(task_id,
-  created_at)`` for ``find_by_task_id`` WHERE + ORDER BY in one B-tree scan.
-* ``ix_external_review_gates_reviewer_decision`` — composite
-  ``(reviewer_id, decision)`` for ``find_pending_by_reviewer`` WHERE
-  reviewer_id + decision = 'PENDING' filter.
-* ``ix_external_review_gates_decision`` — single-column ``(decision)`` for
-  ``count_by_decision`` WHERE filter (prefix coverage of the composite index
-  above is insufficient for a full COUNT(*) scan).
+* ``ix_external_review_gates_task_id_created`` — 複合 ``(task_id, created_at)``。
+  ``find_by_task_id`` の WHERE + ORDER BY を 1 回の B-tree スキャンで賄う。
+* ``ix_external_review_gates_reviewer_decision`` — 複合
+  ``(reviewer_id, decision)``。``find_pending_by_reviewer`` の WHERE
+  reviewer_id + decision = 'PENDING' フィルタ用。
+* ``ix_external_review_gates_decision`` — 単一カラム ``(decision)``。
+  ``count_by_decision`` WHERE フィルタ用（上記複合インデックスのプレフィックス
+  カバレッジは全件 COUNT(*) スキャンには不十分）。
 """
 
 from __future__ import annotations
@@ -53,7 +52,7 @@ from bakufu.infrastructure.persistence.sqlite.base import (
 
 
 class ExternalReviewGateRow(Base):
-    """ORM mapping for the ``external_review_gates`` table."""
+    """``external_review_gates`` テーブルの ORM マッピング。"""
 
     __tablename__ = "external_review_gates"
 
@@ -63,48 +62,48 @@ class ExternalReviewGateRow(Base):
         ForeignKey("tasks.id", ondelete="CASCADE"),
         nullable=False,
     )
-    # stage_id: intentionally NO FK onto workflow_stages.id —
-    # Aggregate boundary (§設計決定 ERGR-001). GateService validates existence.
+    # stage_id: workflow_stages.id への FK は意図的に持たない —
+    # Aggregate 境界（§設計決定 ERGR-001）。GateService が存在性を検証する。
     stage_id: Mapped[UUID] = mapped_column(UUIDStr, nullable=False)
-    # reviewer_id: intentionally NO FK — Owner Aggregate not yet implemented
-    # (§設計決定 ERGR-001). MVP: CEO = single system owner with fixed UUID.
+    # reviewer_id: 意図的に FK 無し — Owner Aggregate は未実装
+    # （§設計決定 ERGR-001）。MVP: CEO = 固定 UUID を持つ単一システム所有者。
     reviewer_id: Mapped[UUID] = mapped_column(UUIDStr, nullable=False)
     decision: Mapped[str] = mapped_column(String(32), nullable=False)
-    # feedback_text: MaskedText — CEO review comment; approve / reject / cancel
-    # input paths can carry webhook URLs / API keys (§設計決定 ERGR-002,
-    # §確定 R1-E). MaskedText.process_bind_param redacts secrets before SQLite
-    # storage. NOT NULL: domain Gate.feedback_text defaults to "" on PENDING.
+    # feedback_text: MaskedText — CEO のレビュー コメント。approve / reject /
+    # cancel の入力経路は Webhook URL / API キーを持ち得る（§設計決定 ERGR-002、
+    # §確定 R1-E）。MaskedText.process_bind_param が SQLite 格納前にシークレットを
+    # 伏字化する。NOT NULL: ドメインの Gate.feedback_text は PENDING で "" がデフォルト。
     feedback_text: Mapped[str] = mapped_column(MaskedText, nullable=False)
-    # ---- inline deliverable_snapshot copy (§確定 R1-C) ---------------------
-    # snapshot_stage_id: NO FK onto workflow_stages.id — same rationale as
-    # stage_id above (Aggregate boundary).
+    # ---- インライン deliverable_snapshot コピー（§確定 R1-C） ---------------
+    # snapshot_stage_id: workflow_stages.id への FK 無し — 上の stage_id と
+    # 同じ理由（Aggregate 境界）。
     snapshot_stage_id: Mapped[UUID] = mapped_column(UUIDStr, nullable=False)
-    # snapshot_body_markdown: MaskedText — Agent-authored deliverable body;
-    # LLM output may contain secrets embedded in code blocks (§確定 R1-E).
+    # snapshot_body_markdown: MaskedText — Agent が書く成果物本体。LLM 出力には
+    # コード ブロック内にシークレットが埋め込まれることがある（§確定 R1-E）。
     snapshot_body_markdown: Mapped[str] = mapped_column(MaskedText, nullable=False)
-    # snapshot_committed_by: intentionally NO FK onto agents.id —
-    # Agent deletion with CASCADE would destroy audit-frozen snapshot
-    # (§設計決定 ERGR-001, TR-001 同論理).
+    # snapshot_committed_by: 意図的に agents.id への FK 無し —
+    # CASCADE 付きの Agent 削除は監査凍結されたスナップショットを破壊してしまう
+    # （§設計決定 ERGR-001、TR-001 と同論理）。
     snapshot_committed_by: Mapped[UUID] = mapped_column(UUIDStr, nullable=False)
     snapshot_committed_at: Mapped[datetime] = mapped_column(UTCDateTime, nullable=False)
-    # ---- lifecycle timestamps -----------------------------------------------
+    # ---- ライフサイクル タイムスタンプ ----------------------------------------
+    # decided_at: decision == PENDING のときに限り NULL（ドメイン不変条件）。
     created_at: Mapped[datetime] = mapped_column(UTCDateTime, nullable=False)
-    # decided_at: NULL iff decision == PENDING (domain invariant).
     decided_at: Mapped[datetime | None] = mapped_column(UTCDateTime, nullable=True)
 
     __table_args__ = (
-        # §確定 R1-K: composite (task_id, created_at) index for find_by_task_id.
-        # WHERE task_id + ORDER BY created_at ASC covered by one B-tree scan.
+        # §確定 R1-K: find_by_task_id 用の複合 (task_id, created_at) インデックス。
+        # WHERE task_id + ORDER BY created_at ASC を 1 回の B-tree スキャンでカバー。
         Index("ix_external_review_gates_task_id_created", "task_id", "created_at"),
-        # §確定 R1-K: composite (reviewer_id, decision) for find_pending_by_reviewer.
-        # WHERE reviewer_id + decision = 'PENDING' covered without full-table scan.
+        # §確定 R1-K: find_pending_by_reviewer 用の複合 (reviewer_id, decision)。
+        # WHERE reviewer_id + decision = 'PENDING' を全件スキャン無しでカバー。
         Index(
             "ix_external_review_gates_reviewer_decision",
             "reviewer_id",
             "decision",
         ),
-        # §確定 R1-K: single-column (decision) for count_by_decision.
-        # The composite above does not cover COUNT(*) over all reviewers.
+        # §確定 R1-K: count_by_decision 用の単一カラム (decision)。
+        # 上の複合インデックスは全レビュアーにわたる COUNT(*) をカバーしない。
         Index("ix_external_review_gates_decision", "decision"),
     )
 

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/tables/outbox.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/tables/outbox.py
@@ -1,21 +1,19 @@
-"""``domain_event_outbox`` table (Outbox pattern, §確定 K).
+"""``domain_event_outbox`` テーブル（Outbox パターン、§確定 K）。
 
-The Outbox decouples domain event emission from external side effects
-(Discord notifier, LLM Adapter call, etc.). Each row carries a
-``payload_json`` blob — produced by an Aggregate's behavior — that
-**must** be redacted before it lands on disk because raw payloads can
-embed webhook URLs, API keys, or filesystem paths.
+Outbox はドメイン イベントの発行を外部副作用（Discord 通知、LLM Adapter 呼び出し
+等）から疎結合化する。各行は Aggregate の振る舞いが生成した ``payload_json`` blob
+を保持する。raw ペイロードは webhook URL、API キー、ファイルシステム パス等を
+埋め込む可能性があるため、ディスクに到達する前に **必ず** 伏字化する。
 
-Secret-column masking is enforced via :class:`MaskedJSONEncoded` /
-:class:`MaskedText` TypeDecorators in
-:mod:`bakufu.infrastructure.persistence.sqlite.base`. Their
-``process_bind_param`` hooks fire for both ORM ``Session.add()``
-flushes and Core ``session.execute(insert(table).values(...))``
-paths, so the "raw-SQL path is masked too" promise (Confirmation B
-/ Confirmation R1-D / Schneier #6) is honored end-to-end (BUG-PF-001
-fix; see ``docs/features/persistence-foundation/requirements-analysis.md``
-§確定 R1-D for the design rationale and TC-IT-PF-020 for the
-physical regression test).
+シークレット カラムのマスキングは
+:mod:`bakufu.infrastructure.persistence.sqlite.base` の :class:`MaskedJSONEncoded` /
+:class:`MaskedText` TypeDecorator で強制される。それらの ``process_bind_param``
+フックは ORM ``Session.add()`` フラッシュと Core
+``session.execute(insert(table).values(...))`` 経路の両方で発火するため、
+「raw SQL 経路もマスクされる」という約束（Confirmation B / Confirmation R1-D /
+Schneier #6）が端から端まで尊重される（BUG-PF-001 修正、設計根拠は
+``docs/features/persistence-foundation/requirements-analysis.md`` §確定 R1-D
+を、物理回帰テストは TC-IT-PF-020 を参照）。
 """
 
 from __future__ import annotations
@@ -37,12 +35,12 @@ from bakufu.infrastructure.persistence.sqlite.base import (
 
 
 class OutboxRow(Base):
-    """ORM mapping for the ``domain_event_outbox`` table.
+    """``domain_event_outbox`` テーブルの ORM マッピング。
 
-    ``payload_json`` and ``last_error`` use the ``Masked*`` column
-    types so every bind value passes through the masking gateway
-    regardless of whether the row arrives via ORM ``Session.add`` or
-    Core ``session.execute(insert(...).values(...))`` (BUG-PF-001 fix).
+    ``payload_json`` と ``last_error`` は ``Masked*`` カラム型を使うため、行が ORM
+    ``Session.add`` 経由で到達するか Core
+    ``session.execute(insert(...).values(...))`` 経由で到達するかに関わらず、
+    全バインド値がマスキング ゲートウェイを通る（BUG-PF-001 修正）。
     """
 
     __tablename__ = "domain_event_outbox"
@@ -59,7 +57,7 @@ class OutboxRow(Base):
     updated_at: Mapped[datetime] = mapped_column(UTCDateTime, nullable=False)
     dispatched_at: Mapped[datetime | None] = mapped_column(UTCDateTime, nullable=True)
 
-    # Polling SQL filter: `WHERE status = ? AND next_attempt_at <= ?`.
+    # ポーリング SQL フィルタ: `WHERE status = ? AND next_attempt_at <= ?`。
     __table_args__ = (Index("ix_outbox_status_next_attempt", "status", "next_attempt_at"),)
 
 

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/tables/pid_registry.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/tables/pid_registry.py
@@ -1,17 +1,16 @@
-"""``bakufu_pid_registry`` table (orphan-process tracking).
+"""``bakufu_pid_registry`` テーブル（オーファン プロセス追跡）。
 
-Bootstrap stage 4 sweeps this table to kill leftover claude/codex/etc.
-subprocesses from a previous run. The ``cmd`` column may carry CLI
-arguments containing secrets (``--api-key=sk-ant-...``) so the masking
-gateway is mandatory — see Schneier 申し送り #5.
-Secret-column masking is enforced via the :class:`MaskedText`
-TypeDecorator in
-:mod:`bakufu.infrastructure.persistence.sqlite.base`. Its
-``process_bind_param`` hook fires for both ORM ``Session.add()`` and
-Core ``insert(table).values(...)`` paths so the gateway is honored
-end-to-end (BUG-PF-001 fix; see
-``docs/features/persistence-foundation/requirements-analysis.md``
-§確定 R1-D for the design rationale).
+Bootstrap stage 4 がこのテーブルをスイープし、前回実行から残った claude /
+codex 等のサブプロセスを kill する。``cmd`` カラムはシークレット
+（``--api-key=sk-ant-...``）を含む CLI 引数を保持し得るため、マスキング
+ゲートウェイは必須 — Schneier 申し送り #5 を参照。
+シークレット カラムのマスキングは
+:mod:`bakufu.infrastructure.persistence.sqlite.base` の :class:`MaskedText`
+TypeDecorator で強制する。その ``process_bind_param`` フックは ORM の
+``Session.add()`` と Core の ``insert(table).values(...)`` の両経路で発火する
+ため、ゲートウェイは端から端まで尊重される（BUG-PF-001 修正、設計根拠は
+``docs/features/persistence-foundation/requirements-analysis.md`` §確定 R1-D
+を参照）。
 """
 
 from __future__ import annotations
@@ -31,11 +30,10 @@ from bakufu.infrastructure.persistence.sqlite.base import (
 
 
 class PidRegistryRow(Base):
-    """ORM mapping for the ``bakufu_pid_registry`` table.
+    """``bakufu_pid_registry`` テーブルの ORM マッピング。
 
-    ``cmd`` uses :class:`MaskedText` so secrets in CLI flags
-    (``--api-key=sk-ant-...``) are redacted on every persist path
-    (BUG-PF-001 fix).
+    ``cmd`` は :class:`MaskedText` を使うため、CLI フラグ（``--api-key=sk-ant-...``）
+    内のシークレットがすべての永続化経路で伏字化される（BUG-PF-001 修正）。
     """
 
     __tablename__ = "bakufu_pid_registry"

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/tables/room_members.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/tables/room_members.py
@@ -1,27 +1,26 @@
-"""``room_members`` table — AgentMembership child rows of the Room Aggregate.
+"""``room_members`` テーブル — Room Aggregate 用 AgentMembership 子行。
 
-Stores each :class:`bakufu.domain.room.value_objects.AgentMembership` as a
-DB row. A Room can host multiple members; each entry is identified by the
-``(room_id, agent_id, role)`` triplet.
+各 :class:`bakufu.domain.room.value_objects.AgentMembership` を DB 行として保存
+する。1 つの Room は複数のメンバを持ち得、各エントリは ``(room_id, agent_id, role)``
+の 3 つ組で識別される。
 
-Design contracts (§確定 R1-D):
+設計コントラクト（§確定 R1-D）:
 
-* ``room_id`` FK → ``rooms.id`` ON DELETE CASCADE: removing the Room
-  purges all its membership rows.
-* ``agent_id`` has **no FK** onto ``agents.id``. Room §確定 freezes Agent
-  existence checking as the application-layer's responsibility
-  (``RoomService.add_member`` calls ``AgentRepository.find_by_id``). A FK
-  CASCADE would silently delete memberships when the Agent row disappears;
-  FK RESTRICT would block clean removal of archived Agents from Rooms.
-  Neither is correct for the MVP model — application-layer check only.
-* Composite PK ``(room_id, agent_id, role)`` plus an explicit named
-  ``UniqueConstraint`` for CI Layer 2 arch-test detectability. The PK
-  implies UNIQUE but ``__table_args__`` scanning in the arch test only
-  catches explicit constraint declarations (agent_providers pattern,
-  detailed-design §確定 R1-D rationale).
-* ``joined_at`` uses ``DateTime(timezone=True)`` so aiosqlite preserves
-  the UTC ``tzinfo`` on read — the hydrated ``AgentMembership.joined_at``
-  is always tz-aware as frozen in room/detailed-design.
+* ``room_id`` FK → ``rooms.id`` ON DELETE CASCADE: Room を削除すると全メンバーシップ
+  行を消去する。
+* ``agent_id`` は ``agents.id`` への FK を **持たない**。Room §確定 は Agent 存在
+  チェックをアプリケーション層の責務として凍結する（``RoomService.add_member`` が
+  ``AgentRepository.find_by_id`` を呼ぶ）。FK CASCADE は Agent 行が消えたときに
+  メンバーシップをサイレントに削除してしまう。FK RESTRICT はアーカイブ済み Agent
+  を Room からきれいに削除することをブロックしてしまう。MVP モデルではどちらも
+  正しくない — アプリケーション層チェックのみとする。
+* 複合 PK ``(room_id, agent_id, role)`` に加え、CI Layer 2 アーキテクチャ テストの
+  検出性のために明示的な名前付き ``UniqueConstraint`` を併設する。PK は UNIQUE を
+  暗黙に含むが、アーキ テストの ``__table_args__`` スキャンは明示的な制約宣言のみ
+  を捕捉する（agent_providers パターン、detailed-design §確定 R1-D の根拠）。
+* ``joined_at`` は ``DateTime(timezone=True)`` を使うため、aiosqlite は読み取り時に
+  UTC ``tzinfo`` を保持する — 水和された ``AgentMembership.joined_at`` は
+  room/detailed-design で凍結された通り常に tz-aware。
 """
 
 from __future__ import annotations
@@ -36,7 +35,7 @@ from bakufu.infrastructure.persistence.sqlite.base import Base, UUIDStr
 
 
 class RoomMemberRow(Base):
-    """ORM mapping for the ``room_members`` table."""
+    """``room_members`` テーブルの ORM マッピング。"""
 
     __tablename__ = "room_members"
 
@@ -50,16 +49,16 @@ class RoomMemberRow(Base):
         UUIDStr,
         primary_key=True,
         nullable=False,
-        # Intentionally no FK onto agents.id — see module docstring.
+        # agents.id への FK は意図的に持たない — モジュール docstring 参照。
     )
     role: Mapped[str] = mapped_column(String(32), primary_key=True, nullable=False)
     joined_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
 
     __table_args__ = (
-        # §確定 R1-D: explicit UniqueConstraint mirrors the composite PK so the
-        # CI Layer 2 arch test can assert UNIQUE-constraint existence by scanning
-        # ``__table_args__``. PK-derived implicit UNIQUE is invisible to that
-        # scan, so the redundancy is load-bearing for the Defense-in-Depth floor.
+        # §確定 R1-D: 明示的な UniqueConstraint が複合 PK をミラーすることで、
+        # CI Layer 2 アーキ テストが ``__table_args__`` をスキャンして UNIQUE 制約の
+        # 存在をアサートできる。PK 由来の暗黙 UNIQUE はそのスキャンには見えないため、
+        # この冗長性が多層防御の基盤として機能する。
         UniqueConstraint(
             "room_id",
             "agent_id",

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/tables/rooms.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/tables/rooms.py
@@ -1,30 +1,27 @@
-"""``rooms`` table — Room Aggregate root row.
+"""``rooms`` テーブル — Room Aggregate ルート行。
 
-Holds the seven scalar columns of the Room aggregate root. The member
-collection (``room_members``) lives in the companion module
-:mod:`...tables.room_members` so the root row width stays bounded and
-CASCADE targets are obvious.
+Room Aggregate ルートの 7 個のスカラー カラムを保持する。メンバ コレクション
+（``room_members``）はコンパニオン モジュール :mod:`...tables.room_members` に
+置き、ルート行の幅を抑え CASCADE 対象を明確にする。
 
-``empire_id`` carries an ``ON DELETE CASCADE`` foreign key onto
-``empires.id`` — when an Empire is removed, its Rooms go with it.
+``empire_id`` は ``empires.id`` への ``ON DELETE CASCADE`` 外部キーを持つ —
+Empire が削除されると Room も一緒に削除される。
 
-``workflow_id`` carries an ``ON DELETE RESTRICT`` foreign key onto
-``workflows.id`` — Workflow is a reference target, not an owner, so
-deleting a Workflow while Rooms still reference it is a hard failure
-(§確定 R1-I: Defense-in-Depth alongside the application-layer check).
+``workflow_id`` は ``workflows.id`` への ``ON DELETE RESTRICT`` 外部キーを持つ —
+Workflow は所有者ではなく参照対象であるため、Room がまだ参照している状態で
+Workflow を削除しようとすると hard failure する（§確定 R1-I: アプリケーション層
+チェックと並ぶ多層防御）。
 
-``name`` is intentionally **not** declared UNIQUE at the DB level. The
-"name unique within an Empire" invariant is enforced by the application
-layer via :meth:`RoomRepository.find_by_name` (agent §R1-B same logic)
-so MSG-RM-NNN wording stays in the application layer's voice rather than
-being preempted by ``IntegrityError``.
+``name`` は意図的に DB レベルで UNIQUE として **宣言しない**。「Empire 内で名前
+一意」の不変条件は :meth:`RoomRepository.find_by_name` 経由でアプリケーション層
+が強制する（agent §R1-B と同じロジック）。これにより、``IntegrityError`` に
+先取りされず、MSG-RM-NNN 文言がアプリケーション層の声で出る。
 
-``prompt_kit_prefix_markdown`` is a :class:`MaskedText` column (room
-§確定 G 実適用). ``MaskingGateway`` replaces embedded API keys / OAuth
-tokens / Discord webhook secrets etc. with ``<REDACTED:*>`` *before* the
-row hits SQLite — preventing DB-dump / SQL-log secret leaks. The masking
-is irreversible; see §確定 R1-J and :mod:`...repositories.room_repository`
-for the full contract.
+``prompt_kit_prefix_markdown`` は :class:`MaskedText` カラム（room §確定 G 実適用）。
+``MaskingGateway`` が、行が SQLite に到達する *前* に埋め込まれた API キー /
+OAuth トークン / Discord webhook シークレット等を ``<REDACTED:*>`` に置換する —
+DB ダンプ / SQL ログのシークレット漏洩を防ぐ。マスキングは不可逆。完全な
+コントラクトは §確定 R1-J および :mod:`...repositories.room_repository` を参照。
 """
 
 from __future__ import annotations
@@ -42,7 +39,7 @@ from bakufu.infrastructure.persistence.sqlite.base import (
 
 
 class RoomRow(Base):
-    """ORM mapping for the ``rooms`` table."""
+    """``rooms`` テーブルの ORM マッピング。"""
 
     __tablename__ = "rooms"
 
@@ -63,9 +60,9 @@ class RoomRow(Base):
     archived: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
 
     __table_args__ = (
-        # §確定 R1-F: non-UNIQUE composite index for Empire-scoped find_by_name
-        # lookup. Left-prefix optimises both ``WHERE empire_id = ?`` and
-        # ``WHERE empire_id = ? AND name = ?`` queries.
+        # §確定 R1-F: Empire スコープの find_by_name ルックアップ用の非 UNIQUE
+        # 複合インデックス。左プレフィックスが ``WHERE empire_id = ?`` と
+        # ``WHERE empire_id = ? AND name = ?`` の両方のクエリを最適化する。
         Index("ix_rooms_empire_id_name", "empire_id", "name", unique=False),
     )
 

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/tables/task_assigned_agents.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/tables/task_assigned_agents.py
@@ -1,19 +1,17 @@
-"""``task_assigned_agents`` table — AgentId list for Task Aggregate.
+"""``task_assigned_agents`` テーブル — Task Aggregate 用 AgentId リスト。
 
-Each row represents one assigned agent for a given Task. The list order is
-preserved via ``order_index`` (0-indexed, matching the Aggregate's
-``assigned_agent_ids: list[AgentId]`` position).
+各行は与えられた Task に対するアサイン エージェント 1 件を表す。リスト順は
+``order_index``（0 始まり、Aggregate の ``assigned_agent_ids: list[AgentId]`` 位置
+と一致）で保存される。
 
-``agent_id`` intentionally has **no FK** onto ``agents.id`` — this is a
-permanent Aggregate boundary design decision (§設計決定 TR-001). Adding a FK
-would risk CASCADE deletion of assigned-agent rows when an Agent is archived,
-corrupting IN_PROGRESS Tasks. The room-repository ``room_members.agent_id``
-establishes the same precedent.
+``agent_id`` は ``agents.id`` への FK を意図的に **持たない** — 恒久的な Aggregate
+境界の設計決定（§設計決定 TR-001）。FK を加えると Agent アーカイブ時にアサイン
+エージェント行が CASCADE 削除され、IN_PROGRESS Task を破壊するリスクがある。
+room-repository の ``room_members.agent_id`` が同じ先例を確立している。
 
-UNIQUE(task_id, agent_id) prevents duplicate assignment of the same Agent to
-one Task, mirroring the Aggregate-level
-``_validate_assigned_agents_unique`` invariant at the database level for
-defense-in-depth.
+UNIQUE(task_id, agent_id) は同じ Agent を 1 つの Task に重複アサインすることを
+防ぎ、Aggregate レベルの ``_validate_assigned_agents_unique`` 不変条件をデータ
+ベース レベルでもミラーする多層防御。
 """
 
 from __future__ import annotations
@@ -27,7 +25,7 @@ from bakufu.infrastructure.persistence.sqlite.base import Base, UUIDStr
 
 
 class TaskAssignedAgentRow(Base):
-    """ORM mapping for the ``task_assigned_agents`` table."""
+    """``task_assigned_agents`` テーブルの ORM マッピング。"""
 
     __tablename__ = "task_assigned_agents"
 
@@ -37,15 +35,15 @@ class TaskAssignedAgentRow(Base):
         primary_key=True,
         nullable=False,
     )
-    # agent_id: intentionally NO FK onto agents.id.
-    # Aggregate boundary: agent deletion must not cascade-delete assigned-agent
-    # rows (§設計決定 TR-001, room_members.agent_id 前例同方針).
+    # agent_id: agents.id への FK は意図的に持たない。
+    # Aggregate 境界: Agent 削除をアサイン エージェント行に CASCADE 伝播させては
+    # ならない（§設計決定 TR-001、room_members.agent_id 先例と同方針）。
     agent_id: Mapped[UUID] = mapped_column(UUIDStr, primary_key=True, nullable=False)
     order_index: Mapped[int] = mapped_column(Integer, nullable=False)
 
     __table_args__ = (
-        # Defense-in-Depth: explicit UNIQUE mirrors Aggregate invariant
-        # _validate_assigned_agents_unique at the DB level.
+        # 多層防御: 明示的な UNIQUE が Aggregate 不変条件
+        # _validate_assigned_agents_unique を DB レベルでミラーする。
         UniqueConstraint("task_id", "agent_id", name="uq_task_assigned_agents"),
     )
 

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/tables/tasks.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/tables/tasks.py
@@ -1,37 +1,33 @@
-"""``tasks`` table — Task Aggregate root row.
+"""``tasks`` テーブル — Task Aggregate ルート行。
 
-Holds the eight scalar columns of the Task aggregate root. Child
-collections (assigned agents / conversations / messages / deliverables /
-attachments) live in companion modules so the root row width stays bounded
-and CASCADE targets are obvious.
+Task Aggregate ルートの 8 個のスカラー カラムを保持する。子コレクション
+（アサイン エージェント / 会話 / メッセージ / 成果物 / 添付）はコンパニオン
+モジュールに置き、ルート行の幅を抑え CASCADE 対象を明確にする。
 
-``room_id`` carries an ``ON DELETE CASCADE`` foreign key onto ``rooms.id`` —
-when a Room is removed, its associated Tasks go with it.
+``room_id`` は ``rooms.id`` に対する ``ON DELETE CASCADE`` 外部キーを持つ —
+Room が削除されると関連 Task も一緒に削除される。
 
-``directive_id`` carries an ``ON DELETE CASCADE`` foreign key onto
-``directives.id`` — when a Directive is removed, its associated Tasks go
-with it.
+``directive_id`` は ``directives.id`` に対する ``ON DELETE CASCADE`` 外部キーを
+持つ — Directive が削除されると関連 Task も一緒に削除される。
 
-``current_stage_id`` intentionally has **no FK** onto ``workflow_stages.id``
-— Task and Workflow are separate Aggregates; adding a FK would create an
-Aggregate boundary violation and cause ON DELETE ambiguity (§確定 R1-G).
-Existence validation is the application layer's responsibility
-(``TaskService``).
+``current_stage_id`` は ``workflow_stages.id`` への FK を意図的に **持たない** —
+Task と Workflow は別の Aggregate であり、FK を加えると Aggregate 境界違反となり、
+ON DELETE の曖昧性も生じる（§確定 R1-G）。存在検証はアプリケーション層
+（``TaskService``）の責務。
 
-``last_error`` is a :class:`MaskedText` column (§確定 R1-E). The masking
-gateway replaces embedded API keys / OAuth tokens / LLM error secrets with
-``<REDACTED:*>`` *before* the row hits SQLite — preventing DB-dump / SQL-log
-secret leaks. Nullable: only BLOCKED Tasks carry a ``last_error`` value.
+``last_error`` は :class:`MaskedText` カラム（§確定 R1-E）。マスキング ゲートウェイ
+が、行が SQLite に到達する *前* に埋め込まれた API キー / OAuth トークン / LLM
+エラー シークレットを ``<REDACTED:*>`` に置換する — DB ダンプ / SQL ログからの
+シークレット漏洩を防ぐ。Nullable: BLOCKED の Task のみ ``last_error`` 値を持つ。
 
-Two indexes are created (§確定 R1-K):
+2 つのインデックスを作成する（§確定 R1-K）:
 
-* ``ix_tasks_room_id`` — non-UNIQUE single-column index on ``room_id`` for
-  ``count_by_room`` WHERE filters.
-* ``ix_tasks_status_updated_id`` — composite ``(status, updated_at, id)``
-  non-UNIQUE index that optimises ``find_blocked``
-  ``WHERE status = 'BLOCKED' ORDER BY updated_at DESC, id DESC`` with a
-  single B-tree scan. The status prefix also accelerates
-  ``count_by_status``.
+* ``ix_tasks_room_id`` — ``count_by_room`` の WHERE フィルタ用。``room_id`` 上の
+  非 UNIQUE 単一カラム インデックス。
+* ``ix_tasks_status_updated_id`` — 複合 ``(status, updated_at, id)`` 非 UNIQUE
+  インデックス。``find_blocked`` の ``WHERE status = 'BLOCKED' ORDER BY
+  updated_at DESC, id DESC`` を 1 回の B-tree スキャンで最適化する。status
+  プレフィックスは ``count_by_status`` にも効く。
 """
 
 from __future__ import annotations
@@ -51,7 +47,7 @@ from bakufu.infrastructure.persistence.sqlite.base import (
 
 
 class TaskRow(Base):
-    """ORM mapping for the ``tasks`` table."""
+    """``tasks`` テーブルの ORM マッピング。"""
 
     __tablename__ = "tasks"
 
@@ -66,26 +62,26 @@ class TaskRow(Base):
         ForeignKey("directives.id", ondelete="CASCADE"),
         nullable=False,
     )
-    # current_stage_id: intentionally NO FK onto workflow_stages.id.
-    # Task and Workflow are separate Aggregates; Aggregate boundary dictates
-    # that Task must not depend on Workflow's internal stage table directly.
-    # Existence validation is TaskService's responsibility (§確定 R1-G).
+    # current_stage_id: workflow_stages.id への FK は意図的に持たない。
+    # Task と Workflow は別の Aggregate であり、Aggregate 境界により Task は
+    # Workflow の内部 stage テーブルに直接依存してはならない。
+    # 存在検証は TaskService の責務（§確定 R1-G）。
     current_stage_id: Mapped[UUID] = mapped_column(UUIDStr, nullable=False)
     status: Mapped[str] = mapped_column(String(32), nullable=False)
-    # last_error: MaskedText — LLM error messages may contain API keys /
-    # auth tokens. MaskedText.process_bind_param redacts secrets before
-    # SQLite storage (§確定 R1-E, masking is irreversible).
+    # last_error: MaskedText — LLM のエラー メッセージは API キー / 認証トークンを
+    # 含み得る。MaskedText.process_bind_param が SQLite 格納前にシークレットを
+    # 伏字化する（§確定 R1-E、伏字化は不可逆）。
     last_error: Mapped[str | None] = mapped_column(MaskedText, nullable=True)
     created_at: Mapped[datetime] = mapped_column(UTCDateTime, nullable=False)
     updated_at: Mapped[datetime] = mapped_column(UTCDateTime, nullable=False)
 
     __table_args__ = (
-        # §確定 R1-K: non-UNIQUE single-column index for count_by_room.
+        # §確定 R1-K: count_by_room 用の非 UNIQUE 単一カラム インデックス。
         Index("ix_tasks_room_id", "room_id"),
-        # §確定 R1-K: composite (status, updated_at, id) index.
-        # WHERE status = 'BLOCKED' in find_blocked uses the leading prefix;
-        # ORDER BY updated_at DESC, id DESC uses the trailing columns.
-        # count_by_status also benefits from the status prefix.
+        # §確定 R1-K: 複合 (status, updated_at, id) インデックス。
+        # find_blocked の WHERE status = 'BLOCKED' は先頭プレフィックスを使い、
+        # ORDER BY updated_at DESC, id DESC は後続カラムを使う。
+        # count_by_status も status プレフィックスの恩恵を受ける。
         Index("ix_tasks_status_updated_id", "status", "updated_at", "id"),
     )
 

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/tables/workflow_stages.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/tables/workflow_stages.py
@@ -1,38 +1,35 @@
-"""``workflow_stages`` table — Workflow ↔ Stage child rows.
+"""``workflow_stages`` テーブル — Workflow ↔ Stage 子行。
 
-Stores :class:`bakufu.domain.workflow.entities.Stage` values as a side
-table of the Workflow Aggregate. ``stage_id`` is **intentionally not** a
-foreign key onto ``workflows.entry_stage_id`` (§確定 J in
-``docs/features/workflow-repository/detailed-design.md``); the
-Aggregate-level ``_validate_entry_in_stages`` already enforces the
-reference invariant.
+:class:`bakufu.domain.workflow.entities.Stage` の値を Workflow Aggregate の関連
+テーブルとして保存する。``stage_id`` は意図的に ``workflows.entry_stage_id`` への
+外部キーには **しない**（``docs/features/workflow-repository/detailed-design.md``
+§確定 J）。Aggregate レベルの ``_validate_entry_in_stages`` が既に参照不変条件を
+強制している。
 
-Cascade: deleting a Workflow row purges its stage rows
-(``ON DELETE CASCADE``). The ``UNIQUE(workflow_id, stage_id)`` constraint
-mirrors :func:`bakufu.domain.workflow.dag_validators._validate_stage_id_unique`
-at the row level.
+カスケード: Workflow 行の削除はその stage 行を消去する（``ON DELETE CASCADE``）。
+``UNIQUE(workflow_id, stage_id)`` 制約は
+:func:`bakufu.domain.workflow.dag_validators._validate_stage_id_unique` を行レベル
+でミラーする。
 
-Per-column secret-handling (§確定 H + 申し送り #6 of M2 persistence
-foundation):
+カラム別シークレット ハンドリング（§確定 H + M2 persistence foundation 申し送り #6）:
 
-* ``notify_channels_json`` is a :class:`MaskedJSONEncoded` column. The
-  ``process_bind_param`` hook re-routes every nested ``target`` field
-  through :func:`bakufu.infrastructure.security.masking.mask_in` so the
-  Discord webhook ``token`` segment never reaches disk in plaintext.
-  Defense-in-depth: ``NotifyChannel.field_serializer(when_used='json')``
-  already masks at ``model_dump(mode='json')`` time, but the
-  TypeDecorator is the *gate* that fires for both ORM and Core
-  ``insert(table).values(...)`` paths (BUG-PF-001 contract).
-* ``completion_policy_json`` is a plain :class:`JSONEncoded` column —
-  the VO carries no secret-bearing values per the Schneier申し送り #6
-  six-category scan, so ``MaskedJSONEncoded`` would be **over-masking**
-  (banned by §確定 I of the detailed design).
-* The remaining columns hold UUIDs / enums / CEO-authored Markdown
-  templates; none qualify as the six masking categories.
+* ``notify_channels_json`` は :class:`MaskedJSONEncoded` カラム。
+  ``process_bind_param`` フックがネストされた各 ``target`` フィールドを
+  :func:`bakufu.infrastructure.security.masking.mask_in` 経由でルーティングする
+  ため、Discord webhook の ``token`` セグメントが平文でディスクに到達することはない。
+  多層防御: ``NotifyChannel.field_serializer(when_used='json')`` も
+  ``model_dump(mode='json')`` 時にマスクするが、TypeDecorator が ORM と Core
+  ``insert(table).values(...)`` の両経路で発火する *ゲート* となる（BUG-PF-001
+  コントラクト）。
+* ``completion_policy_json`` は通常の :class:`JSONEncoded` カラム — VO は
+  Schneier 申し送り #6 の 6 カテゴリ スキャンに照らしてもシークレット保持値を
+  持たないため、``MaskedJSONEncoded`` だと **過剰マスキング**（詳細設計 §確定 I
+  で禁止）になる。
+* 残りのカラムは UUID / enum / CEO 著作の Markdown テンプレートを保持し、6 つの
+  マスキング カテゴリには該当しない。
 
-The CI three-layer defense pins exactly one
-``MaskedJSONEncoded`` column on this table (positive contract on
-``notify_channels_json``, no-mask on every other column).
+CI 3 層防御は本テーブル上の ``MaskedJSONEncoded`` カラム数を厳密に 1 個に固定する
+（``notify_channels_json`` への positive コントラクト、その他全カラムは no-mask）。
 """
 
 from __future__ import annotations
@@ -52,7 +49,7 @@ from bakufu.infrastructure.persistence.sqlite.base import (
 
 
 class WorkflowStageRow(Base):
-    """ORM mapping for the ``workflow_stages`` table."""
+    """``workflow_stages`` テーブルの ORM マッピング。"""
 
     __tablename__ = "workflow_stages"
 
@@ -72,9 +69,9 @@ class WorkflowStageRow(Base):
         default="",
     )
     completion_policy_json: Mapped[Any] = mapped_column(JSONEncoded, nullable=False)
-    # Default ``[]`` is enforced at the SQL level by the ``server_default``
-    # in 0003_workflow_aggregate.py; ORM-side defaulting is unnecessary
-    # because the Repository always passes an explicit list.
+    # デフォルト ``[]`` は 0003_workflow_aggregate.py の ``server_default`` で SQL
+    # レベルにおいて強制される。Repository が常に明示的なリストを渡すため、
+    # ORM 側のデフォルト指定は不要。
     notify_channels_json: Mapped[Any] = mapped_column(MaskedJSONEncoded, nullable=False)
 
     __table_args__ = (

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/tables/workflow_transitions.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/tables/workflow_transitions.py
@@ -1,23 +1,20 @@
-"""``workflow_transitions`` table — Workflow ↔ Transition child rows.
+"""``workflow_transitions`` テーブル — Workflow ↔ Transition 子行。
 
-Stores :class:`bakufu.domain.workflow.entities.Transition` values as a
-side table of the Workflow Aggregate. ``from_stage_id`` /
-``to_stage_id`` are **intentionally not** foreign keys (§確定 J in
-``docs/features/workflow-repository/detailed-design.md``); the
-Aggregate-level ``_validate_transition_refs`` already enforces that
-both ends live inside the Workflow's ``stages`` collection at
-construction time.
+:class:`bakufu.domain.workflow.entities.Transition` の値を Workflow Aggregate の
+関連テーブルとして保存する。``from_stage_id`` / ``to_stage_id`` は **意図的に**
+外部キーには **しない**（``docs/features/workflow-repository/detailed-design.md``
+§確定 J）。Aggregate レベルの ``_validate_transition_refs`` が、構築時に両端が
+Workflow の ``stages`` コレクション内に存在することを既に強制する。
 
-Cascade: deleting a Workflow row purges its transition rows
-(``ON DELETE CASCADE``). The ``UNIQUE(workflow_id, transition_id)``
-constraint mirrors
-:func:`bakufu.domain.workflow.dag_validators._validate_transition_id_unique`
-at the row level.
+カスケード: Workflow 行の削除はその transition 行を消去する（``ON DELETE CASCADE``）。
+``UNIQUE(workflow_id, transition_id)`` 制約は
+:func:`bakufu.domain.workflow.dag_validators._validate_transition_id_unique` を行
+レベルでミラーする。
 
-No ``Masked*`` TypeDecorator on any column — neither the source /
-target stage IDs nor the enum-string ``condition`` / human label fall
-into the Schneier 申し送り #6 secret categories. Registered with the
-CI three-layer defense's no-mask contract.
+どのカラムにも ``Masked*`` TypeDecorator は付けない — ソース／ターゲットの stage
+ID も、enum 文字列の ``condition`` も、人間可読ラベルも Schneier 申し送り #6 の
+シークレット カテゴリには該当しない。CI 3 層防御のノー マスク コントラクトに
+登録される。
 """
 
 from __future__ import annotations
@@ -31,7 +28,7 @@ from bakufu.infrastructure.persistence.sqlite.base import Base, UUIDStr
 
 
 class WorkflowTransitionRow(Base):
-    """ORM mapping for the ``workflow_transitions`` table."""
+    """``workflow_transitions`` テーブルの ORM マッピング。"""
 
     __tablename__ = "workflow_transitions"
 

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/tables/workflows.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/tables/workflows.py
@@ -1,25 +1,21 @@
-"""``workflows`` table — Workflow Aggregate root row.
+"""``workflows`` テーブル — Workflow Aggregate ルート行。
 
-Holds three scalar columns (``id`` / ``name`` / ``entry_stage_id``); the
-``stages`` and ``transitions`` collections live in the side tables
-:mod:`...tables.workflow_stages` /
-:mod:`...tables.workflow_transitions` so the row width stays bounded
-and CASCADE targets are obvious.
+3 個のスカラー カラム（``id`` / ``name`` / ``entry_stage_id``）を保持する。
+``stages`` と ``transitions`` のコレクションは
+:mod:`...tables.workflow_stages` / :mod:`...tables.workflow_transitions` の
+関連テーブルに置き、行幅を抑え CASCADE 対象を明確にする。
 
-``entry_stage_id`` is **intentionally not a foreign key** onto
-``workflow_stages.stage_id`` — see
-``docs/features/workflow-repository/detailed-design.md`` §確定 J. The
-natural FK would form a circular reference (``workflows`` ↔
-``workflow_stages``) that requires deferred constraints. SQLite's
-``PRAGMA defer_foreign_keys`` works but tightens portability against
-the M5+ PostgreSQL migration goal. The Aggregate-level
-``_validate_entry_in_stages`` already proves ``entry_stage_id`` lives
-inside ``stages``, so the DB constraint is redundant.
+``entry_stage_id`` は ``workflow_stages.stage_id`` への外部キーを **意図的に
+持たない** — ``docs/features/workflow-repository/detailed-design.md`` §確定 J
+を参照。自然な FK は循環参照（``workflows`` ↔ ``workflow_stages``）を形成し、
+deferred 制約が必要となる。SQLite の ``PRAGMA defer_foreign_keys`` は動作するが、
+M5+ の PostgreSQL 移行目標に対する portability を狭めてしまう。Aggregate レベル
+の ``_validate_entry_in_stages`` が ``entry_stage_id`` が ``stages`` 内に存在する
+ことを既に証明しているため、DB 制約は冗長。
 
-No ``Masked*`` TypeDecorator on any column. The CI three-layer defense
-(grep guard + arch test + storage.md §逆引き表) registers this absence
-so a future PR cannot silently swap a column to a secret-bearing
-semantic.
+どのカラムにも ``Masked*`` TypeDecorator は付けない。CI 3 層防御（grep ガード +
+アーキ テスト + storage.md §逆引き表）はこの不在を登録するため、将来の PR が
+カラムをサイレントにシークレット保持の意味へ置き換えることはできない。
 """
 
 from __future__ import annotations
@@ -33,7 +29,7 @@ from bakufu.infrastructure.persistence.sqlite.base import Base, UUIDStr
 
 
 class WorkflowRow(Base):
-    """ORM mapping for the ``workflows`` table."""
+    """``workflows`` テーブルの ORM マッピング。"""
 
     __tablename__ = "workflows"
 

--- a/backend/src/bakufu/infrastructure/security/__init__.py
+++ b/backend/src/bakufu/infrastructure/security/__init__.py
@@ -1,22 +1,20 @@
-"""Secret masking gateway.
+"""シークレット マスキング ゲートウェイ。
 
-The single source of truth for redacting secrets *before* they hit any
-persistence boundary (SQLite rows, structured log files, audit log).
-Two consumer surfaces:
+あらゆる永続化境界（SQLite 行、構造化ログファイル、監査ログ）にシークレット
+が到達する *前* に、それらを伏字化する単一の信頼できる出所（SSOT）。
+利用者向けに 2 つの API を提供する:
 
-* :func:`bakufu.infrastructure.security.masking.mask` — single-string
-  redaction.
-* :func:`bakufu.infrastructure.security.masking.mask_in` — recursive
-  walker for ``dict`` / ``list`` / ``tuple`` payloads.
+* :func:`bakufu.infrastructure.security.masking.mask` — 単一文字列の
+  伏字化。
+* :func:`bakufu.infrastructure.security.masking.mask_in` — ``dict`` /
+  ``list`` / ``tuple`` ペイロードを再帰的に走査するウォーカ。
 
-Wiring contracts (Confirmation B) live in the table modules under
-``infrastructure/persistence/sqlite/tables/``: each table that holds
-secret-bearing columns declares its columns with the
-:class:`MaskedJSONEncoded` / :class:`MaskedText` TypeDecorators
-(defined in :mod:`bakufu.infrastructure.persistence.sqlite.base`) so
-that ``process_bind_param`` routes the values through this gateway
-on every Core / ORM bind. See
-``docs/features/persistence-foundation/requirements-analysis.md``
-§確定 R1-D for why event listeners were reverse-rejected
-(BUG-PF-001).
+配線契約（Confirmation B）は ``infrastructure/persistence/sqlite/tables/``
+のテーブルモジュールに記述される。シークレットを保持するカラムを持つ各
+テーブルは、それらのカラムを :class:`MaskedJSONEncoded` /
+:class:`MaskedText` TypeDecorator（:mod:`bakufu.infrastructure.persistence.sqlite.base`
+で定義）で宣言し、Core / ORM のバインドのたびに ``process_bind_param`` が
+本ゲートウェイを経由するようにする。イベントリスナがリバース棄却された
+理由（BUG-PF-001）は ``docs/features/persistence-foundation/requirements-analysis.md``
+§確定 R1-D を参照。
 """

--- a/backend/src/bakufu/infrastructure/security/masked_env.py
+++ b/backend/src/bakufu/infrastructure/security/masked_env.py
@@ -1,35 +1,35 @@
-"""Layer 1 of the masking gateway: known-environment-variable redaction.
+"""マスキング ゲートウェイのレイヤ 1: 既知の環境変数値の伏字化。
 
-Bootstrap collects values from a fixed allow-list of environment
-variables at startup time and compiles them into a regex-replacement
-table. The table is queried for every ``mask()`` call and every entry
-matched is replaced with ``<REDACTED:ENV:{NAME}>``.
+Bootstrap が起動時に固定アローリストに従って環境変数値を収集し、正規
+表現置換テーブルへコンパイルする。本テーブルは ``mask()`` 呼び出し
+ごとに参照され、合致したエントリは ``<REDACTED:ENV:{NAME}>`` で置換
+される。
 
-Why an allow-list (vs. "every env var")?
-----------------------------------------
-Some environment variables hold benign data (``PATH``, ``HOME``,
-``LANG``). Including them all would over-redact CLI output / audit
-text and make troubleshooting impossible. The allow-list is the same
-list ``docs/design/domain-model/storage.md`` froze, with one
-substitution: ``BAKUFU_DB_KEY`` is removed (MVP doesn't ship SQLCipher;
-see Confirmation in ``masking.md``) and ``BAKUFU_DISCORD_BOT_TOKEN`` is
-added in its place because the Discord notifier path keeps it as a
-high-confidentiality asset (threat-model §資産).
+なぜアローリストか（vs.「全環境変数」を対象にしない理由）
+----------------------------------------------------------
+``PATH``、``HOME``、``LANG`` のように無害なデータを保持する環境変数も
+存在する。それらまで含めると CLI 出力や監査テキストが過剰に伏字化され、
+トラブルシューティングが困難になる。アローリストは
+``docs/design/domain-model/storage.md`` で確定した一覧と同一だが、
+1 点だけ置換している: MVP では SQLCipher を採用しないため
+``BAKUFU_DB_KEY`` を除外し（``masking.md`` の Confirmation を参照）、
+代わりに ``BAKUFU_DISCORD_BOT_TOKEN`` を追加する。Discord 通知系統は
+脅威モデル §資産 でも高機密資産として位置づけられるためである。
 
-Length floor of 8 characters
-----------------------------
-A short value (e.g. an empty string or a 4-character marker) would
-match almost anything by accident. We skip values shorter than 8 and
-INFO-log the skip so operators can spot a misconfigured env var.
+文字数下限 8 文字
+----------------
+短い値（空文字や 4 文字程度のマーカ等）は事故的にあらゆる箇所と一致して
+しまう。8 文字未満の値はスキップしつつ INFO ログを残し、運用者が
+誤設定された環境変数に気付けるようにする。
 
-Fail-Fast contract (§確定 F)
----------------------------
-``load_env_patterns`` raises :class:`bakufu.infrastructure.exceptions.BakufuConfigError`
-with ``msg_id='MSG-PF-008'`` if the OS rejects ``os.environ`` access
-itself or any individual value cannot be regex-compiled. Bootstrap
-intercepts and exits non-zero — running with masking layer 1 disabled
-would silently degrade the trust boundary the rest of the system
-relies on.
+Fail-Fast 契約（§確定 F）
+-------------------------
+``load_env_patterns`` は OS が ``os.environ`` アクセス自体を拒否したり、
+値の正規表現コンパイルに失敗した場合に
+:class:`bakufu.infrastructure.exceptions.BakufuConfigError` を
+``msg_id='MSG-PF-008'`` で送出する。Bootstrap がこれを捕捉し非ゼロ
+終了する。マスキング レイヤ 1 を無効化したまま起動すれば、システムの
+他部分が依存する信頼境界を黙って弱化させてしまうためである。
 """
 
 from __future__ import annotations
@@ -42,8 +42,9 @@ from bakufu.infrastructure.exceptions import BakufuConfigError
 
 logger = logging.getLogger(__name__)
 
-# Fixed allow-list per ``docs/features/persistence-foundation/detailed-design/modules.md``
-# §Module masked_env.py. Changes go through a design doc PR first.
+# ``docs/features/persistence-foundation/detailed-design/modules.md``
+# §Module masked_env.py に従う固定アローリスト。変更は設計ドキュメントの
+# PR を経由する。
 KNOWN_ENV_KEYS: tuple[str, ...] = (
     "ANTHROPIC_API_KEY",
     "OPENAI_API_KEY",
@@ -54,31 +55,31 @@ KNOWN_ENV_KEYS: tuple[str, ...] = (
     "BAKUFU_DISCORD_BOT_TOKEN",
 )
 
-# Values shorter than this are skipped to avoid catastrophic over-matching.
+# この値より短い値はスキップする。誤マッチによる過剰伏字化を防止する。
 MIN_ENV_VALUE_LENGTH: int = 8
 
 
 def load_env_patterns() -> list[tuple[str, re.Pattern[str]]]:
-    """Compile the known-env-var redaction table.
+    """既知環境変数の伏字化テーブルをコンパイルする。
 
     Returns:
-        A list of ``(env_name, compiled_pattern)`` pairs. Empty when no
-        known env var is set in the current process — that is a
-        legitimate state in CI / fresh dev environments and produces an
-        INFO log entry rather than a failure.
+        ``(env_name, compiled_pattern)`` タプルのリスト。現プロセスに
+        該当環境変数が一つも設定されていなければ空リストを返す。CI や
+        新しい開発環境では正当な状態であり、失敗ではなく INFO ログを
+        出すに留める。
 
     Raises:
-        BakufuConfigError: ``msg_id='MSG-PF-008'`` when ``os.environ``
-            access itself raises or any value fails ``re.compile``.
-            Bootstrap exits non-zero on this — running with layer 1
-            disabled is not an acceptable degraded mode.
+        BakufuConfigError: ``msg_id='MSG-PF-008'``。``os.environ``
+            アクセス自体が例外を送出した場合や、いずれかの値が
+            ``re.compile`` に失敗した場合。Bootstrap はここで
+            非ゼロ終了する。レイヤ 1 を無効化した縮退運転は許容しない。
     """
     try:
         env_snapshot = dict(os.environ)
     except OSError as exc:
-        # `os.environ` access can fail under exotic OS-level conditions
-        # (chroot misconfig, broken FS). Fail Fast — masking layer 1 is
-        # part of the trust boundary, not optional.
+        # ``os.environ`` アクセスは特殊な OS 状態（chroot 不全、FS 破損
+        # 等）で失敗し得る。マスキング レイヤ 1 は信頼境界の一部であり
+        # オプションではないため、ここで Fail Fast する。
         raise BakufuConfigError(
             msg_id="MSG-PF-008",
             message=(
@@ -102,8 +103,8 @@ def load_env_patterns() -> list[tuple[str, re.Pattern[str]]]:
         try:
             patterns.append((env_name, re.compile(re.escape(raw))))
         except re.error as exc:
-            # Theoretically unreachable since `re.escape` produces a
-            # safe pattern, but Fail Fast preserves the trust boundary.
+            # ``re.escape`` は安全なパターンを生成するため理論上ここには
+            # 到達しないが、信頼境界を維持するため Fail Fast する。
             raise BakufuConfigError(
                 msg_id="MSG-PF-008",
                 message=(

--- a/backend/src/bakufu/infrastructure/security/masking.py
+++ b/backend/src/bakufu/infrastructure/security/masking.py
@@ -1,28 +1,28 @@
-"""Masking gateway with Fail-Secure fallback (§確定 A + §確定 F).
+"""Fail-Secure フォールバック付きマスキング ゲートウェイ（§確定 A + §確定 F）。
 
-Layered redaction (order is **fixed**, see Confirmation A):
+レイヤード伏字化（順序は **固定**、Confirmation A 参照）:
 
-1. **Environment-variable values** — known secret env vars are
-   redacted to ``<REDACTED:ENV:{NAME}>``.
-2. **Regex patterns** — nine well-known secret-string formats
-   (Anthropic / OpenAI / GitHub PAT / GitHub fine-grained PAT / AWS
+1. **環境変数値** — 既知のシークレット環境変数を ``<REDACTED:ENV:{NAME}>``
+   へ置換する。
+2. **正規表現パターン** — 9 種類の代表的シークレット文字列形式
+   （Anthropic / OpenAI / GitHub PAT / GitHub fine-grained PAT / AWS
    access key / AWS secret / Slack token / Discord bot token / Bearer
-   token).
-3. **Home path** — the running user's ``$HOME`` absolute path is
-   replaced with ``<HOME>`` so log output does not leak the FS layout.
+   token）。
+3. **ホームパス** — 実行ユーザの ``$HOME`` 絶対パスを ``<HOME>`` に
+   置換し、ログ出力で FS レイアウトを漏らさないようにする。
 
-Fail-Secure contract (§確定 F)
--------------------------------
-``mask`` and ``mask_in`` **never raise**. Any internal failure is
-caught and the offending payload is replaced with a sentinel
-(``<REDACTED:MASK_ERROR>`` / ``<REDACTED:MASK_OVERFLOW>`` /
-``<REDACTED:LISTENER_ERROR>``). The raw value is **never** allowed to
-propagate downstream — operations continuity is sacrificed before
-secret leakage.
+Fail-Secure 契約（§確定 F）
+---------------------------
+``mask`` および ``mask_in`` は **絶対に例外を送出しない**。内部失敗は
+すべて捕捉され、対象ペイロードはセンチネル
+（``<REDACTED:MASK_ERROR>`` / ``<REDACTED:MASK_OVERFLOW>`` /
+``<REDACTED:LISTENER_ERROR>``）に置換される。生の値が下流へ伝播する
+ことは **決して** 許さない。シークレット漏洩を起こすくらいなら運用継続
+を犠牲にする方針である。
 
-The ``Bootstrap`` initializes this module by calling
-:func:`init` once at startup. Subsequent ``mask`` / ``mask_in`` calls
-read from the module-level state.
+``Bootstrap`` は起動時に :func:`init` を 1 度呼び出して本モジュールを
+初期化する。以降の ``mask`` / ``mask_in`` 呼び出しはモジュールレベルの
+状態を参照する。
 """
 
 from __future__ import annotations
@@ -37,28 +37,28 @@ from bakufu.infrastructure.security.masked_env import load_env_patterns
 
 logger = logging.getLogger(__name__)
 
-# Sentinel constants for Fail-Secure replacement (§確定 F).
+# §確定 F の Fail-Secure 置換用センチネル定数。
 REDACT_MASK_ERROR: Final = "<REDACTED:MASK_ERROR>"
 REDACT_MASK_OVERFLOW: Final = "<REDACTED:MASK_OVERFLOW>"
 REDACT_LISTENER_ERROR: Final = "<REDACTED:LISTENER_ERROR>"
 
-# Confirmation F: cap dict / list traversal to keep accidental 10-MB
-# payloads from spinning the masker. Anything larger than this is
-# replaced wholesale.
+# Confirmation F: dict / list の走査に上限を設け、誤って 10 MB 級の
+# ペイロードを渡された際にマスカが暴走しないようにする。これを超える
+# 場合は構造ごと一括置換する。
 MAX_BYTES_FOR_RECURSION: Final = 1_048_576  # 1 MiB
 
-# Confirmation A: nine regex patterns (order matters — Anthropic is
-# applied before OpenAI because the OpenAI pattern would otherwise
-# match `sk-ant-...` prefixes; we keep the explicit Anthropic pattern
-# in front to make the precedence visible to readers).
+# Confirmation A: 9 つの正規表現パターン（順序は重要）。OpenAI パターンが
+# `sk-ant-...` プレフィックスにも一致してしまうため、Anthropic を先に
+# 適用する。優先順位を読者に分かりやすくするため、明示的な Anthropic
+# パターンを先頭に置く。
 _REGEX_PATTERNS: Final[list[tuple[re.Pattern[str], str]]] = [
     (
         re.compile(r"sk-ant-(?:api03-)?[A-Za-z0-9_\-]{40,}"),
         "<REDACTED:ANTHROPIC_KEY>",
     ),
-    # OpenAI uses a `sk-` prefix that overlaps with Anthropic's. Use a
-    # negative lookahead so we don't double-mask Anthropic keys with the
-    # OpenAI replacement string.
+    # OpenAI の `sk-` プレフィックスは Anthropic と重複する。Anthropic
+    # キーを OpenAI 用置換文字列で二重伏字化しないよう否定先読みを
+    # 用いる。
     (
         re.compile(r"sk-(?!ant-)[A-Za-z0-9]{20,}"),
         "<REDACTED:OPENAI_KEY>",
@@ -84,32 +84,32 @@ _REGEX_PATTERNS: Final[list[tuple[re.Pattern[str], str]]] = [
         re.compile(r"[MN][A-Za-z\d]{23,}\.[\w-]{6}\.[\w-]{27,}"),
         "<REDACTED:DISCORD_TOKEN>",
     ),
-    # Bearer tokens (HTTP Authorization header). Preserve the
-    # `Authorization: Bearer ` prefix for readability and only redact
-    # the token portion.
+    # Bearer トークン（HTTP Authorization ヘッダ）。可読性のため
+    # `Authorization: Bearer ` プレフィックスを残し、トークン部のみを
+    # 伏字化する。
     (
         re.compile(r"(?i)(authorization\s*:\s*bearer\s+)[A-Za-z0-9._\-]+"),
         r"\1<REDACTED:BEARER>",
     ),
 ]
 
-# Module-level state populated by `init`.
+# `init` で設定されるモジュールレベル状態。
 _env_patterns: list[tuple[str, re.Pattern[str]]] = []
 _home_pattern: re.Pattern[str] | None = None
 _initialized: bool = False
 
 
 def init() -> None:
-    """Compile env-var patterns + home path. Call once from Bootstrap.
+    """環境変数パターン + ホームパスをコンパイルする。Bootstrap から 1 度だけ呼ぶ。
 
-    Idempotent: subsequent calls reload the env patterns. This lets
-    test setups bracket their assertions with new env values without
-    needing to reach into module internals.
+    冪等性: 後続呼び出しは環境変数パターンを再ロードする。これによりテスト
+    セットアップは新しい環境変数値で前後をブラケットしつつ、モジュール
+    内部に手を入れる必要がなくなる。
 
     Raises:
-        BakufuConfigError: when env-var snapshot fails (Fail-Fast,
-            MSG-PF-008). Bubbled up unchanged from
-            :func:`load_env_patterns`.
+        BakufuConfigError: 環境変数スナップショット取得失敗時
+            （Fail-Fast、MSG-PF-008）。:func:`load_env_patterns` から
+            そのまま再送出される。
     """
     global _env_patterns, _home_pattern, _initialized
     _env_patterns = load_env_patterns()
@@ -119,19 +119,18 @@ def init() -> None:
 
 
 def mask(value: object) -> str:
-    """Redact known secrets from ``value``. Never raises (§確定 F).
+    """``value`` から既知のシークレットを伏字化する。例外は送出しない（§確定 F）。
 
-    Accepts ``object`` (not just ``str``) so the Fail-Secure listener
-    outer-catch can funnel arbitrary payloads through the gateway
-    without first having to validate the type. Internal failures are
-    caught and the *entire* string is replaced with
-    :data:`REDACT_MASK_ERROR` so a partial / unredacted leak is
-    impossible. A WARN is logged so operators can investigate.
+    引数型を ``object``（``str`` 限定ではない）にするのは、Fail-Secure
+    リスナの外側 catch が任意のペイロードを型検証なくゲートウェイへ
+    流せるようにするためである。内部失敗は捕捉され、文字列 *全体* が
+    :data:`REDACT_MASK_ERROR` に置換される。これにより部分的な未伏字化
+    漏洩を不可能にする。運用者が調査できるよう WARN ログを残す。
     """
     if not isinstance(value, str):
-        # Defensive: callers should pass strings, but the listener
-        # outer-catch may funnel weird payloads here. Fail-Secure
-        # converts to a string and proceeds.
+        # 防御的処理: 呼び出し側は文字列を渡す前提だが、リスナの外側
+        # catch が異質なペイロードを通過させる可能性がある。Fail-Secure
+        # の方針として文字列化してから処理を継続する。
         try:
             value = str(value)
         except Exception:
@@ -142,13 +141,13 @@ def mask(value: object) -> str:
             return REDACT_MASK_ERROR
     try:
         out: str = value
-        # Layer 1: env vars first (most specific).
+        # レイヤ 1: 最も特定性の高い環境変数値を最優先で適用。
         for env_name, pattern in _env_patterns:
             out = pattern.sub(f"<REDACTED:ENV:{env_name}>", out)
-        # Layer 2: regex patterns (Anthropic before OpenAI).
+        # レイヤ 2: 正規表現パターン（Anthropic を OpenAI より先に）。
         for pattern, replacement in _REGEX_PATTERNS:
             out = pattern.sub(replacement, out)
-        # Layer 3: home path.
+        # レイヤ 3: ホームパス。
         if _home_pattern is not None:
             out = _home_pattern.sub("<HOME>", out)
         return out
@@ -161,16 +160,15 @@ def mask(value: object) -> str:
 
 
 def mask_in(value: object) -> object:
-    """Recursively walk ``value`` and apply :func:`mask` to every string.
+    """``value`` を再帰的に走査し、すべての文字列に :func:`mask` を適用する。
 
-    Supports ``str`` / ``list`` / ``tuple`` / ``dict`` / scalar
-    pass-throughs (``int`` / ``float`` / ``bool`` / ``None``). Any
-    other object is coerced via ``str()`` first then masked.
+    対応する型: ``str`` / ``list`` / ``tuple`` / ``dict``、およびスカラ
+    （``int`` / ``float`` / ``bool`` / ``None``）。それ以外のオブジェクト
+    は ``str()`` で文字列化してからマスクする。
 
-    Confirmation F overflow guard: if the structure is so large that
-    walking it would exceed :data:`MAX_BYTES_FOR_RECURSION` (estimated
-    via ``sys.getsizeof``), the *entire* structure is replaced with
-    :data:`REDACT_MASK_OVERFLOW`.
+    Confirmation F のオーバーフローガード: 構造体が大きすぎて走査時に
+    :data:`MAX_BYTES_FOR_RECURSION` を超える（``sys.getsizeof`` 概算）
+    場合、構造体 *全体* を :data:`REDACT_MASK_OVERFLOW` で置換する。
     """
     try:
         if sys.getsizeof(value) > MAX_BYTES_FOR_RECURSION:
@@ -181,8 +179,8 @@ def mask_in(value: object) -> object:
             )
             return REDACT_MASK_OVERFLOW
     except (TypeError, OSError):  # pragma: no cover — defensive
-        # Some custom objects don't implement getsizeof correctly.
-        # Treat as small and proceed.
+        # 一部のカスタムオブジェクトは getsizeof を正しく実装しない。
+        # その場合は小さいものとみなして処理を続行する。
         pass
 
     if value is None or isinstance(value, bool | int | float):
@@ -198,8 +196,8 @@ def mask_in(value: object) -> object:
     if isinstance(value, dict):
         items_dict = cast("dict[object, object]", value)
         return {key: mask_in(val) for key, val in items_dict.items()}
-    # Fallback: stringify unknown types so masking still applies. This
-    # is the §確定 F "datetime / bytes" path.
+    # フォールバック: 未知型は文字列化してマスクを適用する。これは
+    # §確定 F の「datetime / bytes」経路に該当する。
     try:
         return mask(str(value))
     except Exception:
@@ -210,11 +208,11 @@ def mask_in(value: object) -> object:
 
 
 def is_initialized() -> bool:
-    """``True`` once :func:`init` has been called.
+    """:func:`init` 呼び出し済みなら ``True``。
 
-    Listeners check this so they can short-circuit the test setups that
-    forget to call :func:`init` and would otherwise leak raw values
-    into the test DB.
+    リスナ側はこれを参照することで、:func:`init` を呼び忘れた
+    テストセットアップで生値がテスト DB に漏洩する事態を未然に
+    短絡できる。
     """
     return _initialized
 

--- a/backend/src/bakufu/infrastructure/storage/__init__.py
+++ b/backend/src/bakufu/infrastructure/storage/__init__.py
@@ -1,5 +1,6 @@
-"""File-system storage roots managed by bakufu.
+"""bakufu が管理するファイルシステム ストレージのルート群。
 
-Currently only the attachments root lives here; future PRs add log
-file rotation / on-disk archive directories under the same package.
+現時点では添付ファイル用ルートのみを保持する。将来の PR では
+ログファイルローテーションやオンディスクのアーカイブディレクトリも
+同じパッケージ配下に追加する予定。
 """

--- a/backend/src/bakufu/infrastructure/storage/attachment_root.py
+++ b/backend/src/bakufu/infrastructure/storage/attachment_root.py
@@ -1,15 +1,16 @@
-"""Attachments FS root + 24h orphan-GC scheduler skeleton.
+"""添付ファイル FS ルート + 24 時間オーファン GC スケジューラの骨組み。
 
-Bootstrap stage 5 calls :func:`ensure_root` to materialize the
-``<DATA_DIR>/attachments/`` directory with mode ``0o700`` (POSIX).
-Stage 7 calls :func:`start_orphan_gc_scheduler` to launch the
-periodic GC asyncio task.
+Bootstrap Stage 5 が :func:`ensure_root` を呼び、``<DATA_DIR>/attachments/``
+ディレクトリをモード ``0o700``（POSIX）で実体化する。Stage 7 が
+:func:`start_orphan_gc_scheduler` を呼び、定期 GC の asyncio タスクを
+起動する。
 
-The actual GC (matching FS files against ``Conversation`` /
-``Deliverable`` references and deleting orphans) lives in the
-``feature/attachment-store`` PR. Here we lay down the skeleton so
-Bootstrap's stage list is complete on day 1 and the cleanup contract
-in Confirmation J has a real ``Task`` to cancel.
+実際の GC 処理（FS 上のファイルを ``Conversation`` /
+``Deliverable`` の参照と突き合わせ、孤児を削除する処理）は
+``feature/attachment-store`` PR で実装される。本 PR では骨組みのみを
+配置し、Bootstrap の Stage 一覧を初日から完備しつつ、Confirmation J の
+クリーンアップ契約が cancel 対象として実体ある ``Task`` を持てるように
+する。
 """
 
 from __future__ import annotations
@@ -26,19 +27,20 @@ logger = logging.getLogger(__name__)
 ATTACHMENTS_SUBDIR: str = "attachments"
 ATTACHMENTS_MODE: int = 0o700
 
-# 24 hours per docs/features/persistence-foundation/requirements.md REQ-PF-009.
+# docs/features/persistence-foundation/requirements.md REQ-PF-009 に
+# 従い 24 時間。
 ORPHAN_GC_INTERVAL_SECONDS: int = 24 * 60 * 60
 
 
 def ensure_root(data_dir: Path) -> Path:
-    """Create the attachments directory and enforce ``0700`` (POSIX).
+    """添付ファイル用ディレクトリを作成し、``0700``（POSIX）を強制する。
 
     Args:
-        data_dir: The resolved BAKUFU_DATA_DIR.
+        data_dir: 解決済みの BAKUFU_DATA_DIR。
 
     Raises:
-        BakufuConfigError: ``msg_id='MSG-PF-003'`` if mkdir or chmod
-            fails. Bootstrap exits non-zero.
+        BakufuConfigError: ``msg_id='MSG-PF-003'``。mkdir または
+            chmod が失敗した場合。Bootstrap は非ゼロ終了する。
     """
     root = data_dir / ATTACHMENTS_SUBDIR
     try:
@@ -65,25 +67,27 @@ def ensure_root(data_dir: Path) -> Path:
 
 
 def start_orphan_gc_scheduler() -> asyncio.Task[None]:
-    """Schedule the 24-hour orphan-GC sweep.
+    """24 時間ごとのオーファン GC スイープをスケジュールする。
 
     Returns:
-        The asyncio task wrapping the loop. Bootstrap stores it for
-        LIFO cleanup.
+        ループをラップする asyncio タスク。Bootstrap は LIFO クリーン
+        アップのために本タスクを保持する。
 
-    The actual sweep logic (matching FS files against the
-    ``Conversation`` / ``Deliverable`` Aggregate references) lives in
-    ``feature/attachment-store`` and replaces :func:`_run_loop` there.
+    実際のスイープロジック（FS 上のファイルを ``Conversation`` /
+    ``Deliverable`` Aggregate の参照と突き合わせる処理）は
+    ``feature/attachment-store`` で実装され、本ファイルの
+    :func:`_run_loop` を置き換える。
     """
     return asyncio.create_task(_run_loop())
 
 
 async def _run_loop() -> None:
-    """Periodic sweep loop. No-op skeleton in this PR."""
+    """定期スイープループ。本 PR では何もしない骨組み実装。"""
     while True:
-        # The body is intentionally empty until ``feature/attachment-store``
-        # provides the sweep implementation. Sleeping the full interval
-        # keeps the asyncio task alive for Bootstrap's cancel path.
+        # ``feature/attachment-store`` がスイープ実装を提供するまで本体は
+        # 意図的に空のまま。インターバル全体スリープすることで asyncio
+        # タスクを生かしておき、Bootstrap の cancel 経路が機能するように
+        # する。
         try:
             await asyncio.sleep(ORPHAN_GC_INTERVAL_SECONDS)
         except asyncio.CancelledError:

--- a/backend/src/bakufu/interfaces/http/dependencies.py
+++ b/backend/src/bakufu/interfaces/http/dependencies.py
@@ -25,7 +25,7 @@ from bakufu.application.services.room_service import RoomService
 from bakufu.application.services.task_service import TaskService
 from bakufu.application.services.workflow_service import WorkflowService
 
-# Suppress unused-import warnings: these are re-exported for type-checking use.
+# 未使用 import の警告抑制: 型チェック用途で再エクスポートしている。
 __all__ = [
     "AgentRepository",
     "EmpireRepository",

--- a/backend/src/bakufu/main.py
+++ b/backend/src/bakufu/main.py
@@ -1,12 +1,11 @@
-"""bakufu Backend entry point.
+"""bakufu Backend のエントリポイント。
 
-The CLI launches :func:`main` which wires the production
-:class:`Bootstrap` (with the Alembic migration runner attached) and
-runs the eight-stage cold start. Stage 8 (FastAPI bind) is supplied
-via the ``listener_starter`` coroutine that runs uvicorn in-process
-(REQ-HAF-007, 確定 G).
+CLI は :func:`main` を起動し、本番用の :class:`Bootstrap`
+（Alembic マイグレーションランナーを接続済み）を構築して 8 段階のコールドスタート
+を実行する。Stage 8（FastAPI バインド）は ``listener_starter`` コルーチンで供給され、
+プロセス内で uvicorn を実行する（REQ-HAF-007、確定 G）。
 
-Execution: ``uv run python -m bakufu.main``.
+実行方法: ``uv run python -m bakufu.main``。
 """
 
 from __future__ import annotations
@@ -46,8 +45,8 @@ async def _run() -> int:
     try:
         await bootstrap.run()
     except BakufuConfigError as exc:
-        # Stage failure already logged a FATAL line; emit the canonical
-        # MSG-PF-NNN message to stderr for parity with operator runbooks.
+        # Stage 失敗時には既に FATAL ログが出力済みのため、運用ランブックとの整合のため
+        # 確定文言の MSG-PF-NNN メッセージを stderr に出力する。
         sys.stderr.write(f"{exc.message}\n")
         return 1
     return 0

--- a/backend/tests/architecture/test_masking_columns.py
+++ b/backend/tests/architecture/test_masking_columns.py
@@ -12,9 +12,9 @@
 SQLAlchemy が `Base.metadata.tables` に積んだ実カラムオブジェクトの
 ``type`` を参照することで、ソース表記に依らず実行時の型を物理保証する。
 
-Two contract surfaces:
+二つの契約面:
 
-* **Positive contract** — each row in §逆引き表「masking 対象あり」は
+* **Positive contract** — §逆引き表「masking 対象あり」の各行は
   指定された ``Masked*`` 型で宣言されていること。
 * **No-mask contract** — Empire 関連テーブルなど「対象なし」と
   凍結された Aggregate のテーブル群は ``MaskedJSONEncoded`` /
@@ -31,10 +31,9 @@ from bakufu.infrastructure.persistence.sqlite.base import (
     MaskedText,
 )
 
-# Importing the table modules registers every ORM mapping with
-# ``Base.metadata`` so the assertions below see the same set of
-# tables that production / Alembic see. The imported names are
-# intentionally unused — only the import side effect matters.
+# テーブルモジュールを import することで全 ORM マッピングが ``Base.metadata`` に
+# 登録される ── 後続のアサーションは本番 / Alembic と同一のテーブル集合を見る。
+# import 名自体は意図的に未使用 ── import 副作用のみが目的。
 from bakufu.infrastructure.persistence.sqlite.tables import (
     agent_providers,  # noqa: F401  # pyright: ignore[reportUnusedImport]
     agent_skills,  # noqa: F401  # pyright: ignore[reportUnusedImport]
@@ -61,8 +60,8 @@ from bakufu.infrastructure.persistence.sqlite.tables import (
 )
 
 # Positive contract: §逆引き表「masking 対象あり」.
-# Future Repository PRs append rows for ``Persona.prompt_body`` /
-# ``PromptKit.prefix_markdown`` / ``Conversation.body_markdown`` etc.
+# 今後の Repository PR で ``Persona.prompt_body`` /
+# ``PromptKit.prefix_markdown`` / ``Conversation.body_markdown`` 等の行を追加する。
 _MASKING_CONTRACT: list[tuple[str, str, type]] = [
     ("audit_log", "args_json", MaskedJSONEncoded),
     ("audit_log", "error_text", MaskedText),
@@ -72,7 +71,7 @@ _MASKING_CONTRACT: list[tuple[str, str, type]] = [
     # Workflow Repository (PR #31, detailed-design.md §確定 H).
     ("workflow_stages", "notify_channels_json", MaskedJSONEncoded),
     # Agent Repository (PR #32, detailed-design.md §確定 H + Schneier
-    # 申し送り #3 实適用).
+    # 申し送り #3 実適用).
     ("agents", "prompt_body", MaskedText),
     # Room Repository (PR #33, detailed-design.md §確定 R1-E +
     # room §確定 G 実適用).
@@ -80,105 +79,105 @@ _MASKING_CONTRACT: list[tuple[str, str, type]] = [
     # Directive Repository (PR #34, detailed-design.md §確定 R1-E).
     ("directives", "text", MaskedText),
     # Task Repository (PR #35, detailed-design.md §確定 R1-E):
-    # tasks.last_error — BLOCKED 隔離理由(LLM error に secret 混入の可能性).
+    # tasks.last_error ── BLOCKED 隔離理由(LLM error に secret 混入の可能性).
     ("tasks", "last_error", MaskedText),
     # conversation_messages.body_markdown は §BUG-TR-002 凍結済みのため除外。
-    # deliverables.body_markdown — Agent 出力に secret 混入の可能性.
+    # deliverables.body_markdown ── Agent 出力に secret 混入の可能性.
     ("deliverables", "body_markdown", MaskedText),
     # ExternalReviewGate Repository (PR #36, detailed-design.md §確定 R1-E,
     # §設計決定 ERGR-002):
-    # external_review_gates.snapshot_body_markdown — Agent 出力に secret 混入.
+    # external_review_gates.snapshot_body_markdown ── Agent 出力に secret 混入.
     ("external_review_gates", "snapshot_body_markdown", MaskedText),
-    # external_review_gates.feedback_text — CEO review comment; approve /
-    # reject / cancel input paths can carry webhook URLs / API keys.
+    # external_review_gates.feedback_text ── CEO レビューコメント。approve /
+    # reject / cancel の入力経路は webhook URL / API キーを運び得る。
     ("external_review_gates", "feedback_text", MaskedText),
-    # external_review_audit_entries.comment — CEO-authored free-form text;
-    # same secret-bearing input path as feedback_text.
+    # external_review_audit_entries.comment ── CEO 記述の自由テキスト。
+    # feedback_text と同じく secret を含み得る入力経路。
     ("external_review_audit_entries", "comment", MaskedText),
 ]
 
 # No-mask contract: §逆引き表「Empire 関連カラム: masking 対象なし」 +
 # Workflow root + Workflow transitions.
-# Each subsequent Aggregate Repository PR extends this list with the
-# tables it adds when those tables are designated "no masking".
+# 後続の Aggregate Repository PR が、masking 対象なしと指定したテーブルを
+# 本リストに順次追加する。
 _NO_MASK_TABLES: list[str] = [
     "empires",
     "empire_room_refs",
     "empire_agent_refs",
     # Workflow Repository (PR #31, detailed-design.md §確定 E):
-    # workflows / workflow_transitions register zero masking targets;
-    # only workflow_stages.notify_channels_json is secret-bearing.
+    # workflows / workflow_transitions は masking 対象を持たない。
+    # secret を運ぶのは workflow_stages.notify_channels_json のみ。
     "workflows",
     "workflow_transitions",
     # Agent Repository (PR #32, detailed-design.md §確定 E):
-    # agent_providers / agent_skills carry no Schneier #6 secret
-    # categories; only agents.prompt_body is masked.
+    # agent_providers / agent_skills は Schneier #6 secret カテゴリを
+    # 持たない。masking 対象は agents.prompt_body のみ。
     "agent_providers",
     "agent_skills",
     # Room Repository (PR #33, detailed-design.md §確定 R1-E):
-    # room_members carries no secret semantics; agent_id is not masked.
+    # room_members は secret セマンティクスを持たない。agent_id は masking しない。
     "room_members",
     # Task Repository (PR #35, detailed-design.md §確定 R1-E):
-    # task_assigned_agents / deliverable_attachments carry no secret semantics.
-    # tasks / deliverables are registered in _PARTIAL_MASK_TABLES (each has
-    # exactly one masked column). conversations / conversation_messages are
-    # §BUG-TR-002 凍結済みのため除外。
+    # task_assigned_agents / deliverable_attachments は secret セマンティクスを持たない。
+    # tasks / deliverables は _PARTIAL_MASK_TABLES に登録される (各 1 列のみ masking)。
+    # conversations / conversation_messages は §BUG-TR-002 凍結済みのため除外。
     "task_assigned_agents",
     "deliverable_attachments",
     # ExternalReviewGate Repository (PR #36, detailed-design.md §確定 R1-E):
-    # external_review_gate_attachments carries no secret semantics — file
-    # metadata (sha256 / filename / mime_type / size_bytes) carries no
-    # Schneier #6 secret categories.
+    # external_review_gate_attachments は secret セマンティクスを持たない ──
+    # ファイルメタデータ (sha256 / filename / mime_type / size_bytes) は
+    # Schneier #6 secret カテゴリに該当しない。
     "external_review_gate_attachments",
 ]
 
-# Partial-mask contract: tables that have **exactly one** masked
-# column. Used to catch over-masking — a future PR that switches
-# another column on the same table to a Masked* TypeDecorator must
-# update §逆引き表 first; otherwise this assertion fires.
+# Partial-mask contract: **ちょうど 1 列**だけ masking されているテーブル。
+# 過剰 masking を検出する用途 ── 同テーブル上の別カラムを
+# Masked* TypeDecorator に切り替える PR は、まず §逆引き表 を更新せよ。
+# さもないと本アサーションが発火する。
 #
-# Format: ``(table_name, allowed_column_name)``.
+# 形式: ``(table_name, allowed_column_name)``.
 _PARTIAL_MASK_TABLES: list[tuple[str, str]] = [
     ("workflow_stages", "notify_channels_json"),
     # Agent Repository (PR #32, detailed-design.md §確定 E):
-    # agents.prompt_body is the only masked column; persona-adjacent
-    # scalar fields stay un-masked.
+    # masking されるのは agents.prompt_body のみ。
+    # ペルソナ周辺のスカラフィールドは masking しない。
     ("agents", "prompt_body"),
     # Room Repository (PR #33, detailed-design.md §確定 R1-E):
-    # rooms.prompt_kit_prefix_markdown is the only masked column (room
-    # §確定 G 実適用); other columns (name / description / archived) stay
-    # un-masked.
+    # masking されるのは rooms.prompt_kit_prefix_markdown のみ
+    # (room §確定 G 実適用)。他カラム (name / description / archived) は
+    # masking しない。
     ("rooms", "prompt_kit_prefix_markdown"),
     # Directive Repository (PR #34, detailed-design.md §確定 R1-E):
-    # directives.text is the only masked column; target_room_id /
-    # created_at / task_id carry no secret semantics.
+    # masking されるのは directives.text のみ。target_room_id /
+    # created_at / task_id は secret セマンティクスを持たない。
     ("directives", "text"),
     # Task Repository (PR #35, detailed-design.md §確定 R1-E):
-    # tasks.last_error is the only masked column; room_id / directive_id /
-    # current_stage_id / status / created_at / updated_at carry no secret
-    # semantics.
+    # masking されるのは tasks.last_error のみ。room_id / directive_id /
+    # current_stage_id / status / created_at / updated_at は
+    # secret セマンティクスを持たない。
     ("tasks", "last_error"),
     # conversation_messages.body_markdown は §BUG-TR-002 凍結済みのため除外。
-    # deliverables.body_markdown is the only masked column;
-    # id / task_id / stage_id / committed_by / committed_at carry no secret
-    # semantics.
+    # masking されるのは deliverables.body_markdown のみ。
+    # id / task_id / stage_id / committed_by / committed_at は
+    # secret セマンティクスを持たない。
     ("deliverables", "body_markdown"),
     # ExternalReviewGate Repository (PR #36, detailed-design.md §確定 R1-E):
-    # external_review_audit_entries.comment is the only masked column;
-    # id / gate_id / actor_id / action / occurred_at carry no secret semantics.
+    # masking されるのは external_review_audit_entries.comment のみ。
+    # id / gate_id / actor_id / action / occurred_at は
+    # secret セマンティクスを持たない。
     ("external_review_audit_entries", "comment"),
 ]
 
-# Dual-mask contract: tables that have **exactly two** masked columns.
-# Used to catch both under-masking (a required masked column was removed)
-# and over-masking (a non-secret column was accidentally masked).
+# Dual-mask contract: **ちょうど 2 列**だけ masking されているテーブル。
+# 過小 masking (必要な masking 列の削除) と過剰 masking
+# (secret でないカラムを誤って masking) の双方を検出する。
 #
 # ExternalReviewGate Repository (PR #36, detailed-design.md §確定 R1-E +
-# §設計決定 ERGR-002): external_review_gates requires exactly two masked
-# columns (snapshot_body_markdown for Agent-authored content and
-# feedback_text for CEO-authored review comments).
+# §設計決定 ERGR-002): external_review_gates は厳密に 2 つの masking 列を
+# 必要とする (Agent 由来の snapshot_body_markdown と CEO 由来の
+# feedback_text)。
 #
-# Format: ``(table_name, frozenset_of_allowed_column_names)``.
+# 形式: ``(table_name, frozenset_of_allowed_column_names)``.
 _DUAL_MASK_TABLES: list[tuple[str, frozenset[str]]] = [
     (
         "external_review_gates",
@@ -188,7 +187,7 @@ _DUAL_MASK_TABLES: list[tuple[str, frozenset[str]]] = [
 
 
 class TestMaskingColumnContract:
-    """Each row in §逆引き表 maps a column to the Masked* type it must use."""
+    """§逆引き表の各行は、該当カラムが使用すべき Masked* 型を規定する。"""
 
     @pytest.mark.parametrize(
         ("table_name", "column_name", "expected_type"),
@@ -201,11 +200,12 @@ class TestMaskingColumnContract:
         column_name: str,
         expected_type: type,
     ) -> None:
-        """Assert ``Base.metadata.tables[table].c[column].type`` is the contracted ``Masked*`` type.
+        """``Base.metadata.tables[table].c[column].type`` が契約された
+        ``Masked*`` 型であることを表明する。
 
-        Failing here means a refactor swapped the column type back to
-        the un-masked variant (``JSONEncoded`` / ``Text``), which would
-        leak raw secrets to disk on the next INSERT.
+        失敗時は、リファクタリングでカラム型が masking なしバリアント
+        (``JSONEncoded`` / ``Text``) に戻された状態 ── 次の INSERT で
+        生 secret がディスクへ漏れる危険がある。
         """
         table = Base.metadata.tables.get(table_name)
         assert table is not None, (
@@ -224,13 +224,13 @@ class TestMaskingColumnContract:
 
 
 class TestNoMaskContract:
-    """Tables explicitly registered as 'masking 対象なし' must stay un-masked.
+    """'masking 対象なし' と明示登録されたテーブルは masking なしを維持しなければならない。
 
-    Empire Repository PR (#25) introduced the "explicit no-mask"
-    pattern: a table that the design freezes as carrying no secrets
-    asserts the absence of every ``Masked*`` column type at runtime.
-    A future PR that swaps a column to a secret-bearing semantic
-    must update §逆引き表 first; otherwise this assertion fires.
+    Empire Repository PR (#25) で「explicit no-mask」パターンを導入。
+    secret を持たないと設計上凍結したテーブルは、実行時に
+    あらゆる ``Masked*`` カラム型を含まないことをアサートする。
+    ある PR でカラムを secret セマンティクスに切り替える場合は、
+    まず §逆引き表 を更新せよ ── さもないと本アサーションが発火する。
     """
 
     @pytest.mark.parametrize(
@@ -239,7 +239,7 @@ class TestNoMaskContract:
         ids=_NO_MASK_TABLES,
     )
     def test_table_has_no_masked_columns(self, table_name: str) -> None:
-        """Assert the table's columns include zero ``Masked*`` types."""
+        """テーブルのカラム集合に ``Masked*`` 型が一つも含まれないことを表明する。"""
         table = Base.metadata.tables.get(table_name)
         assert table is not None, (
             f"table {table_name!r} missing from Base.metadata; "
@@ -260,15 +260,14 @@ class TestNoMaskContract:
 
 
 class TestPartialMaskContract:
-    """Tables registered as 'partial mask' must mask exactly one named column.
+    """'partial mask' 登録のテーブルは指定の 1 カラムのみを masking しなければならない。
 
-    Workflow Repository (PR #31) introduces the 'partial mask'
-    pattern: ``workflow_stages.notify_channels_json`` is the *only*
-    masked column on the table; every other column must stay un-masked
-    so we don't bleed over-masking into ``deliverable_template`` /
-    ``completion_policy_json`` / etc. A future PR that masks an
-    additional column must update §逆引き表 first; otherwise this
-    assertion fires.
+    Workflow Repository (PR #31) で 'partial mask' パターンを導入。
+    ``workflow_stages.notify_channels_json`` のみが masking 対象で、
+    他カラムは masking しない ── ``deliverable_template`` /
+    ``completion_policy_json`` 等への過剰 masking を防ぐため。
+    別カラムを追加で masking する PR は、まず §逆引き表 を更新せよ。
+    さもないと本アサーションが発火する。
     """
 
     @pytest.mark.parametrize(
@@ -281,7 +280,7 @@ class TestPartialMaskContract:
         table_name: str,
         allowed_column: str,
     ) -> None:
-        """Assert exactly one masked column, and that it's the allowed one."""
+        """masking 列がちょうど 1 つで、それが許可列であることを表明する。"""
         table = Base.metadata.tables.get(table_name)
         assert table is not None, (
             f"table {table_name!r} missing from Base.metadata; "
@@ -302,16 +301,16 @@ class TestPartialMaskContract:
 
 
 class TestDualMaskContract:
-    """Tables registered as 'dual mask' must mask exactly two named columns.
+    """'dual mask' 登録のテーブルは指定の 2 カラムのみを masking しなければならない。
 
-    ExternalReviewGate Repository (PR #36) introduces the 'dual mask'
-    pattern: ``external_review_gates`` has two secret-bearing columns
-    (``snapshot_body_markdown`` for Agent output and ``feedback_text`` for
-    CEO review comments). Both are required; neither may be removed or
-    supplemented with a third masked column without updating §逆引き表.
+    ExternalReviewGate Repository (PR #36) で 'dual mask' パターンを導入。
+    ``external_review_gates`` は 2 つの secret 列を持つ
+    (Agent 出力の ``snapshot_body_markdown`` と CEO レビューコメントの
+    ``feedback_text``)。両方とも必須で、§逆引き表 を更新せずに
+    どちらかを削除したり 3 つ目を追加することはできない。
 
-    A future PR that masks an additional column or removes one must update
-    §逆引き表 first; otherwise this assertion fires.
+    別カラムを追加で masking する / 既存を削除する PR は、まず §逆引き表
+    を更新せよ ── さもないと本アサーションが発火する。
     """
 
     @pytest.mark.parametrize(
@@ -324,7 +323,7 @@ class TestDualMaskContract:
         table_name: str,
         allowed_columns: frozenset[str],
     ) -> None:
-        """Assert exactly the allowed masked columns, no more, no less."""
+        """許可された masking 列がちょうど含まれ、それ以外を持たないことを表明する。"""
         table = Base.metadata.tables.get(table_name)
         assert table is not None, (
             f"table {table_name!r} missing from Base.metadata; "

--- a/backend/tests/architecture/test_masking_columns.py
+++ b/backend/tests/architecture/test_masking_columns.py
@@ -97,7 +97,7 @@ _MASKING_CONTRACT: list[tuple[str, str, type]] = [
 ]
 
 # No-mask contract: §逆引き表「Empire 関連カラム: masking 対象なし」 +
-# Workflow root + Workflow transitions.
+# Workflow ルート + Workflow transitions。
 # 後続の Aggregate Repository PR が、masking 対象なしと指定したテーブルを
 # 本リストに順次追加する。
 _NO_MASK_TABLES: list[str] = [

--- a/backend/tests/docs/test_storage_md_back_index.py
+++ b/backend/tests/docs/test_storage_md_back_index.py
@@ -1,13 +1,12 @@
-"""storage.md §逆引き表 contract test (TC-DOC-EMR-001).
+"""storage.md §逆引き表 の契約テスト (TC-DOC-EMR-001)。
 
-Per ``docs/features/empire-repository/test-design.md``. The reverse-
-lookup table is the design source of truth for "which DB column is
-masked, which one is explicitly declared no-mask"; the CI three-layer
-defense (grep guard + arch test + this doc test) makes the lookup
-table physically authoritative.
+``docs/features/empire-repository/test-design.md`` に従う。逆引き表は
+「どの DB カラムをマスクするか・どれを明示的にノーマスク宣言するか」の
+設計上の真実源であり、CI の三層防御 (grep ガード + アーキテクチャテスト +
+本ドキュメントテスト) によって本表を物理的に権威づけする。
 
-Future Repository PRs append rows for their Aggregate's tables; the
-shape of the assertion stays identical.
+今後の Repository PR では各 Aggregate のテーブルに対応する行を追加していくが、
+アサーションの形は同一に保たれる。
 """
 
 from __future__ import annotations
@@ -22,7 +21,7 @@ _STORAGE_MD = _REPO_ROOT / "docs" / "design" / "domain-model" / "storage.md"
 
 @pytest.fixture(scope="module")
 def storage_md_text() -> str:
-    """Read storage.md once per module (the file is small)."""
+    """モジュールごとに 1 回だけ storage.md を読み込む(ファイルは小さい)。"""
     assert _STORAGE_MD.is_file(), (
         f"storage.md missing at {_STORAGE_MD}; the §逆引き表 lives there per "
         f"docs/design/domain-model/storage.md."
@@ -31,21 +30,20 @@ def storage_md_text() -> str:
 
 
 class TestBackIndexHasEmpireRow:
-    """TC-DOC-EMR-001: §逆引き表 includes the Empire 'masking 対象なし' entry."""
+    """TC-DOC-EMR-001: §逆引き表 に Empire の「masking 対象なし」エントリが含まれることを検証。"""
 
     def test_empire_row_present(self, storage_md_text: str) -> None:
-        """TC-DOC-EMR-001: at least one Empire row is registered as no-mask.
+        """TC-DOC-EMR-001: 少なくとも 1 件の Empire 行がノーマスクとして登録されている。
 
-        We check for the substring rather than the exact bullet so the
-        assertion survives cosmetic edits (table ordering, alternative
-        phrasing). The presence is the contract; the precise format
-        belongs to the design review.
+        体裁の変更(表の並び順や言い回しの差し替え)にアサーションが耐えられるよう、
+        箇条書きの厳密一致ではなく部分文字列で検査する。存在することが契約であり、
+        厳密なフォーマットは設計レビューの管轄である。
         """
         assert "Empire" in storage_md_text, (
             "storage.md must mention Empire so the §逆引き表 can register "
             "the 'masking 対象なし' entry per empire-repository §確定 E."
         )
-        # Either Japanese phrasing variant freezes the no-mask intent.
+        # いずれかの日本語表現がノーマスクの意図を凍結する
         no_mask_phrasing_present = any(
             phrase in storage_md_text
             for phrase in (
@@ -62,14 +60,13 @@ class TestBackIndexHasEmpireRow:
         )
 
     def test_empire_table_row_co_locates_no_mask_phrase(self, storage_md_text: str) -> None:
-        """TC-DOC-EMR-001: §逆引き表 row contains both 'Empire' and 'masking 対象なし'.
+        """TC-DOC-EMR-001: §逆引き表 の行に 'Empire' と 'masking 対象なし' が同居することを検証。
 
-        The reverse-lookup table renders Empire as a single Markdown
-        table row that lists the three Empire tables alongside the
-        explicit "masking 対象なし" declaration. We assert that **at
-        least one line** in storage.md carries both substrings — that
-        is the operator-readable contract: scrolling to the Empire row
-        reveals the no-mask declaration without further navigation.
+        逆引き表では Empire を Markdown テーブルの 1 行として表現し、3 つの Empire
+        テーブルと明示的な「masking 対象なし」宣言を併記する。storage.md の中に
+        **少なくとも 1 行**が両方の部分文字列を含んでいることをアサートする ——
+        運用者が読みやすさを担保する契約であり、Empire 行までスクロールすれば
+        追加のナビゲーションなしにノーマスク宣言を読み取れる。
         """
         co_located_lines = [
             line
@@ -87,23 +84,22 @@ class TestBackIndexHasEmpireRow:
 
 
 class TestBackIndexHasWorkflowRows:
-    """TC-DOC-WFR-001: §逆引き表 includes the Workflow partial-mask + no-mask entries.
+    """TC-DOC-WFR-001: §逆引き表 に Workflow の partial-mask + no-mask エントリが含まれる。
 
-    The Workflow PR (#41) introduces the *partial-mask* template
-    alongside the empire-repo no-mask template: ``workflow_stages.notify_channels_json``
-    is the **only** masked column on the Workflow surface, and
-    ``workflows`` / ``workflow_transitions`` / the rest of
-    ``workflow_stages`` are explicitly registered as no-mask. We
-    assert both halves of that contract live on operator-readable
-    lines in ``storage.md``.
+    Workflow PR (#41) は empire-repo のノーマスクテンプレートに加えて
+    *partial-mask* テンプレートを導入する: ``workflow_stages.notify_channels_json``
+    が Workflow 表面で**唯一**マスクされるカラムであり、``workflows`` /
+    ``workflow_transitions`` および ``workflow_stages`` の残りのカラムは
+    明示的にノーマスクとして登録される。本契約の両側が ``storage.md``
+    の運用者可読な行として記載されていることをアサートする。
     """
 
     def test_workflow_stages_notify_channels_row_present(self, storage_md_text: str) -> None:
-        """TC-DOC-WFR-001a: §逆引き表 declares ``MaskedJSONEncoded`` on the notify column.
+        """TC-DOC-WFR-001a: §逆引き表 が notify カラムに ``MaskedJSONEncoded`` を宣言する。
 
-        The line must co-locate ``workflow_stages.notify_channels_json``
-        and ``MaskedJSONEncoded`` so an operator scrolling to the
-        Workflow row sees the redaction policy directly.
+        運用者が Workflow 行までスクロールすればマスキングポリシーを直接読み取れるよう、
+        ``workflow_stages.notify_channels_json`` と ``MaskedJSONEncoded`` が
+        同一行に併記されていなければならない。
         """
         co_located_lines = [
             line
@@ -118,11 +114,11 @@ class TestBackIndexHasWorkflowRows:
         )
 
     def test_workflow_no_mask_row_present(self, storage_md_text: str) -> None:
-        """TC-DOC-WFR-001b: §逆引き表 declares the Workflow remaining columns no-mask.
+        """TC-DOC-WFR-001b: §逆引き表 が Workflow の残りのカラムをノーマスクとして宣言する。
 
-        The contract phrase is "masking 対象なし" co-located with
-        ``Workflow`` (so the partial-mask Aggregate's *non*-masked
-        columns are still operator-readable from the Workflow row).
+        契約フレーズは ``Workflow`` と同一行に併記された「masking 対象なし」である
+        (これにより partial-mask Aggregate の*非*マスクカラムも Workflow 行から
+        直接読み取れる)。
         """
         co_located_lines = [
             line
@@ -139,23 +135,21 @@ class TestBackIndexHasWorkflowRows:
 
 
 class TestBackIndexHasAgentRows:
-    """TC-DOC-AGR-001: §逆引き表 includes the Agent partial-mask + no-mask entries.
+    """TC-DOC-AGR-001: §逆引き表 に Agent の partial-mask + no-mask エントリが含まれる。
 
-    The Agent Repository PR (#45) is the second partial-mask
-    Aggregate (after Workflow): ``agents.prompt_body`` is the
-    **only** masked column on the Agent surface, with
-    ``agent_providers`` / ``agent_skills`` and the rest of
-    ``agents`` registered as no-mask. **Schneier 申し送り #3 实適用
-    クローズ** is documented through this line.
+    Agent Repository PR (#45) は (Workflow に続く) 2 番目の partial-mask
+    Aggregate である: ``agents.prompt_body`` が Agent 表面で**唯一**
+    マスクされるカラムであり、``agent_providers`` / ``agent_skills`` および
+    ``agents`` の残りのカラムはノーマスクとして登録される。本行を通じて
+    **Schneier 申し送り #3 实適用クローズ**が文書化される。
     """
 
     def test_agents_prompt_body_row_present(self, storage_md_text: str) -> None:
-        """§逆引き表 declares ``MaskedText`` on ``agents.prompt_body``.
+        """§逆引き表 が ``agents.prompt_body`` に ``MaskedText`` を宣言する。
 
-        The line must co-locate ``Persona.prompt_body`` (or
-        ``agents.prompt_body``) and ``MaskedText`` so an operator
-        scrolling to the Agent row sees the redaction policy
-        directly.
+        運用者が Agent 行までスクロールすればマスキングポリシーを直接読み取れるよう、
+        ``Persona.prompt_body`` (または ``agents.prompt_body``) と ``MaskedText``
+        が同一行に併記されていなければならない。
         """
         co_located_lines = [
             line
@@ -174,11 +168,11 @@ class TestBackIndexHasAgentRows:
         )
 
     def test_agent_no_mask_row_present(self, storage_md_text: str) -> None:
-        """§逆引き表 declares the Agent remaining columns no-mask.
+        """§逆引き表 が Agent の残りのカラムをノーマスクとして宣言する。
 
-        agent_providers / agent_skills and other agents columns are
-        registered as "masking 対象なし" so the partial-mask intent
-        is visible from the Agent row directly.
+        agent_providers / agent_skills およびその他の agents カラムは
+        「masking 対象なし」として登録され、partial-mask の意図が Agent 行から
+        直接読み取れるようになっている。
         """
         co_located_lines = [
             line
@@ -195,18 +189,18 @@ class TestBackIndexHasAgentRows:
 
 
 class TestBackIndexHasDirectiveRows:
-    """TC-DOC-DRR-001: §逆引き表 includes Directive partial-mask + no-mask entries.
+    """TC-DOC-DRR-001: §逆引き表 に Directive の partial-mask + no-mask エントリが含まれる。
 
-    Directive Repository PR (#34): ``directives.text`` is the **only**
-    masked column (directive §確定 G 実適用), with the remaining columns
-    (id / target_room_id / created_at / task_id) registered as no-mask.
+    Directive Repository PR (#34): ``directives.text`` が**唯一**マスクされる
+    カラムであり (directive §確定 G 実適用)、残りのカラム
+    (id / target_room_id / created_at / task_id) はノーマスクとして登録される。
     """
 
     def test_directives_text_masked_text_row_present(self, storage_md_text: str) -> None:
-        """TC-DOC-DRR-001a: §逆引き表 declares MaskedText on directives.text.
+        """TC-DOC-DRR-001a: §逆引き表 が directives.text に MaskedText を宣言する。
 
-        The line must co-locate ``directives.text`` (or ``Directive.text``)
-        and ``MaskedText`` so an operator sees the redaction policy directly.
+        運用者がマスキングポリシーを直接読み取れるよう、``directives.text``
+        (または ``Directive.text``) と ``MaskedText`` が同一行に併記されていなければならない。
         """
         co_located_lines = [
             line
@@ -220,10 +214,10 @@ class TestBackIndexHasDirectiveRows:
         )
 
     def test_directive_no_mask_row_present(self, storage_md_text: str) -> None:
-        """TC-DOC-DRR-001b: §逆引き表 declares Directive remaining columns no-mask.
+        """TC-DOC-DRR-001b: §逆引き表 が Directive の残りのカラムをノーマスクとして宣言する。
 
-        id / target_room_id / created_at / task_id carry no secret semantics
-        and are registered as 'masking 対象なし' so over-masking is prevented.
+        id / target_room_id / created_at / task_id は秘匿セマンティクスを持たず、
+        過剰マスキングを防止するため「masking 対象なし」として登録される。
         """
         co_located_lines = [
             line
@@ -238,22 +232,22 @@ class TestBackIndexHasDirectiveRows:
 
 
 class TestBackIndexHasTaskRows:
-    """TC-DOC-TR-001: §逆引き表 includes Task partial-mask + no-mask entries.
+    """TC-DOC-TR-001: §逆引き表 に Task の partial-mask + no-mask エントリが含まれる。
 
-    Task Repository PR (#35) is the third partial-mask Aggregate:
+    Task Repository PR (#35) は 3 番目の partial-mask Aggregate である:
     * ``tasks.last_error`` — MaskedText (Task §確定 G 実適用)
     * ``deliverables.body_markdown`` — MaskedText
     * ``conversation_messages.body_markdown`` — MaskedText
-    The remaining Task-aggregate columns (task_assigned_agents / conversations /
+    残りの Task Aggregate のカラム (task_assigned_agents / conversations /
     conversation_messages の body_markdown 以外 / deliverables の body_markdown
-    以外 / deliverable_attachments) are registered as 'masking 対象なし'.
+    以外 / deliverable_attachments) は「masking 対象なし」として登録される。
     """
 
     def test_tasks_last_error_masked_text_row_present(self, storage_md_text: str) -> None:
-        """TC-DOC-TR-001a: §逆引き表 declares MaskedText on tasks.last_error.
+        """TC-DOC-TR-001a: §逆引き表 が tasks.last_error に MaskedText を宣言する。
 
-        The line must co-locate ``tasks`` and ``MaskedText`` so an operator
-        scrolling to the Task row sees the redaction policy directly.
+        運用者が Task 行までスクロールすればマスキングポリシーを直接読み取れるよう、
+        ``tasks`` と ``MaskedText`` が同一行に併記されていなければならない。
         """
         co_located_lines = [
             line
@@ -269,15 +263,16 @@ class TestBackIndexHasTaskRows:
     def test_conversation_messages_bug_tr_002_frozen_row_present(
         self, storage_md_text: str
     ) -> None:
-        """TC-DOC-TR-001b: §逆引き表 declares §BUG-TR-002 凍結 for conversation_messages.
+        """TC-DOC-TR-001b: §逆引き表 が conversation_messages について §BUG-TR-002 凍結 を宣言する。
 
-        conversation_messages.body_markdown masking is deferred to
-        feature/conversation-repository (§BUG-TR-002 凍結). The storage.md
-        §逆引き表 must document this frozen state so future PR reviewers can
-        identify the pending masking requirement without opening the issue.
+        conversation_messages.body_markdown のマスキングは
+        feature/conversation-repository に延期されている (§BUG-TR-002 凍結)。
+        storage.md §逆引き表 はこの凍結状態を文書化していなければならず、
+        これにより今後の PR レビュアーは Issue を開かずに保留中のマスキング
+        要求を特定できる。
 
-        The line must co-locate ``conversation_messages`` (or ``Conversation``)
-        and ``BUG-TR-002`` so the frozen state is operator-readable directly.
+        凍結状態が直接運用者可読となるよう、``conversation_messages``
+        (または ``Conversation``) と ``BUG-TR-002`` が同一行に併記されていなければならない。
         """
         co_located_lines = [
             line
@@ -293,9 +288,9 @@ class TestBackIndexHasTaskRows:
         )
 
     def test_deliverables_body_markdown_masked_text_row_present(self, storage_md_text: str) -> None:
-        """TC-DOC-TR-001c: §逆引き表 declares MaskedText on deliverables.body_markdown.
+        """TC-DOC-TR-001c: §逆引き表 が deliverables.body_markdown に MaskedText を宣言する。
 
-        The line must co-locate ``deliverables`` and ``MaskedText``.
+        ``deliverables`` と ``MaskedText`` が同一行に併記されていなければならない。
         """
         co_located_lines = [
             line
@@ -309,10 +304,10 @@ class TestBackIndexHasTaskRows:
         )
 
     def test_task_no_mask_row_present(self, storage_md_text: str) -> None:
-        """TC-DOC-TR-001d: §逆引き表 declares Task remaining columns no-mask.
+        """TC-DOC-TR-001d: §逆引き表 が Task の残りのカラムをノーマスクとして宣言する。
 
         task_assigned_agents / conversations / conversation_messages 除 body_markdown /
-        deliverables 除 body_markdown / deliverable_attachments は 'masking 対象なし'
+        deliverables 除 body_markdown / deliverable_attachments は「masking 対象なし」
         として登録されており、過剰マスキングを防止する。
         """
         co_located_lines = [

--- a/backend/tests/domain/__init__.py
+++ b/backend/tests/domain/__init__.py
@@ -1,1 +1,1 @@
-"""Unit and integration tests for the bakufu domain layer aggregates."""
+"""bakufu ドメイン層集約に対する単体および統合テスト。"""

--- a/backend/tests/domain/agent/__init__.py
+++ b/backend/tests/domain/agent/__init__.py
@@ -1,1 +1,1 @@
-"""Agent aggregate tests, split per feature surface (Norman §file-split rule)."""
+"""Agent 集約のテスト。機能面ごとに分割している（Norman §file-split rule）。"""

--- a/backend/tests/domain/agent/conftest.py
+++ b/backend/tests/domain/agent/conftest.py
@@ -1,11 +1,11 @@
-"""Pytest fixtures shared across agent aggregate tests.
+"""Agent 集約のテスト全体で共有する pytest フィクスチャ。
 
-The ``BAKUFU_DATA_DIR`` env var is mandatory for ``SkillRef.path`` H10
-(:func:`bakufu.domain.agent.path_validators._h10_check_base_escape`). In
-production the launcher sets it; in unit tests we autouse-fixture a stable
-fake directory string so every SkillRef construction can complete H10
-without relying on the actual filesystem (``Path.resolve(strict=False)``
-on a non-existent path simply returns the lexically-resolved form).
+``BAKUFU_DATA_DIR`` 環境変数は ``SkillRef.path`` の H10 チェック
+（:func:`bakufu.domain.agent.path_validators._h10_check_base_escape`）に必須である。
+本番環境ではランチャが設定するが、単体テストでは autouse フィクスチャで
+固定のダミーディレクトリ文字列を設定し、実ファイルシステムに依存せずに
+SkillRef の構築で H10 を完遂できるようにする（``Path.resolve(strict=False)``
+は存在しないパスでも字句解決された形式を返すだけである）。
 """
 
 from __future__ import annotations
@@ -15,9 +15,9 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def _bakufu_data_dir(monkeypatch: pytest.MonkeyPatch) -> None:  # pyright: ignore[reportUnusedFunction]
-    """Set ``BAKUFU_DATA_DIR`` for the duration of every agent test.
+    """全 agent テストの実行中、``BAKUFU_DATA_DIR`` を設定する。
 
-    Autouse fixture — pytest invokes it via dependency injection, so the
-    function appears unused to pyright. The pragma below silences that.
+    autouse フィクスチャ — pytest が依存性注入で呼び出すため、pyright からは
+    未使用に見える。下の pragma がそれを抑止する。
     """
     monkeypatch.setenv("BAKUFU_DATA_DIR", "/tmp/bakufu-test-root")

--- a/backend/tests/domain/agent/test_application_responsibility.py
+++ b/backend/tests/domain/agent/test_application_responsibility.py
@@ -1,13 +1,13 @@
-"""Application-layer responsibility lock (TC-UT-AG-029 / REQ-AG R1-B).
+"""アプリケーション層責務のロック（TC-UT-AG-029 / REQ-AG R1-B）。
 
-Confirmation R1-B in the requirements analysis says **name uniqueness inside
-an Empire is the application service's job**, not the aggregate's. Two
-Agents with identical names but different ids must construct cleanly at the
-domain layer; the duplicate check belongs in ``AgentService.hire``.
+要求分析の Confirmation R1-B では、**Empire 内での名前の一意性は
+アプリケーションサービスの責務**であり、集約の責務ではない、と定めている。
+名前が同じで id が異なる 2 つの Agent はドメイン層で問題なく構築できなければ
+ならず、重複チェックは ``AgentService.hire`` に属する。
 
-These tests lock that contract so a future refactor cannot silently move the
-check into the aggregate (which would give a false sense of "name uniqueness
-is now defended at multiple layers" while breaking the layered design).
+これらのテストはその契約を固定し、将来のリファクタリングでチェックが
+こっそり集約側に移動されることを防ぐ（移動されると「名前一意性が複数層で
+防御された」ように見える一方で、層構造の設計を壊してしまうため）。
 """
 
 from __future__ import annotations
@@ -16,11 +16,11 @@ from tests.factories.agent import make_agent
 
 
 class TestNameUniquenessLeftToApplicationLayer:
-    """TC-UT-AG-029 — Agent aggregate does NOT enforce intra-Empire name uniqueness."""
+    """TC-UT-AG-029 — Agent 集約は Empire 内での名前一意性を強制しない。"""
 
     def test_two_agents_with_same_name_but_different_ids_construct(self) -> None:
-        """REQ-AG R1-B: Aggregate accepts duplicate names — uniqueness lives in AgentService."""
+        """REQ-AG R1-B: 集約は名前重複を受理する — 一意性は AgentService にある。"""
         a1 = make_agent(name="ダリオ")
         a2 = make_agent(name="ダリオ")
-        # Both Agents construct successfully and carry distinct ids.
+        # 両 Agent ともに構築に成功し、異なる id を持つ
         assert a1.name == a2.name and a1.id != a2.id

--- a/backend/tests/domain/agent/test_archive.py
+++ b/backend/tests/domain/agent/test_archive.py
@@ -1,9 +1,9 @@
-"""Archive idempotency (REQ-AG-005 / Confirmation D).
+"""アーカイブ冪等性（REQ-AG-005 / Confirmation D）。
 
-Covers TC-UT-AG-010 / 020 / 025. The contract that ``archive()`` always
-returns a *new* instance is verified explicitly with ``is`` comparison so
-that future "skip if already archived" optimizations cannot reintroduce
-identity-based caching without breaking these tests.
+TC-UT-AG-010 / 020 / 025 をカバーする。``archive()`` が常に *新しい* インスタンス
+を返すという契約は ``is`` 比較で明示的に検証され、将来の「アーカイブ済みなら
+スキップ」のような最適化で identity ベースのキャッシュが密かに入り込むことを
+防ぐ。
 """
 
 from __future__ import annotations
@@ -12,49 +12,49 @@ from tests.factories.agent import make_agent, make_archived_agent
 
 
 class TestArchiveBasic:
-    """TC-UT-AG-010 — archive flips archived=True."""
+    """TC-UT-AG-010 — archive で archived=True に切り替わる。"""
 
     def test_archive_returns_archived_true(self) -> None:
-        """TC-UT-AG-010: archive() flips archived to True on the returned Agent."""
+        """TC-UT-AG-010: archive() は返す Agent の archived を True に切り替える。"""
         agent = make_agent()
         archived = agent.archive()
         assert archived.archived is True
 
     def test_archive_does_not_mutate_original(self) -> None:
-        """TC-UT-AG-010: original Agent stays archived=False."""
+        """TC-UT-AG-010: 元の Agent は archived=False のまま維持される。"""
         agent = make_agent()
         agent.archive()
         assert agent.archived is False
 
 
 class TestArchiveIdempotency:
-    """TC-UT-AG-020 / 025 — idempotency = state equality, NOT object identity."""
+    """TC-UT-AG-020 / 025 — 冪等性 = 状態の等価性。オブジェクト同一性ではない。"""
 
     def test_archive_on_already_archived_does_not_raise(self) -> None:
-        """TC-UT-AG-020: archive() on archived=True Agent succeeds (no exception)."""
+        """TC-UT-AG-020: archived=True の Agent への archive() は成功（例外なし）。"""
         agent = make_archived_agent()
-        result = agent.archive()  # must not raise
+        result = agent.archive()  # 例外を送出してはならない
         assert result.archived is True
 
     def test_archive_on_already_archived_returns_new_instance(self) -> None:
-        """TC-UT-AG-020 / Confirmation D: archive() ALWAYS returns a new instance.
+        """TC-UT-AG-020 / Confirmation D: archive() は常に新しいインスタンスを返す。
 
-        ``a1 is a2`` must be False — Confirmation D forbids object-identity
-        caching. Idempotency is defined as "result state matches", proven by
-        the structural-equality assertion in the next test.
+        ``a1 is a2`` は False でなければならない — Confirmation D は
+        オブジェクト同一性キャッシュを禁じている。冪等性は「結果の状態が一致する」
+        ことで定義され、次のテストの構造的等価アサーションで証明される。
         """
         agent = make_archived_agent()
         result = agent.archive()
         assert result is not agent
 
     def test_archive_on_already_archived_is_structurally_equal(self) -> None:
-        """TC-UT-AG-020: result of redundant archive() is == the original archived Agent."""
+        """TC-UT-AG-020: 冗長な archive() の結果は元のアーカイブ済み Agent と == である。"""
         agent = make_archived_agent()
         result = agent.archive()
-        assert result == agent  # same fields, different identity
+        assert result == agent  # フィールドは同一、identity は異なる
 
     def test_three_consecutive_archive_calls_yield_archived_true(self) -> None:
-        """TC-UT-AG-025: archive().archive().archive() all keep archived=True."""
+        """TC-UT-AG-025: archive().archive().archive() 全てで archived=True を維持。"""
         agent = make_agent()
         a1 = agent.archive()
         a2 = a1.archive()
@@ -62,7 +62,7 @@ class TestArchiveIdempotency:
         assert a1.archived is True and a2.archived is True and a3.archived is True
 
     def test_three_consecutive_archive_calls_each_yield_distinct_instance(self) -> None:
-        """TC-UT-AG-025: each archive() call returns a distinct object identity."""
+        """TC-UT-AG-025: 各 archive() 呼び出しは別個のオブジェクト identity を返す。"""
         agent = make_agent()
         a1 = agent.archive()
         a2 = a1.archive()

--- a/backend/tests/domain/agent/test_construction.py
+++ b/backend/tests/domain/agent/test_construction.py
@@ -1,7 +1,7 @@
-"""Construction & name normalization (TC-UT-AG-001 / 002 / 012 / 030).
+"""構築と名前の正規化（TC-UT-AG-001 / 002 / 012 / 030）。
 
-Covers REQ-AG-001 minimal contracts and the NFC + strip pipeline shared with
-empire / workflow.
+REQ-AG-001 の最小契約と、empire / workflow と共通の NFC + strip パイプラインを
+カバーする。
 """
 
 from __future__ import annotations
@@ -15,43 +15,43 @@ from tests.factories.agent import make_agent
 
 
 class TestAgentConstruction:
-    """REQ-AG-001 / TC-UT-AG-001 — minimal Agent contract."""
+    """REQ-AG-001 / TC-UT-AG-001 — Agent の最小契約。"""
 
     def test_default_factory_yields_one_provider_no_skills(self) -> None:
-        """TC-UT-AG-001: Agent built via factory has 1 provider, 0 skills, archived=False."""
+        """TC-UT-AG-001: ファクトリで生成した Agent は provider=1、skill=0、archived=False。"""
         agent = make_agent()
         assert len(agent.providers) == 1 and len(agent.skills) == 0 and agent.archived is False
 
 
 class TestAgentNameBoundaries:
-    """REQ-AG-001 / TC-UT-AG-002 — name length 1〜40."""
+    """REQ-AG-001 / TC-UT-AG-002 — name の長さ 1〜40。"""
 
     @pytest.mark.parametrize("valid_length", [1, 40])
     def test_accepts_lower_and_upper_boundary(self, valid_length: int) -> None:
-        """TC-UT-AG-002: 1-char and 40-char names construct successfully."""
+        """TC-UT-AG-002: 1 文字・40 文字の name は構築に成功する。"""
         agent = make_agent(name="a" * valid_length)
         assert len(agent.name) == valid_length
 
     @pytest.mark.parametrize("invalid_name", ["", "a" * 41, "   "])
     def test_rejects_zero_fortyone_or_whitespace_only(self, invalid_name: str) -> None:
-        """TC-UT-AG-002: 0-char / 41-char / whitespace-only names raise."""
+        """TC-UT-AG-002: 0 文字 / 41 文字 / 空白のみの name は例外を送出する。"""
         with pytest.raises(AgentInvariantViolation) as excinfo:
             make_agent(name=invalid_name)
         assert excinfo.value.kind == "name_range"
 
 
 class TestAgentNameNormalization:
-    """TC-UT-AG-012 — NFC + strip pipeline shared with empire / workflow."""
+    """TC-UT-AG-012 — empire / workflow と共通の NFC + strip パイプライン。"""
 
     def test_decomposed_kana_normalized_to_nfc(self) -> None:
-        """TC-UT-AG-012: decomposed kana with dakuten (e.g. 'がが') is normalized."""
+        """TC-UT-AG-012: 濁点付き分解形カナ（例 'がが'）が正規化される。"""
         composed = "がが"
         decomposed = unicodedata.normalize("NFD", composed)
-        assert decomposed != composed  # sanity
+        assert decomposed != composed  # sanity チェック
         agent = make_agent(name=decomposed)
         assert agent.name == composed
 
     def test_surrounding_whitespace_stripped(self) -> None:
-        """TC-UT-AG-012: leading/trailing whitespace is stripped."""
+        """TC-UT-AG-012: 先頭・末尾の空白は除去される。"""
         agent = make_agent(name="  ダリオ  ")
         assert agent.name == "ダリオ"

--- a/backend/tests/domain/agent/test_frozen_extra.py
+++ b/backend/tests/domain/agent/test_frozen_extra.py
@@ -1,8 +1,8 @@
-"""frozen=True / extra='forbid' invariants (TC-UT-AG-026 / 027 / 011).
+"""frozen=True / extra='forbid' の不変条件（TC-UT-AG-026 / 027 / 011）。
 
-Verifies that the Pydantic v2 frozen contract physically prevents post-
-construction mutation across all aggregate / VO surfaces, and that unknown
-fields in payloads are rejected before any aggregate validation runs.
+Pydantic v2 の frozen 契約が、全集約 / VO 面で構築後の変更を物理的に阻止する
+こと、およびペイロードの未知フィールドが集約バリデーション実行前に拒否される
+ことを検証する。
 """
 
 from __future__ import annotations
@@ -23,7 +23,7 @@ from tests.factories.agent import (
 
 
 class TestFrozenContract:
-    """TC-UT-AG-026 — Agent / Persona / ProviderConfig / SkillRef frozen."""
+    """TC-UT-AG-026 — Agent / Persona / ProviderConfig / SkillRef の frozen 性。"""
 
     def test_agent_rejects_attribute_assignment(self) -> None:
         agent = make_agent()
@@ -47,7 +47,7 @@ class TestFrozenContract:
 
 
 class TestStructuralEquality:
-    """TC-UT-AG-011 — VOs use structural equality and hashing."""
+    """TC-UT-AG-011 — VO は構造的等価性とハッシュを用いる。"""
 
     def test_two_personas_with_identical_fields_compare_equal(self) -> None:
         a = make_persona(display_name="reviewer", archetype="r", prompt_body="p")
@@ -61,10 +61,10 @@ class TestStructuralEquality:
 
 
 class TestExtraForbid:
-    """TC-UT-AG-027 — extra='forbid' rejects unknown fields."""
+    """TC-UT-AG-027 — extra='forbid' は未知フィールドを拒否する。"""
 
     def test_agent_model_validate_rejects_unknown_field(self) -> None:
-        """Agent.model_validate refuses payloads with unknown keys."""
+        """Agent.model_validate は未知キーを含むペイロードを拒否する。"""
         payload: dict[str, object] = {
             "id": str(uuid4()),
             "name": "ok",

--- a/backend/tests/domain/agent/test_helpers_independence.py
+++ b/backend/tests/domain/agent/test_helpers_independence.py
@@ -1,11 +1,10 @@
-"""Aggregate + path helpers invoked independently (Confirmation F equivalent).
+"""集約・パスヘルパの独立呼び出し（Confirmation F 同等）。
 
-The 5 ``_validate_*`` helpers in ``aggregate_validators.py`` and the 10
-``_h*_check_*`` helpers in ``path_validators.py`` are module-level pure
-functions — tests can import and call them directly without first
-constructing an Agent. This proves the aggregate path does not share code
-with the VO self-checks (twin-defense from workflow Confirmation F carried
-forward to agent).
+``aggregate_validators.py`` の 5 つの ``_validate_*`` ヘルパと、
+``path_validators.py`` の 10 個の ``_h*_check_*`` ヘルパはモジュールレベルの
+純関数である — テストは Agent を構築する前に直接 import して呼び出せる。
+これは集約経路が VO 自己検証とコードを共有していないこと（workflow の
+Confirmation F に由来する双子防御を agent にも引き継いだもの）を証明する。
 """
 
 from __future__ import annotations
@@ -40,7 +39,7 @@ from tests.factories.agent import make_provider_config, make_skill_ref
 
 
 class TestAggregateHelpersIndependent:
-    """Each ``_validate_*`` is invokable directly and raises the right kind."""
+    """各 ``_validate_*`` は直接呼び出し可能で、正しい kind を送出する。"""
 
     def test_provider_capacity_rejects_zero(self) -> None:
         with pytest.raises(AgentInvariantViolation) as excinfo:
@@ -93,7 +92,7 @@ class TestAggregateHelpersIndependent:
 
 
 class TestPathHelpersIndependent:
-    """Each Hx helper raises with the corresponding ``check`` discriminator."""
+    """各 Hx ヘルパは対応する ``check`` 識別子を伴う例外を送出する。"""
 
     def test_h1_normalizes(self) -> None:
         import unicodedata
@@ -143,7 +142,7 @@ class TestPathHelpersIndependent:
 
 
 class TestValueObjectFactoryRegistry:
-    """Synthetic-vs-real bookkeeping (cross-cutting smoke)."""
+    """合成と実体の判別管理（クロスカット系のスモークテスト）。"""
 
     def test_factory_built_persona_is_synthetic(self) -> None:
         from tests.factories.agent import is_synthetic

--- a/backend/tests/domain/agent/test_integration.py
+++ b/backend/tests/domain/agent/test_integration.py
@@ -36,39 +36,39 @@ class TestAgentLifecycleIntegration:
         skill = make_skill_ref()
         agent = make_agent(providers=providers, skills=[skill])
 
-        # 1) Switch the default to CODEX.
+        # 1) デフォルトを CODEX に切替
         switched = agent.set_default_provider(ProviderKind.CODEX)
         codex = next(p for p in switched.providers if p.provider_kind is ProviderKind.CODEX)
         assert codex.is_default is True
 
-        # 2) Add a second skill.
+        # 2) スキルを 1 件追加
         new_skill = make_skill_ref(name="planner", path="bakufu-data/skills/planner.md")
         with_two_skills = switched.add_skill(new_skill)
         assert len(with_two_skills.skills) == 2
 
-        # 3) Remove the original skill.
+        # 3) 元のスキルを削除
         with_one_skill = with_two_skills.remove_skill(skill.skill_id)
         assert len(with_one_skill.skills) == 1
         assert with_one_skill.skills[0].skill_id == new_skill.skill_id
 
-        # 4) Archive the agent — Confirmation D returns a *new* instance.
+        # 4) Agent をアーカイブ — Confirmation D により *新しい* インスタンスを返す
         archived = with_one_skill.archive()
         assert archived.archived is True and archived is not with_one_skill
 
     def test_failed_set_default_does_not_block_subsequent_operations(self) -> None:
-        """TC-IT-AG-002: a failed set_default_provider leaves Agent ready for further changes."""
+        """TC-IT-AG-002: set_default_provider が失敗しても、後続の変更は可能。"""
         agent = make_agent()
 
-        # 1) Switching to an unregistered kind fails; original stays unchanged.
+        # 1) 未登録 kind への切替は失敗し、元は変更されない
         with pytest.raises(AgentInvariantViolation):
             agent.set_default_provider(ProviderKind.GEMINI)
         assert len(agent.providers) == 1
 
-        # 2) add_skill then succeeds against the unchanged aggregate.
+        # 2) その後の add_skill は変更されていない集約に対して成功する
         new_skill = make_skill_ref()
         with_skill = agent.add_skill(new_skill)
         assert len(with_skill.skills) == 1
 
-        # 3) archive() then succeeds against that further-mutated aggregate.
+        # 3) さらに変更された集約に対する archive() も成功する
         archived = with_skill.archive()
         assert archived.archived is True

--- a/backend/tests/domain/agent/test_integration.py
+++ b/backend/tests/domain/agent/test_integration.py
@@ -1,10 +1,9 @@
-"""Aggregate-internal lifecycle integration (TC-IT-AG-001 / 002).
+"""集約内ライフサイクル統合（TC-IT-AG-001 / 002）。
 
-Same pattern as ``empire`` / ``workflow`` integration suites: domain layer
-has no public entry point, so we validate the round-trip behavior across
-the Aggregate's mutator chain (set_default_provider → add_skill →
-remove_skill → archive) plus the resilience scenario where a mid-chain
-failure leaves the original aggregate intact.
+``empire`` / ``workflow`` の統合スイートと同じパターン: ドメイン層は
+公開エントリポイントを持たないため、集約の mutator チェーン
+（set_default_provider → add_skill → remove_skill → archive）を通したラウンド
+トリップ動作と、チェーン途中の失敗が元の集約を無傷で残す耐性シナリオを検証する。
 """
 
 from __future__ import annotations
@@ -21,13 +20,13 @@ from tests.factories.agent import (
 
 
 class TestAgentLifecycleIntegration:
-    """TC-IT-AG-001 / 002 — full lifecycle + resilience."""
+    """TC-IT-AG-001 / 002 — 全ライフサイクル + 耐性。"""
 
     def test_full_lifecycle_round_trip(self) -> None:
-        """TC-IT-AG-001: hire → add_skill → switch default → remove_skill → archive.
+        """TC-IT-AG-001: hire → add_skill → switch default → remove_skill → archive。
 
-        Pre-state: 2-provider Agent (CLAUDE_CODE default + CODEX non-default),
-        1 skill. Walk the full mutator chain and verify the final shape.
+        前提状態: 2 プロバイダの Agent（CLAUDE_CODE がデフォルト + CODEX が非デフォルト）、
+        スキル 1 件。mutator チェーンを全部通し、最終形を検証する。
         """
         providers = [
             make_provider_config(provider_kind=ProviderKind.CLAUDE_CODE, is_default=True),

--- a/backend/tests/domain/agent/test_invariants.py
+++ b/backend/tests/domain/agent/test_invariants.py
@@ -1,10 +1,10 @@
-"""Aggregate-level invariants (REQ-AG-001 / 005 / 006).
+"""集約レベルの不変条件（REQ-AG-001 / 005 / 006）。
 
-Covers TC-UT-AG-003 / 004 / 013〜015 / 018 / 021. Each invariant lives in its
-own ``Test*`` class so failures cluster by which collection contract was
-violated. Capacity overflow paths use ``model_construct`` to bypass the Agent
-constructor's eager Pydantic validation when the test needs to feed the
-helper an already-built collection.
+TC-UT-AG-003 / 004 / 013〜015 / 018 / 021 をカバーする。各不変条件は専用の
+``Test*`` クラスに置かれ、どのコレクション契約が破られたかで失敗がクラスタ化
+されるようにしている。容量超過の経路は、既に構築されたコレクションをヘルパに
+渡したいときに Agent コンストラクタの即時 Pydantic 検証を回避するため
+``model_construct`` を用いる。
 """
 
 from __future__ import annotations
@@ -22,38 +22,38 @@ from tests.factories.agent import (
 
 
 class TestProvidersRequired:
-    """TC-UT-AG-013 — providers must contain at least one entry."""
+    """TC-UT-AG-013 — providers は少なくとも 1 件含まなければならない。"""
 
     def test_empty_providers_raises_no_provider(self) -> None:
-        """TC-UT-AG-013: providers=[] raises no_provider."""
+        """TC-UT-AG-013: providers=[] は no_provider を送出する。"""
         with pytest.raises(AgentInvariantViolation) as excinfo:
             make_agent(providers=[])
         assert excinfo.value.kind == "no_provider"
 
 
 class TestProviderCapacity:
-    """TC-UT-AG-014 — providers ≤ MAX_PROVIDERS (Confirmation C)."""
+    """TC-UT-AG-014 — providers ≤ MAX_PROVIDERS（Confirmation C）。"""
 
     def test_overflow_raises_provider_capacity_exceeded(self) -> None:
-        """TC-UT-AG-014: 11 providers raises provider_capacity_exceeded."""
-        # 10 with is_default=False + 1 with is_default=True so the
-        # default-count helper would pass (it runs after capacity).
+        """TC-UT-AG-014: 11 providers で provider_capacity_exceeded を送出する。"""
+        # is_default=False を 10 件 + is_default=True を 1 件にして、
+        # デフォルト数ヘルパが（容量チェックの後に走るので）通るようにする
         providers = [
             make_provider_config(provider_kind=kind, is_default=False)
             for kind in list(ProviderKind)[:6]
         ]
-        # Append duplicates beyond MAX_PROVIDERS by varying model strings
-        # (we just need >MAX_PROVIDERS entries; provider_kind uniqueness
-        # check would catch it but capacity runs first).
+        # model 文字列を変えて MAX_PROVIDERS を超える重複を追加
+        # （MAX_PROVIDERS 超のエントリ数が必要なだけ。provider_kind の一意性チェックでも
+        # 検知されるが、capacity の方が先に走る）
         providers.extend(
             make_provider_config(
                 provider_kind=ProviderKind.CLAUDE_CODE,
                 model=f"sonnet-{i}",
                 is_default=False,
             )
-            for i in range(MAX_PROVIDERS - 5)  # tops out beyond MAX
+            for i in range(MAX_PROVIDERS - 5)  # MAX を超えるまで埋める
         )
-        # Need at least one default — append one more.
+        # デフォルトが少なくとも 1 件必要 — 追加する
         providers.append(make_provider_config(is_default=True))
         with pytest.raises(AgentInvariantViolation) as excinfo:
             make_agent(providers=providers)
@@ -61,10 +61,10 @@ class TestProviderCapacity:
 
 
 class TestProviderKindUnique:
-    """TC-UT-AG-015 — provider_kind must be unique across providers."""
+    """TC-UT-AG-015 — provider_kind は providers 全体で一意でなければならない。"""
 
     def test_duplicate_provider_kind_raises_provider_duplicate(self) -> None:
-        """TC-UT-AG-015: two ProviderConfigs with same provider_kind raises."""
+        """TC-UT-AG-015: 同一 provider_kind の ProviderConfig 2 件は例外を送出する。"""
         p1 = make_provider_config(provider_kind=ProviderKind.CLAUDE_CODE, is_default=True)
         p2 = make_provider_config(
             provider_kind=ProviderKind.CLAUDE_CODE, model="opus", is_default=False
@@ -75,10 +75,10 @@ class TestProviderKindUnique:
 
 
 class TestDefaultProviderCount:
-    """TC-UT-AG-003 / 004 / 021 — exactly one is_default=True."""
+    """TC-UT-AG-003 / 004 / 021 — is_default=True はちょうど 1 件。"""
 
     def test_zero_defaults_raises_default_not_unique(self) -> None:
-        """TC-UT-AG-003: all is_default=False raises default_not_unique with count=0."""
+        """TC-UT-AG-003: 全て is_default=False のとき count=0 で default_not_unique。"""
         providers = [
             make_provider_config(provider_kind=ProviderKind.CLAUDE_CODE, is_default=False),
             make_provider_config(provider_kind=ProviderKind.CODEX, is_default=False),
@@ -89,7 +89,7 @@ class TestDefaultProviderCount:
         assert excinfo.value.detail.get("default_count") == 0
 
     def test_two_defaults_raises_default_not_unique(self) -> None:
-        """TC-UT-AG-004: two is_default=True raises default_not_unique with count=2."""
+        """TC-UT-AG-004: is_default=True が 2 件のとき count=2 で default_not_unique。"""
         providers = [
             make_provider_config(provider_kind=ProviderKind.CLAUDE_CODE, is_default=True),
             make_provider_config(provider_kind=ProviderKind.CODEX, is_default=True),
@@ -108,7 +108,7 @@ class TestDefaultProviderCount:
         ],
     )
     def test_count_outside_one_raises(self, default_flags: list[bool], expected_count: int) -> None:
-        """TC-UT-AG-021: 0 / 2 / 3 default counts all raise (boundary all sweep)."""
+        """TC-UT-AG-021: デフォルト数 0 / 2 / 3 は全て例外（境界の総当たり）。"""
         kinds = [ProviderKind.CLAUDE_CODE, ProviderKind.CODEX, ProviderKind.GEMINI]
         providers = [
             make_provider_config(provider_kind=kind, is_default=flag)
@@ -120,7 +120,7 @@ class TestDefaultProviderCount:
         assert excinfo.value.detail.get("default_count") == expected_count
 
     def test_exactly_one_default_succeeds(self) -> None:
-        """TC-UT-AG-021: exactly one is_default=True (boundary success case)."""
+        """TC-UT-AG-021: is_default=True がちょうど 1 件の境界成功ケース。"""
         providers = [
             make_provider_config(provider_kind=ProviderKind.CLAUDE_CODE, is_default=True),
             make_provider_config(provider_kind=ProviderKind.CODEX, is_default=False),
@@ -132,10 +132,10 @@ class TestDefaultProviderCount:
 
 
 class TestSkillCapacity:
-    """TC-UT-AG-018 — skills ≤ MAX_SKILLS (Confirmation C)."""
+    """TC-UT-AG-018 — skills ≤ MAX_SKILLS（Confirmation C）。"""
 
     def test_overflow_raises_skill_capacity_exceeded(self) -> None:
-        """TC-UT-AG-018: MAX_SKILLS+1 skills raises skill_capacity_exceeded."""
+        """TC-UT-AG-018: MAX_SKILLS+1 件で skill_capacity_exceeded を送出する。"""
         skills = [
             make_skill_ref(name=f"skill-{i:02d}", path=f"bakufu-data/skills/s{i:02d}.md")
             for i in range(MAX_SKILLS + 1)
@@ -146,14 +146,14 @@ class TestSkillCapacity:
 
 
 class TestSkillIdUnique:
-    """TC-UT-AG-008 — skill_id must be unique (mirrors stage / transition rule).
+    """TC-UT-AG-008 — skill_id は一意でなければならない（stage / transition と同様）。
 
-    Steve PR #16 symmetry: every "no duplicate id" collection contract gets a
-    dedicated helper. The Agent ``_validate_skill_id_unique`` mirrors that.
+    Steve PR #16 の対称性: 「id 重複なし」のコレクション契約には全て専用ヘルパを
+    用意する。Agent の ``_validate_skill_id_unique`` もそれを踏襲している。
     """
 
     def test_duplicate_skill_id_raises_skill_duplicate(self) -> None:
-        """TC-UT-AG-008: two SkillRef sharing skill_id raises skill_duplicate."""
+        """TC-UT-AG-008: skill_id を共有する 2 件の SkillRef で skill_duplicate。"""
         s1 = make_skill_ref()
         s2 = make_skill_ref(skill_id=s1.skill_id, name="another")
         with pytest.raises(AgentInvariantViolation) as excinfo:

--- a/backend/tests/domain/agent/test_msg_wording.py
+++ b/backend/tests/domain/agent/test_msg_wording.py
@@ -1,8 +1,8 @@
-"""MSG-AG-001〜012 exact wording (TC-UT-AG-030〜037 / 045).
+"""MSG-AG-001〜012 の文言一致テスト（TC-UT-AG-030〜037 / 045）。
 
-Each violation kind maps to a static string template in detailed-design.md
-§MSG. Tests assert the message **exactly** so future i18n / refactoring
-cannot silently drift the operator-visible wording.
+各違反 kind は detailed-design.md §MSG の静的文字列テンプレートに対応している。
+テストではメッセージを **完全一致** で検証し、将来の i18n / リファクタリングで
+運用者向けの文言がこっそりずれないようにする。
 """
 
 from __future__ import annotations
@@ -20,22 +20,22 @@ from tests.factories.agent import (
 
 
 class TestMessageWording:
-    """MSG-AG exact wording (TC-UT-AG-030〜037 / 045)."""
+    """MSG-AG の文言一致（TC-UT-AG-030〜037 / 045）。"""
 
     def test_msg_ag_001_for_oversized_name(self) -> None:
-        """TC-UT-AG-030: MSG-AG-001 wording matches '[FAIL] Agent name ...'."""
+        """TC-UT-AG-030: MSG-AG-001 の文言が '[FAIL] Agent name ...' と一致する。"""
         with pytest.raises(AgentInvariantViolation) as excinfo:
             make_agent(name="a" * 41)
         assert excinfo.value.message == "[FAIL] Agent name must be 1-40 characters (got 41)"
 
     def test_msg_ag_002_for_no_provider(self) -> None:
-        """TC-UT-AG-031: MSG-AG-002 'Agent must have at least one provider'."""
+        """TC-UT-AG-031: MSG-AG-002 'Agent must have at least one provider' の確認。"""
         with pytest.raises(AgentInvariantViolation) as excinfo:
             make_agent(providers=[])
         assert excinfo.value.message == "[FAIL] Agent must have at least one provider"
 
     def test_msg_ag_003_for_zero_defaults(self) -> None:
-        """TC-UT-AG-032 (count=0): MSG-AG-003 wording reports got 0."""
+        """TC-UT-AG-032（count=0）: MSG-AG-003 の文言が got 0 を含む。"""
         providers = [
             make_provider_config(provider_kind=ProviderKind.CLAUDE_CODE, is_default=False),
         ]
@@ -46,7 +46,7 @@ class TestMessageWording:
         )
 
     def test_msg_ag_003_for_two_defaults(self) -> None:
-        """TC-UT-AG-032 (count=2): MSG-AG-003 wording reports got 2."""
+        """TC-UT-AG-032（count=2）: MSG-AG-003 の文言が got 2 を含む。"""
         providers = [
             make_provider_config(provider_kind=ProviderKind.CLAUDE_CODE, is_default=True),
             make_provider_config(provider_kind=ProviderKind.CODEX, is_default=True),
@@ -58,7 +58,7 @@ class TestMessageWording:
         )
 
     def test_msg_ag_004_for_duplicate_provider_kind(self) -> None:
-        """TC-UT-AG-033: MSG-AG-004 wording carries the duplicate provider_kind."""
+        """TC-UT-AG-033: MSG-AG-004 の文言に重複した provider_kind が含まれる。"""
         providers = [
             make_provider_config(provider_kind=ProviderKind.CLAUDE_CODE, is_default=True),
             make_provider_config(
@@ -71,7 +71,7 @@ class TestMessageWording:
         assert "CLAUDE_CODE" in excinfo.value.message
 
     def test_msg_ag_005_for_oversized_prompt_body(self) -> None:
-        """TC-UT-AG-034: MSG-AG-005 wording reports 10001-char prompt_body."""
+        """TC-UT-AG-034: MSG-AG-005 の文言が 10001 文字の prompt_body を報告する。"""
         with pytest.raises(AgentInvariantViolation) as excinfo:
             Persona(display_name="p", prompt_body="a" * 10_001)
         assert (
@@ -80,14 +80,14 @@ class TestMessageWording:
         )
 
     def test_msg_ag_006_for_unknown_provider_in_set_default(self) -> None:
-        """TC-UT-AG-035: MSG-AG-006 wording carries the unregistered provider_kind."""
+        """TC-UT-AG-035: MSG-AG-006 の文言に未登録 provider_kind が含まれる。"""
         agent = make_agent()
         with pytest.raises(AgentInvariantViolation) as excinfo:
             agent.set_default_provider(ProviderKind.GEMINI)
         assert excinfo.value.message == "[FAIL] provider_kind not registered: GEMINI"
 
     def test_msg_ag_007_for_duplicate_skill_id(self) -> None:
-        """TC-UT-AG-036: MSG-AG-007 wording carries the duplicate skill_id."""
+        """TC-UT-AG-036: MSG-AG-007 の文言に重複した skill_id が含まれる。"""
         skill = make_skill_ref()
         agent = make_agent(skills=[skill])
         with pytest.raises(AgentInvariantViolation) as excinfo:
@@ -95,7 +95,7 @@ class TestMessageWording:
         assert excinfo.value.message == f"[FAIL] Skill already added: skill_id={skill.skill_id}"
 
     def test_msg_ag_008_for_remove_unknown_skill(self) -> None:
-        """TC-UT-AG-037: MSG-AG-008 wording carries the missing skill_id."""
+        """TC-UT-AG-037: MSG-AG-008 の文言に存在しない skill_id が含まれる。"""
         from uuid import uuid4
 
         agent = make_agent()
@@ -105,7 +105,7 @@ class TestMessageWording:
         assert excinfo.value.message == f"[FAIL] Skill not found in agent: skill_id={unknown}"
 
     def test_msg_ag_skill_path_invalid_prefix(self) -> None:
-        """TC-UT-AG-045: skill_path_invalid messages start with the consistent prefix."""
+        """TC-UT-AG-045: skill_path_invalid のメッセージが共通のプレフィックスで始まる。"""
         from uuid import uuid4
 
         from bakufu.domain.agent import SkillRef

--- a/backend/tests/domain/agent/test_skillref_path.py
+++ b/backend/tests/domain/agent/test_skillref_path.py
@@ -1,15 +1,18 @@
-"""SkillRef.path traversal defense H1〜H10 (Confirmation H / TC-UT-AG-038〜044).
+"""SkillRef.path traversal 防御 H1〜H10 (Confirmation H / TC-UT-AG-038〜044)。
 
-Each ``Test*`` class targets one Hx rule. Failures cluster by which rule was
-violated, mirroring the workflow ``test_notify_channel_ssrf.py`` structure
-that Norman / Schneier approved for SSRF G1〜G10.
+各 ``Test*`` クラスは Hx ルール 1 つをターゲット。
+失敗は違反ルールでクラスタリング、Norman / Schneier が
+SSRF G1〜G10 に承認した workflow ``test_notify_channel_ssrf.py``
+構造をミラーリング。
 
-The aggregate-side path goes through ``SkillRef.field_validator`` which
-delegates to :func:`_validate_skill_path`. We exercise the public surface
-(constructor + ``model_validate``) so future refactors of the orchestrator
-internals do not silently drop coverage. The orchestrator function carries a
-leading underscore (Steve PR #17 naming-symmetry rule): all path / aggregate
-helpers are module-private until a real cross-feature consumer arrives.
+Aggregate 側パスは ``SkillRef.field_validator`` を通り、
+:func:`_validate_skill_path` にデリゲート。
+公開サーフェス (コンストラクタ + ``model_validate``) を実行して
+オーケストレーター内部の将来のリファクタリングがカバレッジを
+静かにドロップしないようにする。オーケストレーター関数は
+先頭アンダースコアを持つ (Steve PR #17 命名対称ルール):
+実際のクロス機能コンシューマーが到着するまで全パス / Aggregate
+ヘルパはモジュールプライベート。
 """
 
 from __future__ import annotations
@@ -22,15 +25,15 @@ from bakufu.domain.exceptions import AgentInvariantViolation
 
 
 def _ref(path: str) -> SkillRef:
-    """Build a SkillRef with arbitrary id/name and the given path."""
+    """任意の id/name と与えられた path で SkillRef を構築。"""
     return SkillRef(skill_id=uuid4(), name="test-skill", path=path)
 
 
 class TestH1NFCNormalization:
-    """H1 / TC-UT-AG-038 — NFC normalization of the path string."""
+    """H1 / TC-UT-AG-038 — path 文字列の NFC 正規化。"""
 
     def test_decomposed_kana_in_path_is_normalized(self) -> None:
-        """H1: 'がが' decomposed in path is stored as the composed form."""
+        """H1: path に分解した 'がが' は合成形で保存。"""
         import unicodedata
 
         composed_filename = "がが.md"
@@ -41,19 +44,19 @@ class TestH1NFCNormalization:
 
 
 class TestH3ForbiddenChars:
-    """H3 / TC-UT-AG-039 — NUL / control / backslash forbidden in path."""
+    """H3 / TC-UT-AG-039 — path に禁止: NUL / 制御 / バックスラッシュ。"""
 
     @pytest.mark.parametrize(
         "bad_path",
         [
-            "bakufu-data/skills/foo\\bar.md",  # backslash
+            "bakufu-data/skills/foo\\bar.md",  # バックスラッシュ
             "bakufu-data/skills/foo\x00.md",  # NUL
-            "bakufu-data/skills/foo\x01.md",  # ASCII control
+            "bakufu-data/skills/foo\x01.md",  # ASCII 制御
             "bakufu-data/skills/foo\x7f.md",  # DEL
         ],
     )
     def test_forbidden_chars_rejected(self, bad_path: str) -> None:
-        """H3: backslash / NUL / control / DEL all raise skill_path_invalid."""
+        """H3: バックスラッシュ / NUL / 制御 / DEL すべて skill_path_invalid を発火。"""
         with pytest.raises(AgentInvariantViolation) as excinfo:
             _ref(bad_path)
         assert excinfo.value.kind == "skill_path_invalid"
@@ -61,43 +64,43 @@ class TestH3ForbiddenChars:
 
 
 class TestH4LeadingChar:
-    """H4 / TC-UT-AG-039 — POSIX abs / Windows abs / tilde rejected."""
+    """H4 / TC-UT-AG-039 — POSIX 絶対 / Windows 絶対 / チルダ 拒否。"""
 
     @pytest.mark.parametrize(
         "bad_path",
         [
-            "/etc/passwd",  # POSIX absolute
-            "~/secret",  # tilde home expansion
-            "C:\\Windows\\system32",  # Windows absolute backslash
-            "D:/foo/bar",  # Windows absolute forward slash
+            "/etc/passwd",  # POSIX 絶対
+            "~/secret",  # チルダ ホーム展開
+            "C:\\Windows\\system32",  # Windows 絶対バックスラッシュ
+            "D:/foo/bar",  # Windows 絶対フォワードスラッシュ
         ],
     )
     def test_leading_char_rejected(self, bad_path: str) -> None:
-        """H4: leading slash / tilde / Windows-drive prefix raise."""
+        """H4: 先頭スラッシュ / チルダ / Windows ドライブプレフィックスを発火。"""
         with pytest.raises(AgentInvariantViolation) as excinfo:
             _ref(bad_path)
         assert excinfo.value.kind == "skill_path_invalid"
-        # Backslash inside the path also trips H3; we just verify rejection
-        # against a stable check identifier from the H3+H4 pair.
+        # path 内のバックスラッシュも H3 をトリップ; H3+H4 ペアから
+        # 安定した check 識別子に対する拒否を検証するだけ。
         assert excinfo.value.detail.get("check") in {"H3", "H4"}
 
 
 class TestH5TraversalSequences:
-    """H5 / TC-UT-AG-040 — '..' traversal and surrounding whitespace rejected."""
+    """H5 / TC-UT-AG-040 — '..' traversal と周囲空白を拒否。"""
 
     @pytest.mark.parametrize(
         "bad_path",
         [
-            "bakufu-data/skills/../../../etc/passwd",  # classic traversal
-            "bakufu-data/skills/sub/../escape",  # mid-path traversal
-            "bakufu-data/skills/legitimate/../../../escape",  # multi-up
-            "..",  # bare parent
-            "./relative",  # current-dir prefix
-            "../escape",  # parent prefix
+            "bakufu-data/skills/../../../etc/passwd",  # 古典的 traversal
+            "bakufu-data/skills/sub/../escape",  # 中間パス traversal
+            "bakufu-data/skills/legitimate/../../../escape",  # 複数上
+            "..",  # 裸の親
+            "./relative",  # カレントディレクトリ プレフィックス
+            "../escape",  # 親プレフィックス
         ],
     )
     def test_traversal_or_dot_prefix_rejected(self, bad_path: str) -> None:
-        """H5: any '..' segment in the path raises skill_path_invalid."""
+        """H5: path 内の任意の '..' セグメント は skill_path_invalid を発火。"""
         with pytest.raises(AgentInvariantViolation) as excinfo:
             _ref(bad_path)
         assert excinfo.value.kind == "skill_path_invalid"
@@ -105,12 +108,12 @@ class TestH5TraversalSequences:
     @pytest.mark.parametrize(
         "bad_path",
         [
-            " bakufu-data/skills/file.md",  # leading space
-            "bakufu-data/skills/file.md ",  # trailing space
+            " bakufu-data/skills/file.md",  # 先頭空白
+            "bakufu-data/skills/file.md ",  # 末尾空白
         ],
     )
     def test_surrounding_whitespace_rejected(self, bad_path: str) -> None:
-        """H5: leading or trailing whitespace raises skill_path_invalid."""
+        """H5: 先頭または末尾空白は skill_path_invalid を発火。"""
         with pytest.raises(AgentInvariantViolation) as excinfo:
             _ref(bad_path)
         assert excinfo.value.kind == "skill_path_invalid"
@@ -118,19 +121,19 @@ class TestH5TraversalSequences:
 
 
 class TestH7PrefixEnforcement:
-    """H7 / TC-UT-AG-041 — path must start with 'bakufu-data/skills/<rest>'."""
+    """H7 / TC-UT-AG-041 — path は 'bakufu-data/skills/<rest>' で開始必須。"""
 
     @pytest.mark.parametrize(
         "bad_path",
         [
-            "other/path/file.md",  # wrong root
-            "bakufu-data/other/file.md",  # second segment wrong
-            "skills/file.md",  # missing 'bakufu-data'
-            "bakufu-data/skills",  # too short (no <rest>)
+            "other/path/file.md",  # 不正ルート
+            "bakufu-data/other/file.md",  # 2 番目セグメント不正
+            "skills/file.md",  # 'bakufu-data' 欠落
+            "bakufu-data/skills",  # 短すぎ (<rest> なし)
         ],
     )
     def test_wrong_prefix_rejected(self, bad_path: str) -> None:
-        """H7: prefix not matching ('bakufu-data', 'skills') raises."""
+        """H7: プレフィックスが ('bakufu-data', 'skills') に一致しない場合発火。"""
         with pytest.raises(AgentInvariantViolation) as excinfo:
             _ref(bad_path)
         assert excinfo.value.kind == "skill_path_invalid"
@@ -138,22 +141,22 @@ class TestH7PrefixEnforcement:
 
 
 class TestH9WindowsReserved:
-    """H9 / TC-UT-AG-043 — Windows reserved device names (CON / NUL / etc.)."""
+    """H9 / TC-UT-AG-043 — Windows 予約デバイス名 (CON / NUL / 等)。"""
 
     @pytest.mark.parametrize(
         "bad_path",
         [
             "bakufu-data/skills/CON.md",
-            "bakufu-data/skills/prn.txt",  # case-insensitive
-            "bakufu-data/skills/AUX",  # no extension
+            "bakufu-data/skills/prn.txt",  # 大文字小文字を区別しない
+            "bakufu-data/skills/AUX",  # 拡張子なし
             "bakufu-data/skills/NUL.markdown",
             "bakufu-data/skills/COM1.md",
             "bakufu-data/skills/LPT9.md",
-            "bakufu-data/skills/con",  # bare lowercase
+            "bakufu-data/skills/con",  # 裸の小文字
         ],
     )
     def test_windows_reserved_name_rejected(self, bad_path: str) -> None:
-        """H9: every Windows reserved device name (case-insensitive) raises."""
+        """H9: あらゆる Windows 予約デバイス名 (大文字小文字を区別しない) を発火。"""
         with pytest.raises(AgentInvariantViolation) as excinfo:
             _ref(bad_path)
         assert excinfo.value.kind == "skill_path_invalid"
@@ -161,10 +164,10 @@ class TestH9WindowsReserved:
 
 
 class TestH10BaseEscape:
-    """H10 / TC-UT-AG-042 — resolved path must stay under BAKUFU_DATA_DIR/skills/."""
+    """H10 / TC-UT-AG-042 — 解決パスは BAKUFU_DATA_DIR/skills/ 配下に留まる必須。"""
 
     def test_unset_bakufu_data_dir_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """H10: missing BAKUFU_DATA_DIR is a structured failure (not a silent skip)."""
+        """H10: 欠落 BAKUFU_DATA_DIR は構造化失敗 (静かなスキップではない)。"""
         monkeypatch.delenv("BAKUFU_DATA_DIR", raising=False)
         with pytest.raises(AgentInvariantViolation) as excinfo:
             _ref("bakufu-data/skills/sample.md")
@@ -173,23 +176,23 @@ class TestH10BaseEscape:
 
 
 class TestPathLengthBoundary:
-    """H2 / TC-UT-AG-044 — path length 1〜500 (lower bound enforced via H4 / structural)."""
+    """H2 / TC-UT-AG-044 — path 長 1〜500 (下限は H4 / 構造で強制)。"""
 
     def test_500_char_valid_path_succeeds(self) -> None:
-        """H2: a structurally-valid 500-char path constructs."""
-        # Build "bakufu-data/skills/" (19 chars) + (some extra prefix) + filename
-        # to total exactly 500 chars.
+        """H2: 構造的に有効な 500 文字 path は構築。"""
+        # "bakufu-data/skills/" (19 文字) + (いくつかの余分プレフィックス)
+        # + ファイル名を正確に 500 文字に合計。
         prefix = "bakufu-data/skills/"
         remaining = 500 - len(prefix)
-        # Use a long filename of 'a'*remaining; H9 stem is 'a'*remaining minus
-        # extension which is fine (not a reserved name).
+        # 'a'*remaining の長いファイル名を使用; H9 stem は 'a'*remaining
+        # マイナス拡張子で問題なし (予約名ではない)。
         path = prefix + "a" * remaining
         assert len(path) == 500
         ref = _ref(path)
         assert ref.path == path
 
     def test_501_char_path_rejected(self) -> None:
-        """H2: a 501-char path raises skill_path_invalid (H2)."""
+        """H2: 501 文字 path は skill_path_invalid (H2) を発火。"""
         prefix = "bakufu-data/skills/"
         remaining = 501 - len(prefix)
         path = prefix + "a" * remaining
@@ -201,14 +204,14 @@ class TestPathLengthBoundary:
 
 
 class TestValidPathHappyPath:
-    """Sanity: a fully valid SkillRef.path constructs and is stored normalized."""
+    """サニティ: 完全に有効な SkillRef.path は構築され正規化で保存。"""
 
     def test_canonical_path_constructs(self) -> None:
-        """Happy path: 'bakufu-data/skills/reviewer.md' goes through all H1〜H10."""
+        """Happy path: 'bakufu-data/skills/reviewer.md' は H1〜H10 全部を通る。"""
         ref = _ref("bakufu-data/skills/reviewer.md")
         assert ref.path == "bakufu-data/skills/reviewer.md"
 
     def test_nested_subdir_constructs(self) -> None:
-        """Happy path: nested subdir under skills/ is permitted."""
+        """Happy path: skills/ 配下ネストサブディレクトリが許可。"""
         ref = _ref("bakufu-data/skills/sub/sub2/file.md")
         assert ref.path == "bakufu-data/skills/sub/sub2/file.md"

--- a/backend/tests/domain/directive/test_application_responsibility.py
+++ b/backend/tests/domain/directive/test_application_responsibility.py
@@ -18,28 +18,27 @@ from tests.factories.directive import make_directive
 
 
 class TestTargetRoomIdReferentialIntegrityNotEnforcedByAggregate:
-    """TC-UT-DR-018: Aggregate accepts any UUID as ``target_room_id``."""
+    """TC-UT-DR-018: Aggregate は任意の UUID を ``target_room_id`` として受け入れる。"""
 
     def test_arbitrary_room_id_constructs(self) -> None:
-        """TC-UT-DR-018: Room existence is verified by DirectiveService, not Directive."""
-        # The UUID is arbitrary — no Room with this id exists. Aggregate
-        # accepts because referential integrity is application-layer scope.
+        """TC-UT-DR-018: Room 存在性は DirectiveService で検証、Directive ではない。"""
+        # UUID は任意。該当 Room は存在しない。Aggregate は受け入れるが、
+        # 参照完全性はアプリケーション層責務。
         directive = make_directive(target_room_id=uuid4())
         assert directive.target_room_id is not None
 
 
 class TestDollarPrefixNotNormalizedByAggregate:
-    """TC-UT-DR-019: Aggregate stores ``text`` verbatim — no ``$`` prefix injection."""
+    """TC-UT-DR-019: Aggregate は ``text`` を逐語的に保存。``$`` プレフィックス注入はない。"""
 
     def test_text_without_dollar_prefix_constructs_unchanged(self) -> None:
-        """TC-UT-DR-019: ``$`` prefix normalization is DirectiveService responsibility.
+        """TC-UT-DR-019: ``$`` プレフィックス正規化は DirectiveService 責務。
 
-        ``DirectiveService.issue(raw_text)`` is the layer that ensures
-        ``text`` starts with ``$``. The Aggregate trusts the input
-        verbatim — same pattern Agent §確定 I uses for ``provider_kind``
-        MVP gating.
+        ``DirectiveService.issue(raw_text)`` が ``text`` 先頭に ``$`` を
+        確保するレイヤー。Aggregate は入力を逐語的に信頼する——
+        Agent §確定 I の ``provider_kind`` MVP gating と同パターン。
         """
-        # No ``$`` prefix in the input — Aggregate keeps the text as-is.
+        # 入力に ``$`` プレフィックスなし、Aggregate はテキストをそのまま保持。
         directive = make_directive(text="ブログ分析機能を作って")
         assert not directive.text.startswith("$")
         assert directive.text == "ブログ分析機能を作って"

--- a/backend/tests/domain/directive/test_construction.py
+++ b/backend/tests/domain/directive/test_construction.py
@@ -1,9 +1,9 @@
-"""Directive construction + boundary value tests
-(TC-UT-DR-001 / 002 / 003 / 004 / 014 / 015).
+"""Directive 構築 + 境界値テスト
+(TC-UT-DR-001 / 002 / 003 / 004 / 014 / 015)。
 
-Covers REQ-DR-001 (construction) + ``text`` length boundary + NFC
-normalization + the deliberately *non-stripping* contract +
-constructor-path Repository hydration (§確定 C) + tz-aware enforcement.
+REQ-DR-001 (構築) + ``text`` 長境界 + NFC
+正規化 + 意図的な **ノンストリップ** 契約 +
+コンストラクターパス Repository ハイドレーション (§確定 C) + tz-aware 強制をカバー。
 """
 
 from __future__ import annotations
@@ -23,42 +23,42 @@ from tests.factories.directive import (
 
 
 class TestDefaultConstruction:
-    """TC-UT-DR-001: factory default is a valid Directive with task_id=None."""
+    """TC-UT-DR-001: ファクトリーデフォルトは task_id=None の有効 Directive。"""
 
     def test_default_directive_has_no_task_link(self) -> None:
-        """TC-UT-DR-001: factory default constructs with task_id=None."""
+        """TC-UT-DR-001: ファクトリーデフォルト は task_id=None で構築。"""
         directive = make_directive()
         assert directive.task_id is None
 
     def test_default_directive_has_tz_aware_created_at(self) -> None:
-        """TC-UT-DR-001: factory default carries a tz-aware datetime."""
+        """TC-UT-DR-001: ファクトリーデフォルト は tz-aware datetime を含む。"""
         directive = make_directive()
         assert directive.created_at.tzinfo is not None
 
     def test_default_directive_text_is_short_with_dollar_prefix(self) -> None:
-        """TC-UT-DR-001: default text follows the application-layer ``$`` convention."""
+        """TC-UT-DR-001: デフォルト text は アプリケーション層 ``$`` 規約に従う。"""
         directive = make_directive()
         assert directive.text.startswith("$ ")
 
 
 class TestTextBoundary:
-    """TC-UT-DR-002: text length boundary 0 / 1 / 10000 / 10001 (確定 B)."""
+    """TC-UT-DR-002: text 長境界 0 / 1 / 10000 / 10001 (確定 B)。"""
 
     @pytest.mark.parametrize("length", [1, 10_000])
     def test_valid_lengths_succeed(self, length: int) -> None:
-        """TC-UT-DR-002: text lengths 1 and 10000 succeed."""
+        """TC-UT-DR-002: text 長 1 と 10000 は成功。"""
         directive = make_directive(text="a" * length)
         assert len(directive.text) == length
 
     def test_empty_text_raises_text_range(self) -> None:
-        """TC-UT-DR-002: text length 0 raises text_range with detail.length=0."""
+        """TC-UT-DR-002: text 長 0 は detail.length=0 で text_range を発火。"""
         with pytest.raises(DirectiveInvariantViolation) as excinfo:
             make_directive(text="")
         assert excinfo.value.kind == "text_range"
         assert excinfo.value.detail.get("length") == 0
 
     def test_oversized_text_raises_text_range(self) -> None:
-        """TC-UT-DR-002: text length 10001 raises text_range with detail.length=10001."""
+        """TC-UT-DR-002: text 長 10001 は detail.length=10001 で text_range を発火。"""
         with pytest.raises(DirectiveInvariantViolation) as excinfo:
             make_directive(text="a" * 10_001)
         assert excinfo.value.kind == "text_range"
@@ -66,10 +66,10 @@ class TestTextBoundary:
 
 
 class TestNfcNormalization:
-    """TC-UT-DR-003: NFC normalization unifies composed and decomposed forms (確定 B)."""
+    """TC-UT-DR-003: NFC 正規化は合成・分解形を統一 (確定 B)。"""
 
     def test_composed_and_decomposed_forms_collapse(self) -> None:
-        """TC-UT-DR-003: composed and decomposed forms produce the same NFC string."""
+        """TC-UT-DR-003: 合成・分解形は同じ NFC 文字列を生成。"""
         composed = "ダリオ要件"
         decomposed = "ダリオ要件"
         d_composed = make_directive(text=composed)
@@ -78,14 +78,14 @@ class TestNfcNormalization:
 
 
 class TestStripIsNotApplied:
-    """TC-UT-DR-004: text is NFC-only, no strip — leading/trailing newlines kept."""
+    """TC-UT-DR-004: text は NFC のみ、ストリップなし — 先頭/末尾改行を保持。"""
 
     def test_leading_and_trailing_newlines_are_preserved(self) -> None:
-        """TC-UT-DR-004: '\\n# Directive\\n\\nbody\\n\\n' is held verbatim.
+        """TC-UT-DR-004: '\\n# Directive\\n\\nbody\\n\\n' は逐語的に保持。
 
-        CEO directives may rely on multi-paragraph structure; stripping
-        would silently rewrite the intent. Confirmation B freezes this
-        as the documented design choice.
+        CEO directives は複数段落構造に依存する可能性; ストリップは
+        インテント を静かに書き換える。Confirmation B はこれを
+        文書化設計選択として fix。
         """
         text = "\n# Directive\n\nbody\n\n"
         directive = make_directive(text=text)
@@ -93,33 +93,33 @@ class TestStripIsNotApplied:
 
 
 class TestRepositoryHydrationViaConstructor:
-    """TC-UT-DR-014: constructor accepts ``task_id=existing TaskId`` (§確定 C)."""
+    """TC-UT-DR-014: コンストラクタは ``task_id=existing TaskId`` を受け入れ (§確定 C)。"""
 
     def test_directive_can_be_constructed_with_task_id(self) -> None:
-        """TC-UT-DR-014: Repository-hydrated state ``task_id != None`` constructs cleanly."""
+        """TC-UT-DR-014: Repository ハイドレーション状態 ``task_id != None`` は清潔に構築。"""
         existing_task_id = uuid4()
         directive = make_linked_directive(task_id=existing_task_id)
         assert directive.task_id == existing_task_id
 
 
 class TestCreatedAtMustBeTzAware:
-    """TC-UT-DR-015: naive datetime raises pydantic.ValidationError (MSG-DR-003)."""
+    """TC-UT-DR-015: naïve datetime は pydantic.ValidationError を発火 (MSG-DR-003)。"""
 
     def test_naive_datetime_is_rejected(self) -> None:
-        """TC-UT-DR-015: ``created_at=datetime.utcnow()`` (naive) → ValidationError."""
-        # Pydantic surfaces the ``_require_tz_aware`` ValueError as a
-        # ``ValidationError`` when the assertion lives inside an
-        # ``after`` validator.
+        """TC-UT-DR-015: ``created_at=datetime.utcnow()`` (naïve) → ValidationError。"""
+        # Pydantic は ``_require_tz_aware`` ValueError を
+        # ``after`` validator 内のアサートが存在するとき
+        # ``ValidationError`` として表示。
         with pytest.raises(ValidationError):
             Directive(
                 id=uuid4(),
                 text="$ test",
                 target_room_id=uuid4(),
-                created_at=datetime(2026, 4, 27, 10, 0, 0),  # naive
+                created_at=datetime(2026, 4, 27, 10, 0, 0),  # naïve
                 task_id=None,
             )
 
     def test_tz_aware_utc_datetime_succeeds(self) -> None:
-        """TC-UT-DR-015 supplemental: tz-aware UTC datetime is the only allowed shape."""
+        """TC-UT-DR-015 補足: tz-aware UTC datetime が唯一許可形。"""
         directive = make_directive(created_at=datetime(2026, 4, 27, 10, 0, 0, tzinfo=UTC))
         assert directive.created_at.tzinfo is not None

--- a/backend/tests/domain/directive/test_helpers_independence.py
+++ b/backend/tests/domain/directive/test_helpers_independence.py
@@ -1,11 +1,12 @@
-"""Module-level helper independence (Boy Scout twin-defense symmetry).
+"""モジュールレベルヘルパー独立性 (Boy Scout 双防御対称性)。
 
-agent / room precedent: every aggregate-level invariant helper lives at
-module scope so tests can ``import`` and invoke directly. Mirrors the
-agent / room ``test_helpers_independence.py`` pattern. These tests
-freeze the helper signatures and entry-point contract — the Aggregate
-stays a thin dispatch over them, and a refactor that inlines a helper
-back into the model_validator has to update this test file too.
+agent / room 前例: あらゆる Aggregate レベル不変ヘルパーは
+モジュールスコープに存在し、テストが ``import`` して直接呼び出し可能。
+agent / room ``test_helpers_independence.py`` パターンをミラーリング。
+これらテストはヘルパー署名とエントリポイント契約を freeze —
+Aggregate はその上の薄いディスパッチであり、
+ヘルパをモデル_validator に内置するリファクタはこのテストファイルも
+アップデート必須。
 """
 
 from __future__ import annotations
@@ -23,30 +24,30 @@ from bakufu.domain.exceptions import DirectiveInvariantViolation
 
 
 class TestValidateTextRange:
-    """``_validate_text_range`` is a module-level pure function."""
+    """``_validate_text_range`` はモジュールレベル純粋関数。"""
 
     @pytest.mark.parametrize("length", [MIN_TEXT_LENGTH, MAX_TEXT_LENGTH])
     def test_valid_lengths_return_none(self, length: int) -> None:
-        """Valid lengths return ``None`` without raising."""
+        """有効長は発火せず ``None`` を返す。"""
         result = _validate_text_range("a" * length)
         assert result is None
 
     @pytest.mark.parametrize("length", [0, MAX_TEXT_LENGTH + 1])
     def test_invalid_lengths_raise_text_range(self, length: int) -> None:
-        """Out-of-range lengths raise ``DirectiveInvariantViolation(kind='text_range')``."""
+        """範囲外の長さは ``DirectiveInvariantViolation(kind='text_range')`` を発火。"""
         with pytest.raises(DirectiveInvariantViolation) as excinfo:
             _validate_text_range("a" * length)
         assert excinfo.value.kind == "text_range"
 
 
 class TestValidateTaskLinkImmutable:
-    """``_validate_task_link_immutable`` is a module-level pure function (確定 C / D)."""
+    """``_validate_task_link_immutable`` はモジュールレベル純粋関数 (確定 C / D)。"""
 
     def test_existing_none_passes(self) -> None:
-        """Confirmation C: existing_task_id=None permits any attempted_task_id."""
+        """Confirmation C: existing_task_id=None は任意の attempted_task_id を許可。"""
         directive_id = uuid4()
         attempted = uuid4()
-        # Returns ``None`` (no raise) when existing is None.
+        # existing が None のとき ``None`` を返す (発火なし)。
         result = _validate_task_link_immutable(
             directive_id=directive_id,
             existing_task_id=None,
@@ -55,7 +56,7 @@ class TestValidateTaskLinkImmutable:
         assert result is None
 
     def test_existing_value_raises_on_different_attempt(self) -> None:
-        """Confirmation C: existing → different new task_id raises."""
+        """Confirmation C: 既存 → 異なる新 task_id は発火。"""
         directive_id = uuid4()
         existing = uuid4()
         attempted = uuid4()
@@ -68,7 +69,7 @@ class TestValidateTaskLinkImmutable:
         assert excinfo.value.kind == "task_already_linked"
 
     def test_existing_value_raises_on_identical_attempt(self) -> None:
-        """Confirmation D: existing == attempted task_id still raises (no idempotency)."""
+        """Confirmation D: 既存 == attempted task_id もまだ発火 (冪等性なし)。"""
         directive_id = uuid4()
         same = uuid4()
         with pytest.raises(DirectiveInvariantViolation) as excinfo:

--- a/backend/tests/domain/directive/test_integration.py
+++ b/backend/tests/domain/directive/test_integration.py
@@ -1,15 +1,14 @@
-"""Round-trip scenarios across Directive + DirectiveInvariantViolation
-(TC-IT-DR-001 / 002).
+"""Directive + DirectiveInvariantViolation 全体のラウンドトリップシナリオ
+(TC-IT-DR-001 / 002)。
 
-The directive feature is domain-only with zero external I/O, so
-"integration" here means *aggregate-internal module integration*:
-chained behaviors over a Directive lifecycle, with the original
-Directive observed unchanged at each step (frozen + pre-validate
-rebuild, Confirmation A).
+Directive 機能は domain のみで外部 I/O なし。ここで「integration」は
+*aggregate 内モジュール統合* を意味する：Directive ライフサイクルをまたぐ
+チェーン動作。元の Directive は各ステップで変更されずに観察される
+(frozen + pre-validate rebuild, Confirmation A)。
 
-These tests intentionally compose the production constructors /
-behaviors directly — no mocks, no test-only back doors — and exercise
-the documented acceptance criteria 1, 5, 6 in a single sequence.
+これらのテストは意図的に production constructors / behaviors を直接組み合わせる —
+mocks なし、test-only back doors なし — 記載された受け入れ基準
+1, 5, 6 を単一シーケンスで実行。
 """
 
 from __future__ import annotations
@@ -26,62 +25,64 @@ from tests.factories.directive import (
 
 
 class TestDirectiveLifecycleRoundTrip:
-    """TC-IT-DR-001: full Directive lifecycle (construct → link → re-link rejected)."""
+    """TC-IT-DR-001: 完全な Directive ライフサイクル (construct → link → re-link rejected)。"""
 
     def test_full_lifecycle_preserves_immutability(self) -> None:
-        """TC-IT-DR-001: construct → link_task → second link_task rejected."""
-        # Step 1: construct an unlinked Directive.
+        """TC-IT-DR-001: construct → link_task → 2 番目の link_task
+        が rejected."""
+        # Step 1: リンクされていない Directive を構築
         d0 = make_directive()
         assert d0.task_id is None
 
-        # Step 2: link a Task. New instance has the new task_id.
+        # Step 2: Task をリンク。新インスタンスが新 task_id を持つ
         task_id_1 = uuid4()
         d1 = d0.link_task(task_id_1)
         assert d1.task_id == task_id_1
 
-        # Step 3: re-linking d1 must Fail Fast.
+        # Step 3: d1 を再リンク。Fail Fast しなければならない
         task_id_2 = uuid4()
         with pytest.raises(DirectiveInvariantViolation) as excinfo:
             d1.link_task(task_id_2)
         assert excinfo.value.kind == "task_already_linked"
 
-        # Step 4: original Directives are unchanged across the
-        # sequence (frozen + pre-validate rebuild contract).
+        # Step 4: 元の Directives はシーケンス全体で変更されない
+        # （frozen + pre-validate rebuild 契約）
         assert d0.task_id is None
         assert d1.task_id == task_id_1
 
-        # Step 5: structural equality — d0 and d1 must NOT compare
-        # equal because their task_id values differ.
+        # Step 5: 構造上の等価性。d0 と d1 は task_id 値が異なるため
+        # 等しくない
         assert d0 != d1
 
 
 class TestRelinkFailureContinuity:
-    """TC-IT-DR-002: re-link failure isolates state across repeated attempts."""
+    """TC-IT-DR-002: re-link 失敗により繰り返した試行を超えて状態が分離。"""
 
     def test_repeated_relink_attempts_do_not_corrupt_state(self) -> None:
-        """TC-IT-DR-002: 3 consecutive failed re-links leave task_id unchanged."""
+        """TC-IT-DR-002: 3 回連続した失敗 re-link で task_id は変化
+        しない."""
         existing_task_id = uuid4()
         d = make_linked_directive(task_id=existing_task_id)
 
-        # Three different attempted_task_ids — each must fail.
+        # 3 つの異なる attempted_task_id。各失敗必須
         for _ in range(3):
             new_task_id = uuid4()
             with pytest.raises(DirectiveInvariantViolation) as excinfo:
                 d.link_task(new_task_id)
             assert excinfo.value.kind == "task_already_linked"
 
-        # The Directive's existing task_id survives intact — the
-        # re-link contract is permanent (Confirmation D).
+        # Directive の既存 task_id は intact で生き残る。re-link 契約は
+        # 永続的（Confirmation D）
         assert d.task_id == existing_task_id
 
     def test_relink_failure_does_not_block_unrelated_directives(self) -> None:
-        """TC-IT-DR-002 supplemental: failure isolation across instances."""
-        # Link Directive A; re-link must fail.
+        """TC-IT-DR-002 補足: インスタンス間のエラー分離."""
+        # Directive A をリンク。re-link は失敗必須
         a = make_linked_directive(task_id=uuid4())
         with pytest.raises(DirectiveInvariantViolation):
             a.link_task(uuid4())
 
-        # Independent Directive B can still be linked normally.
+        # 独立した Directive B はまだ通常リンク可能
         b = make_directive()
         new_task_id = uuid4()
         b_linked = b.link_task(new_task_id)

--- a/backend/tests/domain/directive/test_link_task.py
+++ b/backend/tests/domain/directive/test_link_task.py
@@ -102,7 +102,7 @@ class TestPreValidateRollback:
         directive = make_linked_directive(task_id=existing_task_id)
         with pytest.raises(DirectiveInvariantViolation):
             directive.link_task(uuid4())
-        # The original instance still references the original task_id.
+        # 元のインスタンスは元の task_id を参照したままである。
         assert directive.task_id == existing_task_id
 
     def test_failed_relink_can_be_repeated_without_progress(self) -> None:

--- a/backend/tests/domain/directive/test_link_task.py
+++ b/backend/tests/domain/directive/test_link_task.py
@@ -1,11 +1,9 @@
-"""``link_task`` behavior + uniqueness contract tests
-(TC-UT-DR-005 / 006 / 016 / 017).
+"""link_task 振る舞い + 一意性契約テスト（TC-UT-DR-005 / 006 / 016 / 017）.
 
-Confirmation C / D: ``link_task`` flips ``task_id`` from ``None`` to a
-real value exactly once. Re-linking — *even with the same TaskId* — is
-always a Fail Fast. The constructor path (Repository hydration) is
-allowed to carry an existing ``task_id`` because that is a permanent
-attribute value, not a transition.
+Confirmation C / D: link_task は task_id を None から実値に正確に 1 回反転。
+再リンク（同じ TaskId でも）は常に Fail Fast。コンストラクタ経路
+（リポジトリ再構成）は既存 task_id を持つことができる。それは
+永続属性値であって遷移ではないため。
 """
 
 from __future__ import annotations
@@ -22,23 +20,26 @@ from tests.factories.directive import (
 
 
 class TestLinkTaskHappyPath:
-    """TC-UT-DR-005: link_task flips None → valid TaskId, returns new instance."""
+    """TC-UT-DR-005: link_task は None → 有効な TaskId に反転、
+    新インスタンス返却."""
 
     def test_link_task_returns_directive_with_task_id(self) -> None:
-        """TC-UT-DR-005: returned Directive carries the new task_id."""
+        """TC-UT-DR-005: 返却される Directive は新 task_id を持つ."""
         directive = make_directive()
         task_id = uuid4()
         linked = directive.link_task(task_id)
         assert linked.task_id == task_id
 
     def test_link_task_does_not_mutate_original(self) -> None:
-        """TC-UT-DR-005: original Directive.task_id stays None after link_task."""
+        """TC-UT-DR-005: 元の Directive.task_id は link_task 後も
+        None のまま."""
         directive = make_directive()
         directive.link_task(uuid4())
         assert directive.task_id is None
 
     def test_linked_directive_preserves_other_attributes(self) -> None:
-        """TC-UT-DR-005: only task_id changes; id / text / target_room_id / created_at survive."""
+        """TC-UT-DR-005: task_id のみ変化。id / text / target_room_id /
+        created_at は保持."""
         directive = make_directive()
         new_task_id = uuid4()
         linked = directive.link_task(new_task_id)
@@ -49,10 +50,12 @@ class TestLinkTaskHappyPath:
 
 
 class TestLinkTaskRejectsRelink:
-    """TC-UT-DR-006: link_task on an already-linked Directive raises (§確定 C)."""
+    """TC-UT-DR-006: リンク済み Directive の link_task は例外
+    （§確定 C）."""
 
     def test_relink_with_different_task_id_raises(self) -> None:
-        """TC-UT-DR-006: existing → new task_id raises ``task_already_linked``."""
+        """TC-UT-DR-006: 既存 → 新 task_id は
+        task_already_linked を発火."""
         existing_task_id = uuid4()
         directive = make_linked_directive(task_id=existing_task_id)
         new_task_id = uuid4()
@@ -61,7 +64,8 @@ class TestLinkTaskRejectsRelink:
         assert excinfo.value.kind == "task_already_linked"
 
     def test_relink_detail_includes_pair_identifiers(self) -> None:
-        """TC-UT-DR-006: detail dict carries directive_id / existing_task_id / attempted_task_id."""
+        """TC-UT-DR-006: detail dict は directive_id / existing_task_id
+        / attempted_task_id を持つ."""
         existing_task_id = uuid4()
         directive = make_linked_directive(task_id=existing_task_id)
         new_task_id = uuid4()
@@ -74,24 +78,26 @@ class TestLinkTaskRejectsRelink:
 
 
 class TestLinkTaskNoIdempotency:
-    """TC-UT-DR-016: same TaskId re-link still raises (§確定 D — no idempotency)."""
+    """TC-UT-DR-016: 同じ TaskId 再リンクは例外（§確定 D — 冪等なし）."""
 
     def test_relink_with_identical_task_id_still_raises(self) -> None:
-        """TC-UT-DR-016: re-linking with the *same* task_id is still a Fail Fast."""
+        """TC-UT-DR-016: 同じ task_id での再リンクは Fail Fast."""
         existing_task_id = uuid4()
         directive = make_linked_directive(task_id=existing_task_id)
-        # Confirmation D freezes "1 link only, second call always fails"
-        # — the simpler contract avoids special cases in the validator.
+        # Confirmation D は「1 リンクのみ、2 回目呼び出しは常に失敗」を
+        # 固定。より単純な契約は validator の特殊ケースを回避。
         with pytest.raises(DirectiveInvariantViolation) as excinfo:
             directive.link_task(existing_task_id)
         assert excinfo.value.kind == "task_already_linked"
 
 
 class TestPreValidateRollback:
-    """TC-UT-DR-017: failed link_task leaves the original Directive intact (§確定 A)."""
+    """TC-UT-DR-017: 失敗した link_task は元 Directive をそのままに
+    （§確定 A）."""
 
     def test_link_task_failure_does_not_mutate_original(self) -> None:
-        """TC-UT-DR-017: original Directive.task_id stays unchanged after a failed re-link."""
+        """TC-UT-DR-017: 元の Directive.task_id は失敗した再リンク後も
+        変化しない."""
         existing_task_id = uuid4()
         directive = make_linked_directive(task_id=existing_task_id)
         with pytest.raises(DirectiveInvariantViolation):
@@ -100,11 +106,11 @@ class TestPreValidateRollback:
         assert directive.task_id == existing_task_id
 
     def test_failed_relink_can_be_repeated_without_progress(self) -> None:
-        """TC-UT-DR-017: state damage does not accumulate across repeated failures."""
+        """TC-UT-DR-017: 状態破損は繰り返し失敗で蓄積しない."""
         existing_task_id = uuid4()
         directive = make_linked_directive(task_id=existing_task_id)
-        # Three different attempted task_ids — each must fail and the
-        # Directive must remain identifiable as "linked to the original".
+        # 3 つの異なる試行 task_id。各失敗必須。Directive は
+        # 「元にリンク」のまま識別可能
         for _ in range(3):
             with pytest.raises(DirectiveInvariantViolation):
                 directive.link_task(uuid4())

--- a/backend/tests/domain/directive/test_msg_wording.py
+++ b/backend/tests/domain/directive/test_msg_wording.py
@@ -1,22 +1,20 @@
-"""MSG-DR-001 / 002 wording + Next: hint physical guarantee
-(TC-UT-DR-022 / 023).
+"""MSG-DR-001 / 002 ワーディング + Next: ヒント物理保証
+（TC-UT-DR-022 / 023）.
 
-Each MSG follows the 2-line structure (Confirmation F, room §確定 I
-踏襲):
+各 MSG は 2 行構造に従う（Confirmation F、room §確定 I 踏襲）:
 
     [FAIL] <failure fact>
     Next: <recommended next action>
 
-The first line is asserted **exactly** so future i18n / refactoring
-cannot silently drift the operator-visible failure fact. The second
-line is asserted via substring on the leading ``Next:`` token *and* a
-topic phrase so the design-time hint contract survives cosmetic edits
-while the "hint exists" property is locked in by CI.
+1 行目は **厳密に** アサート。i18n / リファクタリング後の運用者側
+可視化失敗事実の無言漂流を防止。2 行目は先頭 Next: トークンと
+トピック フレーズでアサート。設計時ヒント契約は化粧直しに耐え、
+「ヒント存在」プロパティは CI で施錠。
 
-MSG-DR-003 (type violation) travels the :class:`pydantic.ValidationError`
-path; it is covered in ``test_construction.py``. MSG-DR-004 / 005
-belong to the application layer (``DirectiveService.issue()``) — out of
-scope for this aggregate test suite.
+MSG-DR-003（型違反）は pydantic.ValidationError 経路を辿る。
+test_construction.py でカバー。MSG-DR-004 / 005 はアプリケーション層
+（DirectiveService.issue()）に属す。本アグリゲートテストスイート
+の対象外。
 """
 
 from __future__ import annotations
@@ -33,10 +31,11 @@ from tests.factories.directive import (
 
 
 class TestMsgDr001TextRange:
-    """TC-UT-DR-022: MSG-DR-001 + Next: hint."""
+    """TC-UT-DR-022: MSG-DR-001 + Next: ヒント."""
 
     def test_failure_line_matches_exact_wording(self) -> None:
-        """TC-UT-DR-022: '[FAIL] Directive text must be 1-10000 ...' exact prefix."""
+        """TC-UT-DR-022: '[FAIL] Directive text must be 1-10000 ...'
+        厳密なプレフィックス."""
         with pytest.raises(DirectiveInvariantViolation) as excinfo:
             make_directive(text="a" * 10_001)
         assert excinfo.value.message.startswith(
@@ -44,21 +43,23 @@ class TestMsgDr001TextRange:
         )
 
     def test_next_hint_present_with_topic_phrase(self) -> None:
-        """TC-UT-DR-022: 'Next:' hint exists with multi-directive / trim topic phrase."""
+        """TC-UT-DR-022: 'Next:' ヒントが複数 directive / trim
+        トピック フレーズで存在."""
         with pytest.raises(DirectiveInvariantViolation) as excinfo:
             make_directive(text="a" * 10_001)
         message = excinfo.value.message
         assert "Next:" in message
-        # Hint must mention either trimming or splitting into multiple
-        # directives (Confirmation F's documented ``Next`` phrase).
+        # ヒントはトリミングまたは複数 directive への分割を示す必須
+        # （Confirmation F の設計済み Next フレーズ）
         assert ("Trim" in message) or ("multiple directives" in message)
 
 
 class TestMsgDr002TaskAlreadyLinked:
-    """TC-UT-DR-023: MSG-DR-002 + Next: hint (issue a new Directive)."""
+    """TC-UT-DR-023: MSG-DR-002 + Next: ヒント（新 Directive 発行）."""
 
     def test_failure_line_includes_pair_identifiers(self) -> None:
-        """TC-UT-DR-023: '[FAIL] Directive already has a linked Task: ...' format."""
+        """TC-UT-DR-023: '[FAIL] Directive already has a linked Task: ...'
+        フォーマット."""
         existing_task_id = uuid4()
         directive = make_linked_directive(task_id=existing_task_id)
         new_task_id = uuid4()
@@ -70,12 +71,14 @@ class TestMsgDr002TaskAlreadyLinked:
         assert f"existing_task_id={existing_task_id}" in message
 
     def test_next_hint_advises_new_directive_and_states_one_to_one(self) -> None:
-        """TC-UT-DR-023: 'Next:' hint mentions issuing a new Directive + 1:1 design statement."""
+        """TC-UT-DR-023: 'Next:' ヒントが新 Directive 発行 + 1:1 設計文
+        を言及."""
         directive = make_linked_directive(task_id=uuid4())
         with pytest.raises(DirectiveInvariantViolation) as excinfo:
             directive.link_task(uuid4())
         message = excinfo.value.message
         assert "Next:" in message
         assert "Issue a new Directive" in message
-        # Confirmation F's design statement: "one Directive maps to one Task by design".
+        # Confirmation F の設計文: 「1 つの Directive は 1 つの Task に
+        # マップされる」
         assert "one Directive maps to one Task" in message

--- a/backend/tests/domain/directive/test_webhook_masking.py
+++ b/backend/tests/domain/directive/test_webhook_masking.py
@@ -1,13 +1,13 @@
-"""DirectiveInvariantViolation webhook auto-mask tests (TC-UT-DR-007).
+"""DirectiveInvariantViolation webhook auto-mask テスト (TC-UT-DR-007)。
 
-Confirmation E: ``DirectiveInvariantViolation`` runs
-``mask_discord_webhook`` over ``message`` and ``mask_discord_webhook_in``
-over ``detail`` *before* :class:`Exception` ``__init__`` so the secret
-``token`` segment of any embedded webhook URL never leaks through
-serialization, logging, or HTTP error responses. CEO directives can
-include user-pasted text that may carry a webhook URL; the aggregate
-boundary is the last layer where masking can still happen before
-persistence.
+Confirmation E: ``DirectiveInvariantViolation`` は
+:class:`Exception` ``__init__`` **前に** ``message`` 上で
+``mask_discord_webhook`` を、``detail`` 上で
+``mask_discord_webhook_in`` を実行し、埋め込み webhook URL の
+シークレット ``token`` セグメントがシリアライズ、ロギング、
+HTTP エラーレスポンスを通してリークしない。CEO directives は
+webhook URL を含む可能性があるユーザーペースト テキストを含められる;
+Aggregate 境界はマスキング可能な最後のレイヤー (永続化前)。
 """
 
 from __future__ import annotations
@@ -17,9 +17,9 @@ from bakufu.domain.exceptions import DirectiveInvariantViolation
 
 from tests.factories.directive import make_directive
 
-# A valid-shape Discord webhook URL. The numeric ``id`` segment must
-# stay visible (audit traceability) while the token segment must be
-# redacted to ``<REDACTED:DISCORD_WEBHOOK>``.
+# 有効形の Discord webhook URL。数値 ``id`` セグメントは
+# 表示を保つ (監査追跡可能) トークンセグメントは
+# ``<REDACTED:DISCORD_WEBHOOK>`` にマスキング必須。
 _WEBHOOK_ID = "1234567890123456789"
 _WEBHOOK_TOKEN = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWX"
 _WEBHOOK_URL = f"https://discord.com/api/webhooks/{_WEBHOOK_ID}/{_WEBHOOK_TOKEN}"
@@ -27,18 +27,18 @@ _REDACTED = "<REDACTED:DISCORD_WEBHOOK>"
 
 
 class TestWebhookMaskingOnTextRangeViolation:
-    """TC-UT-DR-007: webhook URL inside oversize text is redacted in exception text."""
+    """TC-UT-DR-007: 過大テキスト内 webhook URL は例外テキストでマスキング。"""
 
     def test_token_does_not_appear_in_message(self) -> None:
-        """TC-UT-DR-007: exception.message contains the redacted marker only."""
-        # Build a 10001-char text that *contains* the webhook URL.
+        """TC-UT-DR-007: exception.message はマスキング済みマーカーのみを含む。"""
+        # 10001 文字テキストを構築、webhook URL を **含める**。
         text = _WEBHOOK_URL + ("a" * 10_001)
         with pytest.raises(DirectiveInvariantViolation) as excinfo:
             make_directive(text=text)
         assert _WEBHOOK_TOKEN not in excinfo.value.message
 
     def test_token_does_not_leak_into_str_exc(self) -> None:
-        """TC-UT-DR-007: str(exc) (default logging path) is also redacted."""
+        """TC-UT-DR-007: str(exc) (デフォルトロギングパス) もマスキング。"""
         text = _WEBHOOK_URL + ("a" * 10_001)
         with pytest.raises(DirectiveInvariantViolation) as excinfo:
             make_directive(text=text)
@@ -46,10 +46,10 @@ class TestWebhookMaskingOnTextRangeViolation:
 
 
 class TestWebhookMaskingOnDetail:
-    """TC-UT-DR-007: detail dict values are recursively masked too."""
+    """TC-UT-DR-007: detail 辞書値も再帰的にマスキング。"""
 
     def test_detail_values_carry_no_token(self) -> None:
-        """TC-UT-DR-007: every str-valued detail item passes through mask_discord_webhook_in."""
+        """TC-UT-DR-007: あらゆる str 値 detail アイテムは mask_discord_webhook_in を通る。"""
         text = _WEBHOOK_URL + ("a" * 10_001)
         with pytest.raises(DirectiveInvariantViolation) as excinfo:
             make_directive(text=text)
@@ -58,10 +58,10 @@ class TestWebhookMaskingOnDetail:
 
 
 class TestWebhookMaskingIdempotent:
-    """Confirmation E supplemental: masking is idempotent."""
+    """Confirmation E 補足: マスキングは冪等。"""
 
     def test_re_application_does_not_double_substitute(self) -> None:
-        """``mask_discord_webhook`` applied twice yields the same string."""
+        """``mask_discord_webhook`` を 2 回適用すると同じ文字列を得る。"""
         from bakufu.domain.value_objects import mask_discord_webhook
 
         once = mask_discord_webhook(_WEBHOOK_URL)

--- a/backend/tests/domain/external_review_gate/test_gate/__init__.py
+++ b/backend/tests/domain/external_review_gate/test_gate/__init__.py
@@ -1,21 +1,21 @@
-"""ExternalReviewGate Aggregate Root tests, split by topic.
+"""ExternalReviewGate 集約ルートのテスト。トピック別に分割している。
 
-Per ``docs/features/external-review-gate/test-design.md`` and the
-empire-repository PR #29 教訓 (Norman 500-line rule), the test
-surface is split into four siblings from day one:
+``docs/features/external-review-gate/test-design.md`` および empire-repository
+PR #29 の教訓（Norman 500 行ルール）に従い、テスト面を初期から 4 つの兄弟
+モジュールに分割している:
 
-* :mod:`...test_construction` — TC-UT-GT-001 / 002 / 012 (constructor,
-  4 ReviewDecision rehydrations, frozen + structural equality).
+* :mod:`...test_construction` — TC-UT-GT-001 / 002 / 012（コンストラクタ、
+  4 種の ReviewDecision の再構成、frozen + 構造的等価性）。
 * :mod:`...test_state_machine` — TC-UT-GT-003 / 004 / 005 / 006 / 013 /
-  014 / 015 (4x4 = 16-cell dispatch: 7 ✓ transitions, 9 ✗
-  decision_already_decided cells, table immutability, pre-validate
-  fails leave source unchanged, lifecycle scenarios).
+  014 / 015（4x4 = 16 セルのディスパッチ: 7 件の正常遷移、9 件の
+  decision_already_decided セル、テーブル不変性、pre-validate 失敗時に
+  ソースを変更しないこと、ライフサイクルシナリオ）。
 * :mod:`...test_invariants` — TC-UT-GT-007 / 008 / 009 / 010 / 011 /
-  021〜025 (5 validators, 4 改ざんパターン, snapshot triple-defense,
-  auto-mask, MSG 2-line "Next:" hint physical guarantee).
-* :mod:`...test_vo` — AuditEntry / ReviewDecision / AuditAction
-  enums + VO frozen + NFC normalization.
+  021〜025（5 種のバリデータ、4 種の改ざんパターン、スナップショット三重防御、
+  自動マスキング、MSG 2 行の "Next:" ヒントの物理的保証）。
+* :mod:`...test_vo` — AuditEntry / ReviewDecision / AuditAction の Enum と
+  VO の frozen 性および NFC 正規化。
 
-M1 7th sibling — final M1 piece. The factories live at
-``tests/factories/external_review_gate.py``.
+M1 の 7 番目の兄弟モジュール — M1 最終ピース。ファクトリは
+``tests/factories/external_review_gate.py`` に存在する。
 """

--- a/backend/tests/domain/external_review_gate/test_gate/test_construction.py
+++ b/backend/tests/domain/external_review_gate/test_gate/test_construction.py
@@ -1,8 +1,8 @@
 """ExternalReviewGate construction tests (TC-UT-GT-001 / 002 / 012).
 
 Per ``docs/features/external-review-gate/test-design.md`` §Gate 構築.
-Covers construction defaults, the 4 ``ReviewDecision`` rehydration
-cases, frozen + structural equality, and ``extra='forbid'``.
+構築デフォルト値、4つの ReviewDecision 再構成ケース、frozen + 構造
+的等価性、extra='forbid' をカバーする。
 """
 
 from __future__ import annotations
@@ -26,13 +26,14 @@ from tests.factories.external_review_gate import (
 
 
 # ---------------------------------------------------------------------------
-# TC-UT-GT-001: default-valued construction
+# TC-UT-GT-001: デフォルト値での構築
 # ---------------------------------------------------------------------------
 class TestGateDefaults:
-    """TC-UT-GT-001: factory default Gate is structurally PENDING + empty."""
+    """TC-UT-GT-001: ファクトリーデフォルト Gate は構造的に PENDING + 空."""
 
     def test_default_gate_is_pending_with_empty_state(self) -> None:
-        """Defaults: decision=PENDING, audit_trail=[], feedback_text='', decided_at=None."""
+        """デフォルト値: decision=PENDING, audit_trail=[],
+        feedback_text='', decided_at=None."""
         gate = make_gate()
         assert gate.decision == ReviewDecision.PENDING
         assert gate.audit_trail == []
@@ -40,21 +41,20 @@ class TestGateDefaults:
         assert gate.decided_at is None
 
     def test_factory_marks_instance_synthetic(self) -> None:
-        """Factory output is registered in :func:`is_synthetic`."""
+        """ファクトリー出力は is_synthetic() に登録される."""
         gate = make_gate()
         assert is_synthetic(gate)
 
 
 # ---------------------------------------------------------------------------
-# TC-UT-GT-002: rehydration into all 4 ReviewDecision values
+# TC-UT-GT-002: 4つの ReviewDecision 値全てへの再構成
 # ---------------------------------------------------------------------------
 class TestRehydrateAllDecisions:
-    """TC-UT-GT-002: each of the 4 ReviewDecision values constructs cleanly.
+    """TC-UT-GT-002: 4つの ReviewDecision 値それぞれが正常に構築される.
 
-    Repository hydration must be able to land any persisted decision.
-    Terminal states (APPROVED / REJECTED / CANCELLED) need a non-None
-    ``decided_at`` per the consistency invariant; PENDING needs
-    ``decided_at is None``.
+    リポジトリ再構成は永続化された判定値を全て復元できなければならない。
+    終了状態（APPROVED / REJECTED / CANCELLED）は一貫性不変量に従い
+    non-None decided_at が必要。PENDING は decided_at is None が必要。
     """
 
     def test_pending_constructs(self) -> None:
@@ -77,20 +77,20 @@ class TestRehydrateAllDecisions:
 
 
 # ---------------------------------------------------------------------------
-# TC-UT-GT-012: frozen + structural equality + hashable
+# TC-UT-GT-012: frozen + 構造的等価性 + ハッシュ可能
 # ---------------------------------------------------------------------------
 class TestFrozenStructuralEquality:
-    """TC-UT-GT-012: same-attribute Gates are ``==``."""
+    """TC-UT-GT-012: 同じ属性を持つ Gate は ``==`` である."""
 
     def test_same_attributes_compare_equal(self) -> None:
-        """Two Gate instances with identical attrs are ``==``."""
+        """同じ属性を持つ 2 つの Gate インスタンスは ``==`` である."""
         common_id = uuid4()
         common_task = uuid4()
         common_stage = uuid4()
         common_reviewer = uuid4()
         ts = datetime(9999, 1, 1, 0, 0, 0, tzinfo=UTC)
-        # Reuse the same Deliverable so both Gates share an identical
-        # snapshot — equality requires snapshot equality.
+        # 同じ Deliverable を再利用して、両 Gate が同じスナップショットを共有
+        # 　等価性はスナップショットの等価性が必須
         from tests.factories.task import make_deliverable
 
         snapshot = make_deliverable()
@@ -114,13 +114,14 @@ class TestFrozenStructuralEquality:
 
 
 # ---------------------------------------------------------------------------
-# extra='forbid' rejects unknown fields
+# extra='forbid' は未知フィールドを拒否
 # ---------------------------------------------------------------------------
 class TestExtraForbid:
-    """An unknown field at construction time is rejected."""
+    """構築時の未知フィールドは拒否される."""
 
     def test_unknown_field_rejected_via_model_validate(self) -> None:
-        """``ExternalReviewGate.model_validate({..., 'unknown': 'x'})`` raises."""
+        """ExternalReviewGate.model_validate({..., 'unknown': 'x'})
+        は例外を発生させる."""
         from tests.factories.task import make_deliverable
 
         now = datetime.now(UTC)
@@ -139,10 +140,10 @@ class TestExtraForbid:
 
 
 # ---------------------------------------------------------------------------
-# Frozen instance — direct attribute assignment rejected
+# Frozen インスタンス — 直接属性割り当ては拒否
 # ---------------------------------------------------------------------------
 class TestFrozenInstance:
-    """``gate.<attr> = value`` raises on a frozen Pydantic model."""
+    """Frozen Pydantic モデルの gate.<attr> = value は例外を発生させる."""
 
     def test_decision_assignment_rejected(self) -> None:
         gate = make_gate()
@@ -155,7 +156,7 @@ class TestFrozenInstance:
             gate.audit_trail = []  # pyright: ignore[reportAttributeAccessIssue]
 
     def test_deliverable_snapshot_assignment_rejected(self) -> None:
-        """The §確定 D snapshot frozen layer (one of the triple-defense)."""
+        """§確定 D スナップショット frozen レイヤー（三重防御の一部）."""
         from tests.factories.task import make_deliverable
 
         gate = make_gate()
@@ -164,38 +165,37 @@ class TestFrozenInstance:
 
 
 # ---------------------------------------------------------------------------
-# Type errors land as pydantic.ValidationError (§確定 I)
+# 型エラーは pydantic.ValidationError として発生（§確定 I）
 # ---------------------------------------------------------------------------
 class TestTypeErrorsRaisePydanticValidationError:
-    """Type-shaped failures use ``pydantic.ValidationError`` (no kind concept).
+    """型関連の失敗は pydantic.ValidationError を使用（kind 概念なし）.
 
-    The §確定 I contract: structural / field-type errors are pure
-    Pydantic validation errors; only the 5
-    ``ExternalReviewGateInvariantViolation`` kinds are issued by the
-    aggregate's invariants.
+    §確定 I 契約: 構造的/フィールド型エラーは純粋な Pydantic
+    検証エラー。5つの ExternalReviewGateInvariantViolation
+    の種別のみがアグリゲートの不変量によって発行される。
     """
 
     def test_naive_created_at_rejected(self) -> None:
-        """``created_at`` without a timezone must be rejected."""
+        """タイムゾーンなし created_at は拒否される."""
         naive = datetime.now()
         with pytest.raises(ValidationError):
             make_gate(created_at=naive)
 
     def test_naive_decided_at_rejected(self) -> None:
-        """``decided_at`` without a timezone must be rejected when set."""
+        """タイムゾーンなし decided_at は設定時に拒否される."""
         naive = datetime.now()
         with pytest.raises(ValidationError):
             make_gate(decision=ReviewDecision.APPROVED, decided_at=naive)
 
 
 # ---------------------------------------------------------------------------
-# feedback_text NFC normalization (§確定 F)
+# feedback_text NFC 正規化（§確定 F）
 # ---------------------------------------------------------------------------
 class TestFeedbackTextNormalization:
-    """``feedback_text`` is NFC-normalized but **not** stripped."""
+    """feedback_text は NFC 正規化されるが、ストリップは行われない."""
 
     def test_leading_whitespace_preserved(self) -> None:
-        """CEO indent style survives normalization (no strip)."""
+        """CEO インデント スタイルは正規化で保持される（ストリップなし）."""
         raw = "> 引用文\n  続き行\n"
         gate = make_gate(feedback_text=raw)
         assert gate.feedback_text == unicodedata.normalize("NFC", raw)

--- a/backend/tests/domain/external_review_gate/test_gate/test_invariants.py
+++ b/backend/tests/domain/external_review_gate/test_gate/test_invariants.py
@@ -1,17 +1,17 @@
-"""ExternalReviewGate invariant + auto-mask + Next: hint tests.
+"""ExternalReviewGate invariant + auto-mask + Next: ヒントテスト.
 
-TC-UT-GT-007 / 008 / 009 / 010 / 011 / 021〜025 — the 5
-``_validate_*`` helpers (4 used by the model_validator + 1 safety net),
-the §確定 H webhook auto-mask, and the §確定 J / room §確定 I 踏襲
-**Next: hint physical guarantee** across all 5 MSG-GT-001〜005.
+TC-UT-GT-007 / 008 / 009 / 010 / 011 / 021〜025 ── 5 つの ``_validate_*``
+ヘルパ (4 つは model_validator で使用 + 1 つはセーフティネット)、
+§確定 H の webhook auto-mask、§確定 J / room §確定 I 踏襲の
+**Next: ヒント物理保証** を MSG-GT-001〜005 全 5 メッセージに対して検証する。
 
-The §確定 C **audit_trail append-only** contract is the highest-stakes
-one: 4 改ざんパターン (existing edit / prepend / delete / reorder) all
-must raise ``audit_trail_append_only``. The §確定 D
-**deliverable_snapshot triple-defense** is also exercised here at the
-validator-safety-net level (the structural guard — _rebuild_with_state
-not accepting a snapshot arg — is verified in test_state_machine via
-"failed approve does not change snapshot").
+§確定 C の **audit_trail append-only** 契約は最も重大度が高い ──
+4 つの改ざんパターン (既存編集 / 先頭挿入 / 削除 / 並び替え) いずれも
+``audit_trail_append_only`` を発火しなければならない。§確定 D の
+**deliverable_snapshot 三重防御** もここでバリデータセーフティネットとして
+動かしている (構造的ガード ── _rebuild_with_state が snapshot 引数を
+受け付けないこと ── は test_state_machine の "失敗 approve は snapshot を
+変えない" で検証される)。
 """
 
 from __future__ import annotations
@@ -46,22 +46,22 @@ from tests.factories.task import make_deliverable
 # TC-UT-GT-007: decided_at consistency
 # ---------------------------------------------------------------------------
 class TestDecidedAtConsistency:
-    """TC-UT-GT-007: decision==PENDING ⇔ decided_at is None (MSG-GT-002)."""
+    """TC-UT-GT-007: decision==PENDING ⇔ decided_at が None (MSG-GT-002)。"""
 
     def test_pending_with_decided_at_raises(self) -> None:
-        """PENDING + decided_at set → raises."""
+        """PENDING + decided_at が設定済み → 例外発火."""
         with pytest.raises(ExternalReviewGateInvariantViolation) as exc_info:
             _validate_decided_at_consistency(ReviewDecision.PENDING, datetime.now(UTC))
         assert exc_info.value.kind == "decided_at_inconsistent"
 
     def test_approved_with_none_decided_at_raises(self) -> None:
-        """APPROVED + decided_at None → raises."""
+        """APPROVED + decided_at が None → 例外発火."""
         with pytest.raises(ExternalReviewGateInvariantViolation) as exc_info:
             _validate_decided_at_consistency(ReviewDecision.APPROVED, None)
         assert exc_info.value.kind == "decided_at_inconsistent"
 
     def test_pending_with_none_passes(self) -> None:
-        """The legal pairing — PENDING + None — is accepted."""
+        """正当な組み合わせ ── PENDING + None ── は受理される."""
         _validate_decided_at_consistency(ReviewDecision.PENDING, None)
 
     @pytest.mark.parametrize(
@@ -70,55 +70,54 @@ class TestDecidedAtConsistency:
         ids=lambda d: d.value,
     )
     def test_terminal_with_decided_at_passes(self, decision: ReviewDecision) -> None:
-        """Terminal decisions + non-None decided_at are legal."""
+        """terminal な decision + 非 None な decided_at は正当."""
         _validate_decided_at_consistency(decision, datetime.now(UTC))
 
 
 # ---------------------------------------------------------------------------
-# TC-UT-GT-010: feedback_text range
+# TC-UT-GT-010: feedback_text 長さレンジ
 # ---------------------------------------------------------------------------
 class TestFeedbackTextRange:
-    """TC-UT-GT-010: 0 <= len <= 10000 (MSG-GT-004)."""
+    """TC-UT-GT-010: 0 <= len <= 10000 (MSG-GT-004)。"""
 
     def test_empty_string_passes(self) -> None:
-        """Empty feedback (default) is legal."""
+        """空 feedback（デフォルト）は正当."""
         _validate_feedback_text_range("")
 
     def test_at_max_length_passes(self) -> None:
-        """10000 chars is the cap and accepted."""
+        """10000 文字はキャップ上限で受理される."""
         _validate_feedback_text_range("x" * MAX_FEEDBACK_LENGTH)
 
     def test_over_max_length_raises(self) -> None:
-        """10001 chars exceeds the cap."""
+        """10001 文字はキャップ超過."""
         with pytest.raises(ExternalReviewGateInvariantViolation) as exc_info:
             _validate_feedback_text_range("x" * (MAX_FEEDBACK_LENGTH + 1))
         assert exc_info.value.kind == "feedback_text_range"
 
 
 # ---------------------------------------------------------------------------
-# TC-UT-GT-009: audit_trail append-only — 4 改ざんパターン
+# TC-UT-GT-009: audit_trail append-only ── 4 改ざんパターン
 # ---------------------------------------------------------------------------
 class TestAuditTrailAppendOnly:
-    """TC-UT-GT-009: 4 改ざんパターン (§確定 C inputs/expectations table).
+    """TC-UT-GT-009: 4 改ざんパターン（§確定 C inputs/expectations 表）.
 
-    Every modification to the audit_trail beyond a strict
-    "append at the end" pattern raises ``audit_trail_append_only``.
-    The 4 cases enumerated in the design doc:
+    末尾追加だけではない audit_trail の任意の改変は
+    audit_trail_append_only を発火する。設計書で列挙される 4 ケース:
 
-    1. **modification**: existing entry's content edited.
-    2. **prepend**: a new entry inserted before existing ones.
-    3. **delete**: an existing entry removed.
-    4. **reorder**: existing entries shuffled.
+    1. **modification**: 既存エントリの内容編集。
+    2. **prepend**: 既存より前に新エントリを挿入。
+    3. **delete**: 既存エントリの削除。
+    4. **reorder**: 既存エントリの並び替え。
     """
 
     def test_construction_with_no_previous_accepts_any_list(self) -> None:
-        """``previous=None`` (construction) is permissive — pins the initial trail."""
-        # Any non-None list is accepted at construction time.
+        """previous=None（構築時）は寛容 ── 初期 trail を固定."""
+        # 構築時は None でない任意のリストを受理する。
         _validate_audit_trail_append_only(None, [])
         _validate_audit_trail_append_only(None, [make_audit_entry(action=AuditAction.VIEWED)])
 
     def test_legal_append_passes(self) -> None:
-        """Strict append (previous + 1 new entry) is the only legal mutation."""
+        """厳密な追加（previous + 新エントリ 1 件）のみが正当な mutation."""
         e1 = make_audit_entry(action=AuditAction.VIEWED)
         e2 = make_audit_entry(action=AuditAction.APPROVED)
         previous = [e1]
@@ -127,12 +126,11 @@ class TestAuditTrailAppendOnly:
 
     # 改ざんパターン 1: modification
     def test_existing_entry_modification_raises(self) -> None:
-        """Editing an existing entry's content is rejected."""
+        """既存エントリの内容編集は拒絶される."""
         e1 = make_audit_entry(action=AuditAction.VIEWED, comment="original")
         previous = [e1]
-        # Replace e1 with a different entry (different uuid + comment) —
-        # this represents the case where someone tries to "fix a typo"
-        # in an existing audit entry.
+        # e1 を別エントリ（異なる uuid + comment）に置換。
+        # 既存監査エントリの「typo を修正」しようとするケースを表す。
         e1_modified = make_audit_entry(
             action=AuditAction.VIEWED,
             comment="rewritten",
@@ -144,7 +142,7 @@ class TestAuditTrailAppendOnly:
 
     # 改ざんパターン 2: prepend
     def test_prepend_raises(self) -> None:
-        """Inserting a new entry at the head pushes existing entries — rejected."""
+        """先頭への新エントリ挿入は既存をずらす。拒絶される."""
         e1 = make_audit_entry(action=AuditAction.VIEWED)
         previous = [e1]
         e_prepended = make_audit_entry(action=AuditAction.APPROVED)
@@ -155,63 +153,63 @@ class TestAuditTrailAppendOnly:
 
     # 改ざんパターン 3: delete
     def test_delete_raises(self) -> None:
-        """Removing an existing entry shrinks the trail — rejected."""
+        """既存エントリの削除は trail を縮める。拒絶される."""
         e1 = make_audit_entry(action=AuditAction.VIEWED)
         e2 = make_audit_entry(action=AuditAction.APPROVED)
         previous = [e1, e2]
-        current = [e1]  # e2 dropped
+        current = [e1]  # e2 を削除
         with pytest.raises(ExternalReviewGateInvariantViolation) as exc_info:
             _validate_audit_trail_append_only(previous, current)
         assert exc_info.value.kind == "audit_trail_append_only"
 
     # 改ざんパターン 4: reorder
     def test_reorder_raises(self) -> None:
-        """Swapping the order of existing entries is rejected."""
+        """既存エントリの並び替えは拒絶される."""
         e1 = make_audit_entry(action=AuditAction.VIEWED)
         e2 = make_audit_entry(action=AuditAction.APPROVED)
         previous = [e1, e2]
-        current = [e2, e1]  # swapped
+        current = [e2, e1]  # 入れ替え
         with pytest.raises(ExternalReviewGateInvariantViolation) as exc_info:
             _validate_audit_trail_append_only(previous, current)
         assert exc_info.value.kind == "audit_trail_append_only"
 
-    # Composite: deletion-then-append (still illegal because the head is corrupted)
+    # 複合: 削除 + 追加（先頭が破壊されているため依然違法）
     def test_delete_then_append_raises(self) -> None:
-        """Deleting an existing entry while appending a new one is still illegal."""
+        """既存エントリ削除と新エントリ追加の組み合わせも違法."""
         e1 = make_audit_entry(action=AuditAction.VIEWED)
         e2 = make_audit_entry(action=AuditAction.APPROVED)
         previous = [e1, e2]
         e_new = make_audit_entry(action=AuditAction.VIEWED)
-        current = [e1, e_new]  # e2 dropped, e_new appended (but length matches)
+        current = [e1, e_new]  # e2 削除、e_new 追加（長さ一致でも違法）
         with pytest.raises(ExternalReviewGateInvariantViolation) as exc_info:
             _validate_audit_trail_append_only(previous, current)
         assert exc_info.value.kind == "audit_trail_append_only"
 
 
 # ---------------------------------------------------------------------------
-# TC-UT-GT-008: deliverable_snapshot immutability validator (§確定 D safety net)
+# TC-UT-GT-008: deliverable_snapshot 不変性バリデータ (§確定 D セーフティネット)
 # ---------------------------------------------------------------------------
 class TestSnapshotImmutableValidator:
-    """TC-UT-GT-008: validator safety net for §確定 D snapshot immutability.
+    """TC-UT-GT-008: §確定 D snapshot 不変性のバリデータセーフティネット.
 
-    The structural guard is the absence of ``deliverable_snapshot``
-    in ``_rebuild_with_state``'s argument set. This validator is the
-    failure-path safety net if that contract ever leaks. We test it
-    directly here.
+    構造的ガードは _rebuild_with_state の引数集合に
+    deliverable_snapshot が無いこと。本バリデータはその契約が漏れた
+    場合の失敗経路セーフティネット。ここでは直接テストする。
     """
 
     def test_construction_with_no_previous_accepts_any_snapshot(self) -> None:
-        """``previous=None`` is permissive — pins the initial snapshot."""
+        """previous=None は寛容 ── 初期 snapshot を固定."""
         _validate_snapshot_immutable(None, make_deliverable())
 
     def test_same_snapshot_passes(self) -> None:
-        """Equal snapshots round-trip cleanly (Pydantic frozen ``==``)."""
+        """同値 snapshot はラウンドトリップに耐える（Pydantic frozen の
+        ==）."""
         d = make_deliverable()
-        # Reuse the same instance — Pydantic frozen models compare by value.
+        # 同じインスタンスを再利用。Pydantic frozen モデルは値で比較
         _validate_snapshot_immutable(d, d)
 
     def test_different_snapshot_raises(self) -> None:
-        """A different snapshot at rebuild raises ``snapshot_immutable``."""
+        """rebuild 時に別 snapshot を渡すと snapshot_immutable を発火."""
         d1 = make_deliverable(body_markdown="original")
         d2 = make_deliverable(body_markdown="replaced")
         with pytest.raises(ExternalReviewGateInvariantViolation) as exc_info:
@@ -220,41 +218,42 @@ class TestSnapshotImmutableValidator:
 
 
 # ---------------------------------------------------------------------------
-# §確定 D triple-defense behavioural confirmation
+# §確定 D 三重防御の挙動確認
 # ---------------------------------------------------------------------------
 class TestSnapshotImmutableViaBehaviors:
-    """§確定 D: the 4 behavior methods all preserve deliverable_snapshot byte-for-byte.
+    """§確定 D: 4 つの behavior メソッド全てが
+    deliverable_snapshot をバイト等価に保つ.
 
-    This is the **structural guarantee** test — we walk all 4 methods
-    on a Gate and confirm the snapshot field is byte-identical
-    afterwards. Even though the validator catches any leak, having
-    each method tested independently catches the case where one
-    method accidentally accepts a snapshot kwarg in a refactor.
+    これは **構造的保証** テスト。1 つの Gate に対して 4 メソッドを歩き、
+    snapshot フィールドが事後にバイト等価であることを確認。バリデータが
+    任意の漏洩を検出する一方で、各メソッドを独立にテストすることで、
+    リファクタリング中にあるメソッドが誤って snapshot kwarg を受け付ける
+    ケースを捕える。
     """
 
     def test_approve_preserves_snapshot(self) -> None:
-        """``approve`` keeps deliverable_snapshot byte-equal."""
+        """approve は deliverable_snapshot をバイト等価に保つ."""
         gate = make_gate(deliverable_snapshot=make_deliverable(body_markdown="locked"))
         snapshot = gate.deliverable_snapshot
         out = gate.approve(uuid4(), "ok", decided_at=datetime.now(UTC))
         assert out.deliverable_snapshot == snapshot
 
     def test_reject_preserves_snapshot(self) -> None:
-        """``reject`` keeps deliverable_snapshot byte-equal."""
+        """reject は deliverable_snapshot をバイト等価に保つ."""
         gate = make_gate(deliverable_snapshot=make_deliverable(body_markdown="locked"))
         snapshot = gate.deliverable_snapshot
         out = gate.reject(uuid4(), "rev", decided_at=datetime.now(UTC))
         assert out.deliverable_snapshot == snapshot
 
     def test_cancel_preserves_snapshot(self) -> None:
-        """``cancel`` keeps deliverable_snapshot byte-equal."""
+        """cancel は deliverable_snapshot をバイト等価に保つ."""
         gate = make_gate(deliverable_snapshot=make_deliverable(body_markdown="locked"))
         snapshot = gate.deliverable_snapshot
         out = gate.cancel(uuid4(), "withdrawn", decided_at=datetime.now(UTC))
         assert out.deliverable_snapshot == snapshot
 
     def test_record_view_preserves_snapshot(self) -> None:
-        """``record_view`` keeps deliverable_snapshot byte-equal."""
+        """record_view は deliverable_snapshot をバイト等価に保つ."""
         gate = make_gate(deliverable_snapshot=make_deliverable(body_markdown="locked"))
         snapshot = gate.deliverable_snapshot
         out = gate.record_view(uuid4(), viewed_at=datetime.now(UTC))
@@ -265,14 +264,14 @@ class TestSnapshotImmutableViaBehaviors:
 # TC-UT-GT-011: ExternalReviewGateInvariantViolation auto-mask (§確定 H)
 # ---------------------------------------------------------------------------
 class TestExceptionAutoMasksDiscordWebhooks:
-    """TC-UT-GT-011: webhook URLs in feedback / detail get masked at construction.
+    """TC-UT-GT-011: feedback / detail 内の webhook URL が構築時に
+    masking される.
 
-    The §確定 H contract is on
-    ``ExternalReviewGateInvariantViolation.__init__`` — auto-mask
-    fires for every kind / detail shape, not for any specific
-    validator. We construct the exception directly with secret-bearing
-    payloads and assert the redaction sentinel replaces the raw token
-    in both ``message`` and ``detail`` (recursively).
+    §確定 H の契約は ExternalReviewGateInvariantViolation.__init__。
+    auto-mask は kind や detail 形状に依らず常時発動。特定バリデータには
+    依存しない。secret を含むペイロードで例外を直接構築し、message と
+    detail（再帰的）の両方で生トークンが redaction sentinel に置換
+    されていることをアサート。
     """
 
     _SECRET = "https://discord.com/api/webhooks/123456789012345678/SneakyToken-xyz"
@@ -280,7 +279,7 @@ class TestExceptionAutoMasksDiscordWebhooks:
     _RAW_TOKEN = "SneakyToken-xyz"
 
     def test_webhook_redacted_in_message_and_detail(self) -> None:
-        """Both message and recursive detail values lose the raw token."""
+        """message と再帰的な detail 値の両方で生トークンが消える."""
         exc = ExternalReviewGateInvariantViolation(
             kind="audit_trail_append_only",
             message=f"[FAIL] secret in message: {self._SECRET}\nNext: re-input.",
@@ -291,29 +290,30 @@ class TestExceptionAutoMasksDiscordWebhooks:
             },
         )
 
-        # Message: raw token absent, sentinel present.
+        # message: 生トークン消滅、sentinel 出現
         assert self._RAW_TOKEN not in exc.message
         assert self._REDACT_SENTINEL in exc.message
-        # Detail: every nested value masked.
+        # detail: 全ネスト値が masking される
         flat = repr(exc.detail)
         assert self._RAW_TOKEN not in flat
         assert self._REDACT_SENTINEL in flat
 
 
 # ---------------------------------------------------------------------------
-# TC-UT-GT-021〜025: 5 MSG kinds + Next: hint physical guarantee (§確定 J)
+# TC-UT-GT-021〜025: 5 つの MSG kind + Next: ヒント物理保証 (§確定 J)
 # ---------------------------------------------------------------------------
 class TestNextHintPhysicalGuarantee:
-    """All 5 ``ExternalReviewGateViolationKind`` values carry 'Next:' in str(exc).
+    """ExternalReviewGateViolationKind の全 5 値で str(exc) に
+    'Next:' が含まれる.
 
-    The room §確定 I 踏襲 contract: every error message has a 2-line
-    structure (``[FAIL] <fact>\\nNext: <action>``). A failing assertion
-    on ``"Next:" in str(exc)`` means a developer wrote a one-line
-    MSG and the operator-feedback contract is broken.
+    room §確定 I 踏襲の契約: あらゆるエラーメッセージは 2 行構造
+    （[FAIL] <fact>\nNext: <action>）を持つ。"Next:" in str(exc)
+    のアサートが落ちる場合、開発者が 1 行 MSG を書いて運用者向け
+    フィードバック契約を破った証拠となる。
     """
 
     def test_decision_already_decided_carries_next_hint(self) -> None:
-        """TC-UT-GT-021: MSG-GT-001 (decision_already_decided)."""
+        """TC-UT-GT-021: MSG-GT-001（decision_already_decided）."""
         gate = make_approved_gate()
         with pytest.raises(ExternalReviewGateInvariantViolation) as exc_info:
             gate.approve(uuid4(), "double", decided_at=datetime.now(UTC) + timedelta(seconds=1))
@@ -323,7 +323,7 @@ class TestNextHintPhysicalGuarantee:
         assert "decided once" in s
 
     def test_decided_at_inconsistent_carries_next_hint(self) -> None:
-        """TC-UT-GT-022: MSG-GT-002 (decided_at_inconsistent)."""
+        """TC-UT-GT-022: MSG-GT-002（decided_at_inconsistent）."""
         with pytest.raises(ExternalReviewGateInvariantViolation) as exc_info:
             _validate_decided_at_consistency(ReviewDecision.APPROVED, None)
         s = str(exc_info.value)
@@ -332,7 +332,7 @@ class TestNextHintPhysicalGuarantee:
         assert "Repository row integrity" in s
 
     def test_snapshot_immutable_carries_next_hint(self) -> None:
-        """TC-UT-GT-023: MSG-GT-003 (snapshot_immutable)."""
+        """TC-UT-GT-023: MSG-GT-003（snapshot_immutable）."""
         d1 = make_deliverable(body_markdown="a")
         d2 = make_deliverable(body_markdown="b")
         with pytest.raises(ExternalReviewGateInvariantViolation) as exc_info:
@@ -343,7 +343,7 @@ class TestNextHintPhysicalGuarantee:
         assert "frozen at Gate creation" in s
 
     def test_feedback_text_range_carries_next_hint(self) -> None:
-        """TC-UT-GT-024: MSG-GT-004 (feedback_text_range)."""
+        """TC-UT-GT-024: MSG-GT-004（feedback_text_range）."""
         with pytest.raises(ExternalReviewGateInvariantViolation) as exc_info:
             _validate_feedback_text_range("x" * (MAX_FEEDBACK_LENGTH + 1))
         s = str(exc_info.value)
@@ -352,10 +352,10 @@ class TestNextHintPhysicalGuarantee:
         assert "Trim" in s
 
     def test_audit_trail_append_only_carries_next_hint(self) -> None:
-        """TC-UT-GT-025: MSG-GT-005 (audit_trail_append_only)."""
+        """TC-UT-GT-025: MSG-GT-005（audit_trail_append_only）."""
         e1 = make_audit_entry()
         with pytest.raises(ExternalReviewGateInvariantViolation) as exc_info:
-            _validate_audit_trail_append_only([e1], [])  # delete pattern
+            _validate_audit_trail_append_only([e1], [])  # 削除パターン
         s = str(exc_info.value)
         assert s.startswith("[FAIL]")
         assert "Next:" in s
@@ -363,13 +363,13 @@ class TestNextHintPhysicalGuarantee:
 
 
 # ---------------------------------------------------------------------------
-# Composite: a Gate that walks the full lifecycle preserves audit chain
+# 複合: 完全ライフサイクルを歩いた Gate は監査チェーンを保つ
 # ---------------------------------------------------------------------------
 class TestAuditTrailChainIntegrity:
-    """Walking a full lifecycle keeps every previous entry byte-equal."""
+    """完全ライフサイクルを歩いても各既存エントリはバイト等価で残る."""
 
     def test_lifecycle_preserves_all_previous_entries(self) -> None:
-        """record_view x 2 → approve preserves the 2 VIEWED entries verbatim."""
+        """record_view x 2 → approve は 2 件の VIEWED エントリを逐字保持."""
         gate = make_gate()
         v1 = uuid4()
         v2 = uuid4()
@@ -379,15 +379,15 @@ class TestAuditTrailChainIntegrity:
 
         gate = gate.record_view(v1, viewed_at=ts1)
         gate = gate.record_view(v2, viewed_at=ts2)
-        # Snapshot the audit trail at this point.
+        # この時点で監査証跡をスナップショット
         before_approve = copy.copy(gate.audit_trail)
         assert len(before_approve) == 2
 
-        # Approve.
+        # Approve
         gate = gate.approve(uuid4(), "all good", decided_at=ts3)
 
-        # The first 2 entries must be byte-equal (the §確定 C contract);
-        # the third entry is the new APPROVED audit row.
+        # 既存 2 件はバイト等価（§確定 C 契約）
+        # 3 番目のエントリが新たな APPROVED 監査行
         assert gate.audit_trail[:2] == before_approve
         assert gate.audit_trail[2].action == AuditAction.APPROVED
         assert len(gate.audit_trail) == 3

--- a/backend/tests/domain/external_review_gate/test_gate/test_invariants.py
+++ b/backend/tests/domain/external_review_gate/test_gate/test_invariants.py
@@ -383,7 +383,7 @@ class TestAuditTrailChainIntegrity:
         before_approve = copy.copy(gate.audit_trail)
         assert len(before_approve) == 2
 
-        # Approve
+        # 承認
         gate = gate.approve(uuid4(), "all good", decided_at=ts3)
 
         # 既存 2 件はバイト等価（§確定 C 契約）

--- a/backend/tests/domain/external_review_gate/test_gate/test_state_machine.py
+++ b/backend/tests/domain/external_review_gate/test_gate/test_state_machine.py
@@ -1,18 +1,17 @@
-"""ExternalReviewGate state machine tests (TC-UT-GT-003〜006, 013〜015).
+"""ExternalReviewGate ステートマシンテスト (TC-UT-GT-003〜006, 013〜015).
 
-Per ``docs/features/external-review-gate/test-design.md``. The
-§確定 A 4x4 = **16-cell dispatch matrix** is asserted in three
-orthogonal ways here:
+``docs/features/external-review-gate/test-design.md`` 準拠。
+§確定 A の 4x4 = **16 セル分岐マトリクス** を 3 つの直交視点で検証する:
 
-1. **7 ✓ cells**: each allowed transition has its own positive case
-   (PENDING approve / reject / cancel + 4 self-loops via record_view).
-2. **9 ✗ cells**: APPROVED/REJECTED/CANCELLED x approve/reject/cancel
-   parametrize coverage → ``decision_already_decided`` (MSG-GT-001).
-3. **§確定 G 冪等性なし**: same owner + same time = 2 audit entries
-   (audit requirement: 誰がいつ何度見たか).
+1. **7 ✓ セル**: 許可遷移ごとに正常系ケースを 1 件
+   (PENDING approve / reject / cancel + record_view 経由の 4 self-loop)。
+2. **9 ✗ セル**: APPROVED/REJECTED/CANCELLED x approve/reject/cancel の
+   parametrize で全網羅 → ``decision_already_decided`` (MSG-GT-001)。
+3. **§確定 G 冪等性なし**: 同一 owner + 同一時刻 = 監査エントリ 2 件
+   (監査要件: 誰がいつ何度見たか)。
 
-§確定 B (state machine table lock) is asserted via the 7-entry size
-check + ``MappingProxyType`` setitem rejection.
+§確定 B (ステートマシンテーブルロック) は 7 件サイズチェック +
+``MappingProxyType`` setitem 拒絶で検証。
 """
 
 from __future__ import annotations
@@ -39,24 +38,24 @@ from tests.factories.external_review_gate import (
     make_rejected_gate,
 )
 
-# All 4 action names — must match ExternalReviewGate method names 1:1 (§確定 A).
+# 全 4 アクション名 ── ExternalReviewGate のメソッド名と 1:1 対応 (§確定 A)。
 _ALL_ACTIONS: list[GateAction] = ["approve", "reject", "cancel", "record_view"]
 
-# All 4 decision values for the 16-cell matrix.
+# 16 セルマトリクスのための全 4 decision 値。
 _ALL_DECISIONS: list[ReviewDecision] = list(ReviewDecision)
 
-# The 3 PENDING-only actions (terminal-firing).
+# PENDING 限定の 3 アクション (terminal で発火)。
 _PENDING_ONLY_ACTIONS: list[GateAction] = ["approve", "reject", "cancel"]
 
 
 def _next_ts(gate: ExternalReviewGate) -> datetime:
-    """Return a strictly-later UTC timestamp for ``decided_at`` / ``viewed_at``."""
+    """``decided_at`` / ``viewed_at`` 用に厳密に未来の UTC タイムスタンプを返す。"""
     base = gate.decided_at if gate.decided_at is not None else gate.created_at
     return base + timedelta(seconds=1)
 
 
 def _invoke_action(gate: ExternalReviewGate, action: GateAction) -> ExternalReviewGate:
-    """Dispatch ``action`` on ``gate`` with throwaway-but-valid arguments."""
+    """``gate`` 上に ``action`` をディスパッチする (使い捨ての妥当な引数を渡す)。"""
     ts = _next_ts(gate)
     if action == "approve":
         return gate.approve(uuid4(), "synthetic approve comment", decided_at=ts)
@@ -69,7 +68,7 @@ def _invoke_action(gate: ExternalReviewGate, action: GateAction) -> ExternalRevi
 
 
 def _make_gate_in_decision(decision: ReviewDecision) -> ExternalReviewGate:
-    """Build a Gate in the given decision using the appropriate factory."""
+    """指定の decision 状態にある Gate を、対応するファクトリで構築する。"""
     if decision == ReviewDecision.PENDING:
         return make_gate()
     if decision == ReviewDecision.APPROVED:
@@ -80,13 +79,13 @@ def _make_gate_in_decision(decision: ReviewDecision) -> ExternalReviewGate:
 
 
 # ---------------------------------------------------------------------------
-# §確定 B: state machine TABLE shape + immutability (TC-UT-GT-014)
+# §確定 B: ステートマシン TABLE 形状 + 不変性 (TC-UT-GT-014)
 # ---------------------------------------------------------------------------
 class TestStateMachineTableLocked:
-    """TC-UT-GT-014: ``TRANSITIONS`` has 7 entries and rejects mutation."""
+    """TC-UT-GT-014: TRANSITIONS は 7 件で変更不可."""
 
     def test_table_size_is_seven(self) -> None:
-        """The §確定 A dispatch table freezes 7 allowed transitions."""
+        """§確定 A の分岐テーブルは許可遷移 7 件を凍結する."""
         assert len(TRANSITIONS) == 7, (
             f"[FAIL] state machine table size drifted: got {len(TRANSITIONS)}, expected 7.\n"
             f"Next: docs/features/external-review-gate/detailed-design.md §確定 A "
@@ -95,35 +94,36 @@ class TestStateMachineTableLocked:
         )
 
     def test_table_setitem_rejected_at_runtime(self) -> None:
-        """``TRANSITIONS[k] = v`` raises ``TypeError`` (MappingProxyType lock)."""
+        """TRANSITIONS[k] = v は TypeError を発する
+        (MappingProxyType ロック)."""
         with pytest.raises(TypeError):
             TRANSITIONS[(ReviewDecision.APPROVED, "approve")] = ReviewDecision.PENDING  # pyright: ignore[reportIndexIssue]
 
 
 # ---------------------------------------------------------------------------
-# 7 allowed transitions — one positive case per ✓ cell
+# 許可遷移 7 件 ── ✓ セルごとの正常系ケース
 # ---------------------------------------------------------------------------
 class TestSevenAllowedTransitions:
-    """TC-UT-GT-003 / 004 / 006 / 013 — the 7 ✓ cells of the dispatch table."""
+    """TC-UT-GT-003 / 004 / 006 / 013 ── 分岐テーブルの ✓ セル 7 件。"""
 
     # PENDING → APPROVED via approve
     def test_approve_pending_to_approved(self) -> None:
-        """TC-UT-GT-003: ``approve`` on PENDING moves to APPROVED."""
+        """TC-UT-GT-003: PENDING に対する approve は APPROVED へ遷移."""
         gate = make_gate()
         ts = _next_ts(gate)
         out = gate.approve(uuid4(), "looks good", decided_at=ts)
         assert out.decision == ReviewDecision.APPROVED
         assert out.decided_at == ts
         assert out.feedback_text == "looks good"
-        # Audit trail: 1 new APPROVED entry appended.
+        # 監査証跡: APPROVED エントリが 1 件追加
         assert len(out.audit_trail) == len(gate.audit_trail) + 1
         assert out.audit_trail[-1].action == AuditAction.APPROVED
-        # Original Gate unchanged (frozen + pre-validate).
+        # 元の Gate は不変（frozen + pre-validate）
         assert gate.decision == ReviewDecision.PENDING
 
     # PENDING → REJECTED via reject
     def test_reject_pending_to_rejected(self) -> None:
-        """TC-UT-GT-004: ``reject`` on PENDING moves to REJECTED."""
+        """TC-UT-GT-004: PENDING に対する reject は REJECTED へ遷移."""
         gate = make_gate()
         ts = _next_ts(gate)
         out = gate.reject(uuid4(), "needs revision", decided_at=ts)
@@ -134,7 +134,7 @@ class TestSevenAllowedTransitions:
 
     # PENDING → CANCELLED via cancel
     def test_cancel_pending_to_cancelled(self) -> None:
-        """TC-UT-GT-013: ``cancel`` on PENDING moves to CANCELLED."""
+        """TC-UT-GT-013: PENDING に対する cancel は CANCELLED へ遷移."""
         gate = make_gate()
         ts = _next_ts(gate)
         out = gate.cancel(uuid4(), "directive withdrawn", decided_at=ts)
@@ -143,36 +143,37 @@ class TestSevenAllowedTransitions:
         assert out.feedback_text == "directive withdrawn"
         assert out.audit_trail[-1].action == AuditAction.CANCELLED
 
-    # 4 record_view self-loops — one per decision state
+    # 4 record_view self-loop ── 各 decision ごとに 1 件
     @pytest.mark.parametrize(
         "decision",
         list(ReviewDecision),
         ids=lambda d: d.value,
     )
     def test_record_view_self_loop_in_each_state(self, decision: ReviewDecision) -> None:
-        """TC-UT-GT-006: ``record_view`` is a self-loop in every state."""
+        """TC-UT-GT-006: record_view は全状態で self-loop となる."""
         gate = _make_gate_in_decision(decision)
         ts = _next_ts(gate)
         out = gate.record_view(uuid4(), viewed_at=ts)
-        assert out.decision == decision  # state unchanged
-        # Decided_at unchanged (record_view is purely an audit op).
+        assert out.decision == decision  # 状態は変化しない
+        # decided_at は変化しない（record_view は純粋な監査操作）
         assert out.decided_at == gate.decided_at
         assert out.feedback_text == gate.feedback_text
-        # Audit trail: 1 new VIEWED entry appended.
+        # 監査証跡: VIEWED エントリが 1 件追加
         assert len(out.audit_trail) == len(gate.audit_trail) + 1
         assert out.audit_trail[-1].action == AuditAction.VIEWED
 
 
 # ---------------------------------------------------------------------------
-# TC-UT-GT-005: 9 ✗ cells (decision_already_decided)
+# TC-UT-GT-005: 9 ✗ セル (decision_already_decided)
 # ---------------------------------------------------------------------------
 class TestDecisionAlreadyDecidedRejection:
-    """9 ✗ cells: approve/reject/cancel on APPROVED/REJECTED/CANCELLED → MSG-GT-001.
+    """9 ✗ セル: APPROVED/REJECTED/CANCELLED に対する approve/reject/cancel
+    → MSG-GT-001。
 
-    The 16-cell matrix splits as: 7 ✓ + 9 ✗. Every ✗ cell is a
-    PENDING-only action attempted on a non-PENDING Gate.
-    ``decision_already_decided`` fires (MSG-GT-001 with the
-    ``allowed_actions`` hint pointing to record_view).
+    16 セルマトリクスは 7 ✓ + 9 ✗ に分かれる。✗ セルはいずれも PENDING
+    限定アクションを非 PENDING な Gate に投げるケース。
+    decision_already_decided が発火し（MSG-GT-001）、allowed_actions
+    ヒントが record_view を指す。
     """
 
     @pytest.mark.parametrize(
@@ -190,16 +191,17 @@ class TestDecisionAlreadyDecidedRejection:
         decision: ReviewDecision,
         action: GateAction,
     ) -> None:
-        """Each (terminal decision, PENDING-only action) raises decision_already_decided."""
+        """各 (terminal decision, PENDING 限定 action) で
+        decision_already_decided が発火."""
         gate = _make_gate_in_decision(decision)
         with pytest.raises(ExternalReviewGateInvariantViolation) as exc_info:
             _invoke_action(gate, action)
         assert exc_info.value.kind == "decision_already_decided"
-        # The detail surfaces the allowed_actions list — the only
-        # legal action from a terminal decision is ``record_view``.
-        # MSG-GT-001 itself routes the operator via "issue a new
-        # directive" hint; the structured allowed_actions belongs to
-        # detail (consumed by application-layer error reporters).
+        # detail には allowed_actions リストが現れる。terminal decision
+        # から正当な唯一のアクションは record_view。MSG-GT-001 自体は
+        # "issue a new directive" ヒントで運用者を誘導。構造化された
+        # allowed_actions は detail に置く（アプリケーション層の
+        # エラーレポータが消費）。
         allowed = exc_info.value.detail.get("allowed_actions")
         assert allowed == ["record_view"], (
             f"[FAIL] terminal Gate must list ['record_view'] as the only "
@@ -211,15 +213,14 @@ class TestDecisionAlreadyDecidedRejection:
 # TC-UT-GT-006 (補強): record_view 冪等性なし (§確定 G)
 # ---------------------------------------------------------------------------
 class TestRecordViewIsNotIdempotent:
-    """§確定 G: same owner + same timestamp = 2 audit entries.
+    """§確定 G: 同一 owner + 同一 timestamp = 監査エントリ 2 件.
 
-    The audit requirement is "誰がいつ何度見たか" (who, when, how
-    many times). Collapsing duplicates would discard the very
-    frequency signal the audit trail is supposed to preserve.
+    監査要件は「誰がいつ何度見たか」。重複折りたたみは監査証跡が保持
+    すべき頻度シグナル自体を捨ててしまう。
     """
 
     def test_same_owner_same_time_appends_twice(self) -> None:
-        """Two record_view calls with identical owner + time → 2 distinct entries."""
+        """同一 owner + 同一時刻の record_view 2 回 → 別エントリ 2 件."""
         gate = make_gate()
         owner = uuid4()
         ts = datetime(2026, 4, 28, 14, 0, 0, tzinfo=UTC)
@@ -228,15 +229,15 @@ class TestRecordViewIsNotIdempotent:
 
         assert len(once.audit_trail) == 1
         assert len(twice.audit_trail) == 2
-        # Both entries carry the same actor + occurred_at, but their
-        # ``id`` differs (uuid4 inside _rebuild_with_state).
+        # 両エントリは同一 actor + occurred_at を持つが、id は別
+        # （_rebuild_with_state 内の uuid4 由来）
         e1, e2 = twice.audit_trail
         assert e1.actor_id == e2.actor_id == owner
         assert e1.occurred_at == e2.occurred_at == ts
         assert e1.id != e2.id
 
     def test_three_views_record_three_entries(self) -> None:
-        """A 3-view sequence accumulates 3 audit entries."""
+        """3 連続 view で監査エントリは 3 件積まれる."""
         gate = make_gate()
         viewer = uuid4()
         for _ in range(3):
@@ -245,7 +246,8 @@ class TestRecordViewIsNotIdempotent:
         assert all(e.action == AuditAction.VIEWED for e in gate.audit_trail)
 
     def test_record_view_preserves_decision_and_decided_at(self) -> None:
-        """record_view does NOT change decision / decided_at / feedback_text."""
+        """record_view は decision / decided_at / feedback_text
+        を変更しない."""
         gate = make_approved_gate(feedback_text="approved!")
         before_decision = gate.decision
         before_decided_at = gate.decided_at
@@ -259,20 +261,19 @@ class TestRecordViewIsNotIdempotent:
 
 
 # ---------------------------------------------------------------------------
-# TC-UT-GT-015: pre-validate failure leaves source Gate unchanged (§確定 E)
+# TC-UT-GT-015: pre-validate 失敗時に元 Gate は不変 (§確定 E)
 # ---------------------------------------------------------------------------
 class TestPreValidateLeavesSourceUnchanged:
-    """TC-UT-GT-015: a failed behavior call does not mutate the original Gate.
+    """TC-UT-GT-015: 失敗した behavior 呼び出しは元 Gate を変更しない.
 
-    The §確定 E pre-validate rebuild path means a behavior either
-    returns a new Gate or raises — never partially-mutates the source
-    instance. We assert this by attempting a `decision_already_decided`
-    on a terminal Gate and inspecting the original Gate's full
-    attribute set.
+    §確定 E の pre-validate rebuild 経路は、behavior が新 Gate を返す
+    か例外を発するかのいずれかで、元インスタンスを部分的に変更しない。
+    terminal Gate に decision_already_decided を仕掛けて、元 Gate の全
+    属性集合を検査することで保証を確認。
     """
 
     def test_failed_approve_on_approved_keeps_source_unchanged(self) -> None:
-        """An ``approve`` on APPROVED raises and does not touch the source."""
+        """APPROVED に対する approve は例外を発し、元 Gate に触れない."""
         gate = make_approved_gate()
         snapshot = gate.model_dump()
 
@@ -283,55 +284,54 @@ class TestPreValidateLeavesSourceUnchanged:
 
 
 # ---------------------------------------------------------------------------
-# Lifecycle integration scenarios
+# ライフサイクル統合シナリオ
 # ---------------------------------------------------------------------------
 class TestLifecycleIntegration:
-    """Aggregate-internal "integration" — multi-method round-trip scenarios."""
+    """Aggregate 内部「統合」── 複数メソッドのラウンドトリップシナリオ."""
 
     def test_pending_approve_then_views_then_approve_again_rejected(self) -> None:
-        """PENDING → APPROVED → record_view x 2 → re-approve raises."""
+        """PENDING → APPROVED → record_view x 2 → 再 approve は例外発火."""
         gate = make_gate()
         viewer_a = uuid4()
         viewer_b = uuid4()
 
-        # Approve.
+        # Approve
         gate = gate.approve(uuid4(), "all good", decided_at=_next_ts(gate))
         assert gate.decision == ReviewDecision.APPROVED
 
-        # 2 distinct viewers record their views.
+        # 別々の閲覧者 2 名が view を記録
         gate = gate.record_view(viewer_a, viewed_at=_next_ts(gate))
         gate = gate.record_view(viewer_b, viewed_at=_next_ts(gate))
         assert len(gate.audit_trail) == 3  # 1 APPROVED + 2 VIEWED
 
-        # Re-approve must raise — Gate is single-decision.
+        # 再 approve は必ず例外発火。Gate は単一 decision
         with pytest.raises(ExternalReviewGateInvariantViolation) as exc_info:
             gate.approve(uuid4(), "re-approve", decided_at=_next_ts(gate))
         assert exc_info.value.kind == "decision_already_decided"
 
-        # Audit trail must have 3 entries unchanged (the failed
-        # approve did NOT add an entry — pre-validate left source
-        # intact).
+        # 監査証跡は 3 件のまま不変（失敗 approve はエントリを追加しない。
+        # pre-validate が元を保ったため）
         assert len(gate.audit_trail) == 3
 
     def test_pending_reject_record_view_still_legal(self) -> None:
-        """A REJECTED Gate still accepts late record_view audits."""
+        """REJECTED の Gate も後続の record_view 監査を受理."""
         gate = make_gate()
         gate = gate.reject(uuid4(), "needs more work", decided_at=_next_ts(gate))
         assert gate.decision == ReviewDecision.REJECTED
 
         for _ in range(2):
             gate = gate.record_view(uuid4(), viewed_at=_next_ts(gate))
-        # 1 REJECTED + 2 VIEWED = 3 entries.
+        # 1 REJECTED + 2 VIEWED = 3 件。
         assert len(gate.audit_trail) == 3
         assert gate.audit_trail[0].action == AuditAction.REJECTED
         assert gate.audit_trail[1].action == AuditAction.VIEWED
         assert gate.audit_trail[2].action == AuditAction.VIEWED
 
     def test_pending_cancel_then_record_view_still_legal(self) -> None:
-        """A CANCELLED Gate still accepts late record_view audits.
+        """CANCELLED の Gate も後続の record_view 監査を受理.
 
-        §確定 G コンプライアンス観点: "3 ヶ月前に CANCELLED した Gate
-        を再確認した" ログ価値 — record_view permitted in every state.
+        §確定 G コンプライアンス観点: 「3 ヶ月前に CANCELLED した
+        Gate を再確認した」ログ価値。record_view は全状態で許可。
         """
         gate = make_gate()
         gate = gate.cancel(uuid4(), "withdrawn", decided_at=_next_ts(gate))
@@ -341,10 +341,10 @@ class TestLifecycleIntegration:
 
 
 # ---------------------------------------------------------------------------
-# Reachability sanity — each allowed transition produces consistent fields
+# 到達性確認 ── 各許可遷移は整合性あるフィールドを生成
 # ---------------------------------------------------------------------------
 class TestAuditTrailGrowsByOnePerCall:
-    """Every behavior method appends exactly one audit entry."""
+    """全 behavior メソッドは監査エントリをちょうど 1 件追加."""
 
     @pytest.mark.parametrize(
         "decision",
@@ -352,7 +352,7 @@ class TestAuditTrailGrowsByOnePerCall:
         ids=lambda d: d.value,
     )
     def test_legal_action_grows_audit_by_one(self, decision: ReviewDecision) -> None:
-        """For every legal (decision, action), audit_trail length grows by 1."""
+        """合法 (decision, action) 全てで audit_trail 長は +1 となる."""
         legal_actions: list[GateAction] = [a for (d, a) in TRANSITIONS if d == decision]
         assert legal_actions, f"decision {decision} has zero legal actions"
         for action in legal_actions:
@@ -364,5 +364,5 @@ class TestAuditTrailGrowsByOnePerCall:
             )
 
 
-# Sanity import to keep pyright happy with the GateAction type usage above.
+# GateAction 型使用に対して pyright を満足させるサニティ import
 _ = GateAction

--- a/backend/tests/domain/external_review_gate/test_gate/test_state_machine.py
+++ b/backend/tests/domain/external_review_gate/test_gate/test_state_machine.py
@@ -63,7 +63,7 @@ def _invoke_action(gate: ExternalReviewGate, action: GateAction) -> ExternalRevi
         return gate.reject(uuid4(), "synthetic reject comment", decided_at=ts)
     if action == "cancel":
         return gate.cancel(uuid4(), "synthetic cancel reason", decided_at=ts)
-    # record_view
+    # record_view（閲覧記録）
     return gate.record_view(uuid4(), viewed_at=ts)
 
 
@@ -106,7 +106,7 @@ class TestStateMachineTableLocked:
 class TestSevenAllowedTransitions:
     """TC-UT-GT-003 / 004 / 006 / 013 ── 分岐テーブルの ✓ セル 7 件。"""
 
-    # PENDING → APPROVED via approve
+    # PENDING → APPROVED（approve 経由）
     def test_approve_pending_to_approved(self) -> None:
         """TC-UT-GT-003: PENDING に対する approve は APPROVED へ遷移."""
         gate = make_gate()
@@ -121,7 +121,7 @@ class TestSevenAllowedTransitions:
         # 元の Gate は不変（frozen + pre-validate）
         assert gate.decision == ReviewDecision.PENDING
 
-    # PENDING → REJECTED via reject
+    # PENDING → REJECTED（reject 経由）
     def test_reject_pending_to_rejected(self) -> None:
         """TC-UT-GT-004: PENDING に対する reject は REJECTED へ遷移."""
         gate = make_gate()
@@ -132,7 +132,7 @@ class TestSevenAllowedTransitions:
         assert out.feedback_text == "needs revision"
         assert out.audit_trail[-1].action == AuditAction.REJECTED
 
-    # PENDING → CANCELLED via cancel
+    # PENDING → CANCELLED（cancel 経由）
     def test_cancel_pending_to_cancelled(self) -> None:
         """TC-UT-GT-013: PENDING に対する cancel は CANCELLED へ遷移."""
         gate = make_gate()
@@ -295,7 +295,7 @@ class TestLifecycleIntegration:
         viewer_a = uuid4()
         viewer_b = uuid4()
 
-        # Approve
+        # 承認
         gate = gate.approve(uuid4(), "all good", decided_at=_next_ts(gate))
         assert gate.decision == ReviewDecision.APPROVED
 

--- a/backend/tests/domain/external_review_gate/test_gate/test_vo.py
+++ b/backend/tests/domain/external_review_gate/test_gate/test_vo.py
@@ -1,12 +1,12 @@
-"""ExternalReviewGate VO + enum tests.
+"""ExternalReviewGate VO + enum テスト.
 
-Covers:
+カバー範囲:
 
-* :class:`AuditEntry` VO — frozen, comment NFC-only no-strip,
-  occurred_at tz-aware.
-* :class:`ReviewDecision` enum — 4 StrEnum values.
-* :class:`AuditAction` enum — VIEWED / APPROVED / REJECTED /
-  CANCELLED + reserved Phase-2 admin values present.
+* AuditEntry VO — frozen, コメント NFC のみノーストリップ,
+  occurred_at はタイムゾーン対応。
+* ReviewDecision enum — 4 つの StrEnum 値。
+* AuditAction enum — VIEWED / APPROVED / REJECTED / CANCELLED
+  + 予約済みの Phase-2 管理値が存在。
 """
 
 from __future__ import annotations
@@ -33,38 +33,39 @@ from tests.factories.external_review_gate import (
 # AuditEntry VO
 # ---------------------------------------------------------------------------
 class TestAuditEntryConstruction:
-    """AuditEntry constructs valid + rejects oversize comment."""
+    """AuditEntry は有効に構築でき、オーバーサイズコメントは拒否."""
 
     def test_default_audit_entry_constructs(self) -> None:
-        """Factory-default AuditEntry has VIEWED action + tz-aware occurred_at."""
+        """ファクトリーデフォルト AuditEntry は VIEWED アクション +
+        タイムゾーン対応 occurred_at を持つ."""
         entry = make_audit_entry()
         assert entry.action == AuditAction.VIEWED
         assert entry.occurred_at.tzinfo is not None
 
     def test_audit_entry_factory_marks_synthetic(self) -> None:
-        """Factory output is registered in :func:`is_synthetic`."""
+        """ファクトリー出力は is_synthetic() に登録される."""
         entry = make_audit_entry()
         assert is_synthetic(entry)
 
     def test_audit_entry_is_frozen(self) -> None:
-        """Direct attribute assignment on AuditEntry is rejected."""
+        """AuditEntry への直接属性割り当ては拒否される."""
         entry = make_audit_entry()
         with pytest.raises(ValidationError):
             entry.comment = "mutated"  # pyright: ignore[reportAttributeAccessIssue]
 
     def test_comment_at_max_length_accepted(self) -> None:
-        """2000-char comment is at the cap and accepted."""
+        """2000 文字コメントは上限であり受け入れられる."""
         comment = "x" * 2000
         entry = make_audit_entry(comment=comment)
         assert len(entry.comment) == 2000
 
     def test_comment_over_max_length_rejected(self) -> None:
-        """2001-char comment exceeds the cap and raises."""
+        """2001 文字コメントは上限を超過し例外を発生させる."""
         with pytest.raises(ValidationError):
             make_audit_entry(comment="x" * 2001)
 
     def test_naive_occurred_at_rejected(self) -> None:
-        """``occurred_at`` without a timezone is rejected."""
+        """タイムゾーンなし occurred_at は拒否される."""
         naive = datetime.now()
         with pytest.raises(ValidationError):
             AuditEntry(
@@ -76,20 +77,20 @@ class TestAuditEntryConstruction:
             )
 
     def test_comment_nfc_normalization_no_strip(self) -> None:
-        """Comment is NFC-normalized but **not** stripped."""
+        """コメントは NFC 正規化されるが、ストリップは行われない."""
         raw = "  indented quote\n"
         entry = make_audit_entry(comment=raw)
-        # NFC normalization, no strip.
+        # NFC 正規化、ストリップなし
         assert entry.comment == unicodedata.normalize("NFC", raw)
-        assert entry.comment.startswith("  ")  # leading whitespace preserved
-        assert entry.comment.endswith("\n")  # trailing newline preserved
+        assert entry.comment.startswith("  ")  # 先頭の空白は保持
+        assert entry.comment.endswith("\n")  # 末尾の改行は保持
 
 
 class TestAuditEntryStructuralEquality:
-    """Same-attribute AuditEntry instances are ``==``."""
+    """同じ属性を持つ AuditEntry インスタンスは ``==`` である."""
 
     def test_same_attributes_compare_equal(self) -> None:
-        """Two AuditEntry with identical attrs are ``==``."""
+        """同じ属性を持つ 2 つの AuditEntry は ``==`` である."""
         common_id = uuid4()
         actor = uuid4()
         ts = datetime(9999, 1, 1, 0, 0, 0, tzinfo=UTC)
@@ -111,18 +112,18 @@ class TestAuditEntryStructuralEquality:
 
 
 # ---------------------------------------------------------------------------
-# ReviewDecision enum (4 values)
+# ReviewDecision enum（4 値）
 # ---------------------------------------------------------------------------
 class TestReviewDecisionEnum:
-    """ReviewDecision has exactly 4 StrEnum values."""
+    """ReviewDecision は正確に 4 つの StrEnum 値を持つ."""
 
     def test_four_values(self) -> None:
-        """PENDING / APPROVED / REJECTED / CANCELLED — exactly 4."""
+        """PENDING / APPROVED / REJECTED / CANCELLED — 正確に 4 つ."""
         members = list(ReviewDecision)
         assert len(members) == 4
 
     def test_str_enum_equality(self) -> None:
-        """StrEnum members compare equal to their string values."""
+        """StrEnum メンバーは文字列値と等しいと比較される."""
         assert ReviewDecision.PENDING == "PENDING"
         assert ReviewDecision.APPROVED == "APPROVED"
         assert ReviewDecision.REJECTED == "REJECTED"
@@ -130,22 +131,23 @@ class TestReviewDecisionEnum:
 
 
 # ---------------------------------------------------------------------------
-# AuditAction enum (4 core + reserved Phase-2 values)
+# AuditAction enum（4 コア + 予約済み Phase-2 値）
 # ---------------------------------------------------------------------------
 class TestAuditActionEnum:
-    """AuditAction has the 4 core states the Gate Aggregate emits."""
+    """AuditAction は Gate アグリゲートが発行する 4 つのコア状態を持つ."""
 
     def test_core_actions_present(self) -> None:
-        """The 4 core actions are present (VIEWED / APPROVED / REJECTED / CANCELLED)."""
-        # Gate aggregate emits exactly these 4 — Phase 2 admin actions
-        # may extend the enum; we don't pin a specific count so the
-        # test stays stable across enum additions.
+        """4 つのコアアクションが存在（VIEWED / APPROVED / REJECTED /
+        CANCELLED）."""
+        # Gate アグリゲートはちょうどこれら 4 つを発行。Phase 2
+        # 管理アクションで enum が拡張される場合もある。
+        # 特定の数は固定しないため、テストは enum 追加でも安定。
         assert AuditAction.VIEWED == "VIEWED"
         assert AuditAction.APPROVED == "APPROVED"
         assert AuditAction.REJECTED == "REJECTED"
         assert AuditAction.CANCELLED == "CANCELLED"
 
     def test_str_enum_equality(self) -> None:
-        """StrEnum members compare equal to their string values."""
+        """StrEnum メンバーは文字列値と等しいと比較される."""
         for member in AuditAction:
             assert member.value == str(member)

--- a/backend/tests/domain/internal_review_gate/test_integration.py
+++ b/backend/tests/domain/internal_review_gate/test_integration.py
@@ -140,10 +140,10 @@ class TestGateLifecycleAllApproved:
             comment="UX OK",
             decided_at=_ts(),
         )
-        # All required roles have verdicts.
+        # 必須 role 全てに verdict が付与済み。
         submitted_roles = frozenset(v.role for v in gate.verdicts)
         assert submitted_roles == roles
-        # Every verdict is APPROVED.
+        # 全 verdict が APPROVED である。
         assert all(v.decision == VerdictDecision.APPROVED for v in gate.verdicts)
 
 
@@ -165,7 +165,7 @@ class TestGateLifecycleRejected:
             decided_at=_ts(),
         )
         assert gate_rejected.gate_decision == GateDecision.REJECTED
-        # Only 1 verdict: remaining 2 roles are still not submitted.
+        # verdict は 1 件のみ: 残り 2 つの role は未投稿。
         assert len(gate_rejected.verdicts) == 1
         assert gate_rejected.verdicts[0].decision == VerdictDecision.REJECTED
 
@@ -181,7 +181,7 @@ class TestGateLifecycleRejected:
         )
         assert gate.gate_decision == GateDecision.REJECTED
 
-        # ux tries to APPROVE after Gate is already REJECTED.
+        # Gate が REJECTED 後に ux が APPROVE を試みるケース。
         with pytest.raises(InternalReviewGateInvariantViolation) as exc_info:
             gate.submit_verdict(
                 role="ux",

--- a/backend/tests/domain/internal_review_gate/test_integration.py
+++ b/backend/tests/domain/internal_review_gate/test_integration.py
@@ -1,14 +1,14 @@
-"""InternalReviewGate aggregate-internal integration tests (TC-IT-IRG-001, 002).
+"""InternalReviewGate aggregate-internal integration テスト (TC-IT-IRG-001, 002)。
 
-Per ``docs/features/internal-review-gate/domain/test-design.md`` §結合テストケース.
+``docs/features/internal-review-gate/domain/test-design.md`` §結合テストケース に従う。
 
-"Integration" in this module means **Aggregate-internal module collaboration**
-(InternalReviewGate ↔ state_machine ↔ aggregate_validators ↔ Verdict VO) without
-any external I/O — same zero-IO pattern as the sibling agent / directive / room /
-workflow integration tests.
+このモジュール内「Integration」は **Aggregate 内モジュール協調**を意味する
+(InternalReviewGate ↔ state_machine ↔ aggregate_validators ↔ Verdict VO)
+外部 I/O なし — sibling agent / directive / room / workflow
+integration テストと同じゼロ I/O パターン。
 
-Covers:
-  TC-IT-IRG-001  Gate lifecycle 完走(PENDING → ALL_APPROVED)(AC#2, 3, 4)
+対象:
+  TC-IT-IRG-001  Gate ライフサイクル 完走(PENDING → ALL_APPROVED)(AC#2, 3, 4)
   TC-IT-IRG-002  REJECTED 経路(1件 REJECTED → 即遷移、残り未提出でも)(AC#5)
 
 Issue: #65
@@ -34,13 +34,14 @@ def _ts() -> datetime:
 # TC-IT-IRG-001: Gate lifecycle 完走(PENDING → ALL_APPROVED)
 # ---------------------------------------------------------------------------
 class TestGateLifecycleAllApproved:
-    """TC-IT-IRG-001: full multi-step lifecycle PENDING → partial → ALL_APPROVED → guard."""
+    """TC-IT-IRG-001: 完全な複数ステップライフサイクル
+    PENDING → partial → ALL_APPROVED → guard。"""
 
     def test_lifecycle_reaches_all_approved(self) -> None:
-        """Step 1 (reviewer APPROVED) keeps PENDING; step 2 (ux APPROVED) → ALL_APPROVED."""
+        """Step 1 (reviewer APPROVED) が PENDING を保持； step 2 (ux APPROVED) → ALL_APPROVED。"""
         gate = make_gate(required_gate_roles=frozenset({"reviewer", "ux"}))
 
-        # Step 1: reviewer APPROVED → still PENDING.
+        # Step 1: reviewer APPROVED → まだ PENDING。
         reviewer_agent = uuid4()
         gate_after_reviewer = gate.submit_verdict(
             role="reviewer",
@@ -52,7 +53,7 @@ class TestGateLifecycleAllApproved:
         assert gate_after_reviewer.gate_decision == GateDecision.PENDING
         assert len(gate_after_reviewer.verdicts) == 1
 
-        # Step 2: ux APPROVED → ALL_APPROVED.
+        # Step 2: ux APPROVED → ALL_APPROVED。
         ux_agent = uuid4()
         gate_final = gate_after_reviewer.submit_verdict(
             role="ux",
@@ -65,7 +66,7 @@ class TestGateLifecycleAllApproved:
         assert len(gate_final.verdicts) == 2
 
     def test_all_approved_gate_rejects_further_submission(self) -> None:
-        """Step 3: submission to ALL_APPROVED Gate raises gate_already_decided."""
+        """Step 3: ALL_APPROVED Gate への提出が gate_already_decided を raise。"""
         gate = make_gate(required_gate_roles=frozenset({"reviewer", "ux"}))
         gate = gate.submit_verdict(
             role="reviewer",
@@ -94,7 +95,7 @@ class TestGateLifecycleAllApproved:
         assert exc_info.value.kind == "gate_already_decided"
 
     def test_source_gate_unchanged_throughout_lifecycle(self) -> None:
-        """Pre-validate rebuild: every intermediate Gate is immutable."""
+        """Pre-validate rebuild: すべての中間 Gate は immutable。"""
         gate_initial = make_gate(required_gate_roles=frozenset({"reviewer", "ux"}))
         snapshot_initial = gate_initial.model_dump()
 
@@ -115,14 +116,14 @@ class TestGateLifecycleAllApproved:
             decided_at=_ts(),
         )
 
-        # Original and mid-state gates must not have changed.
+        # 元の gate と mid-state gate は変更されてはならない。
         assert gate_initial.model_dump() == snapshot_initial
         assert gate_mid.model_dump() == snapshot_mid
-        # Only the final gate is ALL_APPROVED.
+        # 最終 gate だけが ALL_APPROVED。
         assert gate_final.gate_decision == GateDecision.ALL_APPROVED
 
     def test_all_approved_gate_attribute_consistency(self) -> None:
-        """ALL_APPROVED Gate's attributes are internally consistent post-lifecycle."""
+        """ALL_APPROVED Gate の属性は post-lifecycle で内部整合。"""
         roles = frozenset({"reviewer", "ux"})
         gate = make_gate(required_gate_roles=roles)
         gate = gate.submit_verdict(

--- a/backend/tests/domain/internal_review_gate/test_internal_review_gate/test_decision_logic.py
+++ b/backend/tests/domain/internal_review_gate/test_internal_review_gate/test_decision_logic.py
@@ -37,13 +37,13 @@ class TestComputeDecisionPending:
         assert result == GateDecision.PENDING
 
     def test_partial_approved_is_pending(self) -> None:
-        """1/2 required roles approved → PENDING (need all roles)."""
+        """1/2 必須ロール承認 → PENDING（全ロール必須）."""
         v_reviewer = make_verdict(role="reviewer", decision=VerdictDecision.APPROVED)
         result = compute_decision((v_reviewer,), frozenset({"reviewer", "ux"}))
         assert result == GateDecision.PENDING
 
     def test_superset_required_roles_missing_stays_pending(self) -> None:
-        """3 required roles, 2 approved → PENDING (1 still missing)."""
+        """3 必須ロール、2 承認 → PENDING（1 件未提出）."""
         v1 = make_verdict(role="reviewer", decision=VerdictDecision.APPROVED)
         v2 = make_verdict(role="ux", decision=VerdictDecision.APPROVED)
         result = compute_decision((v1, v2), frozenset({"reviewer", "ux", "security"}))
@@ -54,26 +54,26 @@ class TestComputeDecisionPending:
 # TC-UT-IRG-004 (re): ALL_APPROVED condition
 # ---------------------------------------------------------------------------
 class TestComputeDecisionAllApproved:
-    """compute_decision → ALL_APPROVED when all required roles have APPROVED."""
+    """全必須ロール承認時に compute_decision → ALL_APPROVED."""
 
     def test_all_required_approved_transitions(self) -> None:
-        """All required roles APPROVED → ALL_APPROVED."""
+        """全必須ロール承認 → ALL_APPROVED."""
         v1 = make_verdict(role="reviewer", decision=VerdictDecision.APPROVED)
         v2 = make_verdict(role="ux", decision=VerdictDecision.APPROVED)
         result = compute_decision((v1, v2), frozenset({"reviewer", "ux"}))
         assert result == GateDecision.ALL_APPROVED
 
     def test_single_required_role_approved_transitions(self) -> None:
-        """Even with only 1 required role, APPROVED transitions to ALL_APPROVED."""
+        """必須ロール 1 件でも承認で ALL_APPROVED に遷移."""
         v = make_verdict(role="reviewer", decision=VerdictDecision.APPROVED)
         result = compute_decision((v,), frozenset({"reviewer"}))
         assert result == GateDecision.ALL_APPROVED
 
     def test_extra_verdicts_beyond_required_still_all_approved(self) -> None:
-        """Additional APPROVED verdicts beyond required set don't block ALL_APPROVED."""
+        """必須外の追加承認判定は ALL_APPROVED をブロックしない."""
         v1 = make_verdict(role="reviewer", decision=VerdictDecision.APPROVED)
         v2 = make_verdict(role="ux", decision=VerdictDecision.APPROVED)
-        # required = {"reviewer"} only; ux is extra but still APPROVED → ALL_APPROVED.
+        # required = {"reviewer"} のみ。ux は追加だが承認 → ALL_APPROVED
         result = compute_decision((v1, v2), frozenset({"reviewer"}))
         assert result == GateDecision.ALL_APPROVED
 
@@ -82,30 +82,30 @@ class TestComputeDecisionAllApproved:
 # TC-UT-IRG-005 (re): REJECTED condition — most-pessimistic-wins
 # ---------------------------------------------------------------------------
 class TestComputeDecisionRejected:
-    """compute_decision → REJECTED immediately when any verdict is REJECTED."""
+    """いずれかの判定が却下時に compute_decision → 即座に REJECTED."""
 
     def test_single_rejected_wins_immediately(self) -> None:
-        """1 REJECTED with 2 roles pending → REJECTED (most-pessimistic-wins)."""
+        """1 却下、2 ロール保留中 → REJECTED（最悲観的ルール優先）."""
         v = make_verdict(role="security", decision=VerdictDecision.REJECTED)
         result = compute_decision((v,), frozenset({"reviewer", "ux", "security"}))
         assert result == GateDecision.REJECTED
 
     def test_rejected_overrides_approved(self) -> None:
-        """REJECTED wins even when other roles have APPROVED."""
+        """他のロールが承認でも却下が優先."""
         v_approved = make_verdict(role="reviewer", decision=VerdictDecision.APPROVED)
         v_rejected = make_verdict(role="ux", decision=VerdictDecision.REJECTED)
         result = compute_decision((v_approved, v_rejected), frozenset({"reviewer", "ux"}))
         assert result == GateDecision.REJECTED
 
     def test_rejected_checked_before_all_approved(self) -> None:
-        """Rule 1 (REJECTED check) fires before Rule 2 (ALL_APPROVED check).
+        """ルール 1（却下チェック）がルール 2（全承認チェック）より先に発火.
 
-        If all required roles submitted, but one of them is REJECTED,
-        the result must be REJECTED, not ALL_APPROVED.
+        全必須ロール提出でも 1 件が却下なら、結果は ALL_APPROVED でなく
+        REJECTED でなければならない。
         """
         v_approved = make_verdict(role="reviewer", decision=VerdictDecision.APPROVED)
         v_rejected = make_verdict(role="ux", decision=VerdictDecision.REJECTED)
-        # Both required roles submitted → Rule 2 would fire if Rule 1 didn't exist.
+        # 両必須ロール提出。ルール 1 がなければルール 2 が発火
         result = compute_decision((v_approved, v_rejected), frozenset({"reviewer", "ux"}))
         assert result == GateDecision.REJECTED
 
@@ -114,10 +114,10 @@ class TestComputeDecisionRejected:
 # §確定 C: compute_decision is Final-locked public alias
 # ---------------------------------------------------------------------------
 class TestComputeDecisionFinalLock:
-    """§確定 C: compute_decision is the public alias of _compute_decision."""
+    """§確定 C: compute_decision は _compute_decision の公開エイリアス."""
 
     def test_compute_decision_is_the_private_implementation(self) -> None:
-        """The public alias must point at _compute_decision (same object)."""
+        """公開エイリアスは _compute_decision を指す（同一オブジェクト）."""
         assert compute_decision is _compute_decision
 
     def test_compute_decision_is_callable(self) -> None:

--- a/backend/tests/domain/internal_review_gate/test_internal_review_gate/test_submit_verdict.py
+++ b/backend/tests/domain/internal_review_gate/test_internal_review_gate/test_submit_verdict.py
@@ -36,7 +36,7 @@ from tests.factories.internal_review_gate import (
     make_gate,
 )
 
-# Shared UTC timestamp helper.
+# 共有 UTC タイムスタンプヘルパ。
 _NOW = datetime.now(UTC)
 
 
@@ -48,10 +48,10 @@ def _ts() -> datetime:
 # TC-UT-IRG-003: APPROVED Verdict 提出 → PENDING 継続 (REQ-IRG-002, AC#3)
 # ---------------------------------------------------------------------------
 class TestSubmitVerdictPending:
-    """TC-UT-IRG-003: partial submission keeps gate PENDING."""
+    """TC-UT-IRG-003: 部分提出は gate を PENDING のまま維持する。"""
 
     def test_single_approved_out_of_three_stays_pending(self) -> None:
-        """1/3 APPROVED → gate_decision=PENDING."""
+        """1/3 APPROVED → gate_decision=PENDING。"""
         gate = make_gate(required_gate_roles=frozenset({"reviewer", "ux", "security"}))
         new_gate = gate.submit_verdict(
             role="reviewer",
@@ -74,7 +74,7 @@ class TestSubmitVerdictPending:
         assert len(new_gate.verdicts) == 1
 
     def test_source_gate_is_unchanged_after_submission(self) -> None:
-        """Frozen pre-validate pattern: original Gate must not be mutated."""
+        """Frozen pre-validate パターン: 元 Gate は変更されない。"""
         gate = make_gate(required_gate_roles=frozenset({"reviewer", "ux"}))
         snapshot = gate.model_dump()
         gate.submit_verdict(
@@ -91,7 +91,7 @@ class TestSubmitVerdictPending:
 # TC-UT-IRG-004: 全 GateRole APPROVED → ALL_APPROVED 遷移 (AC#4)
 # ---------------------------------------------------------------------------
 class TestSubmitVerdictAllApproved:
-    """TC-UT-IRG-004: all required roles APPROVED → ALL_APPROVED."""
+    """TC-UT-IRG-004: required な全 role が APPROVED → ALL_APPROVED。"""
 
     def test_all_approved_transitions_to_all_approved(self) -> None:
         gate = make_gate(required_gate_roles=frozenset({"reviewer", "ux"}))
@@ -134,10 +134,10 @@ class TestSubmitVerdictAllApproved:
 # TC-UT-IRG-005: 1件 REJECTED → REJECTED 即遷移(残り未提出でも)(AC#5)
 # ---------------------------------------------------------------------------
 class TestSubmitVerdictRejectedImmediate:
-    """TC-UT-IRG-005: single REJECTED transitions immediately, pending roles irrelevant."""
+    """TC-UT-IRG-005: 単一 REJECTED で即時遷移する (他の未提出 role は無関係)。"""
 
     def test_one_rejected_transitions_immediately(self) -> None:
-        """1/3 roles REJECTED → gate_decision=REJECTED (other 2 roles still pending)."""
+        """1/3 roles REJECTED → gate_decision=REJECTED (残り 2 role は未提出のまま)。"""
         gate = make_gate(required_gate_roles=frozenset({"reviewer", "ux", "security"}))
         new_gate = gate.submit_verdict(
             role="security",
@@ -149,7 +149,7 @@ class TestSubmitVerdictRejectedImmediate:
         assert new_gate.gate_decision == GateDecision.REJECTED
 
     def test_rejected_gate_has_only_one_verdict(self) -> None:
-        """Remaining 2 roles are not submitted; only 1 REJECTED verdict present."""
+        """残り 2 role は未提出。REJECTED の verdict が 1 件のみ存在する。"""
         gate = make_gate(required_gate_roles=frozenset({"reviewer", "ux", "security"}))
         new_gate = gate.submit_verdict(
             role="security",
@@ -161,7 +161,7 @@ class TestSubmitVerdictRejectedImmediate:
         assert len(new_gate.verdicts) == 1
 
     def test_rejected_verdict_comment_is_recorded(self) -> None:
-        """Feedback comment from REJECTED verdict is stored (AC#5)."""
+        """REJECTED verdict のフィードバックコメントが保存される (AC#5)。"""
         gate = make_gate(required_gate_roles=frozenset({"reviewer", "ux"}))
         new_gate = gate.submit_verdict(
             role="reviewer",
@@ -177,7 +177,7 @@ class TestSubmitVerdictRejectedImmediate:
 # TC-UT-IRG-006: 同一 GateRole 重複提出 → raise (REQ-IRG-002/004, AC#6)
 # ---------------------------------------------------------------------------
 class TestRoleAlreadySubmitted:
-    """TC-UT-IRG-006: re-submission of the same role raises role_already_submitted."""
+    """TC-UT-IRG-006: 同一 role の再提出は role_already_submitted を発火する。"""
 
     def test_duplicate_role_raises(self) -> None:
         gate = make_gate(required_gate_roles=frozenset({"reviewer", "ux"}))
@@ -199,9 +199,9 @@ class TestRoleAlreadySubmitted:
         assert exc_info.value.kind == "role_already_submitted"
 
     def test_duplicate_raises_before_gate_already_decided(self) -> None:
-        """Step order: role_already_submitted fires at step 2 (gate is still PENDING)."""
+        """ステップ順: role_already_submitted は step 2 で発火する (gate は PENDING のまま)。"""
         gate = make_gate(required_gate_roles=frozenset({"reviewer", "ux"}))
-        # Submit reviewer once — gate stays PENDING.
+        # reviewer を 1 度提出 ── gate は PENDING のまま。
         gate = gate.submit_verdict(
             role="reviewer",
             agent_id=uuid4(),
@@ -210,7 +210,7 @@ class TestRoleAlreadySubmitted:
             decided_at=_ts(),
         )
         assert gate.gate_decision == GateDecision.PENDING
-        # Re-submit same role → role_already_submitted (not gate_already_decided).
+        # 同一 role を再提出 → role_already_submitted (gate_already_decided ではない)。
         with pytest.raises(InternalReviewGateInvariantViolation) as exc_info:
             gate.submit_verdict(
                 role="reviewer",
@@ -226,11 +226,11 @@ class TestRoleAlreadySubmitted:
 # TC-UT-IRG-007: 確定後の追加 Verdict → raise (REQ-IRG-002, AC#7)
 # ---------------------------------------------------------------------------
 class TestGateAlreadyDecided:
-    """TC-UT-IRG-007: any submission to ALL_APPROVED/REJECTED Gate raises gate_already_decided."""
+    """TC-UT-IRG-007: ALL_APPROVED/REJECTED Gate への任意提出で gate_already_decided が発火。"""
 
     def test_submit_to_all_approved_gate_raises(self) -> None:
-        # Build a gate whose required roles include "reviewer" so we hit
-        # gate_already_decided rather than invalid_role first.
+        # required role に "reviewer" を含む gate を構築する ──
+        # invalid_role ではなく gate_already_decided が先に発火するように。
         all_approved = make_all_approved_gate(required_gate_roles=frozenset({"reviewer", "ux"}))
         with pytest.raises(InternalReviewGateInvariantViolation) as exc_info:
             all_approved.submit_verdict(
@@ -257,11 +257,11 @@ class TestGateAlreadyDecided:
         assert exc_info.value.kind == "gate_already_decided"
 
     def test_gate_already_decided_fires_before_role_already_submitted(self) -> None:
-        """Step 1 (gate_already_decided) fires before step 2 (role_already_submitted)."""
-        # Create a gate where the ALL_APPROVED was reached via reviewer + ux.
+        """Step 1 (gate_already_decided) は step 2 (role_already_submitted) より先に発火する。"""
+        # reviewer + ux 経由で ALL_APPROVED に達した gate を作る。
         all_approved = make_all_approved_gate(required_gate_roles=frozenset({"reviewer", "ux"}))
-        # Try to re-submit "reviewer" (which is both already decided AND role already submitted).
-        # Step 1 must win.
+        # "reviewer" を再提出する (already decided かつ role already submitted の両方に該当)。
+        # Step 1 が勝たねばならない。
         with pytest.raises(InternalReviewGateInvariantViolation) as exc_info:
             all_approved.submit_verdict(
                 role="reviewer",
@@ -277,7 +277,7 @@ class TestGateAlreadyDecided:
 # TC-UT-IRG-008: comment 境界値 (REQ-IRG-002, AC#11)
 # ---------------------------------------------------------------------------
 class TestCommentBoundary:
-    """TC-UT-IRG-008: comment length 0 / 5000 OK; 5001 raises comment_too_long."""
+    """TC-UT-IRG-008: comment 長 0 / 5000 は OK、5001 は comment_too_long。"""
 
     def test_empty_comment_accepted(self) -> None:
         gate = make_gate(required_gate_roles=frozenset({"reviewer"}))
@@ -315,12 +315,12 @@ class TestCommentBoundary:
         assert exc_info.value.kind == "comment_too_long"
 
     def test_comment_length_checked_after_nfc_normalization(self) -> None:
-        """5000 chars after NFC normalization are accepted regardless of raw form."""
-        # NFD 'が' (2 code points) normalizes to NFC 'が' (1 code point).
-        # Build a string that is exactly 5000 NFC chars.
-        nfc_char = "が"  # 1 NFC code point
-        nfd_form = unicodedata.normalize("NFD", nfc_char)  # 2 code points in NFD
-        comment = nfd_form * 5000  # 10000 raw code points → 5000 NFC chars
+        """NFC 正規化後 5000 文字は、生形に関わらず受理される。"""
+        # NFD 'が' (2 コードポイント) は NFC'が' (1 コードポイント) に正規化される。
+        # 厳密に NFC 5000 文字となる文字列を構築する。
+        nfc_char = "が"  # NFC で 1 コードポイント
+        nfd_form = unicodedata.normalize("NFD", nfc_char)  # NFD で 2 コードポイント
+        comment = nfd_form * 5000  # 生では 10000 コードポイント、NFC で 5000 文字
         gate = make_gate(required_gate_roles=frozenset({"reviewer"}))
         new_gate = gate.submit_verdict(
             role="reviewer",
@@ -336,13 +336,13 @@ class TestCommentBoundary:
 # TC-UT-IRG-009: invalid_role (REQ-IRG-004, AC#2, 3)
 # ---------------------------------------------------------------------------
 class TestInvalidRole:
-    """TC-UT-IRG-009: role not in required_gate_roles raises invalid_role."""
+    """TC-UT-IRG-009: required_gate_roles に含まれない role は invalid_role を発火する。"""
 
     def test_role_not_in_required_raises(self) -> None:
         gate = make_gate(required_gate_roles=frozenset({"reviewer", "ux"}))
         with pytest.raises(InternalReviewGateInvariantViolation) as exc_info:
             gate.submit_verdict(
-                role="security",  # not in required_gate_roles
+                role="security",  # required_gate_roles に含まれない
                 agent_id=uuid4(),
                 decision=VerdictDecision.APPROVED,
                 comment="",
@@ -367,11 +367,11 @@ class TestInvalidRole:
 # TC-UT-IRG-011: VerdictDecision 2 値のみ (§確定 F, Q-3)
 # ---------------------------------------------------------------------------
 class TestVerdictDecisionTwoValuesOnly:
-    """TC-UT-IRG-011: only APPROVED and REJECTED are valid VerdictDecision values."""
+    """TC-UT-IRG-011: VerdictDecision の有効値は APPROVED と REJECTED のみ。"""
 
     @pytest.mark.parametrize("bad_value", ["ambiguous", "maybe", "conditional", "pending"])
     def test_invalid_verdict_decision_raises_validation_error(self, bad_value: str) -> None:
-        """§確定 F: values other than APPROVED/REJECTED are type errors."""
+        """§確定 F: APPROVED / REJECTED 以外の値は型エラーとなる。"""
         from bakufu.domain.value_objects import Verdict
 
         with pytest.raises(ValidationError):
@@ -388,10 +388,10 @@ class TestVerdictDecisionTwoValuesOnly:
 # TC-UT-IRG-012: comment NFC + strip しない (§確定 G, Q-3)
 # ---------------------------------------------------------------------------
 class TestCommentNFCNoStrip:
-    """TC-UT-IRG-012: comment is NFC-normalized but leading/trailing whitespace preserved."""
+    """TC-UT-IRG-012: comment は NFC 正規化するが前後の空白は保持する。"""
 
     def test_trailing_newline_preserved(self) -> None:
-        """Trailing newlines in comment are preserved (no strip)."""
+        """comment 末尾の改行は保持される (strip しない)。"""
         gate = make_gate(required_gate_roles=frozenset({"reviewer"}))
         raw = "\n承認コメント\n"
         new_gate = gate.submit_verdict(
@@ -405,8 +405,8 @@ class TestCommentNFCNoStrip:
         assert new_gate.verdicts[0].comment.endswith("\n")
 
     def test_nfd_form_normalized_to_nfc(self) -> None:
-        """NFD-decomposed characters are composed to NFC form."""
-        # 'か' + combining dakuten (U+3099) = NFD 'が'; NFC = 'が' (U+304C)
+        """NFD 分解された文字は NFC 形に合成される。"""
+        # 'か' + 結合濁点 (U+3099) = NFD 'が'。NFC = 'が' (U+304C)
         nfd_comment = "がレビュー"
         gate = make_gate(required_gate_roles=frozenset({"reviewer"}))
         new_gate = gate.submit_verdict(
@@ -425,10 +425,10 @@ class TestCommentNFCNoStrip:
 # TC-UT-IRG-013〜016: MSG 2 行構造 + Next: hint (§確定 H, Q-3)
 # ---------------------------------------------------------------------------
 class TestMsgTwoLineStructure:
-    """TC-UT-IRG-013〜016: InternalReviewGateInvariantViolation messages have 2-line structure."""
+    """TC-UT-IRG-013〜016: InternalReviewGateInvariantViolation メッセージは 2 行構造を持つ。"""
 
     def test_msg_irg_001_starts_with_fail_and_has_next(self) -> None:
-        """TC-UT-IRG-013: MSG-IRG-001 (role_already_submitted) — [FAIL]…\\nNext:…"""
+        """TC-UT-IRG-013: MSG-IRG-001 (role_already_submitted) ── [FAIL]…\\nNext:…"""
         gate = make_gate(required_gate_roles=frozenset({"reviewer", "ux"}))
         gate = gate.submit_verdict(
             role="reviewer",
@@ -450,7 +450,7 @@ class TestMsgTwoLineStructure:
         assert "Next:" in msg
 
     def test_msg_irg_002_starts_with_fail_and_has_next(self) -> None:
-        """TC-UT-IRG-014: MSG-IRG-002 (gate_already_decided) — [FAIL]…\\nNext:…"""
+        """TC-UT-IRG-014: MSG-IRG-002 (gate_already_decided) ── [FAIL]…\\nNext:…"""
         all_approved = make_all_approved_gate(required_gate_roles=frozenset({"reviewer", "ux"}))
         with pytest.raises(InternalReviewGateInvariantViolation) as exc_info:
             all_approved.submit_verdict(
@@ -466,7 +466,7 @@ class TestMsgTwoLineStructure:
         assert "新しい Gate" in msg
 
     def test_msg_irg_003_starts_with_fail_and_has_next(self) -> None:
-        """TC-UT-IRG-015: MSG-IRG-003 (comment_too_long) — [FAIL]…\\nNext:…"""
+        """TC-UT-IRG-015: MSG-IRG-003 (comment_too_long) ── [FAIL]…\\nNext:…"""
         gate = make_gate(required_gate_roles=frozenset({"reviewer"}))
         with pytest.raises(InternalReviewGateInvariantViolation) as exc_info:
             gate.submit_verdict(
@@ -482,7 +482,7 @@ class TestMsgTwoLineStructure:
         assert "5000文字以内" in msg
 
     def test_msg_irg_004_starts_with_fail_and_has_next(self) -> None:
-        """TC-UT-IRG-016: MSG-IRG-004 (invalid_role) — [FAIL]…\\nNext:…"""
+        """TC-UT-IRG-016: MSG-IRG-004 (invalid_role) ── [FAIL]…\\nNext:…"""
         gate = make_gate(required_gate_roles=frozenset({"reviewer", "ux"}))
         with pytest.raises(InternalReviewGateInvariantViolation) as exc_info:
             gate.submit_verdict(
@@ -502,11 +502,11 @@ class TestMsgTwoLineStructure:
 # TC-UT-IRG-017: application 層責務 / 参照整合性 (§確定 I, Q-3)
 # ---------------------------------------------------------------------------
 class TestApplicationLayerResponsibility:
-    """TC-UT-IRG-017: Aggregate does not validate referential integrity of IDs."""
+    """TC-UT-IRG-017: Aggregate は ID の参照整合性を検証しない。"""
 
     def test_nonexistent_task_id_accepted(self) -> None:
-        """Gate construction with a random (non-existent) task_id succeeds."""
-        # The Aggregate holds only the UUID; it does NOT query a repository.
+        """ランダム (非存在) な task_id でも Gate を構築できる。"""
+        # Aggregate は UUID のみを保持し、Repository に問い合わせない。
         gate = make_gate(task_id=uuid4())
         assert gate.task_id is not None
 
@@ -515,11 +515,11 @@ class TestApplicationLayerResponsibility:
         assert gate.stage_id is not None
 
     def test_nonexistent_agent_id_in_verdict_accepted(self) -> None:
-        """Verdict with a random (non-existent) agent_id submits successfully."""
+        """ランダム (非存在) な agent_id を持つ Verdict も提出に成功する。"""
         gate = make_gate(required_gate_roles=frozenset({"reviewer"}))
         new_gate = gate.submit_verdict(
             role="reviewer",
-            agent_id=uuid4(),  # random, does not exist in any repository
+            agent_id=uuid4(),  # ランダム値。どの Repository にも存在しない
             decision=VerdictDecision.APPROVED,
             comment="",
             decided_at=_ts(),

--- a/backend/tests/domain/room/test_application_responsibility.py
+++ b/backend/tests/domain/room/test_application_responsibility.py
@@ -1,15 +1,14 @@
-"""Application-layer responsibility boundary tests (TC-UT-RM-027〜030).
+"""アプリケーション層責任境界テスト (TC-UT-RM-027〜030)。
 
-Room §確定 R1-A / R1-D / R1-E freeze that **Aggregate-internal invariants
-are structural only**: ``(agent_id, role)`` uniqueness, capacity, archived
-terminal, name length, description length. Cross-aggregate concerns —
-``name`` Empire-scoped uniqueness, ``workflow_id`` referential integrity,
-``LEADER`` required-by-Workflow, Agent existence — live in
-``RoomService`` / ``EmpireService`` because they require external
-knowledge. These tests freeze that boundary so a future refactor cannot
-silently push aggregate-level checks into the Room aggregate (the regression
-direction Norman PR #16 / Steve PR #16 worked hard to keep clean for the
-agent feature).
+Room §確定 R1-A / R1-D / R1-E は **Aggregate 内部不変は構造のみ**:
+``(agent_id, role)`` 一意性、容量、アーカイブ終端、名前長、説明長。
+Cross-aggregate 関心事 — ``name`` Empire スコープ一意性、
+``workflow_id`` 参照整合性、``LEADER`` 必須 by Workflow、
+Agent 存在 — は外部知識を要求するため ``RoomService`` /
+``EmpireService`` に存在。これらテストはその境界を fix し
+将来のリファクタリングが集約レベルチェックを Room 集約に
+静かにプッシュできないようにする (Norman PR #16 / Steve PR #16
+エージェント機能用のクリーン保持に努力)。
 """
 
 from __future__ import annotations
@@ -25,14 +24,14 @@ from tests.factories.room import (
 
 
 class TestNameUniquenessNotEnforcedByAggregate:
-    """TC-UT-RM-027: Aggregate constructs two Rooms with the same name."""
+    """TC-UT-RM-027: Aggregate は同じ名前で 2 つの Room を構築。"""
 
     def test_two_rooms_with_same_name_both_construct(self) -> None:
-        """TC-UT-RM-027: Empire-scoped name uniqueness is RoomService responsibility.
+        """TC-UT-RM-027: Empire スコープ名一意性は RoomService 責任。
 
-        The aggregate has no Repository handle, so it can only enforce *local*
-        invariants. Empire-scoped uniqueness is a Repository SELECT pattern
-        in ``RoomService.create()``.
+        Aggregate は Repository ハンドルを持たないため、
+        **ローカル** 不変のみを強制できる。Empire スコープ一意性は
+        ``RoomService.create()`` の Repository SELECT パターン。
         """
         room_a = make_room(name="Vモデル開発室", room_id=uuid4())
         room_b = make_room(name="Vモデル開発室", room_id=uuid4())
@@ -41,40 +40,40 @@ class TestNameUniquenessNotEnforcedByAggregate:
 
 
 class TestWorkflowReferentialIntegrityNotEnforcedByAggregate:
-    """TC-UT-RM-028: any UUID is accepted as workflow_id at the aggregate level."""
+    """TC-UT-RM-028: 集約レベルで任意の UUID が workflow_id として受け入れられる。"""
 
     def test_arbitrary_workflow_id_constructs(self) -> None:
-        """TC-UT-RM-028: Workflow existence is verified by RoomService, not Room."""
-        # The UUID is arbitrary — no Workflow with this id exists. Aggregate
-        # accepts because referential integrity is application-layer scope.
+        """TC-UT-RM-028: Workflow 存在は Room ではなく RoomService で検証。"""
+        # UUID は任意 — このID を持つ Workflow は存在しない。
+        # 参照整合性はアプリケーション層スコープのため Aggregate は受け入れ。
         room = make_room(workflow_id=uuid4())
         assert room.workflow_id is not None
 
 
 class TestLeaderRequirementNotEnforcedByAggregate:
-    """TC-UT-RM-029: Room with zero LEADER role members constructs (chat-room scenario)."""
+    """TC-UT-RM-029: LEADER ロールメンバーなし Room は構築 (チャットルームシナリオ)。"""
 
     def test_room_without_leader_constructs(self) -> None:
-        """TC-UT-RM-029: leader-required-by-Workflow is RoomService responsibility.
+        """TC-UT-RM-029: LEADER 必須 by Workflow は RoomService 責任。
 
-        Some Workflows (e.g. casual-chat or discussion-only flows) do not
-        require a LEADER. The aggregate cannot read Workflow.required_role
-        without a Repository, so it skips the check entirely. Same pattern
-        Agent §確定 I uses for ``provider_kind`` MVP gating.
+        一部 Workflow (カジュアルチャットまたはディスカッション専用フロー等)
+        は LEADER を要求しない。Aggregate は Repository なしで
+        Workflow.required_role を読めないため チェック全体をスキップ。
+        Agent §確定 I が ``provider_kind`` MVP ゲートに使用する同じパターン。
         """
         room = make_room(members=[])
         assert all(m.role != Role.LEADER for m in room.members)
 
 
 class TestAgentExistenceNotEnforcedByAggregate:
-    """TC-UT-RM-030: AgentMembership accepts any UUID as agent_id."""
+    """TC-UT-RM-030: AgentMembership は任意の UUID を agent_id として受け入れ。"""
 
     def test_room_with_unknown_agent_id_constructs(self) -> None:
-        """TC-UT-RM-030: Agent existence is verified by RoomService.add_member().
+        """TC-UT-RM-030: Agent 存在は RoomService.add_member() で検証。
 
-        At the aggregate level, ``agent_id`` is a typed UUID slot. Whether it
-        resolves to an actual Agent row is a Repository concern, not an
-        invariant the aggregate can observe.
+        Aggregate レベルでは ``agent_id`` はタイプ化された UUID スロット。
+        それが実際の Agent 行に解決するかは Repository 関心事、
+        Aggregate が観察できる不変ではない。
         """
         unknown_agent_id = uuid4()
         m = make_agent_membership(agent_id=unknown_agent_id, role=Role.DEVELOPER)

--- a/backend/tests/domain/room/test_integration.py
+++ b/backend/tests/domain/room/test_integration.py
@@ -1,13 +1,14 @@
-"""Round-trip scenarios across Room + PromptKit + AgentMembership + Exception (TC-IT-RM-001 / 002).
+"""Room + PromptKit + AgentMembership + Exception 全体のラウンド
+トリップシナリオ (TC-IT-RM-001 / 002)。
 
-The room feature is domain-only with zero external I/O, so "integration" here
-means *aggregate-internal module integration*: chained behaviors over a
-non-empty member list, with the original Room observed unchanged at each
-step (frozen + pre-validate rebuild, Confirmation A).
+room 機能は domain のみで外部 I/O なし。ここで「integration」は
+*aggregate 内モジュール統合* を意味する： 非空メンバーリストをまたぐ
+チェーン動作。元の Room は各ステップで変更されずに観察される
+(frozen + pre-validate rebuild, Confirmation A)。
 
-These tests intentionally compose the production constructors / behaviors
-directly — no mocks, no test-only back doors — and exercise the documented
-acceptance criteria 1, 4, 7, 10, 11 in a single sequence.
+これらのテストは意図的に production constructors / behaviors を直接組み合わせる —
+mocks なし、test-only back doors なし — 記載された受け入れ基準
+1, 4, 7, 10, 11 を単一シーケンスで実行。
 """
 
 from __future__ import annotations
@@ -27,40 +28,40 @@ from tests.factories.room import (
 
 
 class TestRoomLifecycleRoundTrip:
-    """TC-IT-RM-001: full Room lifecycle exercise across all behaviors."""
+    """TC-IT-RM-001: 全 behaviors を通した Room ライフサイクル完全実行。"""
 
     def test_full_lifecycle_preserves_immutability(self) -> None:
-        """TC-IT-RM-001: add → add → update → remove → archive sequence."""
-        # Step 1: empty Room.
+        """TC-IT-RM-001: add → add → update → remove → archive シーケンス。"""
+        # Step 1: 空の Room。
         room0 = make_room(members=[])
         assert room0.members == []
         assert room0.archived is False
 
-        # Step 2: add a leader.
+        # Step 2: leader を追加。
         leader = make_leader_membership(agent_id=uuid4())
         room1 = room0.add_member(leader)
         assert len(room1.members) == 1
 
-        # Step 3: add a developer.
+        # Step 3: developer を追加。
         developer = make_agent_membership(agent_id=uuid4(), role=Role.DEVELOPER)
         room2 = room1.add_member(developer)
         assert len(room2.members) == 2
 
-        # Step 4: replace PromptKit.
+        # Step 4: PromptKit を置換。
         new_kit = make_prompt_kit(prefix_markdown="# V-Model Room policy\n\nbe rigorous")
         room3 = room2.update_prompt_kit(new_kit)
         assert "V-Model Room policy" in room3.prompt_kit.prefix_markdown
 
-        # Step 5: remove the developer.
+        # Step 5: developer を削除。
         room4 = room3.remove_member(developer.agent_id, developer.role)
         assert len(room4.members) == 1
         assert room4.members[0].agent_id == leader.agent_id
 
-        # Step 6: archive.
+        # Step 6: archive。
         room5 = room4.archive()
         assert room5.archived is True
 
-        # Frozen contract: each earlier Room stays unchanged across steps.
+        # Frozen contract: 各 earlier Room はステップを超えて変更されない。
         assert room0.members == []
         assert len(room1.members) == 1
         assert len(room2.members) == 2
@@ -69,26 +70,26 @@ class TestRoomLifecycleRoundTrip:
 
 
 class TestAddMemberFailureThenSuccess:
-    """TC-IT-RM-002: add_member fails on duplicate, succeeds on a different pair."""
+    """TC-IT-RM-002: add_member は duplicate で失敗、別ペアで成功。"""
 
     def test_failure_does_not_block_subsequent_success(self) -> None:
-        """TC-IT-RM-002: pre-validate isolation lets the next add proceed cleanly."""
+        """TC-IT-RM-002: pre-validate isolation は次の add をきれいに進ませる。"""
         leader = make_leader_membership(agent_id=uuid4())
         room = make_room(members=[leader])
 
-        # First call: duplicate pair fails.
+        # First call: duplicate ペアは失敗。
         with pytest.raises(RoomInvariantViolation) as excinfo:
             room.add_member(make_leader_membership(agent_id=leader.agent_id))
         assert excinfo.value.kind == "member_duplicate"
 
-        # Original Room is unchanged.
+        # 元の Room は変更されない。
         assert len(room.members) == 1
 
-        # Second call: different pair succeeds.
+        # Second call: 異なるペアは成功。
         new_developer = make_agent_membership(agent_id=uuid4(), role=Role.DEVELOPER)
         new_room = room.add_member(new_developer)
         assert len(new_room.members) == 2
-        # Pair set is what we expect.
+        # ペア set は予想通り。
         pairs = {(m.agent_id, m.role) for m in new_room.members}
         assert (leader.agent_id, Role.LEADER) in pairs
         assert (new_developer.agent_id, Role.DEVELOPER) in pairs

--- a/backend/tests/domain/room/test_prompt_kit.py
+++ b/backend/tests/domain/room/test_prompt_kit.py
@@ -1,9 +1,10 @@
-"""PromptKit Value Object tests (TC-UT-RM-019 / 024, Confirmations B / G).
+"""PromptKit Value Object テスト (TC-UT-RM-019 / 024、Confirmations B / G)。
 
-PromptKit is a single-attribute frozen VO held to NFC normalization (no
-strip — Markdown body retains leading/trailing whitespace) and a 10000-char
-upper bound. Length violations surface as :class:`pydantic.ValidationError`
-*not* :class:`RoomInvariantViolation` per Room §確定 I two-stage catch.
+PromptKit は NFC 正規化 (strip なし — Markdown 本体は
+先頭/末尾の空白を保持) と 10000 文字上限に保持される
+単一属性 frozen VO。長さ違反は
+:class:`RoomInvariantViolation` **ではなく** Room §確定 I
+二段階キャッチに従い :class:`pydantic.ValidationError` として表示。
 """
 
 from __future__ import annotations
@@ -16,29 +17,29 @@ from tests.factories.room import make_prompt_kit, make_room
 
 
 class TestPromptKitBoundary:
-    """TC-UT-RM-019: 0 / 10000 / 10001 + leading/trailing newline preservation."""
+    """TC-UT-RM-019: 0 / 10000 / 10001 + 先頭/末尾改行保持。"""
 
     @pytest.mark.parametrize("length", [0, PROMPT_KIT_PREFIX_MAX])
     def test_valid_lengths_succeed(self, length: int) -> None:
-        """TC-UT-RM-019: prefix_markdown of length 0 and 10000 succeed."""
+        """TC-UT-RM-019: 長さ 0 と 10000 の prefix_markdown は成功。"""
         kit = make_prompt_kit(prefix_markdown="a" * length)
         assert len(kit.prefix_markdown) == length
 
     def test_oversized_prefix_raises_validation_error(self) -> None:
-        """TC-UT-RM-019: 10001 chars raises pydantic.ValidationError per §確定 I."""
+        """TC-UT-RM-019: 10001 文字は §確定 I に従い pydantic.ValidationError を発火。"""
         with pytest.raises(ValidationError) as excinfo:
             make_prompt_kit(prefix_markdown="a" * (PROMPT_KIT_PREFIX_MAX + 1))
-        # Confirmation I freezes that PromptKit length errors do *not* travel
-        # the RoomInvariantViolation path. The MSG-RM-007 wording is asserted
-        # in test_msg_wording.py.
+        # Confirmation I は PromptKit 長さエラーが **RoomInvariantViolation パスを
+        # 通わない** ことを fix。MSG-RM-007 wording は test_msg_wording.py で
+        # アサート。
         assert "PromptKit.prefix_markdown" in str(excinfo.value)
 
     def test_prompt_kit_preserves_leading_and_trailing_newlines(self) -> None:
-        """TC-UT-RM-019 + 018: PromptKit applies NFC only — newlines kept.
+        """TC-UT-RM-019 + 018: PromptKit は NFC のみ適用 — 改行を保持。
 
-        Markdown semantics: ``\\n# Heading\\n\\nbody\\n\\n`` retains the
-        wrapping newlines because the body's trailing whitespace is part of
-        the prompt template.
+        Markdown セマンティクス: ``\\n# Heading\\n\\nbody\\n\\n`` は
+        ボディの末尾空白がプロンプト テンプレートの一部であるため
+        ラップ改行を保持。
         """
         text = "\n# Heading\n\nbody\n\n"
         kit = make_prompt_kit(prefix_markdown=text)
@@ -46,22 +47,22 @@ class TestPromptKitBoundary:
 
 
 class TestPromptKitStructuralEquality:
-    """TC-UT-RM-024: PromptKit / Room frozen → structural equality + hashable."""
+    """TC-UT-RM-024: PromptKit / Room frozen → 構造的等価 + ハッシュ可能。"""
 
     def test_two_prompt_kits_with_same_attrs_compare_equal(self) -> None:
-        """TC-UT-RM-024: two PromptKits with identical prefix compare equal."""
+        """TC-UT-RM-024: 同じ prefix の 2 つの PromptKit は等価。"""
         a = PromptKit(prefix_markdown="hello")
         b = PromptKit(prefix_markdown="hello")
         assert a == b
 
     def test_two_prompt_kits_with_same_attrs_hash_equal(self) -> None:
-        """TC-UT-RM-024: structurally equal PromptKits share hash."""
+        """TC-UT-RM-024: 構造的に等価な PromptKit はハッシュを共有。"""
         a = PromptKit(prefix_markdown="hello")
         b = PromptKit(prefix_markdown="hello")
         assert hash(a) == hash(b)
 
     def test_two_rooms_with_same_attrs_compare_equal(self) -> None:
-        """TC-UT-RM-024: two Rooms with identical attributes compare equal."""
+        """TC-UT-RM-024: 同じ属性の 2 つの Room は等価。"""
         from uuid import uuid4
 
         room_id = uuid4()

--- a/backend/tests/domain/room/test_webhook_masking.py
+++ b/backend/tests/domain/room/test_webhook_masking.py
@@ -1,11 +1,12 @@
-"""Discord webhook secret masking on RoomInvariantViolation (TC-UT-RM-014).
+"""Discord Webhook シークレット マスキング (TC-UT-RM-014)。
 
-Confirmation H: ``RoomInvariantViolation`` masks webhook URLs in both
-``message`` and ``detail`` at construction time. ``Room.name`` /
-``Room.description`` / ``PromptKit.prefix_markdown`` may all carry user-
-pasted text containing a webhook URL, so the exception path is the *last*
-defense before that secret would be serialized into a log line or HTTP
-response body.
+Confirmation H: ``RoomInvariantViolation`` は
+``message`` と ``detail`` の両方に含まれる webhook URL を
+構築時にマスキング。``Room.name`` / ``Room.description`` /
+``PromptKit.prefix_markdown`` はすべてユーザーペースト テキストを
+含む可能性があり webhook URL を含む可能性がある。例外パスは
+そのシークレットがログ行または HTTP レスポンス本体に
+シリアライズされる前の**最後の**防御である。
 """
 
 from __future__ import annotations
@@ -15,8 +16,8 @@ from bakufu.domain.exceptions import RoomInvariantViolation
 
 from tests.factories.room import make_room
 
-# A webhook URL designed to fail the description length check (>500 chars).
-# The id segment (numeric) stays visible; the token segment must be redacted.
+# 説明長チェック (>500 文字) に失敗するよう設計された webhook URL。
+# ID セグメント (数値) は表示; トークンセグメントはマスキング対象。
 _WEBHOOK_ID = "1234567890123456789"
 _WEBHOOK_TOKEN = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWX"
 _WEBHOOK_URL = f"https://discord.com/api/webhooks/{_WEBHOOK_ID}/{_WEBHOOK_TOKEN}"
@@ -24,19 +25,19 @@ _REDACTED = "<REDACTED:DISCORD_WEBHOOK>"
 
 
 class TestWebhookMaskingOnDescriptionViolation:
-    """TC-UT-RM-014: webhook URL in oversize description is redacted in exception text."""
+    """TC-UT-RM-014: 説明文内の webhook URL は例外テキストでマスキング。"""
 
     def test_token_segment_is_redacted_in_message(self) -> None:
-        """TC-UT-RM-014: exception.message contains the redacted token marker."""
-        # Build a description >500 chars that *contains* the webhook URL.
+        """TC-UT-RM-014: exception.message はマスキング済みトークンマーカーを含む。"""
+        # >500 文字の説明文を構築、webhook URL を**含める**。
         description = _WEBHOOK_URL + ("a" * 600)
         with pytest.raises(RoomInvariantViolation) as excinfo:
             make_room(description=description)
         assert _WEBHOOK_TOKEN not in excinfo.value.message
-        # The webhook id stays for traceability; only token is redacted.
+        # 追跡可能性のために webhook ID は残す; トークンだけマスキング。
 
     def test_token_segment_does_not_leak_into_str_exc(self) -> None:
-        """TC-UT-RM-014: str(exc) (used by default logging) carries no token."""
+        """TC-UT-RM-014: str(exc) (デフォルトロギングで使用) はトークンを含まない。"""
         description = _WEBHOOK_URL + ("a" * 600)
         with pytest.raises(RoomInvariantViolation) as excinfo:
             make_room(description=description)
@@ -44,32 +45,32 @@ class TestWebhookMaskingOnDescriptionViolation:
 
 
 class TestWebhookMaskingOnDetail:
-    """TC-UT-RM-014: webhook URL embedded in detail dict is also redacted."""
+    """TC-UT-RM-014: detail 辞書に埋め込まれた webhook URL もマスキング。"""
 
     def test_redacted_marker_substitutes_token_in_detail(self) -> None:
-        """TC-UT-RM-014: detail values produced by exception path are masked.
+        """TC-UT-RM-014: 例外パスが生成する detail 値はマスキング。
 
-        We trigger a name_range violation with an oversized name carrying a
-        webhook URL. The aggregate validators only put structural data in
-        ``detail`` (length / count), but the masking pass walks the whole
-        dict so any string-valued context is run through
-        :func:`mask_discord_webhook_in`. The contract is that no detail
-        value contains the raw token segment.
+        webhook URL を含む過大サイズ名で name_range 違反を起動。
+        Aggregate バリデーター は ``detail`` に構造データのみ
+        (長さ / カウント) を配置するが、マスキング パスは全辞書を
+        走査するため、文字列値コンテキストは
+        :func:`mask_discord_webhook_in` を通す。契約は detail 値が
+        生のトークンセグメントを含まないこと。
         """
-        # Build an oversize name (>80 chars) carrying the webhook URL.
+        # webhook URL を含む過大サイズ名 (>80 文字) を構築。
         name = _WEBHOOK_URL + "x"
         with pytest.raises(RoomInvariantViolation) as excinfo:
             make_room(name=name)
-        # Walk all string values in detail; none should expose the token.
+        # detail 内の全文字列値を走査; トークンを公開してはならない。
         for value in excinfo.value.detail.values():
             assert _WEBHOOK_TOKEN not in str(value)
 
 
 class TestWebhookMaskingIdempotent:
-    """Confirmation H supplemental: masking applied twice yields the same string."""
+    """Confirmation H 補足: マスキングを 2 回適用すると同じ文字列になる。"""
 
     def test_already_masked_url_is_not_re_substituted(self) -> None:
-        """``mask_discord_webhook`` is idempotent so re-application is a no-op."""
+        """``mask_discord_webhook`` は冪等のため再適用は no-op。"""
         from bakufu.domain.value_objects import mask_discord_webhook
 
         once = mask_discord_webhook(_WEBHOOK_URL)

--- a/backend/tests/domain/task/test_task/__init__.py
+++ b/backend/tests/domain/task/test_task/__init__.py
@@ -1,17 +1,16 @@
-"""Task Aggregate Root tests, split by topic.
+"""Task 集約ルートのテスト。トピック別に分割している。
 
-Per ``docs/features/task/test-design.md`` and the empire-repository
-PR #29 教訓 (Norman 500-line rule), the test surface is split into
-four siblings from day one so each file stays under the readability
-budget:
+``docs/features/task/test-design.md`` および empire-repository PR #29 の
+教訓（Norman 500 行ルール）に従い、各ファイルが可読性の上限を超えないよう、
+初期からテスト面を 4 つの兄弟モジュールに分割している:
 
 * :mod:`...test_construction` — TC-UT-TS-001 / 002 / 014 / 040 /
-  044 / 045 / 053 (constructor, frozen, NFC, type errors).
+  044 / 045 / 053（コンストラクタ、frozen、NFC、型エラー）。
 * :mod:`...test_state_machine` — TC-UT-TS-003〜008, 030〜035, 038,
-  039 + TC-IT-TS-001〜005 (60-cell dispatch table, 13 transitions,
-  20 terminal cells, lifecycle integration scenarios).
+  039 + TC-IT-TS-001〜005（60 セルのディスパッチテーブル、13 遷移、
+  20 終端セル、ライフサイクル統合シナリオ）。
 * :mod:`...test_invariants` — TC-UT-TS-009〜011, 041〜043, 046〜052
-  (5 validators, auto-mask, Next: hint physical guarantee).
-* :mod:`...test_vo` — TC-UT-TS-012, 013, 036, 037 (Deliverable +
-  Attachment 6-step sanitize + enums).
+  （5 種のバリデータ、自動マスキング、Next: ヒントの物理的保証）。
+* :mod:`...test_vo` — TC-UT-TS-012, 013, 036, 037（Deliverable と
+  Attachment の 6 段階サニタイズおよび Enum）。
 """

--- a/backend/tests/domain/task/test_task/_helpers.py
+++ b/backend/tests/domain/task/test_task/_helpers.py
@@ -46,7 +46,7 @@ ALL_ACTIONS: list[TaskAction] = [
     "cancel",
 ]
 
-# All 6 status values — sanity bound for the 60-cell matrix.
+# 全 6 つの status 値 — 60 セル行列のサニティ範囲。
 ALL_STATUSES: list[TaskStatus] = list(TaskStatus)
 
 
@@ -87,7 +87,7 @@ def invoke_action(task: Task, action: TaskAction, *, agent_id: UUID | None = Non
         return task.block("synthetic reason", "synthetic last_error", updated_at=ts)
     if action == "unblock_retry":
         return task.unblock_retry(updated_at=ts)
-    # cancel
+    # cancel 経路
     return task.cancel(uuid4(), "synthetic cancel reason", updated_at=ts)
 
 

--- a/backend/tests/domain/task/test_task/_helpers.py
+++ b/backend/tests/domain/task/test_task/_helpers.py
@@ -1,17 +1,16 @@
-"""Shared test helpers for the Task state-machine test split.
+"""Task ステートマシンテスト分割のための共有ヘルパ.
 
-The original ``test_state_machine.py`` weighed 633 lines; per Norman
-R-N1 it was split into three sibling files
-(``test_state_machine_table.py`` /
-``test_state_terminal_and_invalid.py`` / ``test_state_lifecycle.py``).
-The 5 module-level helpers below are referenced by 2-3 of those files
-each, so extracting them here keeps all three under the 500-line rule
-without duplicating ~80 lines of fixture machinery.
+元の test_state_machine.py は 633 行。Norman R-N1 に従い 3 つの
+兄弟ファイル（test_state_machine_table.py /
+test_state_terminal_and_invalid.py / test_state_lifecycle.py）に分割。
+以下の 5 つのモジュールレベルヘルパは各 2～3 ファイルから参照。
+ここで抽出してすべて 500 行ルール以下に保持。~80 行の fixture
+機構を複製しない。
 
-Underscore prefix (``_helpers.py``) marks the module as
-package-private; pytest discovery does not match files without a
-``test_`` prefix, so the helpers stay out of the collected test set
-on their own.
+アンダースコア プレフィックス（_helpers.py）はモジュールを
+パッケージプライベートに指定。pytest discovery は test_ プレフィックス
+がないファイルを照合しないため、ヘルパは自動的に収集テスト セットから
+外れる。
 """
 
 from __future__ import annotations
@@ -52,16 +51,17 @@ ALL_STATUSES: list[TaskStatus] = list(TaskStatus)
 
 
 def next_ts(task: Task) -> datetime:
-    """Return a strictly-later UTC timestamp for ``updated_at``."""
+    """updated_at 用に厳密に未来の UTC タイムスタンプを返す."""
     return task.updated_at + timedelta(seconds=1)
 
 
 def invoke_action(task: Task, action: TaskAction, *, agent_id: UUID | None = None) -> Task:
-    """Dispatch ``action`` on ``task`` with throwaway-but-valid arguments.
+    """使い捨ての妥当な引数で task に action をディスパッチ.
 
-    Centralises the per-action signature so the parametrized
-    "every illegal cell raises" test can call any of the 10 methods
-    uniformly without repeating method-specific argument shapes.
+    アクションごとのシグネチャを集約。parametrize された
+    「全ての違法セルが例外を発火」テストが 10 メソッドを
+    均一に呼び出せるようにする。メソッド固有の引数形状を
+    繰り返さない。
     """
     ts = next_ts(task)
     if action == "assign":
@@ -92,7 +92,7 @@ def invoke_action(task: Task, action: TaskAction, *, agent_id: UUID | None = Non
 
 
 def make_task_in_status(status: TaskStatus) -> Task:
-    """Build a Task in the given status using the appropriate factory."""
+    """指定状態の Task を対応するファクトリで構築."""
     if status == TaskStatus.PENDING:
         return make_task()
     if status == TaskStatus.IN_PROGRESS:

--- a/backend/tests/domain/task/test_task/test_construction.py
+++ b/backend/tests/domain/task/test_task/test_construction.py
@@ -1,11 +1,9 @@
-"""Task construction tests (TC-UT-TS-001 / 002 / 014 / 040 / 044 / 045 / 053).
+"""Task 構築テスト (TC-UT-TS-001 / 002 / 014 / 040 / 044 / 045 / 053)。
 
-Per ``docs/features/task/test-design.md`` §Task 構築. Covers
-construction defaults, the 6 ``TaskStatus`` rehydration cases, frozen
-+ structural equality, NFC-without-strip ``last_error`` normalization
-(§確定 C), frozen-instance assignment rejection, ``extra='forbid'``,
-and the type-error class for fields that bypass the kind enum
-(§確定 J).
+``docs/features/task/test-design.md`` §Task 構築 準拠。構築時のデフォルト、
+``TaskStatus`` の 6 ケースの再水和、frozen + 構造的等価性、NFC-without-strip
+``last_error`` 正規化 (§確定 C)、frozen インスタンスの代入拒否、``extra='forbid'``、
+kind enum を経由しないフィールドの type エラークラス (§確定 J) を網羅する。
 """
 
 from __future__ import annotations
@@ -31,13 +29,13 @@ from tests.factories.task import (
 
 
 # ---------------------------------------------------------------------------
-# TC-UT-TS-001: default-valued construction
+# TC-UT-TS-001: デフォルト値での構築
 # ---------------------------------------------------------------------------
 class TestTaskDefaults:
-    """TC-UT-TS-001: factory default Task is structurally PENDING + empty."""
+    """TC-UT-TS-001: factory のデフォルト Task は構造的に PENDING かつ空。"""
 
     def test_default_task_is_pending_with_empty_state(self) -> None:
-        """Defaults: status=PENDING, assigned=[], deliverables={}, last_error=None."""
+        """デフォルト: status=PENDING, assigned=[], deliverables={}, last_error=None。"""
         task = make_task()
         assert task.status == TaskStatus.PENDING
         assert task.assigned_agent_ids == []
@@ -46,20 +44,20 @@ class TestTaskDefaults:
         assert task.created_at <= task.updated_at
 
     def test_factory_marks_instance_synthetic(self) -> None:
-        """Factory output is registered in :func:`is_synthetic`."""
+        """factory の出力は :func:`is_synthetic` に登録される。"""
         task = make_task()
         assert is_synthetic(task)
 
 
 # ---------------------------------------------------------------------------
-# TC-UT-TS-002: rehydration into all 6 TaskStatus values
+# TC-UT-TS-002: 6 種類の TaskStatus すべてへの再水和
 # ---------------------------------------------------------------------------
 class TestRehydrateAllStatuses:
-    """TC-UT-TS-002: each of the 6 TaskStatus values constructs cleanly.
+    """TC-UT-TS-002: 6 種類の TaskStatus 値それぞれが問題なく構築できる。
 
-    Repository hydration must be able to land any persisted status —
-    BLOCKED needs ``last_error``, every other status needs
-    ``last_error is None``.
+    Repository の hydration は永続化された任意の status を着地させられねばならない ──
+    BLOCKED は ``last_error`` を要し、それ以外の status は
+    ``last_error is None`` を要する。
     """
 
     def test_pending_constructs(self) -> None:
@@ -84,13 +82,13 @@ class TestRehydrateAllStatuses:
 
 
 # ---------------------------------------------------------------------------
-# TC-UT-TS-014: frozen + structural equality + hash
+# TC-UT-TS-014: frozen + 構造的等価性 + ハッシュ
 # ---------------------------------------------------------------------------
 class TestFrozenStructuralEquality:
-    """TC-UT-TS-014: same-attributes Tasks are ``==`` and hashable identically."""
+    """TC-UT-TS-014: 同じ属性の Task は ``==`` で、ハッシュも同一。"""
 
     def test_same_attributes_compare_equal(self) -> None:
-        """Two Task instances with identical attrs are ``==``."""
+        """同一属性を持つ 2 つの Task インスタンスは ``==``。"""
         common_id = uuid4()
         common_room = uuid4()
         common_directive = uuid4()
@@ -116,73 +114,72 @@ class TestFrozenStructuralEquality:
 
 
 # ---------------------------------------------------------------------------
-# TC-UT-TS-040: NFC-without-strip on last_error (§確定 C)
+# TC-UT-TS-040: last_error の NFC-without-strip 正規化 (§確定 C)
 # ---------------------------------------------------------------------------
 class TestLastErrorNormalization:
-    """TC-UT-TS-040: ``last_error`` is NFC-normalized but **not** stripped.
+    """TC-UT-TS-040: ``last_error`` は NFC 正規化されるが strip **されない**。
 
-    LLM stack traces rely on leading whitespace for indentation;
-    stripping would silently corrupt the diagnostic. The §確定 C
-    contract is "NFC normalize, never strip".
+    LLM のスタックトレースはインデント保持のために先頭空白に依存する。
+    strip すれば診断情報が静かに破壊される。§確定 C の契約は
+    「NFC 正規化、決して strip しない」。
     """
 
     def test_leading_and_trailing_whitespace_preserved(self) -> None:
-        """Newlines + leading/trailing spaces survive normalization."""
+        """改行 + 先頭/末尾スペースが正規化を生き残る。"""
         raw = "AuthExpired:\n  at line 1\n  at line 2\n"
         task = make_blocked_task(last_error=raw)
-        # The post-validator is mode='before', so it runs before
-        # field type checks. The value should round-trip through NFC
-        # but keep every leading-/trailing-whitespace character.
+        # post-validator は mode='before' のため、フィールド型チェックの前に走る。
+        # 値は NFC を通過するが、先頭/末尾の空白文字はすべて保持される。
         assert task.last_error is not None
         assert task.last_error == unicodedata.normalize("NFC", raw)
         assert task.last_error.startswith("AuthExpired:")
         assert task.last_error.endswith("\n")
-        assert "  at line 1" in task.last_error  # leading space kept
+        assert "  at line 1" in task.last_error  # 先頭スペース保持
 
     def test_decomposed_form_normalizes_to_composed_form(self) -> None:
-        """A composed-form characte equals its decomposed counterpart after NFC."""
-        composed = "café: error"  # NFC-composed (é = U+00E9)
-        decomposed = "café: error"  # NFC-decomposed (e + COMBINING ACCENT)
+        """合成形の文字は NFC 後に分解形と等価になる。"""
+        composed = "café: error"  # NFC 合成形 (é = U+00E9)
+        decomposed = "café: error"  # NFC 分解形 (e + COMBINING ACCENT)
         task_composed = make_blocked_task(last_error=composed)
         task_decomposed = make_blocked_task(last_error=decomposed)
-        # Both forms normalize to the same NFC string, so the field
-        # values match byte-for-byte.
+        # 双方が同じ NFC 文字列に正規化されるため、フィールド値は
+        # バイト等価で一致する。
         assert task_composed.last_error == task_decomposed.last_error
 
 
 # ---------------------------------------------------------------------------
-# TC-UT-TS-044: frozen instance — direct attribute assignment rejected
+# TC-UT-TS-044: frozen インスタンス ── 直接の属性代入を拒否
 # ---------------------------------------------------------------------------
 class TestFrozenInstance:
-    """TC-UT-TS-044: ``task.<attr> = value`` raises on a frozen Pydantic model."""
+    """TC-UT-TS-044: ``task.<attr> = value`` は frozen Pydantic model で例外を起こす。"""
 
     def test_status_assignment_rejected(self) -> None:
-        """Direct ``task.status = ...`` is rejected by Pydantic frozen."""
+        """直接の ``task.status = ...`` は Pydantic frozen により拒否される。"""
         task = make_task()
         with pytest.raises(ValidationError):
             task.status = TaskStatus.IN_PROGRESS  # pyright: ignore[reportAttributeAccessIssue]
 
     def test_assigned_agents_assignment_rejected(self) -> None:
-        """Direct ``task.assigned_agent_ids = ...`` is rejected."""
+        """直接の ``task.assigned_agent_ids = ...`` は拒否される。"""
         task = make_task()
         with pytest.raises(ValidationError):
             task.assigned_agent_ids = [uuid4()]  # pyright: ignore[reportAttributeAccessIssue]
 
     def test_last_error_assignment_rejected(self) -> None:
-        """Direct ``task.last_error = ...`` is rejected."""
+        """直接の ``task.last_error = ...`` は拒否される。"""
         task = make_blocked_task()
         with pytest.raises(ValidationError):
             task.last_error = "new"  # pyright: ignore[reportAttributeAccessIssue]
 
 
 # ---------------------------------------------------------------------------
-# TC-UT-TS-045: extra='forbid' rejects unknown fields
+# TC-UT-TS-045: extra='forbid' は未知フィールドを拒否
 # ---------------------------------------------------------------------------
 class TestExtraForbid:
-    """TC-UT-TS-045: an unknown field at construction time is rejected."""
+    """TC-UT-TS-045: 構築時の未知フィールドは拒否される。"""
 
     def test_unknown_field_rejected_via_model_validate(self) -> None:
-        """``Task.model_validate({..., 'unknown': 'x'})`` raises ValidationError."""
+        """``Task.model_validate({..., 'unknown': 'x'})`` が ValidationError。"""
         now = datetime.now(UTC)
         with pytest.raises(ValidationError):
             Task.model_validate(
@@ -199,26 +196,25 @@ class TestExtraForbid:
 
 
 # ---------------------------------------------------------------------------
-# TC-UT-TS-053: type errors land as pydantic.ValidationError (§確定 J)
+# TC-UT-TS-053: 型エラーは pydantic.ValidationError として現れる (§確定 J)
 # ---------------------------------------------------------------------------
 class TestTypeErrorsRaisePydanticValidationError:
-    """TC-UT-TS-053: type-shaped failures use ``pydantic.ValidationError`` (no kind concept).
+    """TC-UT-TS-053: 型形式の失敗は ``pydantic.ValidationError`` を用いる（kind 概念なし）。
 
-    The §確定 J contract: structural / field-type errors are pure
-    Pydantic validation errors; only the 7 ``TaskInvariantViolation``
-    kinds are issued by the aggregate's invariants. Tests pin this
-    so a hypothetical refactor that wrapped pydantic errors in a
-    custom exception would force a docs revisit.
+    §確定 J の契約: 構造的 / フィールド型の誤りは純粋な Pydantic validation error であり、
+    7 種類の ``TaskInvariantViolation`` kind はアグリゲートの不変条件のみが発行する。
+    Pydantic エラーをカスタム例外でラップする仮想的なリファクタリングが
+    docs の見直しを強制するよう、本テストでこの分担を固定する。
     """
 
     def test_naive_datetime_rejected(self) -> None:
-        """``created_at`` without a timezone must be rejected."""
+        """timezone を持たない ``created_at`` は拒否される。"""
         naive = datetime.now()
         with pytest.raises(ValidationError):
             make_task(created_at=naive)
 
     def test_unknown_status_string_rejected(self) -> None:
-        """A non-enum status string is rejected by the Pydantic enum coercion."""
+        """enum でない status 文字列は Pydantic enum 強制により拒否される。"""
         now = datetime.now(UTC)
         with pytest.raises(ValidationError):
             Task.model_validate(
@@ -234,7 +230,7 @@ class TestTypeErrorsRaisePydanticValidationError:
             )
 
     def test_non_uuid_id_rejected(self) -> None:
-        """A malformed UUID-shaped string for ``id`` is rejected."""
+        """``id`` が不正な UUID 形式の文字列は拒否される。"""
         now = datetime.now(UTC)
         with pytest.raises(ValidationError):
             Task.model_validate(
@@ -250,13 +246,13 @@ class TestTypeErrorsRaisePydanticValidationError:
 
 
 # ---------------------------------------------------------------------------
-# Smoke: created_at > updated_at via factory raises (covered also by invariants)
+# Smoke: factory 経由で created_at > updated_at が例外（不変条件側でも検証あり）
 # ---------------------------------------------------------------------------
 class TestTimestampOrderSmoke:
-    """A construction-time timestamp violation surfaces immediately."""
+    """構築時のタイムスタンプ違反は即座に表面化する。"""
 
     def test_created_after_updated_rejected_at_construction(self) -> None:
-        """``created_at > updated_at`` raises ``TaskInvariantViolation``."""
+        """``created_at > updated_at`` は ``TaskInvariantViolation`` を起こす。"""
         from bakufu.domain.exceptions import TaskInvariantViolation
 
         ts_old = datetime(2026, 4, 27, 10, 0, 0, tzinfo=UTC)

--- a/backend/tests/domain/task/test_task/test_invariants.py
+++ b/backend/tests/domain/task/test_task/test_invariants.py
@@ -1,12 +1,12 @@
-"""Task invariant + MSG + auto-mask tests.
+"""Task invariant + MSG + auto-mask テスト.
 
-TC-UT-TS-009 / 010 / 011 / 041 / 042 / 043 / 046〜052 — the 5
-``_validate_*`` helpers, the §確定 I auto-mask, the §確定 K
-"Aggregate does not enforce application-layer invariants" boundary,
-and the §確定 J / room §確定 I 踏襲 **Next: hint physical guarantee**
-across all 7 MSG-TS-001〜007 messages.
+TC-UT-TS-009 / 010 / 011 / 041 / 042 / 043 / 046〜052 ── 5 つの
+``_validate_*`` ヘルパ、§確定 I の auto-mask、§確定 K
+「Aggregate はアプリケーション層の不変条件を強制しない」境界、
+および §確定 J / room §確定 I 踏襲の **Next: ヒント物理保証**
+を MSG-TS-001〜007 全 7 メッセージに対して検証する。
 
-Per ``docs/features/task/test-design.md``.
+``docs/features/task/test-design.md`` 準拠。
 """
 
 from __future__ import annotations
@@ -39,25 +39,25 @@ from tests.factories.task import (
 # TC-UT-TS-009: assigned_agents_unique
 # ---------------------------------------------------------------------------
 class TestAssignedAgentsUnique:
-    """TC-UT-TS-009: duplicate agent ids raise assigned_agents_unique (MSG-TS-003)."""
+    """TC-UT-TS-009: 重複 agent_id は assigned_agents_unique (MSG-TS-003) を発火。"""
 
     def test_duplicate_agents_raise(self) -> None:
-        """Two of the same AgentId in the list → MSG-TS-003."""
+        """同一 AgentId が 2 つ含まれる → MSG-TS-003。"""
         agent_a = uuid4()
         with pytest.raises(TaskInvariantViolation) as exc_info:
             _validate_assigned_agents_unique([agent_a, uuid4(), agent_a])
         assert exc_info.value.kind == "assigned_agents_unique"
-        # detail surfaces the duplicate (sorted str list).
+        # detail に重複 (sorted str list) が現れる。
         assert "duplicates" in exc_info.value.detail
         assert str(agent_a) in str(exc_info.value.detail["duplicates"])
 
     def test_unique_list_passes(self) -> None:
-        """A duplicate-free list returns without raising."""
-        # Direct call returns None (validator is a side-effecting raise-on-violation).
+        """重複なしリストは例外を出さずに通る。"""
+        # 直接呼び出しは None を返す (バリデータは違反時のみ raise する副作用関数)。
         _validate_assigned_agents_unique([uuid4(), uuid4(), uuid4()])
 
     def test_via_aggregate_construction_raises(self) -> None:
-        """Constructing a Task with duplicate agents raises through the model validator."""
+        """重複 agent を持つ Task を構築するとモデルバリデータ経由で例外発火。"""
         agent_a = uuid4()
         with pytest.raises(TaskInvariantViolation) as exc_info:
             make_in_progress_task(assigned_agent_ids=[agent_a, agent_a])
@@ -68,17 +68,17 @@ class TestAssignedAgentsUnique:
 # TC-UT-TS-041: assigned_agents_capacity (MAX = 5)
 # ---------------------------------------------------------------------------
 class TestAssignedAgentsCapacity:
-    """TC-UT-TS-041: ``len > MAX_ASSIGNED_AGENTS`` raises (MSG-TS-004)."""
+    """TC-UT-TS-041: ``len > MAX_ASSIGNED_AGENTS`` で例外発火 (MSG-TS-004)。"""
 
     def test_six_agents_raises(self) -> None:
-        """6 unique agent_ids exceeds the cap of 5 and raises."""
+        """ユニークな 6 件はキャップ 5 を超えるため例外発火。"""
         with pytest.raises(TaskInvariantViolation) as exc_info:
             _validate_assigned_agents_capacity([uuid4() for _ in range(6)])
         assert exc_info.value.kind == "assigned_agents_capacity"
         assert exc_info.value.detail.get("max") == MAX_ASSIGNED_AGENTS
 
     def test_five_agents_passes(self) -> None:
-        """At-cap list (5 agents) is accepted."""
+        """キャップちょうどのリスト (5 件) は受理される。"""
         _validate_assigned_agents_capacity([uuid4() for _ in range(5)])
 
 
@@ -86,51 +86,50 @@ class TestAssignedAgentsCapacity:
 # TC-UT-TS-010: last_error_consistency
 # ---------------------------------------------------------------------------
 class TestLastErrorConsistency:
-    """TC-UT-TS-010: status==BLOCKED iff last_error is non-empty (MSG-TS-005)."""
+    """TC-UT-TS-010: status==BLOCKED と last_error 非空が同値 (MSG-TS-005)。"""
 
     def test_in_progress_with_last_error_raises(self) -> None:
-        """status=IN_PROGRESS + last_error='something' → MSG-TS-005."""
+        """status=IN_PROGRESS + last_error='something' → MSG-TS-005。"""
         with pytest.raises(TaskInvariantViolation) as exc_info:
             _validate_last_error_consistency(TaskStatus.IN_PROGRESS, "leftover error")
         assert exc_info.value.kind == "last_error_consistency"
 
     def test_blocked_with_none_last_error_raises(self) -> None:
-        """status=BLOCKED + last_error=None → MSG-TS-005."""
+        """status=BLOCKED + last_error=None → MSG-TS-005。"""
         with pytest.raises(TaskInvariantViolation) as exc_info:
             _validate_last_error_consistency(TaskStatus.BLOCKED, None)
         assert exc_info.value.kind == "last_error_consistency"
 
     def test_blocked_with_non_empty_last_error_passes(self) -> None:
-        """The legal pairing — BLOCKED + non-empty string — is accepted."""
+        """正当な組み合わせ ── BLOCKED + 非空文字列 ── は受理される。"""
         _validate_last_error_consistency(TaskStatus.BLOCKED, "AuthExpired")
 
     def test_done_with_none_last_error_passes(self) -> None:
-        """Terminal status + last_error=None is the legal terminal shape."""
+        """終端ステータス + last_error=None は正当な終端形。"""
         _validate_last_error_consistency(TaskStatus.DONE, None)
 
 
 # ---------------------------------------------------------------------------
-# TC-UT-TS-051 (also): blocked_requires_last_error length check
+# TC-UT-TS-051 (also): blocked_requires_last_error 長さチェック
 # ---------------------------------------------------------------------------
 class TestBlockedRequiresLastError:
-    """TC-UT-TS-051: BLOCKED + 0-length last_error raises (MSG-TS-006).
+    """TC-UT-TS-051: BLOCKED + 0 長 last_error は例外発火 (MSG-TS-006)。
 
-    Distinct from ``last_error_consistency`` — when status==BLOCKED
-    and last_error is None or empty string, the *consistency* check
-    catches the structural mismatch first; this validator confirms the
-    NFC-normalized length is in the [1, 10000] band when consistency
-    is satisfied.
+    ``last_error_consistency`` とは別 ── status==BLOCKED で
+    last_error が None / 空文字列の場合、構造の不一致は *consistency*
+    チェックが先に検出する。本バリデータは consistency 充足下で
+    NFC 正規化長が [1, 10000] 範囲に収まることを確認する。
     """
 
     def test_blocked_with_too_long_last_error_raises(self) -> None:
-        """A 10001-char last_error exceeds MAX_LAST_ERROR_LENGTH."""
+        """10001 文字の last_error は MAX_LAST_ERROR_LENGTH を超える。"""
         too_long = "x" * (MAX_LAST_ERROR_LENGTH + 1)
         with pytest.raises(TaskInvariantViolation) as exc_info:
             _validate_blocked_has_last_error(TaskStatus.BLOCKED, too_long)
         assert exc_info.value.kind == "blocked_requires_last_error"
 
     def test_non_blocked_status_short_circuits(self) -> None:
-        """Non-BLOCKED statuses skip the length check entirely."""
+        """BLOCKED 以外のステータスは長さチェックをスキップする。"""
         _validate_blocked_has_last_error(TaskStatus.IN_PROGRESS, None)
         _validate_blocked_has_last_error(TaskStatus.DONE, None)
 
@@ -139,16 +138,16 @@ class TestBlockedRequiresLastError:
 # TC-UT-TS-052: timestamp_order
 # ---------------------------------------------------------------------------
 class TestTimestampOrder:
-    """TC-UT-TS-052: created_at > updated_at raises (MSG-TS-007)."""
+    """TC-UT-TS-052: created_at > updated_at で例外発火 (MSG-TS-007)。"""
 
     def test_created_after_updated_raises(self) -> None:
-        """The validator emits MSG-TS-007 with ISO timestamps in detail."""
+        """バリデータは MSG-TS-007 を発し、detail に ISO タイムスタンプを含める。"""
         ts_old = datetime(2026, 4, 27, 12, 0, 0, tzinfo=UTC)
         ts_new = ts_old - timedelta(seconds=1)
         with pytest.raises(TaskInvariantViolation) as exc_info:
             _validate_timestamp_order(ts_old, ts_new)
         assert exc_info.value.kind == "timestamp_order"
-        # detail surfaces ISO timestamps for forensics.
+        # detail に法定証跡のため ISO タイムスタンプが現れる。
         assert "created_at" in exc_info.value.detail
         assert "updated_at" in exc_info.value.detail
 
@@ -157,13 +156,12 @@ class TestTimestampOrder:
 # TC-UT-TS-011: TaskInvariantViolation auto-mask (§確定 I)
 # ---------------------------------------------------------------------------
 class TestExceptionAutoMasksDiscordWebhooks:
-    """TC-UT-TS-011: webhook URLs in ``last_error`` get masked in the exception.
+    """TC-UT-TS-011: ``last_error`` 内の webhook URL が例外でマスクされる。
 
-    Build a Task whose BLOCKED state carries a webhook URL inside
-    ``last_error``, then trigger an invariant by trying to construct
-    an inconsistent state. The exception's ``str(exc)`` and
-    ``exc.detail`` must both have the token redacted to
-    ``<REDACTED:DISCORD_WEBHOOK>``.
+    BLOCKED 状態の last_error に webhook URL を含む Task を構築し、
+    不整合状態の構築によって invariant を発火させる。例外の
+    ``str(exc)`` と ``exc.detail`` の双方で、トークンが
+    ``<REDACTED:DISCORD_WEBHOOK>`` に置換されていなければならない。
     """
 
     _SECRET = "https://discord.com/api/webhooks/123456789012345678/CataclysmicSecret-token"
@@ -171,18 +169,17 @@ class TestExceptionAutoMasksDiscordWebhooks:
     _RAW_TOKEN = "CataclysmicSecret-token"
 
     def test_webhook_token_redacted_in_message(self) -> None:
-        """str(exc) does not leak the raw token; sentinel is present."""
-        # Pass a webhook URL in the consistency-violation path.
-        # status=IN_PROGRESS + non-empty last_error => MSG-TS-005,
-        # message includes the field values.
+        """str(exc) は生トークンを漏らさず、sentinel が現れる。"""
+        # consistency 違反経路で webhook URL を渡す。
+        # status=IN_PROGRESS + 非空 last_error => MSG-TS-005 で
+        # メッセージにフィールド値が含まれる。
         with pytest.raises(TaskInvariantViolation) as exc_info:
             make_in_progress_task(
                 last_error=self._SECRET,
-                # The actual MSG echoes "non-empty" for consistency,
-                # but the exception's __init__ runs auto-mask on every
-                # detail value pre-emptively. Trigger via the invariant
-                # by constructing an IN_PROGRESS Task with a non-empty
-                # last_error.
+                # 実際の MSG は consistency に対して "non-empty" を反復するが、
+                # 例外の __init__ は detail の各値に対して事前に auto-mask を
+                # 走らせる。IN_PROGRESS Task を非空 last_error で構築すると
+                # invariant を発火できる。
             )
         assert self._RAW_TOKEN not in str(exc_info.value), (
             "[FAIL] Raw Discord webhook token leaked into exception message.\n"
@@ -191,22 +188,20 @@ class TestExceptionAutoMasksDiscordWebhooks:
         )
 
     def test_webhook_token_redacted_in_detail(self) -> None:
-        """exc.detail values are recursively masked.
+        """exc.detail の値が再帰的にマスクされる。
 
-        We trigger the violation through ``block`` with the secret in
-        ``last_error`` then transition to a state-inconsistent build.
-        The detail dict shape varies by validator; we assert that no
-        detail value carries the raw token.
+        secret を ``last_error`` に入れ、状態不整合な構築へ遷移して
+        違反を発火させる。detail dict の形状はバリデータごとに
+        異なるため、いずれの detail 値も生トークンを保持しないことを
+        アサートする。
         """
-        # Force a blocked_requires_last_error violation by building
-        # a Task with status=BLOCKED + last_error=secret + override the
-        # length check by using too-long form... easier: invoke the
-        # validator directly with the secret as the message-bearing
-        # value via _validate_blocked_has_last_error.
-        # We construct the exception directly to avoid coupling to the
-        # specific validator that injects the webhook into detail —
-        # the §確定 I contract is on TaskInvariantViolation.__init__,
-        # not on any specific validator.
+        # blocked_requires_last_error を発火させるには、
+        # status=BLOCKED + last_error=secret + 過大長による長さチェック
+        # 越えで構築する手もあるが、_validate_blocked_has_last_error を
+        # 直接呼び出して secret をメッセージ持ち値として渡す方が容易。
+        # ここでは特定バリデータへの結合を避けるため、例外を直接構築する ──
+        # §確定 I の契約は TaskInvariantViolation.__init__ にあり、
+        # 個別バリデータには無い。
         exc = TaskInvariantViolation(
             kind="blocked_requires_last_error",
             message=f"[FAIL] secret in message: {self._SECRET}\nNext: re-input webhook.",
@@ -217,10 +212,10 @@ class TestExceptionAutoMasksDiscordWebhooks:
             },
         )
 
-        # Message: token gone, sentinel present.
+        # メッセージ: トークン消滅、sentinel 出現。
         assert self._RAW_TOKEN not in exc.message
         assert self._REDACT_SENTINEL in exc.message
-        # Detail: every value recursively masked.
+        # detail: 全ての値が再帰的にマスクされる。
         flat = repr(exc.detail)
         assert self._RAW_TOKEN not in flat, (
             f"[FAIL] Raw token leaked into detail: {flat!r}\n"
@@ -230,21 +225,21 @@ class TestExceptionAutoMasksDiscordWebhooks:
 
 
 # ---------------------------------------------------------------------------
-# §確定 G + K: Aggregate-layer non-enforcement of application invariants
+# §確定 G + K: Aggregate 層はアプリケーション不変条件を強制しない
 # ---------------------------------------------------------------------------
 class TestAggregateDoesNotEnforceApplicationInvariants:
-    """TC-UT-TS-042 / 043: Aggregate does NOT validate cross-aggregate refs."""
+    """TC-UT-TS-042 / 043: Aggregate は跨り Aggregate 参照を検証しない。"""
 
     def test_commit_deliverable_does_not_check_by_agent_id_membership(self) -> None:
-        """TC-UT-TS-042: ``by_agent_id`` need not be in ``assigned_agent_ids``.
+        """TC-UT-TS-042: ``by_agent_id`` は ``assigned_agent_ids`` に含まれなくてよい。
 
-        §確定 G: that membership check is the application service's
-        job. We pass an agent that is NOT in the assigned set and
-        expect the call to succeed at the Aggregate level.
+        §確定 G: そのメンバーシップ確認はアプリケーションサービスの
+        責務。assigned 集合に含まれない agent を渡しても、
+        Aggregate レベルでは成功するはず。
         """
         task = make_in_progress_task(assigned_agent_ids=[uuid4()])
         outsider_agent = uuid4()
-        # Sanity: outsider not in the assigned set.
+        # 確認: outsider は assigned 集合に含まれていない。
         assert outsider_agent not in task.assigned_agent_ids
 
         d = make_deliverable(stage_id=task.current_stage_id)
@@ -257,44 +252,43 @@ class TestAggregateDoesNotEnforceApplicationInvariants:
         assert out.deliverables[task.current_stage_id] == d
 
     def test_arbitrary_room_id_and_directive_id_accepted(self) -> None:
-        """TC-UT-TS-043: random IDs for cross-aggregate refs construct cleanly.
+        """TC-UT-TS-043: 跨り Aggregate 参照のランダム ID でも問題なく構築できる。
 
-        The Aggregate stores VO-typed IDs without verifying the target
-        rows exist (§確定 K). Repository / TaskService verifies
-        existence at hydration / construction; the Aggregate's job is
-        only to keep its **own** state consistent.
+        Aggregate は VO 型 ID を保持するだけで、参照先の行が
+        存在するかは検証しない (§確定 K)。Repository / TaskService が
+        ハイドレート / 構築時に存在性を確認する。Aggregate の責務は
+        **自身**の状態整合性に閉じる。
         """
-        # Random IDs — none of them refer to anything that exists in
-        # any test fixture / DB. The Aggregate accepts them.
+        # ランダム ID ── テストフィクスチャや DB 上にも存在しない値。
+        # Aggregate は受理する。
         task = make_task(
             room_id=uuid4(),
             directive_id=uuid4(),
             current_stage_id=uuid4(),
         )
-        # Construction succeeded; no reference-integrity check fired.
+        # 構築成功。参照整合性チェックは発火しない。
         assert task.room_id is not None
         assert task.directive_id is not None
         assert task.current_stage_id is not None
 
 
 # ---------------------------------------------------------------------------
-# TC-UT-TS-046〜052: 2-line MSG + Next: hint physical guarantee (§確定 J)
+# TC-UT-TS-046〜052: 2 行 MSG + Next: ヒント物理保証 (§確定 J)
 # ---------------------------------------------------------------------------
 class TestNextHintPhysicalGuarantee:
-    """Across all 7 ``TaskViolationKind`` values, ``str(exc)`` carries 'Next:'.
+    """``TaskViolationKind`` の全 7 値で ``str(exc)`` に 'Next:' が含まれる。
 
-    The room §確定 I 踏襲 contract: every error message has a 2-line
-    structure (``[FAIL] <fact>\\nNext: <action>``). A failing assertion
-    on ``"Next:" in str(exc)`` means a developer wrote a one-line MSG
-    and the operator-feedback contract is broken.
+    room §確定 I 踏襲の契約: あらゆるエラーメッセージは 2 行構造
+    (``[FAIL] <fact>\\nNext: <action>``) を持つ。``"Next:" in str(exc)``
+    のアサートが落ちる場合、開発者が 1 行 MSG を書いて運用者向け
+    フィードバック契約を破った証拠となる。
 
-    We trigger each kind through the natural code path (not direct
-    exception construction) so the actual emitted string is what gets
-    asserted.
+    各 kind は自然なコード経路で発火させる (例外を直接構築しない) ──
+    実際に出力される文字列に対してアサートできるようにするため。
     """
 
     def test_terminal_violation_carries_next_hint(self) -> None:
-        """TC-UT-TS-046: MSG-TS-001 (terminal_violation)."""
+        """TC-UT-TS-046: MSG-TS-001 (terminal_violation)。"""
         from tests.factories.task import make_done_task
 
         task = make_done_task()
@@ -303,10 +297,10 @@ class TestNextHintPhysicalGuarantee:
         s = str(exc_info.value)
         assert s.startswith("[FAIL]")
         assert "Next:" in s
-        assert "DONE/CANCELLED" in s  # hint substring
+        assert "DONE/CANCELLED" in s  # ヒントの部分文字列
 
     def test_state_transition_invalid_carries_next_hint(self) -> None:
-        """TC-UT-TS-047: MSG-TS-002 (state_transition_invalid)."""
+        """TC-UT-TS-047: MSG-TS-002 (state_transition_invalid)。"""
         task = make_task()  # PENDING
         with pytest.raises(TaskInvariantViolation) as exc_info:
             task.commit_deliverable(
@@ -321,7 +315,7 @@ class TestNextHintPhysicalGuarantee:
         assert "state_machine.py" in s
 
     def test_assigned_agents_unique_carries_next_hint(self) -> None:
-        """TC-UT-TS-048: MSG-TS-003 (assigned_agents_unique)."""
+        """TC-UT-TS-048: MSG-TS-003 (assigned_agents_unique)。"""
         agent = uuid4()
         with pytest.raises(TaskInvariantViolation) as exc_info:
             _validate_assigned_agents_unique([agent, agent])
@@ -331,7 +325,7 @@ class TestNextHintPhysicalGuarantee:
         assert "Deduplicate" in s
 
     def test_assigned_agents_capacity_carries_next_hint(self) -> None:
-        """TC-UT-TS-049: MSG-TS-004 (assigned_agents_capacity)."""
+        """TC-UT-TS-049: MSG-TS-004 (assigned_agents_capacity)。"""
         with pytest.raises(TaskInvariantViolation) as exc_info:
             _validate_assigned_agents_capacity([uuid4() for _ in range(6)])
         s = str(exc_info.value)
@@ -340,7 +334,7 @@ class TestNextHintPhysicalGuarantee:
         assert "split work" in s
 
     def test_last_error_consistency_carries_next_hint(self) -> None:
-        """TC-UT-TS-050: MSG-TS-005 (last_error_consistency)."""
+        """TC-UT-TS-050: MSG-TS-005 (last_error_consistency)。"""
         with pytest.raises(TaskInvariantViolation) as exc_info:
             _validate_last_error_consistency(TaskStatus.IN_PROGRESS, "oops")
         s = str(exc_info.value)
@@ -349,12 +343,12 @@ class TestNextHintPhysicalGuarantee:
         assert "Repository row integrity" in s
 
     def test_blocked_requires_last_error_carries_next_hint(self) -> None:
-        """TC-UT-TS-051: MSG-TS-006 (blocked_requires_last_error).
+        """TC-UT-TS-051: MSG-TS-006 (blocked_requires_last_error)。
 
-        A direct invocation with status=BLOCKED + empty last_error.
-        Note that the higher-level ``Task.block(..., last_error='')``
-        path raises through the model validator on the rebuild —
-        same kind, same hint.
+        status=BLOCKED + 空 last_error の直接呼び出し。
+        上位の ``Task.block(..., last_error='')`` 経路では
+        rebuild 時のモデルバリデータが発火する ── 同じ kind、
+        同じヒント。
         """
         with pytest.raises(TaskInvariantViolation) as exc_info:
             _validate_blocked_has_last_error(TaskStatus.BLOCKED, "")
@@ -364,7 +358,7 @@ class TestNextHintPhysicalGuarantee:
         assert "1-10000" in s
 
     def test_timestamp_order_carries_next_hint(self) -> None:
-        """TC-UT-TS-052: MSG-TS-007 (timestamp_order)."""
+        """TC-UT-TS-052: MSG-TS-007 (timestamp_order)。"""
         ts_old = datetime(2026, 4, 27, 12, 0, 0, tzinfo=UTC)
         ts_new = ts_old - timedelta(seconds=1)
         with pytest.raises(TaskInvariantViolation) as exc_info:
@@ -376,19 +370,19 @@ class TestNextHintPhysicalGuarantee:
 
 
 # ---------------------------------------------------------------------------
-# Smoke: BLOCKED Task with raw last_error keeps the secret
+# Smoke: 生 last_error を持つ BLOCKED Task は secret を保持する
 # ---------------------------------------------------------------------------
 class TestAggregateKeepsRawLastError:
-    """The Aggregate stores ``last_error`` raw — masking is Repository-side.
+    """Aggregate は ``last_error`` を生のまま保存する ── masking は Repository 側。
 
-    Reaffirms the design separation: ``MaskedText`` is a column
-    decorator on ``tasks.last_error`` in ``feature/task-repository``;
-    the in-memory Task instance must NOT pre-mask the value, otherwise
-    the Aggregate would silently lose forensic information.
+    設計分離の再確認: ``MaskedText`` は ``feature/task-repository`` の
+    ``tasks.last_error`` カラムデコレータ。インメモリの Task インスタンスは
+    値を事前マスクしてはならない ── さもないと Aggregate が
+    法定証跡情報を黙って失う。
     """
 
     def test_in_memory_task_keeps_secret(self) -> None:
-        """``make_blocked_task(last_error=secret)`` keeps the raw secret in-memory."""
+        """``make_blocked_task(last_error=secret)`` はインメモリで生 secret を保持する。"""
         secret = (
             "AuthExpired: https://discord.com/api/webhooks/111122223333444455/RawTokenInMemory-only"
         )

--- a/backend/tests/domain/task/test_task/test_state_lifecycle.py
+++ b/backend/tests/domain/task/test_task/test_state_lifecycle.py
@@ -117,11 +117,11 @@ class TestLifecycleIntegration:
         agent_a = uuid4()
         stage_a = task.current_stage_id
 
-        # Step 1: assign → IN_PROGRESS
+        # Step 1: assign → IN_PROGRESS への遷移
         task = task.assign([agent_a], updated_at=next_ts(task))
         assert task.status == TaskStatus.IN_PROGRESS
 
-        # Step 2: commit_deliverable
+        # Step 2: commit_deliverable で成果物を登録
         d1 = make_deliverable(stage_id=stage_a)
         task = task.commit_deliverable(
             stage_id=stage_a,
@@ -131,7 +131,7 @@ class TestLifecycleIntegration:
         )
         assert task.deliverables[stage_a] == d1
 
-        # Step 3: request_external_review → AWAITING
+        # Step 3: request_external_review → AWAITING への遷移
         task = task.request_external_review(updated_at=next_ts(task))
         assert task.status == TaskStatus.AWAITING_EXTERNAL_REVIEW
 
@@ -141,7 +141,7 @@ class TestLifecycleIntegration:
         assert task.status == TaskStatus.IN_PROGRESS
         assert task.current_stage_id == stage_b
 
-        # Step 5: commit + complete
+        # Step 5: commit + complete でタスク完了
         d2 = make_deliverable(stage_id=stage_b)
         task = task.commit_deliverable(
             stage_id=stage_b,

--- a/backend/tests/domain/task/test_task/test_state_lifecycle.py
+++ b/backend/tests/domain/task/test_task/test_state_lifecycle.py
@@ -1,13 +1,13 @@
-"""Task state machine: BLOCKED contract + pre-validate + lifecycle integration.
+"""Task ステートマシン: BLOCKED 契約 + pre-validate + ライフサイクル統合.
 
-TC-UT-TS-007 (BLOCKED non-empty last_error contract) + TC-UT-TS-038
-(pre-validate leaves original Task untouched) + TC-IT-TS-001〜005
-(multi-method integration scenarios) + ``updated_at`` monotonicity
-across all 13 ✓ transitions.
+TC-UT-TS-007 (BLOCKED 非空 last_error 契約) + TC-UT-TS-038
+(pre-validate は元 Task を変更しない) + TC-IT-TS-001〜005
+(複数メソッドの統合シナリオ) + 13 ✓ 遷移全件における
+``updated_at`` 単調増加。
 
-Per ``docs/features/task/test-design.md``. Split out of
-``test_state_machine.py`` per Norman R-N1 (633 → 3 files). Sibling
-files cover the table lock + 13 ✓ cells and the 47 ✗ cells.
+``docs/features/task/test-design.md`` 準拠。Norman R-N1 に従い
+``test_state_machine.py`` から分割 (633 → 3 ファイル)。
+兄弟ファイルでテーブルロック + 13 ✓ セルおよび 47 ✗ セルを扱う。
 """
 
 from __future__ import annotations
@@ -34,23 +34,23 @@ from tests.factories.task import (
 
 
 # ---------------------------------------------------------------------------
-# TC-UT-TS-007: BLOCKED contract — block() rejects empty last_error
+# TC-UT-TS-007: BLOCKED 契約 ── block() は空 last_error を拒絶する
 # ---------------------------------------------------------------------------
 class TestBlockRequiresNonEmptyLastError:
-    """TC-UT-TS-007: ``block(reason, last_error='')`` Fail-Fast.
+    """TC-UT-TS-007: ``block(reason, last_error='')`` は Fail-Fast。
 
-    BUG-TSK-001 fix landed (commit ``377366e``): ``Task._check_invariants``
-    now runs ``_validate_blocked_has_last_error`` **before**
-    ``_validate_last_error_consistency``, so the empty-string path
-    raises the design-contracted ``MSG-TS-006``
-    (``blocked_requires_last_error``) — the "block() requires non-empty
-    last_error" Next-action hint. The single-kind assertion below pins
-    that contract; a regression that swapped the ordering back would
-    surface here, not behind a permissive ``or`` set.
+    BUG-TSK-001 修正完了 (commit ``377366e``): ``Task._check_invariants``
+    が ``_validate_blocked_has_last_error`` を
+    ``_validate_last_error_consistency`` の **前** に走らせるようになり、
+    空文字列経路では設計契約どおりの ``MSG-TS-006``
+    (``blocked_requires_last_error``) ──「block() は非空 last_error を要する」
+    の Next-action ヒントを発火する。下の単一 kind アサートで契約を固定し、
+    順序を戻すリグレッションをここで検出する (寛容な ``or`` 集合の裏に
+    隠れない)。
     """
 
     def test_block_with_empty_last_error_raises_blocked_requires_last_error(self) -> None:
-        """``block(last_error='')`` raises ``blocked_requires_last_error`` (MSG-TS-006)."""
+        """``block(last_error='')`` は ``blocked_requires_last_error`` (MSG-TS-006) を発火する。"""
         task = make_in_progress_task()
         with pytest.raises(TaskInvariantViolation) as exc_info:
             task.block("retry exhausted", "", updated_at=next_ts(task))
@@ -64,12 +64,11 @@ class TestBlockRequiresNonEmptyLastError:
         )
 
     def test_block_with_too_long_last_error_raises(self) -> None:
-        """A 10001-char ``last_error`` exceeds MAX and raises blocked_requires_last_error.
+        """10001 文字の ``last_error`` は MAX 超過で blocked_requires_last_error を発火する。
 
-        For the over-length path, the consistency check passes
-        (BLOCKED + non-empty string is structurally OK) and the
-        length check fires — same kind as the empty-string path
-        after the BUG-TSK-001 fix.
+        過大長経路では consistency チェックは通過し
+        (BLOCKED + 非空文字列は構造的に OK)、長さチェックが発火する ──
+        BUG-TSK-001 修正後は空文字列経路と同じ kind になる。
         """
         task = make_in_progress_task()
         too_long = "x" * 10_001
@@ -79,41 +78,40 @@ class TestBlockRequiresNonEmptyLastError:
 
 
 # ---------------------------------------------------------------------------
-# TC-UT-TS-038: assign failure leaves the original Task unchanged (§確定 A)
+# TC-UT-TS-038: assign 失敗時に元 Task は不変 (§確定 A)
 # ---------------------------------------------------------------------------
 class TestPreValidateLeavesOriginalUntouched:
-    """TC-UT-TS-038: a failed behavior call does not mutate the original Task.
+    """TC-UT-TS-038: 失敗した behavior 呼び出しは元 Task を変更しない。
 
-    The §確定 A pre-validate rebuild path means a behavior either
-    returns a new Task or raises — never partially-mutates the source
-    instance. We assert this by attempting an illegal action and then
-    inspecting the original Task's full attribute set.
+    §確定 A の pre-validate rebuild 経路は、behavior が新 Task を返すか
+    例外を発するかのいずれかで、元インスタンスを部分的に変更しない。
+    違法アクションを試みた後で、元 Task の全属性集合を検査することで
+    保証を確認する。
     """
 
     def test_failed_assign_on_in_progress_keeps_original_unchanged(self) -> None:
-        """An ``assign`` on IN_PROGRESS raises and does not touch the original."""
+        """IN_PROGRESS に対する ``assign`` は例外を発し、元 Task に触れない。"""
         original = make_in_progress_task()
         snapshot = original.model_dump()
 
         with pytest.raises(TaskInvariantViolation):
             original.assign([uuid4()], updated_at=next_ts(original))
 
-        # Every field byte-identical after the failed call.
+        # 失敗呼び出し後も全フィールドはバイト等価。
         assert original.model_dump() == snapshot
 
 
 # ---------------------------------------------------------------------------
-# Integration scenarios (TC-IT-TS-001〜005)
+# 統合シナリオ (TC-IT-TS-001〜005)
 # ---------------------------------------------------------------------------
 class TestLifecycleIntegration:
-    """Aggregate-internal "integration" — multi-method round-trip scenarios."""
+    """Aggregate 内部「統合」── 複数メソッドのラウンドトリップシナリオ。"""
 
     def test_pending_to_done_full_lifecycle(self) -> None:
-        """TC-IT-TS-002: PENDING → IN_PROGRESS → AWAITING → IN_PROGRESS → DONE.
+        """TC-IT-TS-002: PENDING → IN_PROGRESS → AWAITING → IN_PROGRESS → DONE。
 
-        Walks the §確定 A-2 4-method-separation (approve_review +
-        complete) end-to-end. The final DONE state must reject every
-        subsequent action.
+        §確定 A-2 の 4 メソッド分離 (approve_review + complete) を
+        端から端まで歩く。最終 DONE 状態は後続全アクションを拒絶せねばならない。
         """
         task = make_task()
         agent_a = uuid4()
@@ -137,7 +135,7 @@ class TestLifecycleIntegration:
         task = task.request_external_review(updated_at=next_ts(task))
         assert task.status == TaskStatus.AWAITING_EXTERNAL_REVIEW
 
-        # Step 4: approve_review → IN_PROGRESS at next stage
+        # Step 4: approve_review → 次ステージで IN_PROGRESS
         stage_b = uuid4()
         task = task.approve_review(uuid4(), uuid4(), stage_b, updated_at=next_ts(task))
         assert task.status == TaskStatus.IN_PROGRESS
@@ -155,40 +153,38 @@ class TestLifecycleIntegration:
         assert task.status == TaskStatus.DONE
         assert len(task.deliverables) == 2
 
-        # DONE rejects every subsequent action (cross-check with
-        # TestTerminalGate on a freshly-walked Task).
+        # DONE は後続全アクションを拒絶 (新規 Task に対する TestTerminalGate
+        # との交差確認)。
         for action in ALL_ACTIONS:
             with pytest.raises(TaskInvariantViolation) as exc_info:
                 invoke_action(task, action)
             assert exc_info.value.kind == "terminal_violation"
 
     def test_blocked_recovery_to_done(self) -> None:
-        """TC-IT-TS-003: IN_PROGRESS → BLOCKED → IN_PROGRESS → DONE.
+        """TC-IT-TS-003: IN_PROGRESS → BLOCKED → IN_PROGRESS → DONE。
 
-        Verifies the §確定 D ``last_error`` clear contract: after
-        ``unblock_retry`` the Task is back in IN_PROGRESS with
-        ``last_error is None`` and can complete normally.
+        §確定 D の ``last_error`` クリア契約を検証する: ``unblock_retry``
+        後は IN_PROGRESS に戻り ``last_error is None`` で正常完了できる。
         """
         task = make_in_progress_task()
         agent = task.assigned_agent_ids[0]
         stage = task.current_stage_id
 
-        # Block with a webhook URL in last_error — auto-mask is
-        # exercised at the exception layer, but the Task itself
-        # holds the raw NFC-normalized form (Repository-side masking
-        # is workflow-repository's concern).
+        # last_error に webhook URL を含めて block する ── auto-mask は
+        # 例外層で発動するが、Task 自体は NFC 正規化された生形を保持する
+        # (Repository 側の masking は workflow-repository の関心事)。
         last_err = "AuthExpired: https://discord.com/api/webhooks/123456789012345678/SecretToken-x"
         task = task.block("auth retry exhausted", last_err, updated_at=next_ts(task))
         assert task.status == TaskStatus.BLOCKED
         assert task.last_error is not None
-        assert task.last_error == last_err  # Aggregate keeps raw form
+        assert task.last_error == last_err  # Aggregate は生形のまま保持する
 
-        # Unblock → back to IN_PROGRESS, last_error cleared.
+        # Unblock → IN_PROGRESS に戻り、last_error クリア。
         task = task.unblock_retry(updated_at=next_ts(task))
         assert task.status == TaskStatus.IN_PROGRESS
         assert task.last_error is None
 
-        # Commit + complete.
+        # commit + complete。
         d = make_deliverable(stage_id=stage)
         task = task.commit_deliverable(
             stage_id=stage,
@@ -200,16 +196,16 @@ class TestLifecycleIntegration:
         assert task.status == TaskStatus.DONE
 
     def test_reject_review_and_resubmit_loop(self) -> None:
-        """TC-IT-TS-005: AWAITING → IN_PROGRESS (rejected to rollback) → re-review → DONE.
+        """TC-IT-TS-005: AWAITING → IN_PROGRESS (reject による rollback) → 再 review → DONE。
 
-        Verifies that ``reject_review`` is a real round-trip path:
-        a Task that is rejected can return through a different
-        ``current_stage_id``, re-submit, and eventually complete.
+        ``reject_review`` が真のラウンドトリップ経路となることを検証する:
+        reject された Task は別の ``current_stage_id`` を経て戻ってきて、
+        再投稿し、最終的に完了できる。
         """
         task = make_task_in_status(TaskStatus.AWAITING_EXTERNAL_REVIEW)
         agent = task.assigned_agent_ids[0]
 
-        # Reject — fall back to a "rollback" stage.
+        # Reject ── 「rollback」ステージへ戻す。
         rollback_stage = uuid4()
         task = task.reject_review(
             uuid4(),
@@ -220,7 +216,7 @@ class TestLifecycleIntegration:
         assert task.status == TaskStatus.IN_PROGRESS
         assert task.current_stage_id == rollback_stage
 
-        # Re-commit + re-review.
+        # 再 commit + 再 review。
         d = make_deliverable(stage_id=rollback_stage)
         task = task.commit_deliverable(
             stage_id=rollback_stage,
@@ -231,7 +227,7 @@ class TestLifecycleIntegration:
         task = task.request_external_review(updated_at=next_ts(task))
         assert task.status == TaskStatus.AWAITING_EXTERNAL_REVIEW
 
-        # Approve this time → IN_PROGRESS at next stage.
+        # 今度は approve → 次ステージで IN_PROGRESS。
         next_stage = uuid4()
         task = task.approve_review(
             uuid4(),
@@ -241,17 +237,16 @@ class TestLifecycleIntegration:
         )
         assert task.current_stage_id == next_stage
 
-        # Complete.
+        # complete。
         task = task.complete(uuid4(), uuid4(), updated_at=next_ts(task))
         assert task.status == TaskStatus.DONE
 
     def test_assign_failure_then_alternate_action_succeeds(self) -> None:
-        """TC-IT-TS-001: failed ``assign`` does not break a follow-up valid action.
+        """TC-IT-TS-001: 失敗した ``assign`` が後続の正当アクションを壊さないことを検証する。
 
-        Confirmation H: pre-validate keeps the Task state clean across
-        sequential failures + retries. After an illegal ``assign`` on
-        IN_PROGRESS we should still be able to call ``commit_deliverable``
-        successfully (proving no hidden state corruption).
+        Confirmation H: pre-validate は連続的な失敗 + 再試行を経ても
+        Task 状態をクリーンに保つ。IN_PROGRESS への違法 ``assign`` 後でも
+        ``commit_deliverable`` は成功するはず (隠れた状態破壊なしを示す)。
         """
         task = make_in_progress_task()
         agent = task.assigned_agent_ids[0]
@@ -260,7 +255,7 @@ class TestLifecycleIntegration:
         with pytest.raises(TaskInvariantViolation):
             task.assign([uuid4()], updated_at=next_ts(task))
 
-        # Original Task is unchanged → ``commit_deliverable`` works.
+        # 元 Task は不変 → ``commit_deliverable`` が成功する。
         d = make_deliverable(stage_id=stage)
         out = task.commit_deliverable(
             stage_id=stage,
@@ -272,12 +267,12 @@ class TestLifecycleIntegration:
         assert out.deliverables[stage] == d
 
     def test_cancel_from_each_state_clears_last_error(self) -> None:
-        """TC-IT-TS-004: cancel from PENDING / IN_PROGRESS / AWAITING / BLOCKED clears last_error.
+        """TC-IT-TS-004: PENDING / IN_PROGRESS / AWAITING / BLOCKED
+        いずれからの cancel も last_error をクリア。
 
-        Repeats ``test_cancel_from_each_of_four_states`` (sibling file)
-        with an explicit ``last_error=None`` post-condition assertion
-        even on the BLOCKED-origin path (where ``last_error`` was
-        non-empty before the cancel call).
+        兄弟ファイルの ``test_cancel_from_each_of_four_states`` を、
+        BLOCKED 起点経路 (cancel 前は ``last_error`` が非空) も含めて
+        ``last_error=None`` の事後条件アサートを明示する形で繰り返す。
         """
         for status in (
             TaskStatus.PENDING,
@@ -287,9 +282,9 @@ class TestLifecycleIntegration:
         ):
             task = make_task_in_status(status)
             with contextlib.suppress(TaskInvariantViolation):
-                # PENDING factory yields last_error=None already; the
-                # remaining factories also keep it None except for
-                # BLOCKED which carries the synthetic string.
+                # PENDING ファクトリは既に last_error=None を返す。
+                # 残るファクトリも BLOCKED (合成文字列を持つ) を除いて
+                # None のまま。
                 pass
             out = task.cancel(uuid4(), "manual abort", updated_at=next_ts(task))
             assert out.status == TaskStatus.CANCELLED
@@ -297,10 +292,10 @@ class TestLifecycleIntegration:
 
 
 # ---------------------------------------------------------------------------
-# Reachability sanity: every IN_PROGRESS-incoming method updates updated_at
+# 到達性確認: IN_PROGRESS に入る全メソッドが updated_at を更新する
 # ---------------------------------------------------------------------------
 class TestUpdatedAtAdvances:
-    """All allowed transitions must move ``updated_at`` strictly forward."""
+    """全許可遷移は ``updated_at`` を厳密に前進させなければならない。"""
 
     @pytest.mark.parametrize(
         "status",
@@ -313,17 +308,17 @@ class TestUpdatedAtAdvances:
         ids=lambda s: s.value,
     )
     def test_allowed_action_advances_updated_at(self, status: TaskStatus) -> None:
-        """For every legal (status, action), ``updated_at`` of the result is strictly later."""
-        # ``TRANSITIONS`` keys are tuples of (TaskStatus, TaskAction)
-        # but the iteration loses the Literal narrowing — annotate
-        # explicitly so the action stays typed as TaskAction.
+        """全合法 (status, action) で結果の ``updated_at`` が厳密に未来であることを保証する。"""
+        # ``TRANSITIONS`` のキーは (TaskStatus, TaskAction) のタプルだが、
+        # iteration では Literal narrowing が消える ── action を
+        # TaskAction として明示的に注釈する。
         legal_actions: list[TaskAction] = [a for (s, a) in TRANSITIONS if s == status]
         assert legal_actions, f"status {status} has zero legal actions"
         for action in legal_actions:
             task = make_task_in_status(status)
-            # block requires non-empty last_error which the helper
-            # passes through; commit_deliverable requires a Deliverable
-            # whose stage_id matches; both are handled by invoke_action.
+            # block は非空 last_error を要し、ヘルパが透過する。
+            # commit_deliverable は stage_id 一致の Deliverable を要する ──
+            # いずれも invoke_action 内で吸収される。
             try:
                 out = invoke_action(task, action)
             except TaskInvariantViolation:  # pragma: no cover - defensive

--- a/backend/tests/domain/task/test_task/test_state_machine_table.py
+++ b/backend/tests/domain/task/test_task/test_state_machine_table.py
@@ -1,17 +1,17 @@
-"""Task state machine: table lock + 13 allowed transitions.
+"""Task state machine: テーブルロック + 13 許可遷移。
 
 TC-UT-TS-039 (§確定 B table immutability) + TC-UT-TS-003 / 008 /
-030〜035 + cancel x 4 (§確定 A-2 dispatch table 13 ✓ cells).
+030〜035 + cancel x 4 (§確定 A-2 dispatch table 13 ✓ cells)。
 
-Per ``docs/features/task/test-design.md``. Split out of
-``test_state_machine.py`` per Norman R-N1 (633 → 3 files). Sibling
-files cover the **47 ✗ cells** and the **lifecycle integration**:
+``docs/features/task/test-design.md`` に従う。``test_state_machine.py``
+から Norman R-N1 に従い分割 (633 → 3 ファイル)。関連ファイルは
+**47 ✗ cells** と **ライフサイクル統合** をカバー:
 
-* :mod:`...test_task.test_state_terminal_and_invalid` — 20 terminal
-  ✗ + 27 illegal-non-terminal ✗ cells (MSG-TS-001 / MSG-TS-002).
-* :mod:`...test_task.test_state_lifecycle` — BLOCKED contract +
+* :mod:`...test_task.test_state_terminal_and_invalid` — 20 ターミナル
+  ✗ + 27 illegal-non-terminal ✗ cells (MSG-TS-001 / MSG-TS-002)。
+* :mod:`...test_task.test_state_lifecycle` — BLOCKED 契約 +
   pre-validate + multi-method integration scenarios + updated_at
-  monotonicity.
+  単調性。
 """
 
 from __future__ import annotations
@@ -39,42 +39,42 @@ from tests.factories.task import (
 # §確定 B: state machine TABLE shape + immutability (TC-UT-TS-039)
 # ---------------------------------------------------------------------------
 class TestStateMachineTableLocked:
-    """TC-UT-TS-039: ``TRANSITIONS`` has 13 entries and rejects mutation."""
+    """TC-UT-TS-039: ``TRANSITIONS`` が 13 エントリを持ち mutation を reject。"""
 
     def test_table_size_is_thirteen(self) -> None:
-        """The §確定 A-2 dispatch table freezes 13 allowed transitions."""
+        """§確定 A-2 dispatch table は 13 個の許可遷移を freeze。"""
         assert len(TRANSITIONS) == 13, (
-            f"[FAIL] state machine table size drifted: got {len(TRANSITIONS)}, expected 13.\n"
-            f"Next: docs/features/task/detailed-design.md §確定 A-2 freezes 13 transitions; "
-            f"editing state_machine.py without updating the design is a contract break."
+            f"[FAIL] state machine table size が drift: got {len(TRANSITIONS)}, expected 13.\n"
+            f"Next: docs/features/task/detailed-design.md §確定 A-2 が 13 transitions を freeze; "
+            f"design を更新せずに state_machine.py を編集することは契約違反。"
         )
 
     def test_table_setitem_rejected_at_runtime(self) -> None:
-        """``TRANSITIONS[k] = v`` raises ``TypeError`` (MappingProxyType lock)."""
+        """``TRANSITIONS[k] = v`` が ``TypeError`` を raise (MappingProxyType lock)。"""
         with pytest.raises(TypeError):
             TRANSITIONS[(TaskStatus.DONE, "assign")] = TaskStatus.IN_PROGRESS  # pyright: ignore[reportIndexIssue]
 
 
 # ---------------------------------------------------------------------------
-# 13 allowed transitions — one positive case per ✓ cell
+# 13 許可遷移 — ✓ cell ごと 1 つのポジティブケース
 # ---------------------------------------------------------------------------
 class TestThirteenAllowedTransitions:
-    """TC-UT-TS-003 / 008 / 030〜035 + cancel x 4 = 13 ✓ cells."""
+    """TC-UT-TS-003 / 008 / 030〜035 + cancel x 4 = 13 ✓ cells。"""
 
     # PENDING → IN_PROGRESS via assign
     def test_assign_pending_to_in_progress(self) -> None:
-        """TC-UT-TS-003: ``assign`` on PENDING moves to IN_PROGRESS."""
+        """TC-UT-TS-003: PENDING で ``assign`` が IN_PROGRESS に移行。"""
         task = make_task()
         agent_a = uuid4()
         out = task.assign([agent_a], updated_at=next_ts(task))
         assert out.status == TaskStatus.IN_PROGRESS
         assert out.assigned_agent_ids == [agent_a]
-        # original task unchanged (frozen + pre-validate)
+        # 元のタスク変更なし (frozen + pre-validate)
         assert task.status == TaskStatus.PENDING
 
     # IN_PROGRESS self-loop via commit_deliverable
     def test_commit_deliverable_self_loop(self) -> None:
-        """TC-UT-TS-030: ``commit_deliverable`` on IN_PROGRESS keeps status, adds entry."""
+        """TC-UT-TS-030: IN_PROGRESS で ``commit_deliverable`` がステータス保持、エントリ追加。"""
         task = make_in_progress_task()
         deliverable = make_deliverable(stage_id=task.current_stage_id)
         out = task.commit_deliverable(
@@ -89,14 +89,14 @@ class TestThirteenAllowedTransitions:
 
     # IN_PROGRESS → AWAITING via request_external_review
     def test_request_external_review_to_awaiting(self) -> None:
-        """TC-UT-TS-031: IN_PROGRESS → AWAITING_EXTERNAL_REVIEW."""
+        """TC-UT-TS-031: IN_PROGRESS → AWAITING_EXTERNAL_REVIEW。"""
         task = make_in_progress_task()
         out = task.request_external_review(updated_at=next_ts(task))
         assert out.status == TaskStatus.AWAITING_EXTERNAL_REVIEW
 
     # AWAITING → IN_PROGRESS via approve_review (Gate APPROVED)
     def test_approve_review_back_to_in_progress(self) -> None:
-        """TC-UT-TS-032: ``approve_review`` advances current_stage_id."""
+        """TC-UT-TS-032: ``approve_review`` が current_stage_id を前進。"""
         task = make_task_in_status(TaskStatus.AWAITING_EXTERNAL_REVIEW)
         next_stage = uuid4()
         out = task.approve_review(uuid4(), uuid4(), next_stage, updated_at=next_ts(task))
@@ -105,7 +105,7 @@ class TestThirteenAllowedTransitions:
 
     # AWAITING → IN_PROGRESS via reject_review (Gate REJECTED)
     def test_reject_review_back_to_in_progress(self) -> None:
-        """TC-UT-TS-032b: ``reject_review`` rolls current_stage_id back."""
+        """TC-UT-TS-032b: ``reject_review`` が current_stage_id をロールバック。"""
         task = make_task_in_status(TaskStatus.AWAITING_EXTERNAL_REVIEW)
         rollback_stage = uuid4()
         out = task.reject_review(uuid4(), uuid4(), rollback_stage, updated_at=next_ts(task))
@@ -114,7 +114,7 @@ class TestThirteenAllowedTransitions:
 
     # IN_PROGRESS self-loop via advance_to_next
     def test_advance_to_next_keeps_in_progress(self) -> None:
-        """TC-UT-TS-032c: ``advance_to_next`` updates current_stage_id, status unchanged."""
+        """TC-UT-TS-032c: ``advance_to_next`` が current_stage_id を更新、ステータス変更なし。"""
         task = make_in_progress_task()
         next_stage = uuid4()
         out = task.advance_to_next(uuid4(), uuid4(), next_stage, updated_at=next_ts(task))
@@ -123,10 +123,10 @@ class TestThirteenAllowedTransitions:
 
     # IN_PROGRESS → DONE via complete
     def test_complete_terminates_at_done(self) -> None:
-        """TC-UT-TS-033: ``complete`` is the terminal transition.
+        """TC-UT-TS-033: ``complete`` はターミナル遷移。
 
-        ``current_stage_id`` is intentionally left as-is so downstream
-        consumers can read the last Stage.
+        ``current_stage_id`` は意図的にそのまま残して、
+        ダウンストリーム consumer が最後のステージを読める。
         """
         task = make_in_progress_task()
         original_stage = task.current_stage_id
@@ -136,7 +136,7 @@ class TestThirteenAllowedTransitions:
 
     # IN_PROGRESS → BLOCKED via block
     def test_block_attaches_last_error(self) -> None:
-        """TC-UT-TS-035: ``block`` requires non-empty last_error."""
+        """TC-UT-TS-035: ``block`` は non-empty last_error が必須。"""
         task = make_in_progress_task()
         out = task.block("auth retry exhausted", "AuthExpired: ...", updated_at=next_ts(task))
         assert out.status == TaskStatus.BLOCKED
@@ -144,7 +144,7 @@ class TestThirteenAllowedTransitions:
 
     # BLOCKED → IN_PROGRESS via unblock_retry, last_error cleared (§確定 D)
     def test_unblock_retry_clears_last_error(self) -> None:
-        """TC-UT-TS-008: ``unblock_retry`` clears last_error to None (§確定 D)."""
+        """TC-UT-TS-008: ``unblock_retry`` が last_error を None にクリア (§確定 D)。"""
         task = make_blocked_task(last_error="AuthExpired: synthetic")
         out = task.unblock_retry(updated_at=next_ts(task))
         assert out.status == TaskStatus.IN_PROGRESS
@@ -162,10 +162,10 @@ class TestThirteenAllowedTransitions:
         ids=lambda s: s.value,
     )
     def test_cancel_from_each_of_four_states(self, starting_status: TaskStatus) -> None:
-        """TC-UT-TS-034: ``cancel`` reaches CANCELLED from PENDING/IN_PROG/AWAITING/BLOCKED.
+        """TC-UT-TS-034: ``cancel`` が PENDING/IN_PROG/AWAITING/BLOCKED から CANCELLED に到達。
 
-        §確定 E enumerates exactly these 4 starting states; ``last_error``
-        is reset to None to keep the consistency invariant happy.
+        §確定 E はこれらの 4 つの開始状態を列挙；
+        ``last_error`` は None にリセットして整合性 invariant を満たす。
         """
         task = make_task_in_status(starting_status)
         out = task.cancel(uuid4(), "manual abort", updated_at=next_ts(task))

--- a/backend/tests/domain/task/test_task/test_state_machine_table.py
+++ b/backend/tests/domain/task/test_task/test_state_machine_table.py
@@ -61,7 +61,7 @@ class TestStateMachineTableLocked:
 class TestThirteenAllowedTransitions:
     """TC-UT-TS-003 / 008 / 030〜035 + cancel x 4 = 13 ✓ cells。"""
 
-    # PENDING → IN_PROGRESS via assign
+    # PENDING → IN_PROGRESS（assign 経由）
     def test_assign_pending_to_in_progress(self) -> None:
         """TC-UT-TS-003: PENDING で ``assign`` が IN_PROGRESS に移行。"""
         task = make_task()
@@ -72,7 +72,7 @@ class TestThirteenAllowedTransitions:
         # 元のタスク変更なし (frozen + pre-validate)
         assert task.status == TaskStatus.PENDING
 
-    # IN_PROGRESS self-loop via commit_deliverable
+    # IN_PROGRESS の self-loop（commit_deliverable 経由）
     def test_commit_deliverable_self_loop(self) -> None:
         """TC-UT-TS-030: IN_PROGRESS で ``commit_deliverable`` がステータス保持、エントリ追加。"""
         task = make_in_progress_task()
@@ -87,14 +87,14 @@ class TestThirteenAllowedTransitions:
         assert out.deliverables[task.current_stage_id] == deliverable
         assert out.updated_at > task.updated_at
 
-    # IN_PROGRESS → AWAITING via request_external_review
+    # IN_PROGRESS → AWAITING（request_external_review 経由）
     def test_request_external_review_to_awaiting(self) -> None:
         """TC-UT-TS-031: IN_PROGRESS → AWAITING_EXTERNAL_REVIEW。"""
         task = make_in_progress_task()
         out = task.request_external_review(updated_at=next_ts(task))
         assert out.status == TaskStatus.AWAITING_EXTERNAL_REVIEW
 
-    # AWAITING → IN_PROGRESS via approve_review (Gate APPROVED)
+    # AWAITING → IN_PROGRESS（approve_review 経由、Gate APPROVED）
     def test_approve_review_back_to_in_progress(self) -> None:
         """TC-UT-TS-032: ``approve_review`` が current_stage_id を前進。"""
         task = make_task_in_status(TaskStatus.AWAITING_EXTERNAL_REVIEW)
@@ -103,7 +103,7 @@ class TestThirteenAllowedTransitions:
         assert out.status == TaskStatus.IN_PROGRESS
         assert out.current_stage_id == next_stage
 
-    # AWAITING → IN_PROGRESS via reject_review (Gate REJECTED)
+    # AWAITING → IN_PROGRESS（reject_review 経由、Gate REJECTED）
     def test_reject_review_back_to_in_progress(self) -> None:
         """TC-UT-TS-032b: ``reject_review`` が current_stage_id をロールバック。"""
         task = make_task_in_status(TaskStatus.AWAITING_EXTERNAL_REVIEW)
@@ -112,7 +112,7 @@ class TestThirteenAllowedTransitions:
         assert out.status == TaskStatus.IN_PROGRESS
         assert out.current_stage_id == rollback_stage
 
-    # IN_PROGRESS self-loop via advance_to_next
+    # IN_PROGRESS の self-loop（advance_to_next 経由）
     def test_advance_to_next_keeps_in_progress(self) -> None:
         """TC-UT-TS-032c: ``advance_to_next`` が current_stage_id を更新、ステータス変更なし。"""
         task = make_in_progress_task()
@@ -121,7 +121,7 @@ class TestThirteenAllowedTransitions:
         assert out.status == TaskStatus.IN_PROGRESS
         assert out.current_stage_id == next_stage
 
-    # IN_PROGRESS → DONE via complete
+    # IN_PROGRESS → DONE（complete 経由）
     def test_complete_terminates_at_done(self) -> None:
         """TC-UT-TS-033: ``complete`` はターミナル遷移。
 
@@ -134,7 +134,7 @@ class TestThirteenAllowedTransitions:
         assert out.status == TaskStatus.DONE
         assert out.current_stage_id == original_stage
 
-    # IN_PROGRESS → BLOCKED via block
+    # IN_PROGRESS → BLOCKED（block 経由）
     def test_block_attaches_last_error(self) -> None:
         """TC-UT-TS-035: ``block`` は non-empty last_error が必須。"""
         task = make_in_progress_task()
@@ -142,7 +142,7 @@ class TestThirteenAllowedTransitions:
         assert out.status == TaskStatus.BLOCKED
         assert out.last_error == "AuthExpired: ..."
 
-    # BLOCKED → IN_PROGRESS via unblock_retry, last_error cleared (§確定 D)
+    # BLOCKED → IN_PROGRESS（unblock_retry 経由、last_error はクリア、§確定 D）
     def test_unblock_retry_clears_last_error(self) -> None:
         """TC-UT-TS-008: ``unblock_retry`` が last_error を None にクリア (§確定 D)。"""
         task = make_blocked_task(last_error="AuthExpired: synthetic")
@@ -150,7 +150,7 @@ class TestThirteenAllowedTransitions:
         assert out.status == TaskStatus.IN_PROGRESS
         assert out.last_error is None
 
-    # cancel from each of the 4 non-terminal states (§確定 E)
+    # 4 つの非ターミナル状態それぞれからの cancel（§確定 E）
     @pytest.mark.parametrize(
         "starting_status",
         [
@@ -173,5 +173,5 @@ class TestThirteenAllowedTransitions:
         assert out.last_error is None
 
 
-# Importing Deliverable / Task to use type checkers downstream
+# Deliverable / Task をダウンストリームの型チェッカ用にインポート
 _ = Deliverable, Task

--- a/backend/tests/domain/task/test_task/test_vo.py
+++ b/backend/tests/domain/task/test_task/test_vo.py
@@ -1,15 +1,13 @@
-"""Deliverable / Attachment VO + enum tests.
+"""Deliverable / Attachment VO + enum テスト.
 
-TC-UT-TS-012 / 013 / 036 / 037 — the value objects Task accumulates
-plus the two ``StrEnum``s that drive its lifecycle and error
-classification.
+TC-UT-TS-012 / 013 / 036 / 037 ── Task が積み上げる値オブジェクト群と、
+ライフサイクルとエラー分類を駆動する 2 つの ``StrEnum``。
 
-The Attachment 6-step sanitization pipeline is covered cell-by-cell
-so a regression on any single rejection rule shows up as a single
-named failure rather than as a generic "filename validation broken"
-sweep failure.
+Attachment の 6 段階サニタイズパイプラインはセル単位で網羅する ──
+任意の 1 ルールへのリグレッションが「filename validation broken」のような
+汎用一括失敗ではなく名前付きの単独失敗として顕在化するように。
 
-Per ``docs/features/task/test-design.md``.
+``docs/features/task/test-design.md`` 準拠。
 """
 
 from __future__ import annotations
@@ -27,42 +25,42 @@ from pydantic import ValidationError
 
 from tests.factories.task import make_attachment, make_deliverable
 
-# Canonical valid sha256 reused in multiple cases.
+# 複数のケースで使い回す canonical な妥当 sha256。
 _VALID_SHA = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
 
 # ---------------------------------------------------------------------------
-# TC-UT-TS-012: Deliverable construction + frozen + body_markdown cap
+# TC-UT-TS-012: Deliverable 構築 + frozen + body_markdown キャップ
 # ---------------------------------------------------------------------------
 class TestDeliverableConstruction:
-    """TC-UT-TS-012: Deliverable VO constructs valid + rejects oversize body."""
+    """TC-UT-TS-012: Deliverable VO は妥当値で構築でき、過大 body は拒絶する。"""
 
     def test_default_deliverable_constructs(self) -> None:
-        """Factory-default Deliverable has empty attachments + non-naive committed_at."""
+        """ファクトリ既定の Deliverable は空の attachments と aware な committed_at を持つ。"""
         d = make_deliverable()
         assert d.attachments == []
         assert d.committed_at.tzinfo is not None
 
     def test_deliverable_is_frozen(self) -> None:
-        """Direct attribute assignment on a Deliverable is rejected."""
+        """Deliverable への直接の属性代入は拒絶される。"""
         d = make_deliverable()
         with pytest.raises(ValidationError):
             d.body_markdown = "mutated"  # pyright: ignore[reportAttributeAccessIssue]
 
     def test_body_markdown_at_max_length_accepted(self) -> None:
-        """1,000,000-char body_markdown is at the cap and accepted."""
+        """1,000,000 文字の body_markdown はキャップ上限で受理される。"""
         body = "x" * 1_000_000
         d = make_deliverable(body_markdown=body)
         assert len(d.body_markdown) == 1_000_000
 
     def test_body_markdown_over_max_length_rejected(self) -> None:
-        """1,000,001-char body_markdown exceeds the cap and raises."""
+        """1,000,001 文字の body_markdown はキャップ超過で例外発火。"""
         body = "x" * 1_000_001
         with pytest.raises(ValidationError):
             make_deliverable(body_markdown=body)
 
     def test_naive_committed_at_rejected(self) -> None:
-        """``committed_at`` without a timezone is rejected."""
+        """tz 情報なしの ``committed_at`` は拒絶される。"""
         naive = datetime.now()
         with pytest.raises(ValidationError):
             Deliverable(
@@ -75,96 +73,96 @@ class TestDeliverableConstruction:
 
 
 # ---------------------------------------------------------------------------
-# TC-UT-TS-013: Attachment 6-step sanitize + sha256 + mime + size
+# TC-UT-TS-013: Attachment 6 段階 sanitize + sha256 + mime + size
 # ---------------------------------------------------------------------------
 class TestAttachmentSha256:
-    """TC-UT-TS-013 step 0: sha256 = 64 lowercase hex chars."""
+    """TC-UT-TS-013 step 0: sha256 = 64 桁の小文字 hex。"""
 
     def test_64_hex_lowercase_accepted(self) -> None:
-        """The canonical happy-path sha256."""
+        """正常系の canonical な sha256。"""
         a = make_attachment(sha256=_VALID_SHA)
         assert a.sha256 == _VALID_SHA
 
     def test_63_chars_rejected(self) -> None:
-        """A 63-char digest (one short) is rejected."""
+        """63 文字 (1 文字足りない) digest は拒絶される。"""
         with pytest.raises(ValidationError):
             make_attachment(sha256=_VALID_SHA[:-1])
 
     def test_uppercase_rejected(self) -> None:
-        """Mixed-case hex is rejected (the regex is lowercase-only)."""
+        """大小混在 hex は拒絶される (正規表現は小文字のみ)。"""
         mixed = "0123456789ABCDEF" + _VALID_SHA[16:]
         with pytest.raises(ValidationError):
             make_attachment(sha256=mixed)
 
     def test_non_hex_rejected(self) -> None:
-        """Non-hex characters in the right length still fail the pattern."""
+        """正しい長さでも非 hex 文字はパターンに失敗する。"""
         bogus = "z" * 64
         with pytest.raises(ValidationError):
             make_attachment(sha256=bogus)
 
 
 class TestAttachmentFilenameSanitization:
-    """TC-UT-TS-013: filename 6-step sanitization pipeline.
+    """TC-UT-TS-013: filename 6 段階サニタイズパイプライン。
 
-    Each step's rejection rule has its own test so regressions
-    surface with a precise label rather than a generic "filename
-    validation broken" wave failure.
+    各ステップの拒絶ルールに専用テストを置く ── リグレッションが
+    汎用 "filename validation broken" 一括失敗ではなく、明確なラベル付き
+    単独失敗として表面化するように。
     """
 
-    # Step 1-2: NFC + length [1, 255]
+    # Step 1-2: NFC + 長さ [1, 255]
     def test_empty_filename_rejected(self) -> None:
-        """Length 0 fails the [1, 255] band."""
+        """長さ 0 は [1, 255] バンドに失敗する。"""
         with pytest.raises(ValidationError):
             make_attachment(filename="")
 
     def test_256_char_filename_rejected(self) -> None:
-        """Length 256 exceeds the cap."""
+        """長さ 256 はキャップ超過。"""
         with pytest.raises(ValidationError):
             make_attachment(filename="a" * 256)
 
     def test_255_char_filename_accepted(self) -> None:
-        """Length 255 is at the cap and accepted."""
+        """長さ 255 はキャップ上限で受理される。"""
         a = make_attachment(filename="a" * 255)
         assert len(a.filename) == 255
 
-    # Step 3: rejected characters (path separators, NUL, control chars)
+    # Step 3: 拒絶文字 (パス区切り、NUL、制御文字)
     @pytest.mark.parametrize(
         "bad",
         ["a/b.txt", "a\\b.txt", "name\x00.png", "name\x01.png", "name\x7f.png"],
         ids=["forward_slash", "back_slash", "null_byte", "control_char", "del_char"],
     )
     def test_rejected_characters(self, bad: str) -> None:
-        """Path separators / NUL / ASCII control chars are rejected."""
+        """パス区切り / NUL / ASCII 制御文字は拒絶される。"""
         with pytest.raises(ValidationError):
             make_attachment(filename=bad)
 
-    # Step 4: rejected sequences
+    # Step 4: 拒絶シーケンス
     def test_dot_dot_path_traversal_rejected(self) -> None:
-        """``..`` anywhere in the name is rejected."""
+        """name 中の任意箇所にある ``..`` は拒絶される。"""
         with pytest.raises(ValidationError):
             make_attachment(filename="..hidden.png")
 
     def test_leading_dot_rejected(self) -> None:
-        """Hidden file (leading ``.``) is rejected."""
+        """先頭が ``.`` の隠しファイルは拒絶される。"""
         with pytest.raises(ValidationError):
             make_attachment(filename=".hidden.png")
 
     def test_trailing_dot_rejected(self) -> None:
-        """Trailing ``.`` (Windows extension trick) is rejected."""
+        """末尾の ``.`` (Windows 拡張子トリック) は拒絶される。"""
         with pytest.raises(ValidationError):
             make_attachment(filename="file.png.")
 
     def test_leading_whitespace_rejected(self) -> None:
-        """Leading whitespace is rejected."""
+        """先頭空白は拒絶される。"""
         with pytest.raises(ValidationError):
             make_attachment(filename=" file.png")
 
     def test_colon_rejected(self) -> None:
-        """``:`` (Windows ADS / drive letter) is rejected."""
+        """``:`` (Windows ADS / ドライブレター) は拒絶される。"""
         with pytest.raises(ValidationError):
             make_attachment(filename="file:stream.png")
 
-    # Step 5: Windows reserved device names
+    # Step 5: Windows 予約デバイス名
     @pytest.mark.parametrize(
         "reserved",
         ["CON", "PRN", "AUX", "NUL", "COM1.txt", "LPT9.bin", "con.png", "Com2.bin"],
@@ -180,28 +178,24 @@ class TestAttachmentFilenameSanitization:
         ],
     )
     def test_windows_reserved_names_rejected(self, reserved: str) -> None:
-        """Windows reserved device names with or without extensions are rejected."""
+        """Windows 予約デバイス名は拡張子の有無を問わず拒絶される。"""
         with pytest.raises(ValidationError):
             make_attachment(filename=reserved)
 
-    # Step 6: basename round-trip
+    # Step 6: basename ラウンドトリップ
     def test_path_component_rejected_via_basename_check(self) -> None:
-        """A path-shaped name fails the basename round-trip."""
-        # ``a/b.txt`` is already caught by step 3, but ``foo/bar`` style
-        # paths embedded with various separators still fail step 6.
-        # We exercise this via a slash-containing name that step 3
-        # already rejects, plus directly through the path round-trip
-        # via a UNC-style prefix that step 3 might miss.
-        # In practice all path-shapes are covered by step 3; step 6 is
-        # the defensive double-check, so the assertion is shape:
-        # any rejection at all is acceptable as long as ValidationError
-        # fires.
+        """パス形状の name は basename ラウンドトリップに失敗する。"""
+        # ``a/b.txt`` は step 3 で既に検出されるが、各種区切りを埋め込んだ
+        # ``foo/bar`` 形のパスは step 6 で失敗する。
+        # 実用上はあらゆるパス形状が step 3 で拾われ、step 6 は防御的な
+        # ダブルチェック ── したがってアサート形は ValidationError が
+        # 発火しさえすれば任意の段階で拒絶されたとみなして良い。
         with pytest.raises(ValidationError):
             make_attachment(filename="dir/file.png")
 
 
 class TestAttachmentMimeWhitelist:
-    """TC-UT-TS-013: mime_type whitelist rejects text/html and text/csv."""
+    """TC-UT-TS-013: mime_type ホワイトリストは text/html と text/csv を拒絶。"""
 
     @pytest.mark.parametrize(
         "mime",
@@ -217,7 +211,7 @@ class TestAttachmentMimeWhitelist:
         ],
     )
     def test_whitelisted_mime_accepted(self, mime: str) -> None:
-        """All 8 whitelisted MIME types construct cleanly."""
+        """ホワイトリスト 8 種の MIME 全てで構築に成功する。"""
         a = make_attachment(mime_type=mime)
         assert a.mime_type == mime
 
@@ -227,37 +221,37 @@ class TestAttachmentMimeWhitelist:
         ids=["text_html", "text_csv", "shell_script", "empty"],
     )
     def test_non_whitelisted_mime_rejected(self, mime: str) -> None:
-        """Non-whitelisted MIME values are rejected — XSS / CSV-injection guard."""
+        """ホワイトリスト外の MIME は拒絶される ── XSS / CSV-injection 防御。"""
         with pytest.raises(ValidationError):
             make_attachment(mime_type=mime)
 
 
 class TestAttachmentSizeBytes:
-    """TC-UT-TS-013: size_bytes ∈ [0, 10 MiB]."""
+    """TC-UT-TS-013: size_bytes ∈ [0, 10 MiB]。"""
 
     def test_zero_bytes_accepted(self) -> None:
-        """An empty attachment (0 bytes) is accepted."""
+        """空の attachment (0 byte) は受理される。"""
         a = make_attachment(size_bytes=0)
         assert a.size_bytes == 0
 
     def test_at_max_accepted(self) -> None:
-        """10 MiB exactly is the cap and accepted."""
+        """ちょうど 10 MiB はキャップ上限で受理される。"""
         a = make_attachment(size_bytes=10 * 1024 * 1024)
         assert a.size_bytes == 10 * 1024 * 1024
 
     def test_over_max_rejected(self) -> None:
-        """10 MiB + 1 byte exceeds the cap."""
+        """10 MiB + 1 byte はキャップ超過。"""
         with pytest.raises(ValidationError):
             make_attachment(size_bytes=10 * 1024 * 1024 + 1)
 
     def test_negative_rejected(self) -> None:
-        """Negative size is rejected."""
+        """負のサイズは拒絶される。"""
         with pytest.raises(ValidationError):
             make_attachment(size_bytes=-1)
 
 
 class TestAttachmentFrozen:
-    """Attachment is frozen — direct attribute assignment is rejected."""
+    """Attachment は frozen ── 直接の属性代入は拒絶される。"""
 
     def test_size_bytes_assignment_rejected(self) -> None:
         a = make_attachment()
@@ -266,18 +260,18 @@ class TestAttachmentFrozen:
 
 
 # ---------------------------------------------------------------------------
-# TC-UT-TS-036: TaskStatus enum values
+# TC-UT-TS-036: TaskStatus enum 値
 # ---------------------------------------------------------------------------
 class TestTaskStatusEnum:
-    """TC-UT-TS-036: 6 StrEnum values; StrEnum equality with raw strings."""
+    """TC-UT-TS-036: StrEnum 6 値、生文字列との等価性。"""
 
     def test_six_values(self) -> None:
-        """Exactly 6 TaskStatus members."""
+        """TaskStatus メンバはちょうど 6 個。"""
         members = list(TaskStatus)
         assert len(members) == 6
 
     def test_str_enum_equality(self) -> None:
-        """StrEnum members compare equal to their string value."""
+        """StrEnum メンバはその文字列値と等価比較される。"""
         assert TaskStatus.PENDING == "PENDING"
         assert TaskStatus.IN_PROGRESS == "IN_PROGRESS"
         assert TaskStatus.AWAITING_EXTERNAL_REVIEW == "AWAITING_EXTERNAL_REVIEW"
@@ -287,18 +281,18 @@ class TestTaskStatusEnum:
 
 
 # ---------------------------------------------------------------------------
-# TC-UT-TS-037: LLMErrorKind enum values
+# TC-UT-TS-037: LLMErrorKind enum 値
 # ---------------------------------------------------------------------------
 class TestLLMErrorKindEnum:
-    """TC-UT-TS-037: 5 StrEnum values for LLM-Adapter classification."""
+    """TC-UT-TS-037: LLM-Adapter 分類のための StrEnum 5 値。"""
 
     def test_five_values(self) -> None:
-        """Exactly 5 LLMErrorKind members."""
+        """LLMErrorKind メンバはちょうど 5 個。"""
         members = list(LLMErrorKind)
         assert len(members) == 5
 
     def test_str_enum_equality(self) -> None:
-        """StrEnum members compare equal to their string value."""
+        """StrEnum メンバはその文字列値と等価比較される。"""
         assert LLMErrorKind.SESSION_LOST == "SESSION_LOST"
         assert LLMErrorKind.RATE_LIMITED == "RATE_LIMITED"
         assert LLMErrorKind.AUTH_EXPIRED == "AUTH_EXPIRED"
@@ -307,13 +301,13 @@ class TestLLMErrorKindEnum:
 
 
 # ---------------------------------------------------------------------------
-# Sanity: a Deliverable carries Attachments and round-trips cleanly
+# サニティ: Deliverable は Attachment を運び、ラウンドトリップに耐える
 # ---------------------------------------------------------------------------
 class TestDeliverableWithAttachments:
-    """A Deliverable with attachments carries them through to the model."""
+    """attachments を持つ Deliverable はそのままモデルに伝搬する。"""
 
     def test_attachments_preserved(self) -> None:
-        """Attachments list is preserved verbatim in Deliverable."""
+        """attachments リストは Deliverable で逐字保持される。"""
         a = make_attachment()
         d = Deliverable(
             stage_id=uuid4(),
@@ -325,7 +319,7 @@ class TestDeliverableWithAttachments:
         assert d.attachments == [a]
 
     def test_make_attachment_synthetic(self) -> None:
-        """The factory's :func:`is_synthetic` flag fires on freshly-built attachments."""
+        """ファクトリの :func:`is_synthetic` フラグは新規構築 attachment で発火する。"""
         from tests.factories.task import is_synthetic
 
         a = make_attachment()

--- a/backend/tests/domain/test_empire.py
+++ b/backend/tests/domain/test_empire.py
@@ -1,15 +1,15 @@
-"""Unit + integration tests for the Empire aggregate root.
+"""Empire アグリゲートルートのユニット + 結合テスト.
 
-Covers TC-UT-EM-001〜023 and TC-IT-EM-001〜002 from
-``docs/features/empire/test-design.md``. Tests are grouped into ``Test*``
-classes by feature surface (construction, name boundaries, hire, capacity,
-archive, pre-validate rollback, frozen contract, MSG wording, lifecycle
-integration). Each test docstring carries the trace anchor (TC-ID, REQ-ID,
-MSG-ID where applicable).
+``docs/features/empire/test-design.md`` の TC-UT-EM-001〜023 と
+TC-IT-EM-001〜002 を網羅する。テストは機能面 (構築、name 境界値、hire、
+キャパシティ、archive、pre-validate ロールバック、frozen 契約、MSG 文言、
+ライフサイクル統合) ごとに ``Test*`` クラスにグルーピングしている。
+各テストの docstring にトレース用アンカー (TC-ID, REQ-ID, 該当する場合は
+MSG-ID) を記載する。
 
-Integration scenarios live in this file rather than under ``integration/``
-because the aggregate is pure domain (zero external I/O) — the test-design
-intentionally consolidates "Aggregate-internal round-trip" cases here.
+統合シナリオは ``integration/`` 配下ではなく本ファイルに置く ──
+このアグリゲートは純粋ドメイン (外部 I/O ゼロ) であり、test-design が
+意図的に「Aggregate 内部ラウンドトリップ」ケースをここに集約しているため。
 """
 
 from __future__ import annotations
@@ -26,84 +26,83 @@ from pydantic import ValidationError
 from tests.factories.empire import make_agent_ref, make_empire, make_room_ref
 
 # ===========================================================================
-# REQ-EM-001 — Construction & name normalization
+# REQ-EM-001 ── 構築 + name 正規化
 # ===========================================================================
 
 
 class TestEmpireConstruction:
-    """Empire(id, name) initialization contract (TC-UT-EM-001)."""
+    """Empire(id, name) 初期化契約 (TC-UT-EM-001)。"""
 
     def test_minimal_empire_has_empty_rooms_and_agents(self) -> None:
-        """TC-UT-EM-001: minimal Empire(id, name) returns rooms=[] / agents=[]."""
+        """TC-UT-EM-001: 最小構成の Empire(id, name) は rooms=[] / agents=[] を返す。"""
         empire = make_empire(name="山田の幕府")
         assert empire.rooms == [] and empire.agents == []
 
     def test_construction_preserves_input_name(self) -> None:
-        """TC-UT-EM-001: Empire.name reflects input after NFC+strip pipeline."""
+        """TC-UT-EM-001: NFC+strip パイプライン後も Empire.name が入力を反映する。"""
         empire = make_empire(name="山田の幕府")
         assert empire.name == "山田の幕府"
 
 
 class TestEmpireNameBoundaries:
-    """Empire.name length contract (TC-UT-EM-002, MSG-EM-001)."""
+    """Empire.name 長さ契約 (TC-UT-EM-002, MSG-EM-001)。"""
 
     @pytest.mark.parametrize("valid_length", [1, 80])
     def test_accepts_lower_and_upper_boundary(self, valid_length: int) -> None:
-        """TC-UT-EM-002: 1-char and 80-char names construct successfully."""
+        """TC-UT-EM-002: 1 文字 / 80 文字の name で構築に成功する。"""
         empire = make_empire(name="a" * valid_length)
         assert len(empire.name) == valid_length
 
     @pytest.mark.parametrize("invalid_name", ["", "a" * 81, "   "])
     def test_rejects_zero_eightyone_or_whitespace_only(self, invalid_name: str) -> None:
-        """TC-UT-EM-002: 0-char / 81-char / whitespace-only names raise."""
+        """TC-UT-EM-002: 0 文字 / 81 文字 / 空白のみの name は例外発火。"""
         with pytest.raises(EmpireInvariantViolation) as excinfo:
             make_empire(name=invalid_name)
         assert excinfo.value.kind == "name_range"
 
 
 class TestEmpireNameNormalization:
-    """NFC + strip pipeline (TC-UT-EM-003, Confirmation B)."""
+    """NFC + strip パイプライン (TC-UT-EM-003, Confirmation B)。"""
 
     def test_decomposed_kana_is_normalized_to_nfc(self) -> None:
-        """TC-UT-EM-003: decomposed kana with dakuten is normalized to NFC form."""
-        # 'がが' has true decomposition: U+304C → U+304B U+3099 (kana + combining
-        # voicing mark). Pure katakana like テスト has no decomposition, so
-        # cannot demonstrate the NFC pipeline.
+        """TC-UT-EM-003: 濁点付きの分解仮名が NFC 形へ正規化される。"""
+        # 'がが' は実際に分解可能: U+304C → U+304B U+3099 (仮名 + 結合濁点)。
+        # 純カタカナの「テスト」には分解形が無く、NFC パイプラインを示せない。
         composed = "がが"
         decomposed = unicodedata.normalize("NFD", composed)
-        assert decomposed != composed  # sanity: input is actually decomposed
+        assert decomposed != composed  # 入力が実際に分解形であることを確認
         empire = make_empire(name=decomposed)
         assert empire.name == composed
 
     def test_surrounding_whitespace_is_stripped(self) -> None:
-        """TC-UT-EM-003: leading/trailing whitespace is stripped before storage."""
+        """TC-UT-EM-003: 前後の空白は保存前に strip される。"""
         empire = make_empire(name="  山田の幕府  ")
         assert empire.name == "山田の幕府"
 
 
 # ===========================================================================
-# REQ-EM-002 — hire_agent
+# REQ-EM-002 ── hire_agent
 # ===========================================================================
 
 
 class TestHireAgent:
-    """hire_agent contract (TC-UT-EM-004 / 005 / 006)."""
+    """hire_agent 契約 (TC-UT-EM-004 / 005 / 006)。"""
 
     def test_appends_new_agent_to_list(self) -> None:
-        """TC-UT-EM-004: hire_agent returns a new Empire with the agent appended."""
+        """TC-UT-EM-004: hire_agent は agent を追加した新 Empire を返す。"""
         empire = make_empire()
         agent = make_agent_ref()
         updated = empire.hire_agent(agent)
         assert updated.agents == [agent]
 
     def test_does_not_mutate_original_aggregate(self) -> None:
-        """TC-UT-EM-004: original Empire's agents stay empty after hire_agent."""
+        """TC-UT-EM-004: 元 Empire の agents は hire_agent 後も空のまま。"""
         empire = make_empire()
         empire.hire_agent(make_agent_ref())
         assert empire.agents == []
 
     def test_three_consecutive_distinct_hires_all_persist(self) -> None:
-        """TC-UT-EM-005: chained hire_agent yields all three distinct agents."""
+        """TC-UT-EM-005: hire_agent をチェーンすると 3 件の別 agent が全て残る。"""
         empire = make_empire()
         a1, a2, a3 = make_agent_ref(), make_agent_ref(), make_agent_ref()
         final = empire.hire_agent(a1).hire_agent(a2).hire_agent(a3)
@@ -114,7 +113,7 @@ class TestHireAgent:
         }
 
     def test_rejects_duplicate_agent_id(self) -> None:
-        """TC-UT-EM-006: rehiring the same agent_id raises agent_duplicate."""
+        """TC-UT-EM-006: 同一 agent_id の再採用は agent_duplicate を発火する。"""
         empire = make_empire()
         agent = make_agent_ref()
         after_first_hire = empire.hire_agent(agent)
@@ -125,17 +124,17 @@ class TestHireAgent:
 
 
 class TestHireAgentCapacity:
-    """hire_agent capacity boundary (TC-UT-EM-007, Confirmation C)."""
+    """hire_agent キャパシティ境界 (TC-UT-EM-007, Confirmation C)。"""
 
     def test_succeeds_at_max_agents(self) -> None:
-        """TC-UT-EM-007: hiring up to MAX_AGENTS succeeds."""
+        """TC-UT-EM-007: MAX_AGENTS まで hire は成功する。"""
         empire = make_empire()
         for _ in range(MAX_AGENTS):
             empire = empire.hire_agent(make_agent_ref())
         assert len(empire.agents) == MAX_AGENTS
 
     def test_overflow_raises_capacity_exceeded(self) -> None:
-        """TC-UT-EM-007: hiring the (MAX_AGENTS+1)-th agent raises capacity_exceeded."""
+        """TC-UT-EM-007: (MAX_AGENTS+1) 番目の hire は capacity_exceeded を発火する。"""
         empire = make_empire()
         for _ in range(MAX_AGENTS):
             empire = empire.hire_agent(make_agent_ref())
@@ -145,28 +144,28 @@ class TestHireAgentCapacity:
 
 
 # ===========================================================================
-# REQ-EM-003 — establish_room
+# REQ-EM-003 ── establish_room
 # ===========================================================================
 
 
 class TestEstablishRoom:
-    """establish_room contract (TC-UT-EM-008 / 009)."""
+    """establish_room 契約 (TC-UT-EM-008 / 009)。"""
 
     def test_appends_new_room_to_list(self) -> None:
-        """TC-UT-EM-008: establish_room returns a new Empire with the room appended."""
+        """TC-UT-EM-008: establish_room は room を追加した新 Empire を返す。"""
         empire = make_empire()
         room = make_room_ref()
         updated = empire.establish_room(room)
         assert updated.rooms == [room]
 
     def test_does_not_mutate_original_aggregate(self) -> None:
-        """TC-UT-EM-008: original Empire's rooms stay empty after establish_room."""
+        """TC-UT-EM-008: 元 Empire の rooms は establish_room 後も空のまま。"""
         empire = make_empire()
         empire.establish_room(make_room_ref())
         assert empire.rooms == []
 
     def test_rejects_duplicate_room_id(self) -> None:
-        """TC-UT-EM-009: re-establishing the same room_id raises room_duplicate."""
+        """TC-UT-EM-009: 同一 room_id の再 establish は room_duplicate を発火する。"""
         empire = make_empire()
         room = make_room_ref()
         after_first = empire.establish_room(room)
@@ -177,17 +176,17 @@ class TestEstablishRoom:
 
 
 class TestEstablishRoomCapacity:
-    """establish_room capacity boundary (TC-UT-EM-010, Confirmation C)."""
+    """establish_room キャパシティ境界 (TC-UT-EM-010, Confirmation C)。"""
 
     def test_succeeds_at_max_rooms(self) -> None:
-        """TC-UT-EM-010: establishing up to MAX_ROOMS succeeds."""
+        """TC-UT-EM-010: MAX_ROOMS まで establish は成功する。"""
         empire = make_empire()
         for _ in range(MAX_ROOMS):
             empire = empire.establish_room(make_room_ref())
         assert len(empire.rooms) == MAX_ROOMS
 
     def test_overflow_raises_capacity_exceeded(self) -> None:
-        """TC-UT-EM-010: establishing the (MAX_ROOMS+1)-th room raises capacity_exceeded."""
+        """TC-UT-EM-010: (MAX_ROOMS+1) 番目の establish は capacity_exceeded を発火する。"""
         empire = make_empire()
         for _ in range(MAX_ROOMS):
             empire = empire.establish_room(make_room_ref())
@@ -197,15 +196,15 @@ class TestEstablishRoomCapacity:
 
 
 # ===========================================================================
-# REQ-EM-004 — archive_room
+# REQ-EM-004 ── archive_room
 # ===========================================================================
 
 
 class TestArchiveRoom:
-    """archive_room contract (TC-UT-EM-011 / 012 / 013)."""
+    """archive_room 契約 (TC-UT-EM-011 / 012 / 013)。"""
 
     def test_marks_target_room_as_archived(self) -> None:
-        """TC-UT-EM-011: archive_room flips archived=True on the matching RoomRef."""
+        """TC-UT-EM-011: archive_room は対象 RoomRef の archived を True にする。"""
         rooms = [make_room_ref(), make_room_ref(), make_room_ref()]
         empire = make_empire(rooms=rooms)
         target = rooms[1]
@@ -214,7 +213,7 @@ class TestArchiveRoom:
         assert archived.archived is True
 
     def test_leaves_other_rooms_unchanged(self) -> None:
-        """TC-UT-EM-011: rooms other than the target retain archived=False."""
+        """TC-UT-EM-011: 対象以外の room は archived=False のまま維持される。"""
         rooms = [make_room_ref(), make_room_ref(), make_room_ref()]
         empire = make_empire(rooms=rooms)
         target = rooms[1]
@@ -223,14 +222,14 @@ class TestArchiveRoom:
         assert all(r.archived is False for r in others)
 
     def test_unknown_room_id_raises_room_not_found(self) -> None:
-        """TC-UT-EM-012: archiving a non-existent room_id raises room_not_found."""
+        """TC-UT-EM-012: 存在しない room_id への archive は room_not_found を発火する。"""
         empire = make_empire(rooms=[make_room_ref()])
         with pytest.raises(EmpireInvariantViolation) as excinfo:
             empire.archive_room(uuid4())
         assert excinfo.value.kind == "room_not_found"
 
     def test_does_not_physically_delete_target(self) -> None:
-        """TC-UT-EM-013: archive_room preserves rooms list length (logical archive)."""
+        """TC-UT-EM-013: archive_room は rooms 配列長を保つ (論理アーカイブ)。"""
         rooms = [make_room_ref()]
         empire = make_empire(rooms=rooms)
         updated = empire.archive_room(rooms[0].room_id)
@@ -238,15 +237,15 @@ class TestArchiveRoom:
 
 
 # ===========================================================================
-# REQ-EM-005 — pre-validate rollback (Confirmation A)
+# REQ-EM-005 ── pre-validate ロールバック (Confirmation A)
 # ===========================================================================
 
 
 class TestPreValidateRollback:
-    """Failed mutations leave the original Empire unchanged (TC-UT-EM-014〜016)."""
+    """ミューテーション失敗時、元 Empire は変更されない (TC-UT-EM-014〜016)。"""
 
     def test_failed_hire_agent_keeps_original_empire(self) -> None:
-        """TC-UT-EM-014: failed hire_agent does not mutate caller's Empire."""
+        """TC-UT-EM-014: hire_agent 失敗は呼び出し側の Empire を変更しない。"""
         agent = make_agent_ref()
         empire = make_empire(agents=[agent])
         with pytest.raises(EmpireInvariantViolation):
@@ -254,7 +253,7 @@ class TestPreValidateRollback:
         assert empire.agents == [agent]
 
     def test_failed_establish_room_keeps_original_empire(self) -> None:
-        """TC-UT-EM-015: failed establish_room does not mutate caller's Empire."""
+        """TC-UT-EM-015: establish_room 失敗は呼び出し側の Empire を変更しない。"""
         room = make_room_ref()
         empire = make_empire(rooms=[room])
         with pytest.raises(EmpireInvariantViolation):
@@ -262,7 +261,7 @@ class TestPreValidateRollback:
         assert empire.rooms == [room]
 
     def test_failed_archive_room_keeps_archived_flags(self) -> None:
-        """TC-UT-EM-016: failed archive_room preserves all archived flags."""
+        """TC-UT-EM-016: archive_room 失敗は archived フラグ群を保つ。"""
         room = make_room_ref()
         empire = make_empire(rooms=[room])
         with pytest.raises(EmpireInvariantViolation):
@@ -271,37 +270,37 @@ class TestPreValidateRollback:
 
 
 # ===========================================================================
-# Frozen contract & extra='forbid' (REQ-EM-005)
+# Frozen 契約 + extra='forbid' (REQ-EM-005)
 # ===========================================================================
 
 
 class TestFrozenContract:
-    """frozen=True forbids attribute assignment (TC-UT-EM-017)."""
+    """frozen=True は属性代入を禁ずる (TC-UT-EM-017)。"""
 
     def test_empire_rejects_attribute_assignment(self) -> None:
-        """TC-UT-EM-017: Empire is frozen — direct attribute set raises."""
+        """TC-UT-EM-017: Empire は frozen ── 直接の属性代入は例外発火。"""
         empire = make_empire()
         with pytest.raises(ValidationError):
             empire.name = "改竄"  # type: ignore[misc]
 
     def test_room_ref_rejects_attribute_assignment(self) -> None:
-        """TC-UT-EM-017: RoomRef is frozen — direct attribute set raises."""
+        """TC-UT-EM-017: RoomRef は frozen ── 直接の属性代入は例外発火。"""
         ref = make_room_ref()
         with pytest.raises(ValidationError):
             ref.archived = True  # type: ignore[misc]
 
     def test_agent_ref_rejects_attribute_assignment(self) -> None:
-        """TC-UT-EM-017: AgentRef is frozen — direct attribute set raises."""
+        """TC-UT-EM-017: AgentRef は frozen ── 直接の属性代入は例外発火。"""
         ref = make_agent_ref()
         with pytest.raises(ValidationError):
             ref.role = Role.LEADER  # type: ignore[misc]
 
 
 class TestExtraForbid:
-    """extra='forbid' rejects unknown fields (TC-UT-EM-018)."""
+    """extra='forbid' は未知フィールドを拒絶する (TC-UT-EM-018)。"""
 
     def test_model_validate_rejects_unknown_field(self) -> None:
-        """TC-UT-EM-018: extra='forbid' rejects unknown fields at construction."""
+        """TC-UT-EM-018: extra='forbid' は構築時に未知フィールドを拒絶する。"""
         payload: dict[str, object] = {
             "id": str(uuid4()),
             "name": "ok",
@@ -314,27 +313,27 @@ class TestExtraForbid:
 
 
 # ===========================================================================
-# MSG-EM-001〜005 — exact wording assertions
+# MSG-EM-001〜005 ── 文言の厳密一致アサート
 # ===========================================================================
 
 
 class TestMessageWording:
-    """Message strings match detailed-design §MSG exactly (TC-UT-EM-019〜023)."""
+    """メッセージ文字列が detailed-design §MSG と完全一致する (TC-UT-EM-019〜023)。"""
 
     def test_msg_em_001_for_oversized_name(self) -> None:
-        """TC-UT-EM-019: MSG-EM-001 wording matches '[FAIL] Empire name ...'."""
+        """TC-UT-EM-019: MSG-EM-001 文言が '[FAIL] Empire name ...' に一致する。"""
         with pytest.raises(EmpireInvariantViolation) as excinfo:
             make_empire(name="a" * 81)
         assert excinfo.value.message == "[FAIL] Empire name must be 1-80 characters (got 81)"
 
     def test_msg_em_001_for_whitespace_only_reports_post_strip_length(self) -> None:
-        """TC-UT-EM-019: NFC+strip pipeline reports length=0 for whitespace-only input."""
+        """TC-UT-EM-019: NFC+strip パイプラインは空白のみ入力で長さ 0 を報告する。"""
         with pytest.raises(EmpireInvariantViolation) as excinfo:
             make_empire(name="   ")
         assert excinfo.value.message == "[FAIL] Empire name must be 1-80 characters (got 0)"
 
     def test_msg_em_002_includes_duplicate_agent_id(self) -> None:
-        """TC-UT-EM-020: MSG-EM-002 wording carries the offending agent_id."""
+        """TC-UT-EM-020: MSG-EM-002 文言は重複 agent_id を含む。"""
         agent = make_agent_ref()
         empire = make_empire(agents=[agent])
         with pytest.raises(EmpireInvariantViolation) as excinfo:
@@ -342,7 +341,7 @@ class TestMessageWording:
         assert excinfo.value.message == f"[FAIL] Agent already hired: agent_id={agent.agent_id}"
 
     def test_msg_em_003_includes_duplicate_room_id(self) -> None:
-        """TC-UT-EM-021: MSG-EM-003 wording carries the offending room_id."""
+        """TC-UT-EM-021: MSG-EM-003 文言は重複 room_id を含む。"""
         room = make_room_ref()
         empire = make_empire(rooms=[room])
         with pytest.raises(EmpireInvariantViolation) as excinfo:
@@ -350,7 +349,7 @@ class TestMessageWording:
         assert excinfo.value.message == f"[FAIL] Room already established: room_id={room.room_id}"
 
     def test_msg_em_004_includes_missing_room_id(self) -> None:
-        """TC-UT-EM-022: MSG-EM-004 wording carries the missing room_id."""
+        """TC-UT-EM-022: MSG-EM-004 文言は欠落した room_id を含む。"""
         empire = make_empire()
         unknown = uuid4()
         with pytest.raises(EmpireInvariantViolation) as excinfo:
@@ -358,7 +357,7 @@ class TestMessageWording:
         assert excinfo.value.message == f"[FAIL] Room not found in Empire: room_id={unknown}"
 
     def test_msg_em_005_uses_invariant_violation_prefix(self) -> None:
-        """TC-UT-EM-023: MSG-EM-005 starts with '[FAIL] Empire invariant violation:'."""
+        """TC-UT-EM-023: MSG-EM-005 は '[FAIL] Empire invariant violation:' で始まる。"""
         empire = make_empire()
         for _ in range(MAX_AGENTS):
             empire = empire.hire_agent(make_agent_ref())
@@ -368,15 +367,15 @@ class TestMessageWording:
 
 
 # ===========================================================================
-# Integration scenarios — Aggregate-internal round trip (TC-IT-EM-001 / 002)
+# 統合シナリオ ── Aggregate 内部のラウンドトリップ (TC-IT-EM-001 / 002)
 # ===========================================================================
 
 
 class TestEmpireLifecycleIntegration:
-    """Aggregate-internal round-trip and resilience (TC-IT-EM-001 / 002)."""
+    """Aggregate 内部のラウンドトリップと耐性 (TC-IT-EM-001 / 002)。"""
 
     def test_full_lifecycle_hire_establish_archive_round_trip(self) -> None:
-        """TC-IT-EM-001: Empire→hire→establish→archive yields expected final state."""
+        """TC-IT-EM-001: Empire→hire→establish→archive で期待される最終状態に達する。"""
         empire = make_empire()
         agent = make_agent_ref()
         room = make_room_ref()
@@ -391,26 +390,26 @@ class TestEmpireLifecycleIntegration:
         )
 
     def test_full_lifecycle_keeps_intermediates_immutable(self) -> None:
-        """TC-IT-EM-001: every intermediate Empire stays unmodified through the chain."""
+        """TC-IT-EM-001: チェーン中の各中間 Empire は変更されないまま維持される。"""
         empire = make_empire()
         after_hire = empire.hire_agent(make_agent_ref())
-        after_hire.establish_room(make_room_ref())  # discard return value
+        after_hire.establish_room(make_room_ref())  # 戻り値を破棄
         assert empire.agents == [] and empire.rooms == [] and len(after_hire.rooms) == 0
 
     def test_failed_hire_does_not_block_subsequent_operations(self) -> None:
-        """TC-IT-EM-002: a failed hire_agent leaves Empire ready for further changes."""
+        """TC-IT-EM-002: hire_agent 失敗後でも Empire は後続変更を受け付ける。"""
         agent = make_agent_ref()
         empire = make_empire(agents=[agent])
 
-        # 1) Duplicate hire fails, original is untouched.
+        # 1) 重複 hire は失敗するが、元 Empire は無傷。
         with pytest.raises(EmpireInvariantViolation):
             empire.hire_agent(AgentRef(agent_id=agent.agent_id, name="x", role=Role.LEADER))
 
-        # 2) establish_room then succeeds against the unchanged aggregate.
+        # 2) 続けて establish_room が無傷の aggregate に対して成功する。
         new_room = make_room_ref()
         after_establish = empire.establish_room(new_room)
 
-        # 3) archive_room then succeeds against that further-mutated aggregate.
+        # 3) 続けて archive_room がさらに変更された aggregate に対して成功する。
         after_archive = after_establish.archive_room(new_room.room_id)
         final_room = after_archive.rooms[0]
         assert (

--- a/backend/tests/domain/workflow/__init__.py
+++ b/backend/tests/domain/workflow/__init__.py
@@ -1,17 +1,18 @@
-"""Workflow aggregate tests, split per feature surface (Norman §file-split rule).
+"""Workflow 集約のテスト。機能面ごとに分割している（Norman §file-split rule）。
 
-Tests group by Test* class topology so failures cluster by behavior:
+テストは Test* クラスのトポロジでグループ化し、失敗が振る舞い単位で
+集約されるようにしている:
 
-* :mod:`test_construction` — minimal Workflow + name normalization
-* :mod:`test_dag_invariants` — REQ-WF-005 (entry, reachability, sink, determinism,
-  ref integrity, EXTERNAL_REVIEW notify, required_role)
-* :mod:`test_mutators` — add_stage / add_transition / remove_stage + pre-validate rollback
-* :mod:`test_from_dict` — bulk-import (REQ-WF-006) including T1 attack-surface
-* :mod:`test_frozen_extra` — frozen=True / extra='forbid' invariants
+* :mod:`test_construction` — 最小 Workflow + name 正規化
+* :mod:`test_dag_invariants` — REQ-WF-005（エントリ、到達可能性、シンク、
+  決定性、参照整合性、EXTERNAL_REVIEW 通知、required_role）
+* :mod:`test_mutators` — add_stage / add_transition / remove_stage + pre-validate ロールバック
+* :mod:`test_from_dict` — 一括インポート（REQ-WF-006）。T1 攻撃面を含む
+* :mod:`test_frozen_extra` — frozen=True / extra='forbid' の不変条件
 * :mod:`test_notify_channel_ssrf` — Confirmation G G1〜G10
-* :mod:`test_notify_channel_kind` — MVP `kind='discord'` constraint
-* :mod:`test_notify_channel_masking` — token redaction across serialization paths
-* :mod:`test_helpers_independence` — Confirmation F twin-defense direct invocation
-* :mod:`test_integration` — V-model preset + lifecycle round trips
-* :mod:`test_value_objects` — CompletionPolicy / NotifyChannel / Transition VO units
+* :mod:`test_notify_channel_kind` — MVP `kind='discord'` 制約
+* :mod:`test_notify_channel_masking` — シリアライズ経路全般でのトークン秘匿
+* :mod:`test_helpers_independence` — Confirmation F 双子防御の直接呼び出し
+* :mod:`test_integration` — V モデルプリセット + ライフサイクルラウンドトリップ
+* :mod:`test_value_objects` — CompletionPolicy / NotifyChannel / Transition VO 単体
 """

--- a/backend/tests/domain/workflow/test_dag_invariants.py
+++ b/backend/tests/domain/workflow/test_dag_invariants.py
@@ -1,7 +1,7 @@
-"""DAG invariants 7 種 (REQ-WF-005 / TC-UT-WF-002〜007 / 022 / 023 / 038〜045).
+"""DAG invariants 7 種 (REQ-WF-005 / TC-UT-WF-002〜007 / 022 / 023 / 038〜045)。
 
-Each invariant has its own ``Test*`` class so failures cluster by which
-structural property of the DAG was violated.
+各 invariant には専用の ``Test*`` クラスを設け、DAG のどの構造的性質が
+違反されたかに応じて失敗が集約されるようにしている。
 """
 
 from __future__ import annotations
@@ -19,26 +19,26 @@ from bakufu.domain.workflow import Stage
 
 from tests.factories.workflow import make_stage, make_transition, make_workflow
 
-# Workflow's module-level invariant helpers are private by convention but are
-# intentionally imported by tests under the Confirmation F twin-defense
-# contract. Indirect attribute access keeps pyright strict happy.
+# Workflow のモジュール内 invariant ヘルパは慣習上 private だが、Confirmation F の
+# 二重防衛契約のもとでテストから意図的に import する。属性アクセス経由にすることで
+# pyright strict を満足させる。
 _validate_external_review_notify = _workflow_module._validate_external_review_notify  # pyright: ignore[reportPrivateUsage]
 _validate_required_role_non_empty = _workflow_module._validate_required_role_non_empty  # pyright: ignore[reportPrivateUsage]
 _validate_dag_reachability = _workflow_module._validate_dag_reachability  # pyright: ignore[reportPrivateUsage]
 
 
 class TestEntryStageId:
-    """REQ-WF-005-① / TC-UT-WF-002 / 038."""
+    """REQ-WF-005-① / TC-UT-WF-002 / 038。"""
 
     def test_unknown_entry_raises_entry_not_in_stages(self) -> None:
-        """TC-UT-WF-002: entry_stage_id outside stages raises entry_not_in_stages."""
+        """TC-UT-WF-002: stages 外の entry_stage_id は entry_not_in_stages を起こす。"""
         stage = make_stage()
         with pytest.raises(WorkflowInvariantViolation) as excinfo:
             make_workflow(stages=[stage], entry_stage_id=uuid4())
         assert excinfo.value.kind == "entry_not_in_stages"
 
     def test_msg_wf_002_includes_entry_stage_id(self) -> None:
-        """TC-UT-WF-038: MSG-WF-002 wording carries the offending entry_stage_id."""
+        """TC-UT-WF-038: MSG-WF-002 文言が問題の entry_stage_id を含む。"""
         stage = make_stage()
         unknown = uuid4()
         with pytest.raises(WorkflowInvariantViolation) as excinfo:
@@ -47,10 +47,10 @@ class TestEntryStageId:
 
 
 class TestUnreachableStage:
-    """REQ-WF-005-④ / TC-UT-WF-003 / 039 — BFS reachability."""
+    """REQ-WF-005-④ / TC-UT-WF-003 / 039 ── BFS 到達可能性。"""
 
     def test_orphan_stage_raises_unreachable_stage(self) -> None:
-        """TC-UT-WF-003: stage not reachable from entry raises unreachable_stage."""
+        """TC-UT-WF-003: entry から到達不能な stage は unreachable_stage を起こす。"""
         s0 = make_stage()
         s1 = make_stage()
         s2 = make_stage()  # orphan, no edges in
@@ -64,7 +64,7 @@ class TestUnreachableStage:
         assert excinfo.value.kind == "unreachable_stage"
 
     def test_msg_wf_003_lists_unreachable_stage_ids(self) -> None:
-        """TC-UT-WF-039: MSG-WF-003 includes the unreachable stage's id."""
+        """TC-UT-WF-039: MSG-WF-003 が到達不能 stage の id を含む。"""
         s0 = make_stage()
         s1 = make_stage()
         orphan = make_stage()
@@ -75,10 +75,10 @@ class TestUnreachableStage:
 
 
 class TestSinkStage:
-    """REQ-WF-005-⑤ / TC-UT-WF-004 / 040 — at least one sink Stage."""
+    """REQ-WF-005-⑤ / TC-UT-WF-004 / 040 ── 少なくとも 1 つの sink Stage が存在する。"""
 
     def test_pure_cycle_raises_no_sink_stage(self) -> None:
-        """TC-UT-WF-004: 3 stages all with outgoing edges (cycle) raises no_sink_stage."""
+        """TC-UT-WF-004: 全ステージが外向辺を持つ（循環）→ no_sink_stage を起こす。"""
         s0 = make_stage()
         s1 = make_stage()
         s2 = make_stage()
@@ -94,7 +94,7 @@ class TestSinkStage:
         assert excinfo.value.kind == "no_sink_stage"
 
     def test_msg_wf_004_starts_with_no_sink_prefix(self) -> None:
-        """TC-UT-WF-040: MSG-WF-004 wording starts with '[FAIL] No sink stage'."""
+        """TC-UT-WF-040: MSG-WF-004 文言が '[FAIL] No sink stage' で始まる。"""
         s0 = make_stage()
         s1 = make_stage()
         e1 = make_transition(from_stage_id=s0.id, to_stage_id=s1.id)
@@ -105,10 +105,10 @@ class TestSinkStage:
 
 
 class TestTransitionDeterminism:
-    """REQ-WF-005-③ / TC-UT-WF-005 / 041 — (from, condition) uniqueness."""
+    """REQ-WF-005-③ / TC-UT-WF-005 / 041 ── (from, condition) の一意性。"""
 
     def test_duplicate_from_condition_raises_transition_duplicate(self) -> None:
-        """TC-UT-WF-005: same (from_stage_id, APPROVED) twice raises transition_duplicate."""
+        """TC-UT-WF-005: 同じ (from_stage_id, APPROVED) 2 回 → transition_duplicate を起こす。"""
         s0 = make_stage()
         s1 = make_stage()
         s2 = make_stage()
@@ -127,7 +127,7 @@ class TestTransitionDeterminism:
         assert excinfo.value.kind == "transition_duplicate"
 
     def test_msg_wf_005_includes_from_and_condition(self) -> None:
-        """TC-UT-WF-041: MSG-WF-005 wording carries from_stage and condition."""
+        """TC-UT-WF-041: MSG-WF-005 文言が from_stage と condition を含む。"""
         s0 = make_stage()
         s1 = make_stage()
         s2 = make_stage()
@@ -144,28 +144,27 @@ class TestTransitionDeterminism:
 
 
 class TestExternalReviewNotify:
-    """REQ-WF-007-② / TC-UT-WF-006a / 006b / 042 — twin-defense."""
+    """REQ-WF-007-② / TC-UT-WF-006a / 006b / 042 ── 二重防衛。"""
 
     def test_006a_stage_self_path_rejects_empty_notify(self) -> None:
-        """TC-UT-WF-006a: Stage self-validator rejects empty notify_channels.
+        """TC-UT-WF-006a: Stage 自己バリデータが空の notify_channels を拒否する。
 
-        Construction with ``kind=EXTERNAL_REVIEW`` and ``notify_channels=[]``
-        raises :class:`StageInvariantViolation` directly from the Stage's
-        own ``model_validator(mode='after')``, before any aggregate check
-        runs — fulfilling the twin-defense Stage-side path.
+        ``kind=EXTERNAL_REVIEW`` と ``notify_channels=[]`` での構築は、
+        aggregate チェックが走る前に Stage 自身の ``model_validator(mode='after')``
+        から :class:`StageInvariantViolation` を直接発火させる ──
+        二重防衛の Stage 側経路を満たす。
         """
         with pytest.raises(StageInvariantViolation) as excinfo:
             make_stage(kind=StageKind.EXTERNAL_REVIEW, notify_channels=[])
         assert excinfo.value.kind == "missing_notify"
 
     def test_006b_aggregate_helper_rejects_empty_notify_via_direct_call(self) -> None:
-        """TC-UT-WF-006b: ``_validate_external_review_notify`` raises aggregate violation directly.
+        """TC-UT-WF-006b: ``_validate_external_review_notify`` が aggregate 違反を直接起こす。
 
-        Builds an EXTERNAL_REVIEW Stage *with* notify_channels (so its own
-        validator passes), then reconstructs via ``model_construct`` (skips
-        validators) so the helper sees a state the Stage validator would have
-        rejected. Proves the dual code paths (Stage self vs aggregate
-        helper) do not share code.
+        notify_channels 付き EXTERNAL_REVIEW Stage を構築し（自己バリデータを通過）、
+        その後 ``model_construct``（バリデータをスキップ）で再構築することで、
+        Stage バリデータが拒否したであろう状態をヘルパに見せる。これにより、
+        二系統のコード経路（Stage 自己 vs aggregate ヘルパ）がコードを共有していないことを示す。
         """
         good = make_stage(kind=StageKind.EXTERNAL_REVIEW)
         stage_without_notify = Stage.model_construct(
@@ -182,7 +181,7 @@ class TestExternalReviewNotify:
         assert excinfo.value.kind == "missing_notify_aggregate"
 
     def test_msg_wf_006_includes_stage_id(self) -> None:
-        """TC-UT-WF-042: MSG-WF-006 wording carries the offending stage_id."""
+        """TC-UT-WF-042: MSG-WF-006 文言が問題の stage_id を含む。"""
         with pytest.raises(StageInvariantViolation) as excinfo:
             make_stage(kind=StageKind.EXTERNAL_REVIEW, notify_channels=[])
         assert "EXTERNAL_REVIEW stage" in excinfo.value.message
@@ -190,22 +189,22 @@ class TestExternalReviewNotify:
 
 
 class TestRequiredRoleNonEmpty:
-    """REQ-WF-007-① / TC-UT-WF-007 / 043 — required_role non-empty."""
+    """REQ-WF-007-① / TC-UT-WF-007 / 043 ── required_role が非空。"""
 
     def test_stage_self_path_rejects_empty_required_role(self) -> None:
-        """TC-UT-WF-007: Stage(required_role=frozenset()) raises empty_required_role."""
+        """TC-UT-WF-007: Stage(required_role=frozenset()) は empty_required_role を起こす。"""
         with pytest.raises(StageInvariantViolation) as excinfo:
             make_stage(required_role=frozenset())
         assert excinfo.value.kind == "empty_required_role"
 
     def test_msg_wf_007_includes_stage_id(self) -> None:
-        """TC-UT-WF-043: MSG-WF-007 wording carries the offending stage_id."""
+        """TC-UT-WF-043: MSG-WF-007 文言が問題の stage_id を含む。"""
         with pytest.raises(StageInvariantViolation) as excinfo:
             make_stage(required_role=frozenset())
         assert "required_role must not be empty" in excinfo.value.message
 
     def test_aggregate_helper_rejects_empty_required_role(self) -> None:
-        """`_validate_required_role_non_empty` rejects bypassed stage with empty role set."""
+        """`_validate_required_role_non_empty` が空 role セットの迂回 stage を拒否する。"""
         good = make_stage()
         bad = Stage.model_construct(
             id=good.id,
@@ -222,22 +221,21 @@ class TestRequiredRoleNonEmpty:
 
 
 class TestTransitionIdUnique:
-    """REQ-WF-005-② sibling — symmetric transition_id duplicate guard.
+    """REQ-WF-005-② の兄弟 ── 対称な transition_id 重複ガード。
 
-    Steve's PR #16 review caught the asymmetry where ``_validate_stage_id_unique``
-    rejected duplicate stage ids but transition ids slipped through. Linus
-    added :func:`_validate_transition_id_unique`; these tests lock the
-    aggregate-side behavior so the gap cannot reopen.
+    Steve の PR #16 レビューが、``_validate_stage_id_unique`` は stage id の重複を
+    拒否するのに transition id はすり抜けていた非対称を捕捉した。Linus が
+    :func:`_validate_transition_id_unique` を追加。これらのテストは aggregate 側の
+    挙動を固定し、ギャップが再び開かないようにする。
     """
 
     def test_duplicate_transition_id_raises_through_aggregate(self) -> None:
-        """Aggregate path: two edges sharing a transition.id raise transition_id_duplicate.
+        """Aggregate 経路: transition.id を共有する 2 辺は transition_id_duplicate を起こす。
 
-        Pre-state: 3-stage chain s0→s1→s2 with one APPROVED edge. Add a second
-        edge that shares the first's id but has different (from, to,
-        condition). The aggregate-level helper must reject this even though
-        the determinism check (which keys on (from, condition)) would let it
-        through.
+        前提: s0→s1→s2 の 3 ステージ連鎖と APPROVED エッジ 1 本。最初のエッジと
+        id を共有しつつ (from, to, condition) が異なる 2 本目を追加する。
+        ((from, condition) でキーする) determinism チェックは通過させても、
+        aggregate レベルのヘルパはこれを拒否しなければならない。
         """
         s0 = make_stage()
         s1 = make_stage()
@@ -246,7 +244,7 @@ class TestTransitionIdUnique:
             from_stage_id=s0.id, to_stage_id=s1.id, condition=TransitionCondition.APPROVED
         )
         e_dup = make_transition(
-            transition_id=e0.id,  # collide on transition.id deliberately
+            transition_id=e0.id,  # 意図的に transition.id を衝突させる
             from_stage_id=s1.id,
             to_stage_id=s2.id,
             condition=TransitionCondition.APPROVED,
@@ -260,7 +258,7 @@ class TestTransitionIdUnique:
         assert excinfo.value.kind == "transition_id_duplicate"
 
     def test_msg_for_duplicate_transition_id_includes_id(self) -> None:
-        """Message wording: '[FAIL] Transition id duplicate: <transition_id>'."""
+        """メッセージ文言: '[FAIL] Transition id duplicate: <transition_id>'。"""
         s0 = make_stage()
         s1 = make_stage()
         s2 = make_stage()
@@ -281,10 +279,10 @@ class TestTransitionIdUnique:
 
 
 class TestTransitionRefIntegrity:
-    """REQ-WF-005-② / TC-UT-WF-022 / 045 — Transition refs must point at known Stages."""
+    """REQ-WF-005-② / TC-UT-WF-022 / 045 ── Transition の参照が既知 Stage を指さねばならない。"""
 
     def test_transition_to_unknown_stage_raises(self) -> None:
-        """TC-UT-WF-022: Transition.to_stage_id outside stages raises transition_ref_invalid."""
+        """TC-UT-WF-022: stages 外の Transition.to_stage_id は transition_ref_invalid を起こす。"""
         s0 = make_stage()
         bad_to = uuid4()
         edge = make_transition(from_stage_id=s0.id, to_stage_id=bad_to)
@@ -293,7 +291,7 @@ class TestTransitionRefIntegrity:
         assert excinfo.value.kind == "transition_ref_invalid"
 
     def test_msg_wf_009_includes_from_and_to(self) -> None:
-        """TC-UT-WF-045: MSG-WF-009 wording carries from / to stage ids."""
+        """TC-UT-WF-045: MSG-WF-009 文言が from / to の stage id を含む。"""
         s0 = make_stage()
         bad_to = uuid4()
         edge = make_transition(from_stage_id=s0.id, to_stage_id=bad_to)
@@ -304,15 +302,15 @@ class TestTransitionRefIntegrity:
 
 
 class TestBFSCycleSafety:
-    """TC-UT-WF-023 — BFS terminates on cyclic graphs without infinite loop."""
+    """TC-UT-WF-023 ── BFS が循環グラフでも無限ループせず終了する。"""
 
     def test_helper_terminates_on_cycle(self) -> None:
-        """`_validate_dag_reachability` returns without hanging on a 3-stage cycle."""
+        """`_validate_dag_reachability` が 3 ステージ循環でハングせず戻る。"""
         s0 = make_stage()
         s1 = make_stage()
         s2 = make_stage()
         e1 = make_transition(from_stage_id=s0.id, to_stage_id=s1.id)
         e2 = make_transition(from_stage_id=s1.id, to_stage_id=s2.id)
         e3 = make_transition(from_stage_id=s2.id, to_stage_id=s0.id)
-        # All stages reachable; reachability check should not raise.
+        # 全ステージが到達可能。reachability チェックは raise しないはず。
         _validate_dag_reachability([s0, s1, s2], [e1, e2, e3], s0.id)

--- a/backend/tests/domain/workflow/test_integration.py
+++ b/backend/tests/domain/workflow/test_integration.py
@@ -1,9 +1,9 @@
-"""Workflow lifecycle integration scenarios (TC-IT-WF-001 / 002 / 003).
+"""Workflow ライフサイクル統合シナリオ (TC-IT-WF-001 / 002 / 003)。
 
-Aggregate-internal round trips and the V-model preset. These tests act as
-"E2E by stand-in" for a domain layer with no public entry point — they
-exercise the public Workflow API end-to-end through ``from_dict`` and the
-mutator chain.
+Aggregate 内部ラウンドトリップと V-model プリセット。
+これらテストは公開エントリポイントなしドメイン層の
+"E2E by stand-in" として機能 — ``from_dict`` と
+mutator チェーンを通し公開 Workflow API をエンドツーエンド実行。
 """
 
 from __future__ import annotations
@@ -26,26 +26,27 @@ from tests.factories.workflow import (
 
 
 class TestWorkflowLifecycleIntegration:
-    """Aggregate-internal round-trip + V-model preset + bad-payload variants."""
+    """Aggregate 内部ラウンドトリップ + V-model プリセット + 不良ペイロード亜種。"""
 
     def test_v_model_preset_constructs_via_from_dict(self) -> None:
-        """TC-IT-WF-001: 13-stage / 15-transition V-model payload constructs."""
+        """TC-IT-WF-001: 13 ステージ / 15 遷移 V-model ペイロード は構築。"""
         wf = Workflow.from_dict(build_v_model_payload())
         assert len(wf.stages) == 13 and len(wf.transitions) == 15
 
     def test_v_model_preset_has_external_review_notify_channels(self) -> None:
-        """TC-IT-WF-001: every EXTERNAL_REVIEW Stage has at least one notify_channel."""
+        """TC-IT-WF-001: すべての EXTERNAL_REVIEW Stage は最低 1 つの notify_channel。"""
         wf = Workflow.from_dict(build_v_model_payload())
         review_stages = [s for s in wf.stages if s.kind is StageKind.EXTERNAL_REVIEW]
         assert all(len(s.notify_channels) >= 1 for s in review_stages)
 
     def test_round_trip_failed_then_recover(self) -> None:
-        """TC-IT-WF-002: failed add_transition rolls back; further legitimate add succeeds.
+        """TC-IT-WF-002: 失敗した add_transition はロールバック; 正当な追加は成功。
 
-        Pre-state: 3-stage chain s0→s1→s2 (s2 sink). Try to add a duplicate
-        APPROVED edge s0→s1, which trips ``transition_duplicate``. The
-        original Workflow is unchanged. Then add a REJECTED back-edge s1→s0,
-        which is unique on (s1, REJECTED) and preserves s2 as the sole sink.
+        事前状態: 3 ステージ チェーン s0→s1→s2 (s2 sink)。
+        重複 APPROVED エッジ s0→s1 を追加試行、
+        ``transition_duplicate`` をトリップ。
+        元 Workflow は変更なし。次に REJECTED バックエッジ s1→s0 を追加、
+        (s1, REJECTED) で一意で s2 をシングル sink として保持。
         """
         s0 = make_stage()
         s1 = make_stage()
@@ -63,7 +64,7 @@ class TestWorkflowLifecycleIntegration:
         )
         with pytest.raises(WorkflowInvariantViolation):
             wf.add_transition(bad_dup)
-        assert len(wf.transitions) == 2  # original unchanged
+        assert len(wf.transitions) == 2  # 元は変更なし
 
         e_back = make_transition(
             from_stage_id=s1.id, to_stage_id=s0.id, condition=TransitionCondition.REJECTED
@@ -71,33 +72,33 @@ class TestWorkflowLifecycleIntegration:
         updated = wf.add_transition(e_back)
         assert len(updated.transitions) == 3
 
-        # Failed remove_stage(unknown) leaves updated unchanged.
+        # 失敗 remove_stage(unknown) は updated を変更なしで残す。
         with pytest.raises(WorkflowInvariantViolation):
             updated.remove_stage(uuid4())
         assert len(updated.stages) == 3
 
     def test_t1_payload_variants_all_rejected(self) -> None:
-        """TC-IT-WF-003: bad payload variants (role / uuid / missing entry / dup stage) reject."""
-        # Variant 1: bad role.
+        """TC-IT-WF-003: 不良ペイロード亜種 (role / uuid / 欠落 entry / 重複 stage) は拒否。"""
+        # 亜種 1: 不良 role。
         v1 = build_v_model_payload()
         stages_v1 = cast("list[dict[str, object]]", v1["stages"])
         stages_v1[0]["required_role"] = ["UNKNOWN_ROLE"]
         with pytest.raises((ValidationError, WorkflowInvariantViolation)):
             Workflow.from_dict(v1)
 
-        # Variant 2: bad UUID.
+        # 亜種 2: 不良 UUID。
         v2 = build_v_model_payload()
         v2["id"] = "not-a-uuid"
         with pytest.raises((ValidationError, WorkflowInvariantViolation)):
             Workflow.from_dict(v2)
 
-        # Variant 3: missing entry_stage_id.
+        # 亜種 3: 欠落 entry_stage_id。
         v3 = build_v_model_payload()
         del v3["entry_stage_id"]
         with pytest.raises((ValidationError, WorkflowInvariantViolation)):
             Workflow.from_dict(v3)
 
-        # Variant 4: duplicate stage_id.
+        # 亜種 4: 重複 stage_id。
         v4 = build_v_model_payload()
         stages_v4 = cast("list[dict[str, object]]", v4["stages"])
         stages_v4[1]["id"] = stages_v4[0]["id"]

--- a/backend/tests/domain/workflow/test_mutators.py
+++ b/backend/tests/domain/workflow/test_mutators.py
@@ -1,7 +1,7 @@
-"""Workflow mutators (REQ-WF-002 / 003 / 004) + pre-validate rollback.
+"""Workflow mutators (REQ-WF-002 / 003 / 004) + pre-validate ロールバック。
 
-Covers add_stage / add_transition / remove_stage and Confirmation A's contract
-that failed mutators leave the original Workflow unchanged.
+add_stage / add_transition / remove_stage と Confirmation A の契約を
+カバー: 失敗した mutators は元 Workflow を変更なしで残す。
 """
 
 from __future__ import annotations
@@ -17,17 +17,17 @@ from tests.factories.workflow import make_stage, make_transition, make_workflow
 
 
 class TestAddStage:
-    """REQ-WF-002 / TC-UT-WF-014 / 044.
+    """REQ-WF-002 / TC-UT-WF-014 / 044。
 
-    Note on TC-UT-WF-013: ``add_stage`` in isolation cannot succeed because a
-    newly-added Stage with no incoming Transition is orphaned and the
-    aggregate-level ``_validate_dag_reachability`` rejects it. The "appends"
-    success path is exercised through ``from_dict`` (TC-IT-WF-001) — granular
-    mutators are designed for **constrained** changes.
+    TC-UT-WF-013 の注記: ``add_stage`` は単独では成功できない
+    (新規追加 Stage は incoming Transition なしでは orphan で
+    aggregate レベル ``_validate_dag_reachability`` は拒否)。
+    "appends" 成功パスは ``from_dict`` (TC-IT-WF-001) で実行 —
+    粒度 mutators は **constrained** 変更用に設計。
     """
 
     def test_duplicate_stage_id_raises_stage_duplicate(self) -> None:
-        """TC-UT-WF-014: add_stage with existing id raises stage_duplicate."""
+        """TC-UT-WF-014: 既存 id の add_stage は stage_duplicate を発火。"""
         wf = make_workflow()
         existing = wf.stages[0]
         duplicate = make_stage(stage_id=existing.id)
@@ -36,7 +36,7 @@ class TestAddStage:
         assert excinfo.value.kind == "stage_duplicate"
 
     def test_msg_wf_008_for_duplicate_includes_stage_id(self) -> None:
-        """TC-UT-WF-044: MSG-WF-008 wording carries the duplicate stage_id."""
+        """TC-UT-WF-044: MSG-WF-008 wording は重複 stage_id を含む。"""
         wf = make_workflow()
         existing = wf.stages[0]
         duplicate = make_stage(stage_id=existing.id)
@@ -46,10 +46,10 @@ class TestAddStage:
 
 
 class TestAddStageCapacity:
-    """REQ-WF-002 capacity / TC-UT-WF-015."""
+    """REQ-WF-002 capacity / TC-UT-WF-015。"""
 
     def test_overflow_raises_capacity_exceeded(self) -> None:
-        """TC-UT-WF-015: bulk-importing >MAX_STAGES via from_dict raises capacity_exceeded."""
+        """TC-UT-WF-015: from_dict 経由 >MAX_STAGES 一括インポートは capacity_exceeded を発火。"""
         stages: list[dict[str, object]] = []
         first_id: str | None = None
         for _ in range(MAX_STAGES + 1):
@@ -67,7 +67,7 @@ class TestAddStageCapacity:
             )
             if first_id is None:
                 first_id = sid
-        # Build forward APPROVED chain so we have at least valid topology.
+        # 少なくとも有効なトポロジを持つよう前方 APPROVED チェーンを構築。
         transitions: list[dict[str, object]] = []
         previous: str | None = None
         for stage in stages:
@@ -96,13 +96,13 @@ class TestAddStageCapacity:
 
 
 class TestAddTransition:
-    """REQ-WF-003 / TC-UT-WF-016 / 017."""
+    """REQ-WF-003 / TC-UT-WF-016 / 017。"""
 
     def test_appends_transition_to_list(self) -> None:
-        """TC-UT-WF-016: add_transition returns a new Workflow with the edge appended.
+        """TC-UT-WF-016: add_transition はエッジが追加された新 Workflow を返す。
 
-        Pre-state: 3-stage chain s0→s1→s2 with two forward APPROVED edges.
-        Adding a REJECTED back-edge s1→s0 leaves s2 as the sole sink.
+        事前状態: 2 つの前方 APPROVED エッジを持つ 3 ステージ チェーン s0→s1→s2。
+        REJECTED バックエッジ s1→s0 を追加するとシングル sink として s2 を残す。
         """
         s0 = make_stage()
         s1 = make_stage()
@@ -121,7 +121,7 @@ class TestAddTransition:
         assert len(updated.transitions) == 3
 
     def test_does_not_mutate_original(self) -> None:
-        """TC-UT-WF-016: caller's Workflow stays at 2 transitions after add path."""
+        """TC-UT-WF-016: 呼び出し元の Workflow は add パス後も 2 遷移で留まる。"""
         s0 = make_stage()
         s1 = make_stage()
         s2 = make_stage()
@@ -135,7 +135,7 @@ class TestAddTransition:
         assert len(wf.transitions) == 2
 
     def test_dangling_ref_raises_transition_ref_invalid(self) -> None:
-        """TC-UT-WF-017: add_transition with unknown from/to raises transition_ref_invalid."""
+        """TC-UT-WF-017: 未知 from/to の add_transition は transition_ref_invalid を発火。"""
         wf = make_workflow()
         bad_edge = make_transition(from_stage_id=wf.stages[0].id, to_stage_id=uuid4())
         with pytest.raises(WorkflowInvariantViolation) as excinfo:
@@ -144,10 +144,10 @@ class TestAddTransition:
 
 
 class TestAddTransitionCapacity:
-    """REQ-WF-003 capacity / TC-UT-WF-018."""
+    """REQ-WF-003 capacity / TC-UT-WF-018。"""
 
     def test_overflow_raises_capacity_exceeded(self) -> None:
-        """TC-UT-WF-018: building >MAX_TRANSITIONS via from_dict raises capacity_exceeded."""
+        """TC-UT-WF-018: from_dict 経由 >MAX_TRANSITIONS 構築は capacity_exceeded を発火。"""
         stage_ids = [str(uuid4()) for _ in range(2)]
         stages_payload: list[dict[str, object]] = [
             {
@@ -189,29 +189,29 @@ class TestAddTransitionCapacity:
         }
         with pytest.raises(WorkflowInvariantViolation) as excinfo:
             Workflow.from_dict(payload)
-        # Capacity is checked before determinism, so capacity_exceeded fires first.
+        # Capacity は determinism の前にチェック、capacity_exceeded が先に発火。
         assert excinfo.value.kind == "capacity_exceeded"
 
 
 class TestRemoveStage:
-    """REQ-WF-004 / TC-UT-WF-009 / 019 / 020 / 021 / 046."""
+    """REQ-WF-004 / TC-UT-WF-009 / 019 / 020 / 021 / 046。"""
 
     def test_remove_entry_stage_raises_cannot_remove_entry(self) -> None:
-        """TC-UT-WF-009: remove_stage(entry_stage_id) raises cannot_remove_entry."""
+        """TC-UT-WF-009: remove_stage(entry_stage_id) は cannot_remove_entry を発火。"""
         wf = make_workflow()
         with pytest.raises(WorkflowInvariantViolation) as excinfo:
             wf.remove_stage(wf.entry_stage_id)
         assert excinfo.value.kind == "cannot_remove_entry"
 
     def test_msg_wf_010_includes_stage_id(self) -> None:
-        """TC-UT-WF-046: MSG-WF-010 wording carries the entry stage_id."""
+        """TC-UT-WF-046: MSG-WF-010 wording は entry stage_id を含む。"""
         wf = make_workflow()
         with pytest.raises(WorkflowInvariantViolation) as excinfo:
             wf.remove_stage(wf.entry_stage_id)
         assert excinfo.value.message == f"[FAIL] Cannot remove entry stage: {wf.entry_stage_id}"
 
     def test_unknown_stage_id_raises_stage_not_found(self) -> None:
-        """TC-UT-WF-019: remove_stage(unknown) raises stage_not_found with MSG-WF-012."""
+        """TC-UT-WF-019: remove_stage(unknown) は MSG-WF-012 で stage_not_found を発火。"""
         wf = make_workflow()
         unknown = uuid4()
         with pytest.raises(WorkflowInvariantViolation) as excinfo:
@@ -220,23 +220,23 @@ class TestRemoveStage:
         assert excinfo.value.message == f"[FAIL] Stage not found in workflow: stage_id={unknown}"
 
     def test_cascades_incident_transitions(self) -> None:
-        """TC-UT-WF-020: removing a Stage also drops Transitions referencing it."""
+        """TC-UT-WF-020: Stage を削除すると参照 Transitions も削除。"""
         s0 = make_stage()
         s1 = make_stage()
         s2 = make_stage()
         e0 = make_transition(from_stage_id=s0.id, to_stage_id=s1.id)
         e1 = make_transition(from_stage_id=s1.id, to_stage_id=s2.id)
         wf = make_workflow(stages=[s0, s1, s2], transitions=[e0, e1], entry_stage_id=s0.id)
-        # Removing the trailing stage s2 leaves s0→s1 valid (s1 becomes sink).
+        # 末尾ステージ s2 を削除すると s0→s1 は有効なまま (s1 が sink に)。
         updated = wf.remove_stage(s2.id)
         assert len(updated.stages) == 2 and len(updated.transitions) == 1
 
 
 class TestPreValidateRollback:
-    """Confirmation A — failed mutators leave original Workflow unchanged."""
+    """Confirmation A — 失敗した mutators は元 Workflow を変更なしで残す。"""
 
     def test_failed_add_stage_keeps_original(self) -> None:
-        """TC-UT-WF-008: failed add_stage does not mutate caller's Workflow."""
+        """TC-UT-WF-008: 失敗した add_stage は呼び出し元 Workflow を変更しない。"""
         wf = make_workflow()
         existing = wf.stages[0]
         with pytest.raises(WorkflowInvariantViolation):
@@ -244,7 +244,7 @@ class TestPreValidateRollback:
         assert len(wf.stages) == 1
 
     def test_failed_add_transition_keeps_original(self) -> None:
-        """TC-UT-WF-030: failed add_transition does not mutate caller's Workflow."""
+        """TC-UT-WF-030: 失敗した add_transition は呼び出し元 Workflow を変更しない。"""
         wf = make_workflow()
         bad = make_transition(from_stage_id=wf.stages[0].id, to_stage_id=uuid4())
         with pytest.raises(WorkflowInvariantViolation):
@@ -252,7 +252,7 @@ class TestPreValidateRollback:
         assert wf.transitions == []
 
     def test_failed_remove_stage_keeps_original(self) -> None:
-        """TC-UT-WF-031: failed remove_stage does not mutate caller's Workflow."""
+        """TC-UT-WF-031: 失敗した remove_stage は呼び出し元 Workflow を変更しない。"""
         wf = make_workflow()
         with pytest.raises(WorkflowInvariantViolation):
             wf.remove_stage(uuid4())

--- a/backend/tests/domain/workflow/test_notify_channel_masking.py
+++ b/backend/tests/domain/workflow/test_notify_channel_masking.py
@@ -1,14 +1,15 @@
-"""NotifyChannel secret masking (Confirmation G "target のシークレット扱い").
+"""NotifyChannel シークレット マスキング (Confirmation G "target のシークレット扱い")。
 
-Covers TC-UT-WF-057 / 058 / 059. Token redaction must apply across the three
-serialization paths the design book pins to the domain layer:
+TC-UT-WF-057 / 058 / 059 をカバー。トークン削除は設計書が
+ドメイン層に pin する 3 つのシリアライゼーションパスに
+適用する必須:
 
-* ``model_dump(mode='json')`` via the field_serializer
-* ``Workflow.model_dump_json()`` rolling up the same serializer
-* Exception ``message`` / ``detail`` via ``WorkflowInvariantViolation`` init
+* ``model_dump(mode='json')`` は field_serializer 経由
+* ``Workflow.model_dump_json()`` は同じ serializer にロール・アップ
+* Exception ``message`` / ``detail`` は ``WorkflowInvariantViolation`` init 経由
 
-Persistence-side masking (Outbox / audit_log / Conversation / structured logs)
-is the responsibility of ``feature/persistence`` per design and is out of scope.
+永続化側マスキング (Outbox / audit_log / Conversation / 構造化ログ)
+は設計に従い ``feature/persistence`` 責任でスコープ外。
 """
 
 from __future__ import annotations

--- a/backend/tests/domain/workflow/test_notify_channel_masking.py
+++ b/backend/tests/domain/workflow/test_notify_channel_masking.py
@@ -29,35 +29,35 @@ from tests.factories.workflow import (
 
 
 class TestNotifyChannelMasking:
-    """TC-UT-WF-057 / 058 / 059 — token masked on JSON serialization & exceptions."""
+    """TC-UT-WF-057 / 058 / 059 — JSON シリアライズと例外でトークンマスキング。"""
 
     def test_057_model_dump_json_mode_masks_token(self) -> None:
-        """TC-UT-WF-057: model_dump(mode='json') replaces token with REDACTED."""
+        """TC-UT-WF-057: model_dump(mode='json') はトークンを REDACTED に置換。"""
         channel = make_notify_channel()
         dumped = channel.model_dump(mode="json")
         assert "<REDACTED:DISCORD_WEBHOOK>" in dumped["target"]
         assert "SyntheticToken_-abcXYZ" not in dumped["target"]
 
     def test_057_model_dump_python_mode_preserves_token(self) -> None:
-        """TC-UT-WF-057: model_dump(mode='python') keeps raw target for in-process use."""
+        """TC-UT-WF-057: model_dump(mode='python') はプロセス内使用のため raw target を保持。"""
         channel = make_notify_channel()
         dumped = channel.model_dump()
         assert dumped["target"] == DEFAULT_DISCORD_WEBHOOK
 
     def test_058_model_dump_json_workflow_scans_clean(self) -> None:
-        """TC-UT-WF-058: workflow.model_dump_json() shows no plaintext token segment."""
+        """TC-UT-WF-058: workflow.model_dump_json() は平文トークンセグメントなし。"""
         wf_payload = build_v_model_payload()
         wf = Workflow.from_dict(wf_payload)
         json_text = wf.model_dump_json()
-        # Token segment "SyntheticToken_-abcXYZ" must not appear in JSON output.
+        # トークンセグメント "SyntheticToken_-abcXYZ" は JSON 出力に出現してはならない。
         assert "SyntheticToken_-abcXYZ" not in json_text
         assert "<REDACTED:DISCORD_WEBHOOK>" in json_text
-        # Sanity check: the dumped JSON parses back as well-formed JSON.
+        # サニティチェック: ダンプ JSON は整形式 JSON で解析可能。
         parsed = json.loads(json_text)
         assert parsed["name"] == "V モデル開発フロー"
 
     def test_059_exception_detail_does_not_leak_token(self) -> None:
-        """TC-UT-WF-059: WorkflowInvariantViolation message/detail mask Discord tokens."""
+        """TC-UT-WF-059: WorkflowInvariantViolation message/detail は Discord トークンをマスク。"""
         fake_message = (
             f"[FAIL] something happened with https://discord.com/api/webhooks/123/{'a' * 30}"
         )
@@ -70,12 +70,12 @@ class TestNotifyChannelMasking:
             },
         )
         assert "a" * 30 not in exc.message
-        # Verify masking applied to nested detail dict too.
+        # ネスト detail 辞書にもマスキング適用を検証。
         nested = cast("dict[str, object]", exc.detail["nested"])
         assert "c" * 30 not in str(nested["u"])
 
     def test_mask_helper_is_idempotent(self) -> None:
-        """Applying mask_discord_webhook twice yields the same result (smoke)."""
+        """mask_discord_webhook を 2 回適用すると同じ結果 (スモーク)。"""
         original = f"https://discord.com/api/webhooks/123/{'x' * 20}"
         once = mask_discord_webhook(original)
         twice = mask_discord_webhook(once)

--- a/backend/tests/domain/workflow/test_notify_channel_ssrf.py
+++ b/backend/tests/domain/workflow/test_notify_channel_ssrf.py
@@ -1,9 +1,9 @@
-"""NotifyChannel SSRF allow list G1〜G10 (Confirmation G).
+"""NotifyChannel SSRF allow list G1〜G10 (Confirmation G)。
 
-Covers TC-UT-WF-034〜036, 048〜054. Each ``Test*`` parametrize hits one of the
-ten G-rules, ensuring any future change to ``NotifyChannel._validate_target``
-produces a focused diff in this file rather than scattering the SSRF contract
-across a monolithic test module.
+TC-UT-WF-034〜036, 048〜054 をカバー。各 ``Test*`` parametrize は
+10 の G ルール 1 つをヒット、``NotifyChannel._validate_target`` への
+将来の変更が monolithic test モジュール全体に SSRF 契約を
+散乱させるのではなく、このファイルで焦点 diff を生成することを保証。
 """
 
 from __future__ import annotations
@@ -14,17 +14,17 @@ from pydantic import ValidationError
 
 
 class TestNotifyChannelSSRF:
-    """TC-UT-WF-034〜036, 048〜054 — full G1〜G10 rejection coverage."""
+    """TC-UT-WF-034〜036, 048〜054 — 完全 G1〜G10 拒否カバレッジ。"""
 
     @pytest.mark.parametrize(
         "bad_target",
         [
-            # G3: HTTPS強制
+            # G3: HTTPS 強制
             "http://discord.com/api/webhooks/123/abc-DEF_xyz",
         ],
     )
     def test_034_https_only(self, bad_target: str) -> None:
-        """TC-UT-WF-034 / G3: scheme must be 'https'."""
+        """TC-UT-WF-034 / G3: scheme は 'https' 必須。"""
         with pytest.raises(ValidationError):
             NotifyChannel(kind="discord", target=bad_target)
 
@@ -37,7 +37,7 @@ class TestNotifyChannelSSRF:
         ],
     )
     def test_035_hostname_exact_match(self, bad_target: str) -> None:
-        """TC-UT-WF-035 / G4: hostname must equal 'discord.com' exactly."""
+        """TC-UT-WF-035 / G4: hostname は 'discord.com' に正確に一致必須。"""
         with pytest.raises(ValidationError):
             NotifyChannel(kind="discord", target=bad_target)
 
@@ -49,26 +49,26 @@ class TestNotifyChannelSSRF:
         ],
     )
     def test_036_path_must_be_present(self, bad_target: str) -> None:
-        """TC-UT-WF-036 / G7: path must match /api/webhooks/<id>/<token>."""
+        """TC-UT-WF-036 / G7: path は /api/webhooks/<id>/<token> に一致必須。"""
         with pytest.raises(ValidationError):
             NotifyChannel(kind="discord", target=bad_target)
 
     def test_048_token_at_g7_cap_succeeds_overflow_rejected(self) -> None:
-        """TC-UT-WF-048 / G1+G7: 100-char token (G7 cap) works, 101+ rejected.
+        """TC-UT-WF-048 / G1+G7: 100 文字トークン (G7 キャップ) は機能、101+ は拒否。
 
-        Realistic upper bound on a *valid* Discord webhook URL is reached via
-        G7 (token ≤ 100 chars). We verify that the maximum-permitted shape
-        constructs successfully, that any G7 overflow trips, and that an
-        oversized URL hits G1 independently.
+        **有効な** Discord webhook URL に対するリアルな上限は G7 経由
+        (トークン ≤ 100 文字) で到達。最大許可形は正常に構築、
+        あらゆる G7 オーバーフロー トリップ、過大サイズ URL が
+        G1 をヒットすることを独立で検証。
         """
         base = "https://discord.com/api/webhooks/123456789/"
-        valid = base + "a" * 100  # token at G7 cap
+        valid = base + "a" * 100  # G7 キャップでトークン
         channel = NotifyChannel(kind="discord", target=valid)
         assert channel.target == valid
-        # 101-char token violates G7.
+        # 101 文字トークンは G7 違反。
         with pytest.raises(ValidationError):
             NotifyChannel(kind="discord", target=base + "a" * 101)
-        # 500+ char URL violates G1 too.
+        # 500+ 文字 URL も G1 を違反。
         oversized = "https://discord.com/api/webhooks/1/" + "a" * 500
         assert len(oversized) > 500
         with pytest.raises(ValidationError):
@@ -83,7 +83,7 @@ class TestNotifyChannelSSRF:
         ],
     )
     def test_049_port_must_be_none_or_443(self, bad_target: str) -> None:
-        """TC-UT-WF-049 / G5: port restricted to {None, 443}."""
+        """TC-UT-WF-049 / G5: port は {None, 443} に制限。"""
         with pytest.raises(ValidationError):
             NotifyChannel(kind="discord", target=bad_target)
 
@@ -95,27 +95,27 @@ class TestNotifyChannelSSRF:
         ],
     )
     def test_050_userinfo_rejected(self, bad_target: str) -> None:
-        """TC-UT-WF-050 / G6: userinfo (user/password) rejected."""
+        """TC-UT-WF-050 / G6: userinfo (ユーザー/パスワード) は拒否。"""
         with pytest.raises(ValidationError):
             NotifyChannel(kind="discord", target=bad_target)
 
     @pytest.mark.parametrize(
         "bad_target",
         [
-            "https://discord.com/api/webhooks/abc/def",  # id non-numeric
-            "https://discord.com/api/webhooks/123/!@#",  # token bad chars
-            "https://discord.com/api/webhooks/" + ("0" * 31) + "/abc",  # id 31 digits
-            "https://discord.com/api/webhooks/123/" + ("a" * 101),  # token 101 chars
-            "https://discord.com/api/webhooks/123/abc/extra",  # extra path segment
+            "https://discord.com/api/webhooks/abc/def",  # id 非数値
+            "https://discord.com/api/webhooks/123/!@#",  # トークン不良文字
+            "https://discord.com/api/webhooks/" + ("0" * 31) + "/abc",  # id 31 桁
+            "https://discord.com/api/webhooks/123/" + ("a" * 101),  # トークン 101 文字
+            "https://discord.com/api/webhooks/123/abc/extra",  # 余分パスセグメント
         ],
     )
     def test_051_path_regex_fullmatch(self, bad_target: str) -> None:
-        """TC-UT-WF-051 / G7: path regex must fullmatch /api/webhooks/<id>/<token>."""
+        """TC-UT-WF-051 / G7: path regex は /api/webhooks/<id>/<token> に fullmatch 必須。"""
         with pytest.raises(ValidationError):
             NotifyChannel(kind="discord", target=bad_target)
 
     def test_052_query_rejected(self) -> None:
-        """TC-UT-WF-052 / G8: query string rejected."""
+        """TC-UT-WF-052 / G8: クエリ文字列は拒否。"""
         with pytest.raises(ValidationError):
             NotifyChannel(
                 kind="discord",
@@ -123,7 +123,7 @@ class TestNotifyChannelSSRF:
             )
 
     def test_053_fragment_rejected(self) -> None:
-        """TC-UT-WF-053 / G9: fragment rejected."""
+        """TC-UT-WF-053 / G9: フラグメントは拒否。"""
         with pytest.raises(ValidationError):
             NotifyChannel(
                 kind="discord",
@@ -133,11 +133,11 @@ class TestNotifyChannelSSRF:
     @pytest.mark.parametrize(
         "bad_target",
         [
-            "https://discord.com/API/WEBHOOKS/123/abc",  # uppercase API/WEBHOOKS
-            "https://discord.com/Api/Webhooks/123/abc",  # mixed case
+            "https://discord.com/API/WEBHOOKS/123/abc",  # 大文字 API/WEBHOOKS
+            "https://discord.com/Api/Webhooks/123/abc",  # 混合ケース
         ],
     )
     def test_054_path_case_sensitive(self, bad_target: str) -> None:
-        """TC-UT-WF-054 / G10: path case-sensitive (only lowercase /api/webhooks/)."""
+        """TC-UT-WF-054 / G10: path は大文字小文字を区別 (小文字 /api/webhooks/ のみ)。"""
         with pytest.raises(ValidationError):
             NotifyChannel(kind="discord", target=bad_target)

--- a/backend/tests/e2e/test_empire_http_api.py
+++ b/backend/tests/e2e/test_empire_http_api.py
@@ -70,7 +70,7 @@ class TestEmpireLifecycleE2E:
         roundtrip = await empire_e2e_client.get(f"/api/empires/{empire_id}")
         assert roundtrip.json()["name"] == "新山田の幕府"
 
-        # ── Step 4: DELETE → 204 No Content ────────────────────────────────
+        # ── Step 4: DELETE → 204 No Content（204 応答）─────────────────────
         delete_resp = await empire_e2e_client.delete(f"/api/empires/{empire_id}")
         assert delete_resp.status_code == 204
         assert delete_resp.content == b""

--- a/backend/tests/e2e/test_empire_http_api.py
+++ b/backend/tests/e2e/test_empire_http_api.py
@@ -19,11 +19,11 @@ pytestmark = pytest.mark.asyncio
 
 
 class TestEmpireLifecycleE2E:
-    """TC-E2E-EM-003: Empire HTTP API lifecycle — complete blackbox end-to-end.
+    """TC-E2E-EM-003: Empire HTTP API ライフサイクル — 完全ブラックボックス E2E。
 
-    All assertions are against HTTP responses only (no DB direct access,
-    no internal state inspection).  This test exercises the full stack:
-    httpx → FastAPI → EmpireService → SqliteEmpireRepository → SQLite.
+    すべてのアサーションは HTTP レスポンスのみに対する（DB 直接アクセスなし、
+    内部状態検査なし）。このテストはフルスタックを実行：
+    httpx → FastAPI → EmpireService → SqliteEmpireRepository → SQLite。
     """
 
     async def test_full_lifecycle(self, empire_e2e_client: AsyncClient) -> None:

--- a/backend/tests/factories/agent.py
+++ b/backend/tests/factories/agent.py
@@ -1,15 +1,14 @@
-"""Factories for the Agent aggregate, its entities, and its VOs.
+"""Agent アグリゲートとそのエンティティ、VO のファクトリ群.
 
-Per ``docs/features/agent/test-design.md``. Mirrors the empire / workflow
-pattern: every factory returns a *valid* default instance built through the
-production constructor, allows keyword overrides, and registers the result
-in a :class:`WeakValueDictionary` so :func:`is_synthetic` can later flag
-test-built objects without mutating the frozen Pydantic models.
+``docs/features/agent/test-design.md`` 準拠。empire / workflow と同パターン:
+各ファクトリは本番コンストラクタ経由で *妥当* なデフォルトインスタンスを返し、
+キーワード上書きを許可し、結果を :class:`WeakValueDictionary` に登録する。
+これにより :func:`is_synthetic` が後から、frozen Pydantic モデルを変更せずに
+テスト由来オブジェクトをフラグ付けできる。
 
-``DEFAULT_SKILL_PATH`` and the ``BAKUFU_DATA_DIR`` env var (set by
-``conftest.py``) together make every default ``SkillRef`` pass H1〜H10 so
-tests focused on Agent behavior do not have to thread path payloads through
-their setup.
+``DEFAULT_SKILL_PATH`` と ``BAKUFU_DATA_DIR`` 環境変数 (``conftest.py`` で設定)
+の組み合わせで、デフォルト ``SkillRef`` が H1〜H10 を全てパスするようになる ──
+Agent 挙動に注力したテストはセットアップでパスペイロードを伝搬させる必要が無くなる。
 """
 
 from __future__ import annotations
@@ -30,21 +29,21 @@ from pydantic import BaseModel
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-# Module-scope registry. Values are kept weakly so GC pressure stays neutral.
+# モジュールスコープのレジストリ。値は弱参照で GC 圧は中立に保つ。
 _SYNTHETIC_REGISTRY: WeakValueDictionary[int, BaseModel] = WeakValueDictionary()
 
-# Default SkillRef.path that satisfies H1〜H10 when ``BAKUFU_DATA_DIR`` is set.
+# ``BAKUFU_DATA_DIR`` 設定下で H1〜H10 を満たすデフォルト SkillRef.path。
 DEFAULT_SKILL_PATH: str = "bakufu-data/skills/sample-skill.md"
 
 
 def is_synthetic(instance: BaseModel) -> bool:
-    """Return ``True`` when ``instance`` was created by a factory in this module."""
+    """``instance`` が本モジュールのファクトリで生成されたものなら ``True`` を返す。"""
     cached = _SYNTHETIC_REGISTRY.get(id(instance))
     return cached is instance
 
 
 def _register(instance: BaseModel) -> None:
-    """Record ``instance`` in the synthetic registry."""
+    """``instance`` を合成レジストリに記録する。"""
     _SYNTHETIC_REGISTRY[id(instance)] = instance
 
 
@@ -57,7 +56,7 @@ def make_persona(
     archetype: str = "review-focused",
     prompt_body: str = "You are a thorough reviewer.",
 ) -> Persona:
-    """Build a valid :class:`Persona`."""
+    """妥当な :class:`Persona` を構築する。"""
     persona = Persona(
         display_name=display_name,
         archetype=archetype,
@@ -76,7 +75,7 @@ def make_provider_config(
     model: str = "sonnet-4.5",
     is_default: bool = True,
 ) -> ProviderConfig:
-    """Build a valid :class:`ProviderConfig` with ``is_default=True`` by default."""
+    """妥当な :class:`ProviderConfig` を構築する。デフォルトは ``is_default=True``。"""
     config = ProviderConfig(
         provider_kind=provider_kind,
         model=model,
@@ -95,7 +94,7 @@ def make_skill_ref(
     name: str = "sample-skill",
     path: str = DEFAULT_SKILL_PATH,
 ) -> SkillRef:
-    """Build a valid :class:`SkillRef`. Requires ``BAKUFU_DATA_DIR`` env var (H10)."""
+    """妥当な :class:`SkillRef` を構築する。``BAKUFU_DATA_DIR`` 環境変数を要する (H10)。"""
     ref = SkillRef(
         skill_id=skill_id if skill_id is not None else uuid4(),
         name=name,
@@ -119,13 +118,13 @@ def make_agent(
     skills: Sequence[SkillRef] | None = None,
     archived: bool = False,
 ) -> Agent:
-    """Build a valid :class:`Agent`.
+    """妥当な :class:`Agent` を構築する。
 
-    With no overrides yields the simplest valid Agent: a fresh ``empire_id``,
-    1 ProviderConfig with ``is_default=True``, no skills, ``archived=False``.
-    Tests that exercise the agent-repository ``find_by_name`` scope or any
-    Empire-level membership invariant should override ``empire_id`` so the
-    factory's freshly-generated default does not collide with their setup.
+    上書きなしの場合、最小妥当な Agent を返す: 新規 ``empire_id``、
+    ``is_default=True`` の ProviderConfig 1 件、skill なし、``archived=False``。
+    agent-repository の ``find_by_name`` スコープや Empire レベルの
+    membership 不変条件を検証するテストは ``empire_id`` を上書きすること ──
+    ファクトリが新規生成するデフォルトがテスト側のセットアップと衝突しないように。
     """
     if persona is None:
         persona = make_persona()
@@ -148,7 +147,7 @@ def make_agent(
 
 
 def make_archived_agent(**overrides: object) -> Agent:
-    """Build an Agent with ``archived=True`` for idempotency test setups."""
+    """冪等性テスト用に ``archived=True`` の Agent を構築する。"""
     return make_agent(archived=True, **overrides)  # pyright: ignore[reportArgumentType]
 
 

--- a/backend/tests/factories/directive.py
+++ b/backend/tests/factories/directive.py
@@ -1,16 +1,16 @@
-"""Factories for the Directive Aggregate Root.
+"""Directive アグリゲートルートのファクトリ群.
 
-Per ``docs/features/directive/test-design.md``. Mirrors the
-empire / workflow / agent / room pattern: every factory returns a
-*valid* default instance built through the production constructor,
-allows keyword overrides, and registers the result in a
-:class:`WeakValueDictionary` so :func:`is_synthetic` can later flag
-test-built objects without mutating the frozen Pydantic model.
+``docs/features/directive/test-design.md`` 準拠。
+empire / workflow / agent / room と同パターン: 各ファクトリは本番
+コンストラクタ経由で *妥当* なデフォルトインスタンスを返し、キーワード
+上書きを許可し、結果を :class:`WeakValueDictionary` に登録する。これにより
+:func:`is_synthetic` が後から、frozen Pydantic モデルを変更せずに
+テスト由来オブジェクトをフラグ付けできる。
 
-Default Directive carries a short ``text`` body and ``task_id=None``.
-``LinkedDirectiveFactory`` constructs the post-link state directly
-(Repository hydration scenario, §確定 C). ``LongTextDirectiveFactory``
-sits at the upper boundary (10000 chars).
+デフォルト Directive は短い ``text`` 本文と ``task_id=None`` を持つ。
+``LinkedDirectiveFactory`` は post-link 状態を直接構築する
+(Repository ハイドレートシナリオ、§確定 C)。``LongTextDirectiveFactory`` は
+上限境界 (10000 文字) にある。
 """
 
 from __future__ import annotations
@@ -22,18 +22,18 @@ from weakref import WeakValueDictionary
 from bakufu.domain.directive import Directive
 from pydantic import BaseModel
 
-# Module-scope registry. Values are kept weakly so GC pressure stays neutral.
+# モジュールスコープのレジストリ。値は弱参照で GC 圧は中立に保つ。
 _SYNTHETIC_REGISTRY: WeakValueDictionary[int, BaseModel] = WeakValueDictionary()
 
 
 def is_synthetic(instance: BaseModel) -> bool:
-    """Return ``True`` when ``instance`` was created by a factory in this module."""
+    """``instance`` が本モジュールのファクトリで生成されたものなら ``True`` を返す。"""
     cached = _SYNTHETIC_REGISTRY.get(id(instance))
     return cached is instance
 
 
 def _register(instance: BaseModel) -> None:
-    """Record ``instance`` in the synthetic registry."""
+    """``instance`` を合成レジストリに記録する。"""
     _SYNTHETIC_REGISTRY[id(instance)] = instance
 
 
@@ -45,12 +45,12 @@ def make_directive(
     created_at: datetime | None = None,
     task_id: UUID | None = None,
 ) -> Directive:
-    """Build a valid :class:`Directive`.
+    """妥当な :class:`Directive` を構築する。
 
-    Defaults: short ``text`` containing the ``$`` prefix the
-    application layer would have normalized, ``task_id=None`` (not yet
-    linked), ``created_at=datetime.now(UTC)`` so the tz-aware
-    constraint is satisfied without per-test setup.
+    デフォルト: アプリケーション層が正規化していたであろう ``$`` プレフィックス
+    を含む短い ``text``、``task_id=None`` (まだ link されていない)、
+    ``created_at=datetime.now(UTC)`` ── テストごとのセットアップなしに
+    tz-aware 制約を満たすため。
     """
     directive = Directive(
         id=directive_id if directive_id is not None else uuid4(),
@@ -70,12 +70,11 @@ def make_linked_directive(
     target_room_id: UUID | None = None,
     task_id: UUID | None = None,
 ) -> Directive:
-    """Build a Directive that already has a non-``None`` ``task_id``.
+    """既に非 ``None`` の ``task_id`` を持つ Directive を構築する。
 
-    Repository hydration scenario (§確定 C): the constructor accepts
-    a permanent ``task_id`` value for restoring an already-linked
-    Directive from disk. ``link_task`` against the returned instance
-    will Fail Fast.
+    Repository ハイドレートシナリオ (§確定 C): コンストラクタは永続的な
+    ``task_id`` 値を受理し、既に link 済みの Directive をディスクから
+    復元する。返却インスタンスに対して ``link_task`` を呼ぶと Fail Fast する。
     """
     return make_directive(
         directive_id=directive_id,
@@ -86,7 +85,7 @@ def make_linked_directive(
 
 
 def make_long_text_directive() -> Directive:
-    """Build a Directive at the upper boundary (10000 NFC chars)."""
+    """上限境界 (NFC 10000 文字) の Directive を構築する。"""
     return make_directive(text="a" * 10_000)
 
 

--- a/backend/tests/factories/empire.py
+++ b/backend/tests/factories/empire.py
@@ -1,26 +1,26 @@
-"""Factories for the Empire aggregate and its reference VOs.
+"""Empire アグリゲートと参照 VO のファクトリ群.
 
-Per ``docs/features/empire/test-design.md`` (REQ-EM-001〜005, factories), each
-factory:
+``docs/features/empire/test-design.md`` (REQ-EM-001〜005, factories) 準拠。
+各ファクトリは:
 
-* Returns a *valid* default instance built via the production constructor.
-* Allows keyword overrides so individual tests can exercise specific edge
-  cases without copy-pasting full kwargs.
-* Registers the produced instance in :data:`_SYNTHETIC_REGISTRY` so
-  :func:`is_synthetic` can later confirm "this object came from a factory".
+* 本番コンストラクタ経由で *妥当* なデフォルトインスタンスを返す。
+* キーワード上書きを許可し、個別テストが完全な kwargs を貼り付けずに
+  特定の境界値を検証できるようにする。
+* 生成したインスタンスを :data:`_SYNTHETIC_REGISTRY` に登録し、
+  :func:`is_synthetic` で後から「ファクトリ由来か」を確認できるようにする。
 
-Why a ``WeakValueDictionary`` over inline metadata?
+``WeakValueDictionary`` をインラインメタデータより優先する理由:
 
-* :class:`bakufu.domain.empire.Empire`, :class:`RoomRef` and :class:`AgentRef`
-  are ``frozen=True`` Pydantic v2 models with ``extra='forbid'`` — adding a
-  ``_meta.synthetic`` attribute (the naive approach) is physically impossible.
-* A weak-value registry keyed by ``id(instance)`` lets us flag instances
-  externally; entries auto-evict when the value is garbage collected, so
-  ``id`` reuse on a freshly allocated, unrelated instance simply yields a
-  cache miss instead of a false positive.
+* :class:`bakufu.domain.empire.Empire`、:class:`RoomRef`、:class:`AgentRef`
+  は ``frozen=True`` で ``extra='forbid'`` の Pydantic v2 モデル ──
+  素朴な ``_meta.synthetic`` 属性追加は物理的に不可能。
+* ``id(instance)`` をキーとする弱参照レジストリは外側からインスタンスに
+  フラグ付けする。値が GC されるとエントリは自動失効するので、無関係な
+  新規 allocate で ``id`` が再利用されても false positive ではなく
+  キャッシュミスとなる。
 
-Production code MUST NOT import this module — it lives under ``tests/`` to
-keep the synthetic-data boundary auditable.
+本モジュールを本番コードから import してはならない ── 合成データ境界を
+監査可能に保つため ``tests/`` 配下に配置されている。
 """
 
 from __future__ import annotations
@@ -36,29 +36,29 @@ from pydantic import BaseModel
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-# Module-scope registry. Values are kept weakly so GC pressure stays neutral;
-# we only want to know "did a factory produce this object" while it's alive.
+# モジュールスコープのレジストリ。値は弱参照で保持するので GC 圧は中立 ──
+# 「このオブジェクトはファクトリ由来か」をオブジェクト生存中だけ知ればよい。
 _SYNTHETIC_REGISTRY: WeakValueDictionary[int, BaseModel] = WeakValueDictionary()
 
 
 def is_synthetic(instance: BaseModel) -> bool:
-    """Return ``True`` when ``instance`` was created by a factory in this module.
+    """``instance`` が本モジュールのファクトリで生成されたものなら ``True`` を返す。
 
-    The check is identity-based (``id``) rather than structural so two
-    independently-produced equal instances are still distinguishable: only the
-    actual object the factory returned is marked synthetic.
+    検査は構造的ではなく ID ベース (``id``)。これにより独立に生成された
+    等値の 2 インスタンスは区別される ── ファクトリが返した実オブジェクトのみ
+    合成印が付く。
     """
     cached = _SYNTHETIC_REGISTRY.get(id(instance))
     return cached is instance
 
 
 def _register(instance: BaseModel) -> None:
-    """Record ``instance`` in the synthetic registry."""
+    """``instance`` を合成レジストリに記録する。"""
     _SYNTHETIC_REGISTRY[id(instance)] = instance
 
 
 # ---------------------------------------------------------------------------
-# RoomRef factory
+# RoomRef ファクトリ
 # ---------------------------------------------------------------------------
 def make_room_ref(
     *,
@@ -66,7 +66,7 @@ def make_room_ref(
     name: str = "ルーム",
     archived: bool = False,
 ) -> RoomRef:
-    """Build a valid :class:`RoomRef` and register it as synthetic."""
+    """妥当な :class:`RoomRef` を構築し合成印を付ける。"""
     ref = RoomRef(
         room_id=room_id if room_id is not None else uuid4(),
         name=name,
@@ -77,7 +77,7 @@ def make_room_ref(
 
 
 # ---------------------------------------------------------------------------
-# AgentRef factory
+# AgentRef ファクトリ
 # ---------------------------------------------------------------------------
 def make_agent_ref(
     *,
@@ -85,7 +85,7 @@ def make_agent_ref(
     name: str = "エージェント",
     role: Role = Role.DEVELOPER,
 ) -> AgentRef:
-    """Build a valid :class:`AgentRef` and register it as synthetic."""
+    """妥当な :class:`AgentRef` を構築し合成印を付ける。"""
     ref = AgentRef(
         agent_id=agent_id if agent_id is not None else uuid4(),
         name=name,
@@ -96,7 +96,7 @@ def make_agent_ref(
 
 
 # ---------------------------------------------------------------------------
-# Empire factory
+# Empire ファクトリ
 # ---------------------------------------------------------------------------
 def make_empire(
     *,
@@ -105,12 +105,11 @@ def make_empire(
     rooms: Sequence[RoomRef] | None = None,
     agents: Sequence[AgentRef] | None = None,
 ) -> Empire:
-    """Build a valid :class:`Empire` and register it as synthetic.
+    """妥当な :class:`Empire` を構築し合成印を付ける。
 
-    Defaults yield an empty Empire with no rooms or agents — the simplest
-    valid aggregate state, suitable for the majority of tests that then mutate
-    via the public ``hire_agent`` / ``establish_room`` / ``archive_room``
-    behaviors.
+    上書きなしの場合、room / agent なしの空 Empire を返す ── 最小妥当な
+    aggregate 状態。これは公開 behavior (``hire_agent`` / ``establish_room``
+    / ``archive_room``) で変更する大多数のテストに適している。
     """
     empire = Empire(
         id=empire_id if empire_id is not None else uuid4(),
@@ -129,16 +128,16 @@ def make_populated_empire(
     n_rooms: int = 2,
     n_agents: int = 3,
 ) -> Empire:
-    """Build an Empire with N rooms + M agents for Repository round-trip tests.
+    """Repository ラウンドトリップテスト用に N rooms + M agents の Empire を構築する。
 
-    The Empire-Repository PR (#25) needs this factory to exercise the
-    §確定 B delete-then-insert flow — empty Empires touch only the
-    ``empires`` table while a populated Empire writes all three tables
-    (empires + empire_room_refs + empire_agent_refs) so the test can
-    assert that the side tables actually receive their bulk INSERTs.
+    Empire-Repository PR (#25) は §確定 B delete-then-insert フローを
+    検証するために本ファクトリを必要とする ── 空 Empire は ``empires``
+    テーブルのみを触るが、populated Empire は 3 テーブル全て
+    (empires + empire_room_refs + empire_agent_refs) に書く。これにより
+    side テーブルが実際にバルク INSERT を受けることをテストでアサートできる。
 
-    Roles cycle through DEVELOPER / TESTER / REVIEWER so a 3-agent
-    Empire spans three distinct Role enum values.
+    role は DEVELOPER / TESTER / REVIEWER を巡回する ── 3 agent の Empire は
+    3 つの別 Role enum 値を網羅する。
     """
     rooms = [make_room_ref(name=f"ルーム{i + 1}") for i in range(n_rooms)]
     role_cycle = [Role.DEVELOPER, Role.TESTER, Role.REVIEWER]

--- a/backend/tests/factories/external_review_gate.py
+++ b/backend/tests/factories/external_review_gate.py
@@ -1,25 +1,23 @@
-"""Factories for the ExternalReviewGate aggregate and its VOs.
+"""ExternalReviewGate アグリゲートと VO のファクトリ群.
 
-Per ``docs/features/external-review-gate/test-design.md`` §外部 I/O 依存
-マップ. Mirrors the M1 6-sibling pattern (empire / workflow / agent /
-room / directive / task): every factory returns a *valid* default
-instance built through the production constructor, allows keyword
-overrides, and registers the result in a :class:`WeakValueDictionary`
-so :func:`is_synthetic` can later flag test-built objects without
-mutating the frozen Pydantic models.
+``docs/features/external-review-gate/test-design.md`` §外部 I/O 依存
+マップ 準拠。M1 の 6 兄弟パターン (empire / workflow / agent /
+room / directive / task) を踏襲: 各ファクトリは本番コンストラクタ経由で
+*妥当* なデフォルトインスタンスを返し、キーワード上書きを許可し、結果を
+:class:`WeakValueDictionary` に登録する。これにより :func:`is_synthetic`
+が後から、frozen Pydantic モデルを変更せずにテスト由来オブジェクトを
+フラグ付けできる。
 
-Five Gate factories are exposed (one per ``ReviewDecision`` + a
-PendingGateFactory baseline) so each lifecycle position can be
-reached without walking the state machine in setup. The factories
-build directly via ``ExternalReviewGate.model_validate`` — they do
-NOT call the behavior methods — because tests for the behavior
-methods need a clean entry state without prior method-driven
-mutation (and the §確定 C audit_trail append-only contract means
-factory-set audit_trail bytes are pinned for every subsequent
-mutation).
+5 つの Gate ファクトリを公開する (``ReviewDecision`` ごと + PendingGateFactory
+ベースライン)。これによりセットアップでステートマシンを歩かずに任意の
+ライフサイクル位置へ到達できる。ファクトリは ``ExternalReviewGate.model_validate``
+で直接構築する ── behavior メソッドは呼ばない ── behavior メソッドのテストには
+メソッド駆動の事前変更なしのクリーンな入口状態が必要なため (加えて
+§確定 C audit_trail append-only 契約により、ファクトリで設定した audit_trail
+バイト列は後続のあらゆる mutation に対して固定される)。
 
-Production code MUST NOT import this module — it lives under
-``tests/`` to keep the synthetic-data boundary auditable.
+本モジュールを本番コードから import してはならない ── 合成データ境界を
+監査可能に保つため ``tests/`` 配下に配置されている。
 """
 
 from __future__ import annotations
@@ -43,31 +41,29 @@ from tests.factories.task import make_deliverable
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-# Module-scope registry. Values are kept weakly so GC pressure stays
-# neutral; we only want to know "did a factory produce this object"
-# while it's alive.
+# モジュールスコープのレジストリ。値は弱参照で保持するので GC 圧は中立 ──
+# 「このオブジェクトはファクトリ由来か」をオブジェクト生存中だけ知ればよい。
 _SYNTHETIC_REGISTRY: WeakValueDictionary[int, BaseModel] = WeakValueDictionary()
 
 
 def is_synthetic(instance: BaseModel) -> bool:
-    """Return ``True`` when ``instance`` was created by a factory in this module.
+    """``instance`` が本モジュールのファクトリで生成されたものなら ``True`` を返す。
 
-    The check is identity-based (``id``) rather than structural so
-    two independently-produced equal instances are still
-    distinguishable: only the actual object the factory returned is
-    marked synthetic.
+    検査は構造的ではなく ID ベース (``id``)。これにより独立に生成された
+    等値の 2 インスタンスは区別される ── ファクトリが返した実オブジェクトのみ
+    合成印が付く。
     """
     cached = _SYNTHETIC_REGISTRY.get(id(instance))
     return cached is instance
 
 
 def _register(instance: BaseModel) -> None:
-    """Record ``instance`` in the synthetic registry."""
+    """``instance`` を合成レジストリに記録する。"""
     _SYNTHETIC_REGISTRY[id(instance)] = instance
 
 
 # ---------------------------------------------------------------------------
-# AuditEntry factory
+# AuditEntry ファクトリ
 # ---------------------------------------------------------------------------
 def make_audit_entry(
     *,
@@ -77,11 +73,11 @@ def make_audit_entry(
     comment: str = "",
     occurred_at: datetime | None = None,
 ) -> AuditEntry:
-    """Build a valid :class:`AuditEntry`.
+    """妥当な :class:`AuditEntry` を構築する。
 
-    Defaults to a VIEWED audit entry — the simplest legal shape that
-    every Gate state can carry. Tests that need APPROVED / REJECTED /
-    CANCELLED audit rows override ``action`` explicitly.
+    デフォルトは VIEWED 監査エントリ ── 全ての Gate 状態が運べる最小の
+    正当形。APPROVED / REJECTED / CANCELLED 監査行が要るテストは
+    ``action`` を明示上書きする。
     """
     entry = AuditEntry(
         id=entry_id if entry_id is not None else uuid4(),
@@ -95,7 +91,7 @@ def make_audit_entry(
 
 
 # ---------------------------------------------------------------------------
-# ExternalReviewGate factories — one per ReviewDecision + a baseline
+# ExternalReviewGate ファクトリ ── ReviewDecision ごと + ベースライン
 # ---------------------------------------------------------------------------
 def make_gate(
     *,
@@ -110,16 +106,16 @@ def make_gate(
     created_at: datetime | None = None,
     decided_at: datetime | None = None,
 ) -> ExternalReviewGate:
-    """Build a valid :class:`ExternalReviewGate` directly via ``model_validate``.
+    """妥当な :class:`ExternalReviewGate` を ``model_validate`` 経由で直接構築する。
 
-    Defaults yield a PENDING Gate with no audit entries, no feedback,
-    and ``decided_at=None`` — the canonical entry state right after
-    ``GateService.create()`` (after Task.request_external_review).
+    デフォルトは監査エントリなし、feedback なし、``decided_at=None`` の
+    PENDING Gate ── ``GateService.create()`` 直後 (Task.request_external_review
+    後) の canonical な入口状態。
 
-    Note: ``decision != PENDING`` requires a non-None ``decided_at``
-    per the consistency invariant; tests that need a terminal Gate
-    should use :func:`make_approved_gate` /
-    :func:`make_rejected_gate` / :func:`make_cancelled_gate`.
+    注意: ``decision != PENDING`` は consistency invariant により非 None の
+    ``decided_at`` を要する。terminal Gate が要るテストは
+    :func:`make_approved_gate` / :func:`make_rejected_gate` /
+    :func:`make_cancelled_gate` を使うこと。
     """
     now = datetime.now(UTC)
     gate = ExternalReviewGate.model_validate(
@@ -149,7 +145,7 @@ def make_approved_gate(
     decided_at: datetime | None = None,
     **overrides: object,
 ) -> ExternalReviewGate:
-    """Build an APPROVED Gate. ``decided_at`` is mandatory for the consistency invariant."""
+    """APPROVED Gate を構築する。consistency invariant のため ``decided_at`` 必須。"""
     decided_at = decided_at if decided_at is not None else datetime.now(UTC)
     if audit_trail is None:
         audit_trail = [
@@ -171,7 +167,7 @@ def make_rejected_gate(
     decided_at: datetime | None = None,
     **overrides: object,
 ) -> ExternalReviewGate:
-    """Build a REJECTED Gate."""
+    """REJECTED Gate を構築する。"""
     decided_at = decided_at if decided_at is not None else datetime.now(UTC)
     if audit_trail is None:
         audit_trail = [
@@ -193,7 +189,7 @@ def make_cancelled_gate(
     decided_at: datetime | None = None,
     **overrides: object,
 ) -> ExternalReviewGate:
-    """Build a CANCELLED Gate."""
+    """CANCELLED Gate を構築する。"""
     decided_at = decided_at if decided_at is not None else datetime.now(UTC)
     if audit_trail is None:
         audit_trail = [

--- a/backend/tests/factories/internal_review_gate.py
+++ b/backend/tests/factories/internal_review_gate.py
@@ -1,24 +1,24 @@
-"""Factories for the InternalReviewGate aggregate and its VOs.
+"""InternalReviewGate アグリゲートと VO のファクトリ群.
 
-Per ``docs/features/internal-review-gate/domain/test-design.md`` §外部 I/O 依存マップ.
-Mirrors the M1 sibling pattern (external_review_gate / agent / room / directive / task /
-workflow): every factory returns a *valid* default instance built through the production
-constructor, allows keyword overrides, and registers the result in a
-:class:`WeakValueDictionary` so :func:`is_synthetic` can later flag test-built objects
-without mutating the frozen Pydantic models.
+``docs/features/internal-review-gate/domain/test-design.md`` §外部 I/O 依存マップ
+準拠。M1 兄弟パターン (external_review_gate / agent / room / directive / task /
+workflow) を踏襲: 各ファクトリは本番コンストラクタ経由で *妥当* なデフォルト
+インスタンスを返し、キーワード上書きを許可し、結果を :class:`WeakValueDictionary`
+に登録する。これにより :func:`is_synthetic` が後から、frozen Pydantic モデルを
+変更せずにテスト由来オブジェクトをフラグ付けできる。
 
-Four factories are exposed:
+公開ファクトリ 4 種:
 
-* :func:`make_verdict` — a single APPROVED :class:`Verdict` VO.
-* :func:`make_gate` — a PENDING :class:`InternalReviewGate` (empty verdicts).
-* :func:`make_all_approved_gate` — ALL_APPROVED Gate with all required roles voted.
-* :func:`make_rejected_gate` — REJECTED Gate with one REJECTED verdict.
+* :func:`make_verdict` ── 単一 APPROVED の :class:`Verdict` VO。
+* :func:`make_gate` ── PENDING の :class:`InternalReviewGate` (verdicts 空)。
+* :func:`make_all_approved_gate` ── 全 required role が投票した ALL_APPROVED Gate。
+* :func:`make_rejected_gate` ── REJECTED verdict 1 件を持つ REJECTED Gate。
 
-Factories build directly via ``model_validate`` — they do **NOT** call ``submit_verdict``
-— because unit tests for the behavior methods need a clean entry state without prior
-method-driven mutation.
+ファクトリは ``model_validate`` で直接構築する ── ``submit_verdict`` は **呼ばない**
+── behavior メソッドのユニットテストにはメソッド駆動の事前変更なしの
+クリーンな入口状態が必要なため。
 
-Production code MUST NOT import this module.
+本モジュールを本番コードから import してはならない。
 """
 
 from __future__ import annotations
@@ -35,21 +35,21 @@ from bakufu.domain.value_objects import (
 )
 from pydantic import BaseModel
 
-# Module-scope registry: synthetic instances are tracked weakly so GC pressure
-# stays neutral while the object is alive.
+# モジュールスコープのレジストリ: 合成インスタンスを弱参照で追跡し、
+# オブジェクト生存中の GC 圧を中立に保つ。
 _SYNTHETIC_REGISTRY: WeakValueDictionary[int, BaseModel] = WeakValueDictionary()
 
-# Default role set shared by PENDING / REJECTED factories.
+# PENDING / REJECTED ファクトリで共有するデフォルト role 集合。
 _DEFAULT_ROLES: frozenset[str] = frozenset({"reviewer", "ux", "security"})
-# Smaller role set used by ALL_APPROVED factory (keeps verdicts minimal).
+# ALL_APPROVED ファクトリで使う小さめの role 集合 (verdicts を最小に保つ)。
 _APPROVED_ROLES: frozenset[str] = frozenset({"reviewer", "ux"})
 
 
 def is_synthetic(instance: BaseModel) -> bool:
-    """Return ``True`` when ``instance`` was created by a factory in this module.
+    """``instance`` が本モジュールのファクトリで生成されたものなら ``True`` を返す。
 
-    Check is identity-based (``id()``) so two independently-produced equal
-    instances are still distinguishable.
+    検査は ID ベース (``id()``) ── 独立に生成された等値の 2 インスタンスは
+    区別される。
     """
     cached = _SYNTHETIC_REGISTRY.get(id(instance))
     return cached is instance
@@ -60,7 +60,7 @@ def _register(instance: BaseModel) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Verdict factory
+# Verdict ファクトリ
 # ---------------------------------------------------------------------------
 def make_verdict(
     *,
@@ -70,10 +70,10 @@ def make_verdict(
     comment: str = "",
     decided_at: datetime | None = None,
 ) -> Verdict:
-    """Build a valid :class:`Verdict` VO.
+    """妥当な :class:`Verdict` VO を構築する。
 
-    Defaults to an APPROVED verdict from the ``"reviewer"`` role with an
-    empty comment — the simplest legal shape for unit test setup.
+    デフォルトは ``"reviewer"`` role からの APPROVED verdict、空 comment ──
+    ユニットテストのセットアップに最適な最小の正当形。
     """
     verdict = Verdict(
         role=role,
@@ -87,7 +87,7 @@ def make_verdict(
 
 
 # ---------------------------------------------------------------------------
-# InternalReviewGate factories
+# InternalReviewGate ファクトリ
 # ---------------------------------------------------------------------------
 def make_gate(
     *,
@@ -99,15 +99,16 @@ def make_gate(
     gate_decision: GateDecision = GateDecision.PENDING,
     created_at: datetime | None = None,
 ) -> InternalReviewGate:
-    """Build a valid PENDING :class:`InternalReviewGate` directly via ``model_validate``.
+    """妥当な PENDING :class:`InternalReviewGate` を ``model_validate`` で直接構築する。
 
-    Defaults:
+    デフォルト:
     * ``gate_decision = PENDING``
     * ``verdicts = []``
     * ``required_gate_roles = {"reviewer", "ux", "security"}``
 
-    Pass ``verdicts`` + matching ``gate_decision`` to build terminal-state Gates
-    (prefer :func:`make_all_approved_gate` / :func:`make_rejected_gate` for that).
+    terminal 状態の Gate を構築する場合は ``verdicts`` と整合する
+    ``gate_decision`` を渡す (専用 :func:`make_all_approved_gate` /
+    :func:`make_rejected_gate` を優先するのが望ましい)。
     """
     now = datetime.now(UTC)
     roles = required_gate_roles if required_gate_roles is not None else _DEFAULT_ROLES
@@ -134,11 +135,11 @@ def make_all_approved_gate(
     task_id: UUID | None = None,
     stage_id: UUID | None = None,
 ) -> InternalReviewGate:
-    """Build an ALL_APPROVED :class:`InternalReviewGate`.
+    """ALL_APPROVED :class:`InternalReviewGate` を構築する。
 
-    Defaults to ``required_gate_roles={"reviewer","ux"}`` — the smallest
-    valid set that demonstrates full consensus (2 APPROVED verdicts).
-    Every required role gets an APPROVED Verdict.
+    デフォルトは ``required_gate_roles={"reviewer","ux"}`` ── 全コンセンサス
+    (2 件の APPROVED verdict) を示す最小の妥当集合。required role 全てに
+    APPROVED Verdict を割り当てる。
     """
     roles = required_gate_roles if required_gate_roles is not None else _APPROVED_ROLES
     ts = datetime.now(UTC)
@@ -165,11 +166,10 @@ def make_rejected_gate(
     task_id: UUID | None = None,
     stage_id: UUID | None = None,
 ) -> InternalReviewGate:
-    """Build a REJECTED :class:`InternalReviewGate`.
+    """REJECTED :class:`InternalReviewGate` を構築する。
 
-    One REJECTED Verdict from ``rejecting_role``; remaining required roles
-    are *not* submitted (demonstrates the most-pessimistic-wins rule:
-    immediate REJECTED even with pending roles).
+    ``rejecting_role`` からの REJECTED Verdict 1 件 ── 残りの required role は
+    *未提出* (pessimistic-wins ルールを示す: 未提出 role があっても即時 REJECTED)。
     """
     roles = required_gate_roles if required_gate_roles is not None else _DEFAULT_ROLES
     if rejecting_role not in roles:

--- a/backend/tests/factories/psutil_process.py
+++ b/backend/tests/factories/psutil_process.py
@@ -1,18 +1,17 @@
-"""Factories for psutil.Process behavior under pid_gc tests.
+"""pid_gc テスト下の psutil.Process 挙動のためのファクトリ群.
 
-Per ``docs/features/persistence-foundation/test-design.md`` §外部 I/O
-依存マップ. The pid_gc unit tests cannot spawn / SIGKILL real processes
-(OS-dependent and unsafe in CI), so we build minimal mock objects whose
-``create_time`` / ``children`` / ``is_running`` / ``send_signal`` shapes
-match psutil's documented contract.
+``docs/features/persistence-foundation/test-design.md`` §外部 I/O 依存マップ
+準拠。pid_gc のユニットテストは実プロセスの spawn / SIGKILL を行えない
+(OS 依存で CI では危険) ため、psutil の文書化された契約と同じ
+``create_time`` / ``children`` / ``is_running`` / ``send_signal`` 形状を
+持つ最小限のモックオブジェクトを構築する。
 
-Each factory tags its output with ``_meta = {"synthetic": True}`` so a
-reviewer or future linter can spot test-built objects against real
-``psutil.Process`` instances.
+各ファクトリは出力に ``_meta = {"synthetic": True}`` を付ける ── レビュアや
+将来のリンタが、実 ``psutil.Process`` インスタンスとテスト由来オブジェクトを
+区別できるように。
 
-The mock surface intentionally mirrors only the methods :mod:`pid_gc`
-actually calls — adding more would let tests drift further from the
-production code path.
+モック面は :mod:`pid_gc` が実際に呼ぶメソッドだけを意図的に反映する ──
+それ以上を追加するとテストが本番コード経路から離れ過ぎる。
 """
 
 from __future__ import annotations
@@ -28,8 +27,8 @@ if TYPE_CHECKING:
 
 
 def _tag_synthetic(mock_obj: MagicMock) -> MagicMock:
-    """Stamp ``_meta.synthetic=True`` so reviewers can spot factory output."""
-    mock_obj._meta = {"synthetic": True}  # intentional mock attribute
+    """``_meta.synthetic=True`` を付け、レビュアがファクトリ出力を見分けられるようにする。"""
+    mock_obj._meta = {"synthetic": True}  # 意図的なモック属性
     return mock_obj
 
 
@@ -39,10 +38,10 @@ def make_orphan_process(
     create_time_seconds: float | None = None,
     children: Sequence[MagicMock] | None = None,
 ) -> MagicMock:
-    """Build a psutil.Process mock representing an orphan to kill.
+    """kill 対象のオーファンを表す psutil.Process モックを構築する。
 
-    The ``create_time()`` value matches the recorded ``started_at`` —
-    pid_gc's classifier returns ``'orphan_kill'`` for this shape.
+    ``create_time()`` 値は記録済みの ``started_at`` と一致する ──
+    pid_gc の分類器がこの形状に対して ``'orphan_kill'`` を返す。
     """
     proc = MagicMock(spec=psutil.Process)
     proc.pid = pid
@@ -60,17 +59,16 @@ def make_protected_process(
     pid: int = 5678,
     recorded_started_at: datetime | None = None,
 ) -> MagicMock:
-    """Build a psutil.Process mock whose ``create_time`` mismatches.
+    """``create_time`` が不一致な psutil.Process モックを構築する。
 
-    pid_gc must classify this as ``'protected'`` (PID was reused by an
-    unrelated process) and refuse to send any signal.
+    pid_gc はこれを ``'protected'`` (PID が無関係なプロセスで再利用)
+    と分類し、シグナル送信を拒否しなければならない。
     """
     proc = MagicMock(spec=psutil.Process)
     proc.pid = pid
     if recorded_started_at is None:
         recorded_started_at = datetime.now(UTC)
-    # Live create_time is 1 hour later than what we recorded — clearly
-    # a different process.
+    # 実 create_time は記録値より 1 時間後 ── 明らかに別プロセス。
     proc.create_time.return_value = recorded_started_at.timestamp() + 3600.0
     proc.children.return_value = []
     proc.send_signal = MagicMock()
@@ -79,15 +77,15 @@ def make_protected_process(
 
 
 def make_no_such_process_factory(pid: int = 9999) -> type[psutil.NoSuchProcess]:
-    """Return a ``psutil.NoSuchProcess`` constructor pre-bound to ``pid``."""
+    """``pid`` を事前束縛した ``psutil.NoSuchProcess`` コンストラクタを返す。"""
     return type("_BoundNoSuchProcess", (psutil.NoSuchProcess,), {"_meta_pid": pid})
 
 
 def make_access_denied_process(*, pid: int = 7777) -> MagicMock:
-    """Build a mock whose ``create_time`` raises ``psutil.AccessDenied``.
+    """``create_time`` が ``psutil.AccessDenied`` を発するモックを構築する。
 
-    pid_gc must WARN-log and leave the registry row for the next sweep —
-    DELETE-ing under AccessDenied lets orphans accumulate forever.
+    pid_gc は WARN ログを出して次の sweep までレジストリ行を残さねばならない ──
+    AccessDenied 配下で DELETE すると、オーファンが永遠に積み上がってしまう。
     """
     proc = MagicMock(spec=psutil.Process)
     proc.pid = pid
@@ -99,7 +97,7 @@ def make_access_denied_process(*, pid: int = 7777) -> MagicMock:
 
 
 def make_child_process(*, pid: int) -> MagicMock:
-    """Build a child psutil.Process mock for descendants() output."""
+    """descendants() 出力用に子 psutil.Process モックを構築する。"""
     child = MagicMock(spec=psutil.Process)
     child.pid = pid
     child.send_signal = MagicMock()

--- a/backend/tests/factories/room.py
+++ b/backend/tests/factories/room.py
@@ -1,17 +1,17 @@
-"""Factories for the Room aggregate, its entities, and its VOs.
+"""Room アグリゲート、エンティティ、VO のファクトリ群.
 
-Per ``docs/features/room/test-design.md``. Mirrors the empire / workflow /
-agent pattern: every factory returns a *valid* default instance built through
-the production constructor, allows keyword overrides, and registers the
-result in a :class:`WeakValueDictionary` so :func:`is_synthetic` can later
-flag test-built objects without mutating the frozen Pydantic models.
+``docs/features/room/test-design.md`` 準拠。empire / workflow / agent と
+同パターン: 各ファクトリは本番コンストラクタ経由で *妥当* なデフォルト
+インスタンスを返し、キーワード上書きを許可し、結果を
+:class:`WeakValueDictionary` に登録する。これにより :func:`is_synthetic` が
+後から、frozen Pydantic モデルを変更せずにテスト由来オブジェクトを
+フラグ付けできる。
 
-Default Room composes one ``LeaderMembership`` and zero PromptKit prefix
-content so the simplest construction path covers TC-UT-RM-001 with no extra
-setup. Tests that need an empty members list pass ``members=[]`` explicitly,
-which is allowed (Aggregate-level invariants accept 0〜:data:`MAX_MEMBERS`
-entries — leader-required is an application-layer responsibility, see
-TC-UT-RM-029).
+デフォルト Room は ``LeaderMembership`` 1 件と空の PromptKit prefix を
+組み合わせる ── 最短構築経路で追加セットアップなしに TC-UT-RM-001 を
+カバーするため。空 members リストが要るテストは ``members=[]`` を
+明示的に渡せる (Aggregate レベル不変条件は 0〜:data:`MAX_MEMBERS` を
+受理する ── leader 必須はアプリケーション層責務。TC-UT-RM-029 参照)。
 """
 
 from __future__ import annotations
@@ -32,18 +32,18 @@ from pydantic import BaseModel
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-# Module-scope registry. Values are kept weakly so GC pressure stays neutral.
+# モジュールスコープのレジストリ。値は弱参照で GC 圧は中立に保つ。
 _SYNTHETIC_REGISTRY: WeakValueDictionary[int, BaseModel] = WeakValueDictionary()
 
 
 def is_synthetic(instance: BaseModel) -> bool:
-    """Return ``True`` when ``instance`` was created by a factory in this module."""
+    """``instance`` が本モジュールのファクトリで生成されたものなら ``True`` を返す。"""
     cached = _SYNTHETIC_REGISTRY.get(id(instance))
     return cached is instance
 
 
 def _register(instance: BaseModel) -> None:
-    """Record ``instance`` in the synthetic registry."""
+    """``instance`` を合成レジストリに記録する。"""
     _SYNTHETIC_REGISTRY[id(instance)] = instance
 
 
@@ -56,7 +56,7 @@ def make_agent_membership(
     role: Role = Role.DEVELOPER,
     joined_at: datetime | None = None,
 ) -> AgentMembership:
-    """Build a valid :class:`AgentMembership` (default role DEVELOPER)."""
+    """妥当な :class:`AgentMembership` を構築する (デフォルト role は DEVELOPER)。"""
     membership = AgentMembership(
         agent_id=agent_id if agent_id is not None else uuid4(),
         role=role,
@@ -71,7 +71,7 @@ def make_leader_membership(
     agent_id: UUID | None = None,
     joined_at: datetime | None = None,
 ) -> AgentMembership:
-    """Build a LEADER-role :class:`AgentMembership` for populated Room scenarios."""
+    """populated Room シナリオ用の LEADER role :class:`AgentMembership` を構築する。"""
     return make_agent_membership(
         agent_id=agent_id,
         role=Role.LEADER,
@@ -86,14 +86,14 @@ def make_prompt_kit(
     *,
     prefix_markdown: str = "",
 ) -> PromptKit:
-    """Build a valid :class:`PromptKit` (default empty prefix_markdown)."""
+    """妥当な :class:`PromptKit` を構築する (デフォルト prefix_markdown は空)。"""
     kit = PromptKit(prefix_markdown=prefix_markdown)
     _register(kit)
     return kit
 
 
 def make_long_prompt_kit() -> PromptKit:
-    """Build a :class:`PromptKit` at the upper boundary (10000 chars)."""
+    """上限境界 (10000 文字) の :class:`PromptKit` を構築する。"""
     return make_prompt_kit(prefix_markdown="a" * 10_000)
 
 
@@ -110,11 +110,11 @@ def make_room(
     prompt_kit: PromptKit | None = None,
     archived: bool = False,
 ) -> Room:
-    """Build a valid :class:`Room`.
+    """妥当な :class:`Room` を構築する。
 
-    With no overrides yields the simplest valid Room: zero members, empty
-    description, default empty PromptKit, ``archived=False``. Tests that need
-    populated members pass them explicitly via ``members=[...]``.
+    上書きなしの場合、最小妥当な Room を返す: members ゼロ件、description 空、
+    デフォルトの空 PromptKit、``archived=False``。populated members が要る
+    テストは ``members=[...]`` で明示的に渡すこと。
     """
     if prompt_kit is None:
         prompt_kit = make_prompt_kit()
@@ -132,7 +132,7 @@ def make_room(
 
 
 def make_archived_room(**overrides: object) -> Room:
-    """Build a Room with ``archived=True`` for idempotency / terminal-violation setups."""
+    """冪等性 / terminal-violation セットアップ用に ``archived=True`` の Room を構築する。"""
     return make_room(archived=True, **overrides)  # pyright: ignore[reportArgumentType]
 
 
@@ -143,13 +143,13 @@ def make_populated_room(
     developer_agent_id: UUID | None = None,
     workflow_id: UUID | None = None,
 ) -> Room:
-    """Build a Room with one LEADER + one DEVELOPER membership.
+    """LEADER 1 名 + DEVELOPER 1 名の membership を持つ Room を構築する。
 
-    Useful for TC-IT-RM-001 / 002 round-trip scenarios that exercise add /
-    remove / update / archive transitions over a non-empty member list.
+    非空 member リスト上で add / remove / update / archive 遷移を検証する
+    TC-IT-RM-001 / 002 ラウンドトリップシナリオ向け。
 
-    ``workflow_id`` is forwarded to :func:`make_room` so infrastructure
-    integration tests can pass the seeded workflow FK target.
+    ``workflow_id`` は :func:`make_room` に転送される ── インフラ結合テストが
+    seeded な workflow FK ターゲットを渡せるように。
     """
     return make_room(
         room_id=room_id,
@@ -167,14 +167,14 @@ def make_room_with_secret_prompt_kit(
     prefix_markdown: str,
     workflow_id: UUID | None = None,
 ) -> Room:
-    """Build a Room whose PromptKit carries a secret-bearing ``prefix_markdown``.
+    """secret を含む ``prefix_markdown`` を持つ PromptKit を備えた Room を構築する。
 
-    Used by infrastructure tests that verify ``MaskedText`` redacts the
-    embedded secret before the row hits SQLite (§確定 R1-J 不可逆性凍結).
+    ``MaskedText`` が行を SQLite に書く前に埋め込み secret を redact することを
+    検証するインフラテストで使用する (§確定 R1-J 不可逆性凍結)。
 
-    The caller is responsible for passing a ``prefix_markdown`` that
-    contains a token matching one of the masking gateway's regex patterns
-    so the round-trip is non-identity (raw → masked).
+    呼び出し側は、masking ゲートウェイの正規表現パターンに一致するトークンを
+    含む ``prefix_markdown`` を渡す責務を持つ ── ラウンドトリップが
+    non-identity (raw → masked) となるように。
     """
     kit = make_prompt_kit(prefix_markdown=prefix_markdown)
     return make_room(

--- a/backend/tests/factories/task.py
+++ b/backend/tests/factories/task.py
@@ -1,21 +1,20 @@
-"""Factories for the Task aggregate and its VOs.
+"""Task アグリゲートと VO のファクトリ群.
 
-Per ``docs/features/task/test-design.md`` §外部 I/O 依存マップ, each
-factory returns a *valid* default instance built via the production
-constructor and registers the result in :data:`_SYNTHETIC_REGISTRY`
-so :func:`is_synthetic` can later confirm "this object came from a
-factory" — the WeakValueDictionary pattern established by the M1
-5-sibling factories (empire / workflow / agent / room / directive).
+``docs/features/task/test-design.md`` §外部 I/O 依存マップ 準拠。
+各ファクトリは本番コンストラクタ経由で *妥当* なデフォルトインスタンスを返し、
+結果を :data:`_SYNTHETIC_REGISTRY` に登録する。これにより :func:`is_synthetic`
+が後から「ファクトリ由来か」を確認できる ── M1 の 5 兄弟ファクトリ
+(empire / workflow / agent / room / directive) で確立された WeakValueDictionary
+パターン。
 
-Eight factories are exposed (one per status + DeliverableFactory +
-AttachmentFactory) so each lifecycle position can be reached without
-walking the state machine in setup. The factories build directly via
-``Task.model_validate`` — they do NOT call the behavior methods —
-because tests for the behavior methods need a clean entry state
-without prior method-driven mutation.
+8 つのファクトリを公開する (status ごと + DeliverableFactory + AttachmentFactory)。
+これによりセットアップでステートマシンを歩かずに任意のライフサイクル位置へ
+到達できる。ファクトリは ``Task.model_validate`` で直接構築する ──
+behavior メソッドは呼ばない ── behavior メソッドのテストには、メソッド駆動の
+事前変更なしのクリーンな入口状態が必要なため。
 
-Production code MUST NOT import this module — it lives under
-``tests/`` to keep the synthetic-data boundary auditable.
+本モジュールを本番コードから import してはならない ── 合成データ境界を
+監査可能に保つため ``tests/`` 配下に配置されている。
 """
 
 from __future__ import annotations
@@ -36,35 +35,33 @@ from pydantic import BaseModel
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-# Module-scope registry. Values are kept weakly so GC pressure stays
-# neutral; we only want to know "did a factory produce this object"
-# while it's alive.
+# モジュールスコープのレジストリ。値は弱参照で保持するので GC 圧は中立 ──
+# 「このオブジェクトはファクトリ由来か」をオブジェクト生存中だけ知ればよい。
 _SYNTHETIC_REGISTRY: WeakValueDictionary[int, BaseModel] = WeakValueDictionary()
 
 
 def is_synthetic(instance: BaseModel) -> bool:
-    """Return ``True`` when ``instance`` was created by a factory in this module.
+    """``instance`` が本モジュールのファクトリで生成されたものなら ``True`` を返す。
 
-    The check is identity-based (``id``) rather than structural so
-    two independently-produced equal instances are still
-    distinguishable: only the actual object the factory returned is
-    marked synthetic.
+    検査は構造的ではなく ID ベース (``id``)。これにより独立に生成された
+    等値の 2 インスタンスは区別される ── ファクトリが返した実オブジェクトのみ
+    合成印が付く。
     """
     cached = _SYNTHETIC_REGISTRY.get(id(instance))
     return cached is instance
 
 
 def _register(instance: BaseModel) -> None:
-    """Record ``instance`` in the synthetic registry."""
+    """``instance`` を合成レジストリに記録する。"""
     _SYNTHETIC_REGISTRY[id(instance)] = instance
 
 
-# A canonical 64-hex sha256 used by AttachmentFactory defaults.
+# AttachmentFactory のデフォルトで使う canonical な 64 桁 hex sha256。
 _DEFAULT_SHA256 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
 
 # ---------------------------------------------------------------------------
-# Attachment factory
+# Attachment ファクトリ
 # ---------------------------------------------------------------------------
 def make_attachment(
     *,
@@ -73,7 +70,7 @@ def make_attachment(
     mime_type: str = "image/png",
     size_bytes: int = 1024,
 ) -> Attachment:
-    """Build a valid :class:`Attachment` and register it as synthetic."""
+    """妥当な :class:`Attachment` を構築し合成印を付ける。"""
     attachment = Attachment(
         sha256=sha256,
         filename=filename,
@@ -85,7 +82,7 @@ def make_attachment(
 
 
 # ---------------------------------------------------------------------------
-# Deliverable factory
+# Deliverable ファクトリ
 # ---------------------------------------------------------------------------
 def make_deliverable(
     *,
@@ -95,7 +92,7 @@ def make_deliverable(
     committed_by: UUID | None = None,
     committed_at: datetime | None = None,
 ) -> Deliverable:
-    """Build a valid :class:`Deliverable` and register it as synthetic."""
+    """妥当な :class:`Deliverable` を構築し合成印を付ける。"""
     deliverable = Deliverable(
         stage_id=stage_id if stage_id is not None else uuid4(),
         body_markdown=body_markdown,
@@ -108,7 +105,7 @@ def make_deliverable(
 
 
 # ---------------------------------------------------------------------------
-# Task factories — one per status + a generic make_task
+# Task ファクトリ ── status ごと + 汎用 make_task
 # ---------------------------------------------------------------------------
 def make_task(
     *,
@@ -123,15 +120,15 @@ def make_task(
     created_at: datetime | None = None,
     updated_at: datetime | None = None,
 ) -> Task:
-    """Build a valid :class:`Task` directly via ``model_validate``.
+    """妥当な :class:`Task` を ``model_validate`` 経由で直接構築する。
 
-    Defaults yield a PENDING Task with no assigned agents, no
-    deliverables, and ``last_error=None`` — the canonical entry
-    state right after ``DirectiveService.issue()``.
+    デフォルトは agent 未割り当て、deliverable なし、``last_error=None``
+    の PENDING Task ── ``DirectiveService.issue()`` 直後の canonical な
+    入口状態。
 
-    Note: ``status=BLOCKED`` requires a non-empty ``last_error`` per
-    the consistency invariant; tests that need a BLOCKED Task should
-    use :func:`make_blocked_task` (or pass ``last_error`` themselves).
+    注意: ``status=BLOCKED`` は consistency invariant により非空の
+    ``last_error`` を要する。BLOCKED Task が要るテストは
+    :func:`make_blocked_task` を使うか、``last_error`` を自前で渡すこと。
     """
     now = datetime.now(UTC)
     task = Task.model_validate(
@@ -159,7 +156,7 @@ def make_in_progress_task(
     assigned_agent_ids: Sequence[UUID] | None = None,
     **overrides: object,
 ) -> Task:
-    """Build an IN_PROGRESS Task with at least one assigned agent."""
+    """少なくとも 1 件の agent を割り当てた IN_PROGRESS Task を構築する。"""
     if assigned_agent_ids is None:
         assigned_agent_ids = [uuid4()]
     return make_task(
@@ -174,7 +171,7 @@ def make_awaiting_review_task(
     assigned_agent_ids: Sequence[UUID] | None = None,
     **overrides: object,
 ) -> Task:
-    """Build an AWAITING_EXTERNAL_REVIEW Task."""
+    """AWAITING_EXTERNAL_REVIEW Task を構築する。"""
     if assigned_agent_ids is None:
         assigned_agent_ids = [uuid4()]
     return make_task(
@@ -190,7 +187,7 @@ def make_blocked_task(
     last_error: str = "AuthExpired: synthetic blocking error",
     **overrides: object,
 ) -> Task:
-    """Build a BLOCKED Task. ``last_error`` is required for consistency."""
+    """BLOCKED Task を構築する。consistency のため ``last_error`` 必須。"""
     if assigned_agent_ids is None:
         assigned_agent_ids = [uuid4()]
     return make_task(
@@ -207,7 +204,7 @@ def make_done_task(
     deliverables: dict[UUID, Deliverable] | None = None,
     **overrides: object,
 ) -> Task:
-    """Build a DONE Task with at least one deliverable accumulated."""
+    """少なくとも 1 件の deliverable が積まれた DONE Task を構築する。"""
     if assigned_agent_ids is None:
         assigned_agent_ids = [uuid4()]
     if deliverables is None:
@@ -226,7 +223,7 @@ def make_cancelled_task(
     assigned_agent_ids: Sequence[UUID] | None = None,
     **overrides: object,
 ) -> Task:
-    """Build a CANCELLED Task. ``last_error`` must be None."""
+    """CANCELLED Task を構築する。``last_error`` は None でなければならない。"""
     if assigned_agent_ids is None:
         assigned_agent_ids = [uuid4()]
     return make_task(

--- a/backend/tests/factories/workflow.py
+++ b/backend/tests/factories/workflow.py
@@ -1,26 +1,26 @@
-"""Factories for the Workflow aggregate, its entities, and VOs.
+"""Workflow アグリゲート、エンティティ、VO のファクトリ群.
 
-Per ``docs/features/workflow/test-design.md`` (REQ-WF-001〜007, factories), each
-factory:
+``docs/features/workflow/test-design.md`` (REQ-WF-001〜007, factories) 準拠。
+各ファクトリは:
 
-* Returns a *valid* default instance built via the production constructor.
-* Allows keyword overrides so individual tests can exercise specific edge
-  cases without copy-pasting full kwargs.
-* Registers the produced instance in :data:`_SYNTHETIC_REGISTRY` so
-  :func:`is_synthetic` can later confirm "this object came from a factory".
+* 本番コンストラクタ経由で *妥当* なデフォルトインスタンスを返す。
+* キーワード上書きを許可し、個別テストが完全な kwargs を貼り付けずに
+  特定の境界値を検証できるようにする。
+* 生成したインスタンスを :data:`_SYNTHETIC_REGISTRY` に登録し、
+  :func:`is_synthetic` で後から「ファクトリ由来か」を確認できるようにする。
 
-Why a ``WeakValueDictionary`` over inline metadata?
+``WeakValueDictionary`` をインラインメタデータより優先する理由:
 
-* :class:`bakufu.domain.workflow.Workflow` / :class:`Stage` / :class:`Transition`
-  and the workflow VOs (:class:`NotifyChannel`, :class:`CompletionPolicy`) are
-  ``frozen=True`` Pydantic v2 models with ``extra='forbid'``: adding a
-  ``_meta.synthetic`` attribute is physically impossible.
-* A weak-value registry keyed by ``id(instance)`` flags instances externally;
-  entries auto-evict on GC so id reuse on a freshly allocated, unrelated
-  instance simply yields a cache miss instead of a false positive.
+* :class:`bakufu.domain.workflow.Workflow` / :class:`Stage` /
+  :class:`Transition` および workflow の VO (:class:`NotifyChannel`,
+  :class:`CompletionPolicy`) は ``frozen=True`` で ``extra='forbid'`` の
+  Pydantic v2 モデル ── ``_meta.synthetic`` 属性追加が物理的に不可能。
+* ``id(instance)`` をキーとする弱参照レジストリは外側からインスタンスに
+  フラグ付けする。エントリは GC で自動失効するため、新規 allocate で
+  id が再利用されても false positive ではなくキャッシュミスとなる。
 
-Production code MUST NOT import this module. The module mirrors empire's
-factory pattern (single source of truth for the synthetic-vs-real boundary).
+本モジュールを本番コードから import してはならない。empire の
+ファクトリパターンを踏襲し、合成 vs 実物境界の単一情報源を担う。
 """
 
 from __future__ import annotations
@@ -43,25 +43,25 @@ from pydantic import BaseModel
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-# Module-scope registry. Values are kept weakly so GC pressure stays neutral;
-# we only want to know "did a factory produce this object" while it's alive.
+# モジュールスコープのレジストリ。値は弱参照で保持するので GC 圧は中立 ──
+# 「このオブジェクトはファクトリ由来か」をオブジェクト生存中だけ知ればよい。
 _SYNTHETIC_REGISTRY: WeakValueDictionary[int, BaseModel] = WeakValueDictionary()
 
-# A real-shape Discord webhook URL for tests that need a *valid* target.
-# Token segment uses URL-safe characters (G7) and stays under 100 chars (G7).
+# *妥当* なターゲットを必要とするテスト向けの実形 Discord webhook URL。
+# トークン部は URL-safe 文字 (G7) を使い、100 文字未満に収める (G7)。
 DEFAULT_DISCORD_WEBHOOK = (
     "https://discord.com/api/webhooks/123456789012345678/SyntheticToken_-abcXYZ"
 )
 
 
 def is_synthetic(instance: BaseModel) -> bool:
-    """Return ``True`` when ``instance`` was created by a factory in this module."""
+    """``instance`` が本モジュールのファクトリで生成されたものなら ``True`` を返す。"""
     cached = _SYNTHETIC_REGISTRY.get(id(instance))
     return cached is instance
 
 
 def _register(instance: BaseModel) -> None:
-    """Record ``instance`` in the synthetic registry."""
+    """``instance`` を合成レジストリに記録する。"""
     _SYNTHETIC_REGISTRY[id(instance)] = instance
 
 
@@ -73,7 +73,7 @@ def make_completion_policy(
     kind: str = "approved_by_reviewer",
     description: str = "review approval",
 ) -> CompletionPolicy:
-    """Build a valid :class:`CompletionPolicy`."""
+    """妥当な :class:`CompletionPolicy` を構築する。"""
     policy = CompletionPolicy.model_validate({"kind": kind, "description": description})
     _register(policy)
     return policy
@@ -83,7 +83,7 @@ def make_notify_channel(
     *,
     target: str = DEFAULT_DISCORD_WEBHOOK,
 ) -> NotifyChannel:
-    """Build a valid :class:`NotifyChannel` (kind='discord')."""
+    """妥当な :class:`NotifyChannel` (kind='discord') を構築する。"""
     channel = NotifyChannel(kind="discord", target=target)
     _register(channel)
     return channel
@@ -102,17 +102,17 @@ def make_stage(
     completion_policy: CompletionPolicy | None = None,
     notify_channels: Sequence[NotifyChannel] | None = None,
 ) -> Stage:
-    """Build a valid :class:`Stage`.
+    """妥当な :class:`Stage` を構築する。
 
-    Defaults choose ``kind=WORK`` with ``required_role={DEVELOPER}`` so the
-    Stage's self-validator (REQ-WF-007) passes without further tweaking.
-    Callers exercising EXTERNAL_REVIEW must supply ``notify_channels``.
+    デフォルトは ``kind=WORK`` + ``required_role={DEVELOPER}``。これで
+    Stage の自己バリデータ (REQ-WF-007) が追加調整なしに通過する。
+    EXTERNAL_REVIEW を使う呼び出し側は ``notify_channels`` を渡すこと。
     """
     if required_role is None:
         required_role = frozenset({Role.DEVELOPER})
     if completion_policy is None:
         completion_policy = make_completion_policy()
-    # EXTERNAL_REVIEW requires non-empty notify_channels for the Stage self-check.
+    # EXTERNAL_REVIEW は Stage の自己チェックのため非空の notify_channels を要する。
     if notify_channels is None:
         notify_channels = [make_notify_channel()] if kind is StageKind.EXTERNAL_REVIEW else []
     stage = Stage(
@@ -136,7 +136,7 @@ def make_transition(
     condition: TransitionCondition = TransitionCondition.APPROVED,
     label: str = "",
 ) -> Transition:
-    """Build a valid :class:`Transition`."""
+    """妥当な :class:`Transition` を構築する。"""
     transition = Transition(
         id=transition_id if transition_id is not None else uuid4(),
         from_stage_id=from_stage_id,
@@ -159,10 +159,10 @@ def make_workflow(
     transitions: Sequence[Transition] | None = None,
     entry_stage_id: StageId | None = None,
 ) -> Workflow:
-    """Build a valid :class:`Workflow`.
+    """妥当な :class:`Workflow` を構築する。
 
-    With no overrides, returns a single-Stage workflow where ``entry == sink``
-    (the simplest valid aggregate state per TC-UT-WF-001).
+    上書きなしの場合、``entry == sink`` の単一 Stage ワークフローを返す
+    (TC-UT-WF-001 における最小妥当 aggregate 状態)。
     """
     if stages is None:
         single = make_stage()
@@ -185,11 +185,11 @@ def make_workflow(
 
 
 # ---------------------------------------------------------------------------
-# V-model rendering example (transactions.md §レンダリング例)
+# V モデルレンダリング例 (transactions.md §レンダリング例)
 # ---------------------------------------------------------------------------
-# Stage names from the design book's V-model example. 13 stages: 4 work/review
-# pairs (req analysis, req def, basic design, detail design) + 4 implementation
-# work stages (impl, unit test, integ test, e2e test) + 1 final review.
+# 設計書の V モデル例による Stage 名。13 ステージ: 4 つの作業/レビュー対
+# (要求分析、要件定義、基本設計、詳細設計) + 4 つの実装作業ステージ
+# (実装、単体テスト、結合テスト、e2e テスト) + 最終レビュー 1 つ。
 _V_MODEL_STAGES: tuple[tuple[str, StageKind, frozenset[Role]], ...] = (
     ("要求分析", StageKind.WORK, frozenset({Role.LEADER})),
     ("要求分析レビュー", StageKind.EXTERNAL_REVIEW, frozenset({Role.REVIEWER})),
@@ -208,16 +208,16 @@ _V_MODEL_STAGES: tuple[tuple[str, StageKind, frozenset[Role]], ...] = (
 
 
 def build_v_model_payload() -> dict[str, object]:
-    """Return a ``Workflow.from_dict``-ready payload for the V-model preset.
+    """V モデルプリセット用に ``Workflow.from_dict`` 即可なペイロードを返す。
 
-    Contract:
-        * 13 stages (matches transactions.md §レンダリング例).
-        * 15 transitions: 12 APPROVED forward edges (stage[i] → stage[i+1])
-          plus 3 REJECTED back edges from review → preceding work stage so the
-          deterministic-condition check (one ``(from, condition)`` per pair)
-          stays satisfied while still demonstrating non-trivial topology.
-        * Final stage (``完了レビュー``) has no outgoing edge → satisfies the
-          sink-exists invariant.
+    契約:
+        * 13 ステージ (transactions.md §レンダリング例 と一致)。
+        * 15 transition: 12 件の APPROVED 順方向 (stage[i] → stage[i+1])
+          + review → 直前 work ステージへの REJECTED 逆方向 3 件。
+          これにより決定性条件チェック (各 ``(from, condition)`` が 1 件) を
+          満たしつつ、非自明な topology を示す。
+        * 最終ステージ (``完了レビュー``) は出辺を持たない → sink 存在不変条件を
+          満たす。
     """
     stages: list[dict[str, object]] = []
     stage_ids: list[UUID] = []
@@ -243,7 +243,7 @@ def build_v_model_payload() -> dict[str, object]:
         stages.append(stage_payload)
 
     transitions: list[dict[str, object]] = []
-    # 12 forward APPROVED transitions (stage[i] → stage[i+1]).
+    # 順方向 APPROVED transition 12 件 (stage[i] → stage[i+1])。
     for index in range(len(stage_ids) - 1):
         transitions.append(
             {
@@ -254,8 +254,8 @@ def build_v_model_payload() -> dict[str, object]:
                 "label": "approve",
             }
         )
-    # 3 REJECTED back edges from review → preceding work stage. Use indices
-    # 1, 3, 5 (the early review stages) to vary the pattern.
+    # review → 直前 work ステージへの REJECTED 逆方向 3 件。
+    # パターンを多様にするため、早期 review ステージのインデックス 1, 3, 5 を使う。
     for review_index in (1, 3, 5):
         transitions.append(
             {

--- a/backend/tests/infrastructure/config/test_data_dir.py
+++ b/backend/tests/infrastructure/config/test_data_dir.py
@@ -1,9 +1,9 @@
-"""DataDirResolver unit tests (TC-UT-PF-001 / 002 / 033 / 038 / 039 / 040).
+"""DataDirResolver 単体テスト（TC-UT-PF-001 / 002 / 033 / 038 / 039 / 040）。
 
-Covers REQ-PF-001 (resolve + Fail Fast on invalid env) and the OS-default
-branch tree. Schneier 申し送り #1 物理保証: relative paths, NUL bytes, and
-``..`` segments must be rejected at startup time so a cwd-controlling
-attacker cannot point bakufu at a different directory.
+REQ-PF-001（環境変数が不正な場合の resolve + Fail Fast）と OS 既定の分岐ツリー
+をカバーする。Schneier 申し送り #1 物理保証: 相対パス・NUL バイト・``..``
+セグメントは起動時に拒否されなければならない。これにより cwd を制御できる
+攻撃者であっても bakufu を別ディレクトリへ向けることはできない。
 """
 
 from __future__ import annotations
@@ -18,19 +18,19 @@ from bakufu.infrastructure.exceptions import BakufuConfigError
 
 @pytest.fixture(autouse=True)
 def _reset_singleton() -> Iterator[None]:  # pyright: ignore[reportUnusedFunction]
-    """Clear the module-level singleton before every test."""
+    """各テストの前にモジュール単位のシングルトンをクリアする。"""
     data_dir.reset()
     yield
     data_dir.reset()
 
 
 class TestDefaultsForOs:
-    """TC-UT-PF-001: BAKUFU_DATA_DIR unset falls back per OS."""
+    """TC-UT-PF-001: BAKUFU_DATA_DIR 未設定時は OS ごとの既定値にフォールバックする。"""
 
     def test_linux_xdg_data_home_takes_precedence(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
-        """TC-UT-PF-001: XDG_DATA_HOME wins on Linux when set."""
+        """TC-UT-PF-001: Linux で XDG_DATA_HOME が設定されていれば優先される。"""
         monkeypatch.setattr("platform.system", lambda: "Linux")
         monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
         monkeypatch.delenv("BAKUFU_DATA_DIR", raising=False)
@@ -40,7 +40,7 @@ class TestDefaultsForOs:
     def test_linux_falls_back_to_home_local_share(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
-        """TC-UT-PF-001: HOME/.local/share/bakufu when XDG unset."""
+        """TC-UT-PF-001: XDG が未設定なら HOME/.local/share/bakufu を使用する。"""
         monkeypatch.setattr("platform.system", lambda: "Linux")
         monkeypatch.delenv("XDG_DATA_HOME", raising=False)
         monkeypatch.setenv("HOME", str(tmp_path))
@@ -51,7 +51,7 @@ class TestDefaultsForOs:
     def test_macos_uses_home_local_share(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
-        """TC-UT-PF-001: macOS shares the POSIX path."""
+        """TC-UT-PF-001: macOS は POSIX と同じパスを共用する。"""
         monkeypatch.setattr("platform.system", lambda: "Darwin")
         monkeypatch.delenv("XDG_DATA_HOME", raising=False)
         monkeypatch.setenv("HOME", str(tmp_path))
@@ -62,7 +62,7 @@ class TestDefaultsForOs:
     def test_windows_uses_localappdata(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
-        """TC-UT-PF-001: Windows uses %LOCALAPPDATA%\\bakufu."""
+        """TC-UT-PF-001: Windows は %LOCALAPPDATA%\\bakufu を使用する。"""
         monkeypatch.setattr("platform.system", lambda: "Windows")
         monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
         monkeypatch.delenv("BAKUFU_DATA_DIR", raising=False)
@@ -71,12 +71,12 @@ class TestDefaultsForOs:
 
 
 class TestRelativePathRejected:
-    """TC-UT-PF-002 / 033: relative path raises with MSG-PF-001."""
+    """TC-UT-PF-002 / 033: 相対パスは MSG-PF-001 で拒否される。"""
 
     def test_relative_path_raises_bakufu_config_error(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """TC-UT-PF-002: ./relative/path is rejected."""
+        """TC-UT-PF-002: ./relative/path は拒否される。"""
         monkeypatch.setenv("BAKUFU_DATA_DIR", "./relative/path")
         with pytest.raises(BakufuConfigError) as excinfo:
             data_dir.resolve()
@@ -85,7 +85,7 @@ class TestRelativePathRejected:
     def test_msg_pf_001_wording_starts_with_fail_marker(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """TC-UT-PF-033: '[FAIL] BAKUFU_DATA_DIR must be an absolute path' prefix."""
+        """TC-UT-PF-033: 文言は '[FAIL] BAKUFU_DATA_DIR must be an absolute path' で始まる。"""
         monkeypatch.setenv("BAKUFU_DATA_DIR", "./relative")
         with pytest.raises(BakufuConfigError) as excinfo:
             data_dir.resolve()
@@ -93,18 +93,18 @@ class TestRelativePathRejected:
 
 
 class TestNulByteRejected:
-    """TC-UT-PF-038: NUL byte in env raises (Schneier #1 path-traversal vector).
+    """TC-UT-PF-038: 環境変数中の NUL バイトは拒否される（Schneier #1 パストラバーサル攻撃ベクタ）。
 
-    ``os.environ`` itself rejects NUL bytes at the OS layer, so we
-    invoke the internal validator directly to confirm bakufu's defense
-    fires *before* a malicious value could ever reach the env. This
-    matches the documented Fail-Fast contract.
+    ``os.environ`` 自体が OS レイヤで NUL バイトを拒否するため、内部バリ
+    データを直接呼び出して、悪意のある値が環境変数に到達する *前* に
+    bakufu の防御が発火することを確認する。これは文書化された Fail-Fast
+    契約に合致する。
     """
 
     def test_nul_byte_raises(self) -> None:
-        """TC-UT-PF-038: '/abs/with\\x00null' is rejected by _validate_absolute."""
-        # Reach into the validator helper directly because os.environ
-        # rejects NUL bytes before the env-var fallback path runs.
+        """TC-UT-PF-038: '/abs/with\\x00null' は _validate_absolute によって拒否される。"""
+        # os.environ が env-var フォールバックパスより先に NUL バイトを
+        # 拒否してしまうため、バリデータヘルパーを直接呼び出す。
         with pytest.raises(BakufuConfigError) as excinfo:
             data_dir._validate_absolute("/abs/with\x00null")  # pyright: ignore[reportPrivateUsage]
         assert excinfo.value.msg_id == "MSG-PF-001"
@@ -112,10 +112,10 @@ class TestNulByteRejected:
 
 
 class TestDotDotSegmentRejected:
-    """TC-UT-PF-039: '..' path component raises (path-traversal vector)."""
+    """TC-UT-PF-039: '..' パス成分は拒否される（パストラバーサル攻撃ベクタ）。"""
 
     def test_dot_dot_in_path_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """TC-UT-PF-039: '/abs/../escape' is rejected."""
+        """TC-UT-PF-039: '/abs/../escape' は拒否される。"""
         monkeypatch.setenv("BAKUFU_DATA_DIR", "/abs/../escape")
         with pytest.raises(BakufuConfigError) as excinfo:
             data_dir.resolve()
@@ -124,22 +124,22 @@ class TestDotDotSegmentRejected:
 
 
 class TestSingletonCache:
-    """TC-UT-PF-040: resolve() is O(1) on subsequent calls."""
+    """TC-UT-PF-040: 2 回目以降の resolve() は O(1)。"""
 
     def test_second_call_returns_cached_value(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
-        """TC-UT-PF-040: env-var change after first call is ignored until reset."""
+        """TC-UT-PF-040: 初回呼び出し後の env 変更は reset() するまで無視される。"""
         monkeypatch.setenv("BAKUFU_DATA_DIR", str(tmp_path))
         first = data_dir.resolve()
-        # Mutate env after the cache is filled — second call should still
-        # return the same Path object.
+        # キャッシュ充填後に env を変更しても、2 回目の呼び出しは同じ
+        # Path オブジェクトを返すべき。
         monkeypatch.setenv("BAKUFU_DATA_DIR", str(tmp_path / "different"))
         second = data_dir.resolve()
         assert first == second
 
     def test_reset_clears_cache(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-        """TC-UT-PF-040: data_dir.reset() forces a fresh resolution."""
+        """TC-UT-PF-040: data_dir.reset() で再解決を強制できる。"""
         monkeypatch.setenv("BAKUFU_DATA_DIR", str(tmp_path))
         first = data_dir.resolve()
         data_dir.reset()

--- a/backend/tests/infrastructure/conftest.py
+++ b/backend/tests/infrastructure/conftest.py
@@ -1,9 +1,9 @@
-"""Shared fixtures for infrastructure-layer integration tests.
+"""infrastructure 層の統合テスト向け共有フィクスチャ。
 
-The fixtures here intentionally use **real** SQLite + **real** Alembic
-+ **real** filesystem under ``tmp_path``. The only thing we mock is
-``psutil`` (in ``test_pid_gc.py``) because the OS doesn't let CI spawn
-real subprocess trees safely.
+ここで定義するフィクスチャは、意図的に **本物の** SQLite + **本物の**
+Alembic + **本物の** ファイルシステム（``tmp_path`` 配下）を用いる。
+モックするのは ``psutil`` のみ（``test_pid_gc.py`` で使用）。これは OS が
+CI 上で実プロセスツリーを安全に生成することを許さないためである。
 """
 
 from __future__ import annotations
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 
 @pytest.fixture(autouse=True)
 def _reset_data_dir() -> Iterator[None]:  # pyright: ignore[reportUnusedFunction]
-    """Clear the data_dir singleton before / after every test."""
+    """各テストの前後で data_dir シングルトンをクリアする。"""
     data_dir.reset()
     yield
     data_dir.reset()
@@ -35,7 +35,7 @@ def _reset_data_dir() -> Iterator[None]:  # pyright: ignore[reportUnusedFunction
 
 @pytest.fixture(autouse=True)
 def _clear_handler_registry() -> Iterator[None]:  # pyright: ignore[reportUnusedFunction]
-    """Tests must start with an empty handler registry (Confirmation K)."""
+    """テストはハンドラレジストリが空の状態で開始しなければならない（Confirmation K）。"""
     handler_registry.clear()
     yield
     handler_registry.clear()
@@ -45,7 +45,7 @@ def _clear_handler_registry() -> Iterator[None]:  # pyright: ignore[reportUnused
 def _initialize_masking(  # pyright: ignore[reportUnusedFunction]
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Initialize masking once per test with no provider env vars set."""
+    """provider 系の環境変数を全て外した状態で、テストごとに masking を 1 回だけ初期化する。"""
     for env_key in (
         "ANTHROPIC_API_KEY",
         "OPENAI_API_KEY",
@@ -61,16 +61,16 @@ def _initialize_masking(  # pyright: ignore[reportUnusedFunction]
 
 @pytest_asyncio.fixture
 async def app_engine(tmp_path: Path) -> AsyncIterator[AsyncEngine]:
-    """Real application engine pointed at tmp_path/bakufu.db.
+    """tmp_path/bakufu.db を指す本物のアプリケーションエンジン。
 
-    Runs Alembic ``upgrade head`` so the schema + triggers are in place
-    before the test body executes. Disposes the engine on teardown so
-    tmp_path can be removed cleanly.
+    テスト本体が走る前に Alembic ``upgrade head`` を実行してスキーマと
+    トリガを整えておく。後始末ではエンジンを dispose し、tmp_path を
+    クリーンに削除できるようにする。
 
-    BUG-PF-002 fix: ``alembic/env.py`` now passes
-    ``disable_existing_loggers=False`` so the previous test-side
-    workarounds (``_re_enable_bakufu_loggers`` / ``_patch_alembic_file_config``)
-    are no longer needed.
+    BUG-PF-002 修正: ``alembic/env.py`` が
+    ``disable_existing_loggers=False`` を渡すようになったため、これまで
+    のテスト側回避策（``_re_enable_bakufu_loggers`` /
+    ``_patch_alembic_file_config``）はもう不要。
     """
     db_path = tmp_path / "bakufu.db"
     url = f"sqlite+aiosqlite:///{db_path}"
@@ -86,5 +86,5 @@ async def app_engine(tmp_path: Path) -> AsyncIterator[AsyncEngine]:
 async def session_factory(
     app_engine: AsyncEngine,
 ) -> async_sessionmaker[AsyncSession]:
-    """SessionFactory bound to the migrated test engine."""
+    """マイグレーション済みテストエンジンに紐付いた SessionFactory。"""
     return session_mod.make_session_factory(app_engine)

--- a/backend/tests/infrastructure/persistence/sqlite/outbox/test_dispatcher_fail_loud.py
+++ b/backend/tests/infrastructure/persistence/sqlite/outbox/test_dispatcher_fail_loud.py
@@ -1,9 +1,9 @@
-"""Outbox dispatcher Fail Loud WARN tests
-(TC-IT-PF-008-A / 008-B / 008-C / 008-D, Confirmation K).
+"""Outbox dispatcher の Fail Loud WARN テスト
+（TC-IT-PF-008-A / 008-B / 008-C / 008-D, 確定 K）。
 
-Schneier 中等 3 物理保証 — when the handler registry is empty but
-``domain_event_outbox`` rows are accumulating, the dispatcher must
-WARN exactly once per condition (no log spam, no silent backlog).
+Schneier 中等 3 物理保証 — ハンドラレジストリが空のまま
+``domain_event_outbox`` の行が蓄積している場合、dispatcher は条件ごとに
+WARN を 1 回だけ発行しなければならない（ログスパムも沈黙バックログも禁止）。
 """
 
 from __future__ import annotations
@@ -32,7 +32,7 @@ async def _insert_pending_rows(
     session_factory: async_sessionmaker[AsyncSession],
     count: int,
 ) -> list[OutboxRow]:
-    """Bulk-insert ``count`` PENDING rows for the dispatcher to find."""
+    """dispatcher が拾えるように ``count`` 件の PENDING 行をバルク挿入する。"""
     rows: list[OutboxRow] = []
     async with session_factory() as session, session.begin():
         for _ in range(count):
@@ -48,14 +48,14 @@ async def _insert_pending_rows(
 
 
 class TestEmptyRegistryWarnOnFirstSeenPending:
-    """TC-IT-PF-008-B: pending row + empty registry → WARN once."""
+    """TC-IT-PF-008-B: pending 行 + 空レジストリ → WARN を 1 回。"""
 
     async def test_warn_emitted_once_for_pending_with_empty_registry(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """TC-IT-PF-008-B: dispatcher logs WARN when pending count > 0."""
+        """TC-IT-PF-008-B: pending 件数が 0 を超えると dispatcher が WARN を出力する。"""
         await _insert_pending_rows(session_factory, count=1)
         dispatcher = OutboxDispatcher(session_factory)
 
@@ -70,21 +70,21 @@ class TestEmptyRegistryWarnOnFirstSeenPending:
 
 
 class TestEmptyRegistryWarnDoesNotSpam:
-    """TC-IT-PF-008-C: subsequent polls of the same backlog do NOT re-WARN."""
+    """TC-IT-PF-008-C: 同じバックログに対する後続のポーリングでは再 WARN しない。"""
 
     async def test_second_poll_does_not_re_warn(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """TC-IT-PF-008-C: empty-registry WARN fires once, not on every cycle."""
+        """TC-IT-PF-008-C: 空レジストリ WARN はサイクルごとではなく 1 回だけ発火する。"""
         await _insert_pending_rows(session_factory, count=1)
         dispatcher = OutboxDispatcher(session_factory)
 
-        # First poll — expect WARN.
+        # 1 回目のポーリング — WARN が出ることを期待。
         with caplog.at_level("WARNING"):
             await dispatcher._poll_once()  # pyright: ignore[reportPrivateUsage]
-        # Second poll — should NOT add another WARN.
+        # 2 回目のポーリング — 追加の WARN は出ないこと。
         caplog.clear()
         with caplog.at_level("WARNING"):
             await dispatcher._poll_once()  # pyright: ignore[reportPrivateUsage]
@@ -97,46 +97,46 @@ class TestEmptyRegistryWarnDoesNotSpam:
 
 
 class TestEmptyRegistryWarnRefiresAfterRegistration:
-    """TC-IT-PF-008-A 系: registration + clear restores the WARN trigger."""
+    """TC-IT-PF-008-A 系: 登録 + クリアで WARN トリガが再武装する。"""
 
     async def test_registering_then_clearing_re_arms_warning(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """TC-IT-PF-008-A 系: WARN re-fires after a successful registration cycle.
+        """TC-IT-PF-008-A 系: 正常な登録サイクル後に WARN が再発火する。
 
-        Reset semantics (Confirmation K): the ``_empty_registry_warned``
-        flag only flips back when a poll observes a non-empty registry
-        OR an empty pending queue. So the realistic re-arm sequence is:
+        リセット仕様（確定 K）: ``_empty_registry_warned`` フラグは、
+        ポーリングが「空でないレジストリ」または「空の pending キュー」を
+        観測したときのみ戻る。よって現実的な再武装シーケンスは:
 
-        1. Poll #1 — pending>0, registry empty → WARN fires.
-        2. Register a handler.
-        3. Poll #2 — registry>0 → reset flag (no WARN).
-        4. Clear the registry.
-        5. Poll #3 — pending>0, registry empty again → WARN re-fires.
+        1. Poll #1 — pending>0、レジストリ空 → WARN 発火。
+        2. ハンドラを登録。
+        3. Poll #2 — registry>0 → フラグリセット（WARN なし）。
+        4. レジストリをクリア。
+        5. Poll #3 — pending>0、レジストリ再び空 → WARN 再発火。
         """
         await _insert_pending_rows(session_factory, count=1)
         dispatcher = OutboxDispatcher(session_factory)
 
-        # Poll 1: WARN fires.
+        # Poll 1: WARN が発火する。
         with caplog.at_level("WARNING"):
             await dispatcher._poll_once()  # pyright: ignore[reportPrivateUsage]
 
-        # Register a handler so poll 2 sees a non-empty registry.
+        # poll 2 で空でないレジストリを観測させるためハンドラを登録する。
         async def _noop(_payload: dict[str, object]) -> None:
             return None
 
         handler_registry.register("TestKind", _noop)
 
-        # Poll 2: should reset the flag silently (no new WARN).
+        # Poll 2: 静かにフラグをリセットする（新たな WARN は出ない）。
         with caplog.at_level("WARNING"):
             await dispatcher._poll_once()  # pyright: ignore[reportPrivateUsage]
 
-        # Drop the handler to mirror a hot-fix mistake.
+        # 緊急修正のミスを再現するためハンドラを破棄する。
         handler_registry.clear()
 
-        # Poll 3: empty again, flag was reset → WARN re-fires.
+        # Poll 3: 再び空、フラグはリセット済み → WARN 再発火。
         caplog.clear()
         with caplog.at_level("WARNING"):
             await dispatcher._poll_once()  # pyright: ignore[reportPrivateUsage]
@@ -145,14 +145,14 @@ class TestEmptyRegistryWarnRefiresAfterRegistration:
 
 
 class TestBacklogWarnThreshold:
-    """TC-IT-PF-008-D: pending rows above BACKLOG_WARN_THRESHOLD raises a separate WARN.
+    """TC-IT-PF-008-D: BACKLOG_WARN_THRESHOLD 超過の pending 行で別 WARN が発火する。
 
-    BUG-PF-003 fix: ``OutboxDispatcher._backlog_last_warn_monotonic``
-    now defaults to ``None`` and the throttle treats "never warned"
-    as "warn immediately". The previous boot-time race (where a
-    freshly booted CI clock under 300s would suppress the very first
-    backlog WARN) is gone, so this test runs the threshold logic
-    without needing to back-date the throttle.
+    BUG-PF-003 修正: ``OutboxDispatcher._backlog_last_warn_monotonic``
+    のデフォルトが ``None`` になり、スロットルは「まだ警告していない」
+    状態を「即座に警告する」と扱うようになった。以前のブート時レース
+    （起動直後の CI クロックが 300 秒未満だと最初のバックログ WARN が
+    抑制された問題）は解消したため、このテストはスロットルを過去日時に
+    細工する必要なく閾値ロジックを実行する。
     """
 
     async def test_backlog_above_threshold_warns(
@@ -160,7 +160,7 @@ class TestBacklogWarnThreshold:
         session_factory: async_sessionmaker[AsyncSession],
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """TC-IT-PF-008-D: > 100 PENDING rows triggers backlog WARN."""
+        """TC-IT-PF-008-D: PENDING 行が 100 を超えるとバックログ WARN が発火する。"""
         await _insert_pending_rows(session_factory, count=BACKLOG_WARN_THRESHOLD + 1)
         dispatcher = OutboxDispatcher(session_factory)
 

--- a/backend/tests/infrastructure/persistence/sqlite/outbox/test_masking_fail_secure_e2e.py
+++ b/backend/tests/infrastructure/persistence/sqlite/outbox/test_masking_fail_secure_e2e.py
@@ -1,26 +1,26 @@
-"""Fail-Secure E2E injection tests
-(TC-UT-PF-006-C complement, Confirmation F, Norman 前回 △ 宿題).
+"""Fail-Secure E2E インジェクションテスト
+（TC-UT-PF-006-C 補完, 確定 F, Norman 前回 △ 宿題）。
 
-Confirmation F freezes that **listener-equivalent failures must never
-let raw bytes hit the disk**. Earlier ``test_masking.py`` covers the
-sentinel constants (``REDACT_MASK_ERROR`` / ``REDACTED_MASK_OVERFLOW``
-/ ``REDACT_LISTENER_ERROR``) at the gateway layer, but the Fail-Secure
-E2E loop — *gateway raises → DB SELECT shows sentinel* — was missing.
-This file adds the three injection patterns Norman flagged:
+確定 F は「**リスナー相当の失敗が生バイトをディスクに到達させてはならない**」
+ことを凍結している。先行する ``test_masking.py`` はゲートウェイ層で
+sentinel 定数（``REDACT_MASK_ERROR`` / ``REDACTED_MASK_OVERFLOW``
+/ ``REDACT_LISTENER_ERROR``）を検証するが、Fail-Secure E2E ループ
+（*ゲートウェイが raise → DB SELECT が sentinel を返す*）は欠けていた。
+本ファイルは Norman が指摘した 3 つのインジェクションパターンを補う:
 
-1. :func:`mask_in` raises while encoding ``payload_json`` →
-   ``MaskedJSONEncoded.process_bind_param`` catches the exception and
-   writes ``json.dumps(REDACT_LISTENER_ERROR)`` instead. Subsequent
-   SELECT returns the sentinel string.
-2. :func:`mask` raises while encoding ``last_error`` →
-   ``MaskedText.process_bind_param`` writes ``REDACT_LISTENER_ERROR``
-   instead. SELECT returns the sentinel.
-3. Same path for ``audit_log.error_text`` → confirms the gateway is
-   wired across all three secret-bearing tables.
+1. :func:`mask_in` が ``payload_json`` のエンコード中に raise →
+   ``MaskedJSONEncoded.process_bind_param`` が例外を捕捉し、
+   代わりに ``json.dumps(REDACT_LISTENER_ERROR)`` を書き込む。
+   後続の SELECT は sentinel 文字列を返す。
+2. :func:`mask` が ``last_error`` のエンコード中に raise →
+   ``MaskedText.process_bind_param`` が代わりに ``REDACT_LISTENER_ERROR``
+   を書き込む。SELECT は sentinel を返す。
+3. ``audit_log.error_text`` でも同経路 → ゲートウェイが秘密を持つ
+   3 テーブルすべてに配線されていることを確認する。
 
-The injection is at the **gateway** (`mask` / `mask_in`) so the test
-is independent of which TypeDecorator does the wiring; if Linus ever
-swaps the masker implementation, the contract still holds.
+インジェクションは**ゲートウェイ**（`mask` / `mask_in`）で行うため、
+このテストは TypeDecorator の配線実装に依存しない。Linus がマスク
+実装を差し替えても契約は維持される。
 """
 
 from __future__ import annotations
@@ -43,12 +43,12 @@ pytestmark = pytest.mark.asyncio
 
 
 def _force_mask_in_to_raise(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Make :func:`mask_in` raise when the TypeDecorator calls it.
+    """TypeDecorator が :func:`mask_in` を呼んだとき raise させる。
 
-    We patch the symbol the TypeDecorator imported (the
-    ``base`` module's local ``mask_in`` binding), not the masking
-    module's, because Python ``from X import Y`` captures the
-    reference at import time.
+    パッチ対象は TypeDecorator がインポートしたシンボル
+    （``base`` モジュール内のローカル ``mask_in`` バインディング）であり、
+    masking モジュール側ではない。Python の ``from X import Y`` は
+    インポート時に参照を捕捉するためである。
     """
     from bakufu.infrastructure.persistence.sqlite import base as base_mod
 
@@ -60,7 +60,7 @@ def _force_mask_in_to_raise(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def _force_mask_to_raise(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Make :func:`mask` raise when the TypeDecorator calls it."""
+    """TypeDecorator が :func:`mask` を呼んだとき raise させる。"""
     from bakufu.infrastructure.persistence.sqlite import base as base_mod
 
     def _explode(_value: object) -> str:
@@ -71,12 +71,12 @@ def _force_mask_to_raise(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 class TestMaskInFailureRedactsPayloadJson:
-    """Pattern 1: ``mask_in`` raise → ``payload_json`` becomes the sentinel.
+    """パターン 1: ``mask_in`` が raise → ``payload_json`` が sentinel になる。
 
-    The raw secret in ``payload_json`` must NEVER reach the disk —
-    the TypeDecorator catches the exception and writes
-    ``json.dumps(REDACT_LISTENER_ERROR)`` so a SELECT returns
-    ``REDACT_LISTENER_ERROR`` (a string, not the original dict).
+    ``payload_json`` の生秘密は決してディスクに到達してはならない —
+    TypeDecorator が例外を捕捉し ``json.dumps(REDACT_LISTENER_ERROR)``
+    を書き込むため、SELECT は ``REDACT_LISTENER_ERROR``（元の dict ではなく
+    文字列）を返す。
     """
 
     async def test_payload_json_replaced_with_listener_error_sentinel(
@@ -84,11 +84,11 @@ class TestMaskInFailureRedactsPayloadJson:
         session_factory: async_sessionmaker[AsyncSession],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Fail-Secure E2E: secret payload never lands on disk if mask_in raises."""
+        """Fail-Secure E2E: mask_in が raise しても秘密 payload はディスクに到達しない。"""
         _force_mask_in_to_raise(monkeypatch)
 
-        # The raw payload contains a sk-ant- key; if the Fail-Secure
-        # path is broken, the SELECT below would return that key.
+        # 生 payload に sk-ant- キーが含まれる。Fail-Secure 経路が壊れていれば
+        # 下の SELECT がそのキーを返してしまう。
         row = make_outbox_row(
             payload_json={"key": "sk-ant-api03-" + "A" * 60},
             last_error=None,
@@ -101,21 +101,21 @@ class TestMaskInFailureRedactsPayloadJson:
             stmt = select(OutboxRow).where(OutboxRow.event_id == row.event_id)
             fetched = (await session.execute(stmt)).scalar_one()
 
-        # SELECT must return the sentinel; the original secret must
-        # never appear anywhere in the loaded value.
+        # SELECT は sentinel を返さなければならず、元の秘密は
+        # ロード値のどこにも現れてはならない。
         assert fetched.payload_json == REDACT_LISTENER_ERROR
         assert "sk-ant-" not in str(fetched.payload_json)
 
 
 class TestMaskFailureRedactsLastError:
-    """Pattern 2: ``mask`` raise → ``last_error`` becomes the sentinel."""
+    """パターン 2: ``mask`` が raise → ``last_error`` が sentinel になる。"""
 
     async def test_last_error_replaced_with_listener_error_sentinel(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Fail-Secure E2E: last_error secret never lands on disk if mask raises."""
+        """Fail-Secure E2E: mask が raise しても last_error の秘密はディスクに到達しない。"""
         _force_mask_to_raise(monkeypatch)
 
         row = make_outbox_row(
@@ -136,10 +136,10 @@ class TestMaskFailureRedactsLastError:
 
 
 class TestMaskFailureRedactsAuditLogErrorText:
-    """Pattern 3: ``mask`` raise on ``audit_log.error_text`` → sentinel.
+    """パターン 3: ``audit_log.error_text`` で ``mask`` が raise → sentinel。
 
-    Same gateway, different table. Confirms the TypeDecorator wiring
-    is consistent across all three secret-bearing tables.
+    ゲートウェイは同じ、テーブルは別。TypeDecorator の配線が
+    秘密を持つ 3 テーブル間で一貫していることを確認する。
     """
 
     async def test_audit_log_error_text_replaced_with_sentinel(
@@ -147,7 +147,7 @@ class TestMaskFailureRedactsAuditLogErrorText:
         session_factory: async_sessionmaker[AsyncSession],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Fail-Secure E2E: audit_log error_text secret never lands on disk."""
+        """Fail-Secure E2E: audit_log の error_text の秘密はディスクに到達しない。"""
         _force_mask_to_raise(monkeypatch)
 
         row = make_audit_log_row(
@@ -163,8 +163,7 @@ class TestMaskFailureRedactsAuditLogErrorText:
             stmt = select(AuditLogRow).where(AuditLogRow.id == row.id)
             fetched = (await session.execute(stmt)).scalar_one()
 
-        # ``args_json`` is dict-typed, ``error_text`` is the str column
-        # we drove the failure through.
+        # ``args_json`` は dict 型、``error_text`` は失敗を駆動した str 列。
         loaded_error = fetched.error_text
         assert loaded_error == REDACT_LISTENER_ERROR
         assert loaded_error is not None

--- a/backend/tests/infrastructure/persistence/sqlite/outbox/test_masking_gateway.py
+++ b/backend/tests/infrastructure/persistence/sqlite/outbox/test_masking_gateway.py
@@ -185,5 +185,5 @@ class TestAuditLogAndPidRegistryMaskingHook:
             stmt = select(PidRegistryRow).where(PidRegistryRow.pid == row.pid)
             fetched = (await session.execute(stmt)).scalar_one()
         assert "<REDACTED:ANTHROPIC_KEY>" in fetched.cmd
-        # The plaintext ``ANTHROPIC_KEY`` must not survive.
+        # 平文の ``ANTHROPIC_KEY`` が残ってはならない。
         assert ANTHROPIC_KEY not in fetched.cmd

--- a/backend/tests/infrastructure/persistence/sqlite/outbox/test_masking_gateway.py
+++ b/backend/tests/infrastructure/persistence/sqlite/outbox/test_masking_gateway.py
@@ -1,14 +1,16 @@
-"""Masking gateway integration tests (TC-IT-PF-007 / 020 / 021 / 022).
+"""マスキングゲートウェイ統合テスト（TC-IT-PF-007 / 020 / 021 / 022）。
 
-The **core** of Schneier 申し送り #6 + Confirmation R1-D (post-flip) — the
-masking gateway must fire even when callers bypass the ORM mapper and use a
-raw ``insert(table).values(...)`` statement. The original design specified
-``event.listens_for(target, 'before_insert/before_update')`` mapper
-events, but BUG-PF-001 surfaced that those listeners do **not** fire on
-the Core ``insert(table).values(...)`` path. R1-D was reverted to
-``MaskedJSONEncoded`` / ``MaskedText`` :class:`~sqlalchemy.types.TypeDecorator`
-columns whose ``process_bind_param`` hook fires on **both** ORM and Core
-paths — the very property R1-D originally tried to buy with listeners.
+Schneier 申し送り #6 + 確定 R1-D（フリップ後）の**核**となる契約 —
+呼び出し側が ORM マッパーを迂回して
+``insert(table).values(...)`` の生 Core ステートメントを使う場合でも
+マスキングゲートウェイは発火しなければならない。元の設計は
+``event.listens_for(target, 'before_insert/before_update')`` マッパー
+イベントを使っていたが、BUG-PF-001 によりそれらのリスナーは Core の
+``insert(table).values(...)`` 経路では**発火しない**ことが判明した。
+R1-D は ``MaskedJSONEncoded`` / ``MaskedText``
+:class:`~sqlalchemy.types.TypeDecorator` 列に差し戻された。これらの
+``process_bind_param`` フックは ORM フラッシュと Core 経路の**両方**で
+発火し、まさに R1-D がリスナーで得ようとした性質を満たす。
 """
 
 from __future__ import annotations

--- a/backend/tests/infrastructure/persistence/sqlite/outbox/test_masking_gateway.py
+++ b/backend/tests/infrastructure/persistence/sqlite/outbox/test_masking_gateway.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 
 pytestmark = pytest.mark.asyncio
 
-# Real-shape secrets. Each must end up redacted before SELECT.
+# 実形の secret。SELECT の前にすべて redact されねばならない。
 ANTHROPIC_KEY = "sk-ant-api03-" + "A" * 60
 GITHUB_PAT = "ghp_" + "X" * 40
 AWS_KEY = "AKIA1234567890ABCDEF"  # gitleaks:allow — synthetic test fixture, not a real key
@@ -63,13 +63,13 @@ def _outbox_columns(row: OutboxRow) -> dict[str, object]:
 
 
 class TestOutboxMaskingViaOrm:
-    """TC-IT-PF-007: ORM-path INSERT redacts payload_json + last_error."""
+    """TC-IT-PF-007: ORM パス INSERT は payload_json + last_error を redact する。"""
 
     async def test_payload_json_redacted_after_insert(
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """TC-IT-PF-007: Anthropic + GitHub PAT in payload_json get redacted."""
+        """TC-IT-PF-007: payload_json 内の Anthropic + GitHub PAT は redact される。"""
         row = make_outbox_row(
             payload_json={"key": ANTHROPIC_KEY, "github_pat": GITHUB_PAT},
             last_error=AWS_KEY,
@@ -89,22 +89,21 @@ class TestOutboxMaskingViaOrm:
 
 
 class TestOutboxMaskingViaRawSql:
-    """TC-IT-PF-020: raw ``insert(table).values(...)`` still triggers the masking gateway.
+    """TC-IT-PF-020: 生 ``insert(table).values(...)`` でもマスキングゲートウェイが発火する。
 
-    Post-R1-D-flip contract — the masking gateway is wired via the
-    column TypeDecorators :class:`~bakufu.infrastructure.persistence.sqlite.base.MaskedJSONEncoded`
-    and :class:`~bakufu.infrastructure.persistence.sqlite.base.MaskedText`.
-    Their ``process_bind_param`` runs on every bind-parameter
-    resolution, so both ORM flushes and Core
-    ``insert(table).values(...)`` invocations are masked. A future
-    Repository PR cannot bypass redaction by reaching for raw SQL.
+    R1-D-flip 後の契約 — マスキングゲートウェイは列 TypeDecorator
+    :class:`~bakufu.infrastructure.persistence.sqlite.base.MaskedJSONEncoded`
+    および :class:`~bakufu.infrastructure.persistence.sqlite.base.MaskedText` 経由で配線される。
+    それらの ``process_bind_param`` はバインドパラメータ解決時に毎回実行されるため、
+    ORM フラッシュと Core ``insert(table).values(...)`` の両方が masking される。
+    将来の Repository PR は生 SQL に到達することで redaction を回避できない。
     """
 
     async def test_raw_sql_path_redacts_payload(
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """TC-IT-PF-020: raw insert path equally redacts payload_json + last_error."""
+        """TC-IT-PF-020: 生 insert パスも同様に payload_json + last_error を redact。"""
         row = make_outbox_row(
             payload_json={"key": ANTHROPIC_KEY},
             last_error=GITHUB_PAT,
@@ -124,18 +123,18 @@ class TestOutboxMaskingViaRawSql:
 
 
 class TestOutboxMaskingOnUpdate:
-    """TC-IT-PF-021: ``before_update`` redacts updates as well as inserts."""
+    """TC-IT-PF-021: ``before_update`` は insert と同様に update を redact する。"""
 
     async def test_update_path_redacts_last_error(
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """TC-IT-PF-021: re-marking a row as DEAD_LETTER with raw secrets in last_error."""
+        """TC-IT-PF-021: 行を DEAD_LETTER として再マーク、last_error に生 secret を含む。"""
         row = make_outbox_row(payload_json={"safe": "value"}, last_error=None)
         async with session_factory() as session, session.begin():
             session.add(row)
 
-        # Now load + update with new secret-bearing data.
+        # 次に読み込み + 新しい secret を含むデータで更新。
         async with session_factory() as session, session.begin():
             stmt = select(OutboxRow).where(OutboxRow.event_id == row.event_id)
             target = (await session.execute(stmt)).scalar_one()
@@ -151,13 +150,13 @@ class TestOutboxMaskingOnUpdate:
 
 
 class TestAuditLogAndPidRegistryMaskingHook:
-    """TC-IT-PF-022: hook is wired across the other 2 secret-bearing tables."""
+    """TC-IT-PF-022: フックは他の 2 つの secret を含むテーブルに配線される。"""
 
     async def test_audit_log_redacts_args_and_error(
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """TC-IT-PF-022 (audit_log): args_json + error_text masked."""
+        """TC-IT-PF-022 (audit_log): args_json + error_text が masking される。"""
         row = make_audit_log_row(
             args_json={"token": SLACK_TOKEN},
             error_text=BEARER_PHRASE,

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_agent_repository/__init__.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_agent_repository/__init__.py
@@ -1,22 +1,22 @@
-"""Agent Repository integration tests, split by topic.
+"""トピックごとに分割された Agent Repository の統合テスト群。
 
-Per ``docs/features/agent-repository/test-design.md`` and the
-empire-repository PR #29 教訓 (Norman 500-line rule), the test
-surface is split into four siblings so each file stays under the
-readability budget:
+``docs/features/agent-repository/test-design.md`` および
+empire-repository PR #29 の教訓（Norman の 500 行ルール）に従い、
+各ファイルが可読性の閾値を超えないようにテスト面を 4 つの兄弟ファイル
+に分割している:
 
-* :mod:`...test_protocol_crud` — Protocol surface (4 methods) +
-  ``find_by_id`` / ``count`` / ``find_by_name`` basic CRUD
-  (TC-UT-AGR-001 / 004 / 005).
-* :mod:`...test_save_semantics` — delete-then-insert + 5-step SQL
-  order + ORDER BY contract + Tx boundary + round-trip equality
-  (TC-UT-AGR-002 / 003 / 010 / 011).
-* :mod:`...test_constraints_arch` — DB-level partial unique index
-  二重防衛 + Alembic 0004 + arch-test reference
-  (TC-IT-AGR-007 / 008 / TC-UT-AGR-009).
-* :mod:`...test_masking_persona` — **Schneier #3 实適用 7 経路**:
+* :mod:`...test_protocol_crud` — Protocol 面（4 メソッド）+
+  ``find_by_id`` / ``count`` / ``find_by_name`` の基本 CRUD
+  （TC-UT-AGR-001 / 004 / 005）。
+* :mod:`...test_save_semantics` — delete-then-insert + 5 ステップ SQL
+  順序 + ORDER BY 契約 + Tx 境界 + ラウンドトリップ等価性
+  （TC-UT-AGR-002 / 003 / 010 / 011）。
+* :mod:`...test_constraints_arch` — DB レベルの部分 unique index による
+  二重防衛 + Alembic 0004 + arch-test リファレンス
+  （TC-IT-AGR-007 / 008 / TC-UT-AGR-009）。
+* :mod:`...test_masking_persona` — **Schneier #3 実適用 7 経路**:
   Anthropic / GitHub / OpenAI / Bearer / no-secret / roundtrip /
-  multiple — verifies via raw-SQL SELECT that ``agents.prompt_body``
-  carries ``<REDACTED:*>`` and zero raw token bytes
-  (TC-IT-AGR-006-masking-*).
+  multiple — raw-SQL SELECT を通じて ``agents.prompt_body`` が
+  ``<REDACTED:*>`` を保持しトークン生バイトを含まないことを検証
+  （TC-IT-AGR-006-masking-*）。
 """

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_agent_repository/test_constraints_arch.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_agent_repository/test_constraints_arch.py
@@ -1,23 +1,20 @@
-"""Agent Repository: DB constraints + arch-test reference.
+"""Agent Repository: DB 制約 + arch-test 相互参照。
 
-TC-IT-AGR-007 / TC-UT-AGR-009 — the **partial unique index 二重防衛**
-(§確定 G) and the CI Layer 2 arch-test cross-reference.
+TC-IT-AGR-007 / TC-UT-AGR-009 ── **partial unique index による二重防衛**
+(§確定 G) と CI Layer 2 arch-test の相互参照を扱う。
 
-§確定 G: ``is_default = 1`` rows under the same ``agent_id`` are
-forbidden by **two layers**:
+§確定 G: 同一 ``agent_id`` 配下の ``is_default = 1`` 行は **2 層** で禁止される:
 
-1. **Aggregate-level** (``_validate_default_provider_count`` in the
-   Agent VO chain) catches the violation at construction time.
-2. **DB-level** partial unique index ``uq_agent_providers_default``
-   (``WHERE is_default = 1``) physically rejects the INSERT — the
-   final defense line for code paths that bypass the Aggregate
-   (raw SQL, future Repository implementations that forget the
-   check, dump/restore migrations, etc.).
+1. **Aggregate レベル** (Agent VO チェーン内の ``_validate_default_provider_count``)
+   が構築時に違反を捕捉する。
+2. **DB レベル** の partial unique index ``uq_agent_providers_default``
+   (``WHERE is_default = 1``) が INSERT を物理的に拒否 ── Aggregate を迂回する
+   コード経路（raw SQL、チェックを忘れた将来の Repository 実装、
+   dump/restore マイグレーション等）に対する最終防衛線。
 
-This test exercises **layer 2 in isolation** by writing raw SQL that
-sidesteps the Aggregate. A regression that drops the partial index
-DDL would let the second INSERT succeed silently — that fails this
-test loudly.
+本テストは raw SQL で Aggregate を迂回することで **層 2 を単独で** 検証する。
+partial index DDL を落とす回帰は 2 回目の INSERT を静かに成功させてしまう ──
+本テストはそれを派手に失敗させる。
 """
 
 from __future__ import annotations
@@ -38,15 +35,13 @@ pytestmark = pytest.mark.asyncio
 # TC-IT-AGR-007: partial unique index 二重防衛 (§確定 G)
 # ---------------------------------------------------------------------------
 class TestPartialUniqueIndexDoubleDefense:
-    """TC-IT-AGR-007: ``is_default=1`` x 2 under same agent_id raises IntegrityError.
+    """TC-IT-AGR-007: 同一 agent_id 配下での ``is_default=1`` x 2 は IntegrityError を起こす。
 
-    The Aggregate's ``_validate_default_provider_count`` is the first
-    layer; this test bypasses it by writing raw SQL directly so the
-    partial unique index is the only thing standing between us and a
-    silent corruption. The first INSERT must succeed; the second must
-    raise ``IntegrityError`` (or any ``DBAPIError``-shaped wrapper —
-    SQLAlchemy maps SQLite's UNIQUE constraint violation to
-    ``IntegrityError``).
+    Aggregate の ``_validate_default_provider_count`` が第 1 層。本テストは
+    raw SQL を直書きして Aggregate を迂回するため、partial unique index のみが
+    静かな破壊との間に立つ唯一の防衛線となる。1 回目の INSERT は成功し、
+    2 回目は ``IntegrityError``（SQLAlchemy が SQLite の UNIQUE 制約違反を
+    ``IntegrityError`` にマップするため、``DBAPIError`` 形のラッパでも可）を起こさねばならない。
     """
 
     async def test_duplicate_default_provider_raises_integrity_error(
@@ -54,12 +49,12 @@ class TestPartialUniqueIndexDoubleDefense:
         session_factory: async_sessionmaker[AsyncSession],
         seeded_empire_id: UUID,
     ) -> None:
-        """TC-IT-AGR-007: 2 rows with ``is_default=1`` for same agent_id is rejected by DB."""
+        """TC-IT-AGR-007: 同一 agent_id に対する ``is_default=1`` の 2 行は DB が拒否する。"""
         from sqlalchemy.exc import IntegrityError
 
-        # Seed an Agent row so the FK in agent_providers can resolve.
-        # We bypass the Repository entirely — raw SQL throughout —
-        # to keep the test focused on the DB layer.
+        # agent_providers の FK が解決できるよう Agent 行を seed する。
+        # テストを DB 層に集中させるため、Repository をすべて迂回し、
+        # 全工程を raw SQL で行う。
         agent_id = uuid4()
         empire_id = seeded_empire_id
         async with session_factory() as session, session.begin():
@@ -83,7 +78,7 @@ class TestPartialUniqueIndexDoubleDefense:
                 },
             )
 
-        # First default provider — should succeed.
+        # 最初のデフォルト provider ── 成功するはず。
         async with session_factory() as session, session.begin():
             await session.execute(
                 text(
@@ -99,10 +94,9 @@ class TestPartialUniqueIndexDoubleDefense:
                 },
             )
 
-        # Second default provider on the same agent_id — distinct
-        # provider_kind so the (agent_id, provider_kind) UNIQUE does
-        # NOT trip; only the partial unique index on is_default=1
-        # should fire.
+        # 同じ agent_id に対する 2 つ目のデフォルト provider ── (agent_id,
+        # provider_kind) UNIQUE を踏まないよう provider_kind は別にし、
+        # is_default=1 の partial unique index のみが発火するようにする。
         with pytest.raises(IntegrityError):
             async with session_factory() as session, session.begin():
                 await session.execute(
@@ -113,9 +107,8 @@ class TestPartialUniqueIndexDoubleDefense:
                     ),
                     {
                         "agent_id": agent_id.hex,
-                        # Different provider_kind — so this is not the
-                        # (agent_id, provider_kind) UNIQUE; the
-                        # partial index alone is the relevant defense.
+                        # 別の provider_kind ── したがって (agent_id, provider_kind)
+                        # UNIQUE には引っかからず、partial index のみが該当する防衛線となる。
                         "provider_kind": "claude_api",
                         "model": "haiku-3.5",
                         "is_default": True,
@@ -127,12 +120,11 @@ class TestPartialUniqueIndexDoubleDefense:
         session_factory: async_sessionmaker[AsyncSession],
         seeded_empire_id: UUID,
     ) -> None:
-        """``is_default=0`` rows on the same agent_id are NOT subject to the partial index.
+        """同一 agent_id 配下の ``is_default=0`` 行は partial index の対象外。
 
-        Confirms the partial nature: ``WHERE is_default = 1`` means
-        rows with ``is_default = 0`` can coexist freely on the same
-        agent_id (subject only to the (agent_id, provider_kind)
-        UNIQUE).
+        partial の性質を確認する: ``WHERE is_default = 1`` のため、``is_default = 0``
+        の行は同一 agent_id 配下で自由に共存できる（(agent_id, provider_kind)
+        UNIQUE の制約のみが残る）。
         """
         agent_id = uuid4()
         empire_id = seeded_empire_id
@@ -157,7 +149,7 @@ class TestPartialUniqueIndexDoubleDefense:
                 },
             )
 
-        # Two providers, both is_default=False, distinct kinds — both succeed.
+        # 2 つの provider ── 両方 is_default=False、別 kind ── 両方とも成功する。
         async with session_factory() as session, session.begin():
             for kind in ("claude_code", "claude_api"):
                 await session.execute(
@@ -174,7 +166,7 @@ class TestPartialUniqueIndexDoubleDefense:
                     },
                 )
 
-        # Both rows present; partial index did not fire.
+        # 両方の行が存在し、partial index は発火していない。
         async with session_factory() as session:
             result = await session.execute(
                 text("SELECT COUNT(*) FROM agent_providers WHERE agent_id = :agent_id"),
@@ -188,14 +180,14 @@ class TestPartialUniqueIndexDoubleDefense:
 # TC-IT-AGR-007 補強: same agent_id duplicate (agent_id, provider_kind) → reject
 # ---------------------------------------------------------------------------
 class TestUniqueAgentProviderPair:
-    """The (agent_id, provider_kind) UNIQUE rejects same kind twice."""
+    """(agent_id, provider_kind) UNIQUE が同 kind 2 回挿入を拒否する。"""
 
     async def test_duplicate_agent_provider_pair_raises(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_empire_id: UUID,
     ) -> None:
-        """Same (agent_id, provider_kind) inserted twice → IntegrityError."""
+        """同じ (agent_id, provider_kind) を 2 回挿入 → IntegrityError。"""
         from sqlalchemy.exc import IntegrityError
 
         agent_id = uuid4()
@@ -244,7 +236,7 @@ class TestUniqueAgentProviderPair:
                     ),
                     {
                         "agent_id": agent_id.hex,
-                        "provider_kind": "claude_code",  # same kind
+                        "provider_kind": "claude_code",  # 同じ kind
                         "model": "haiku-3.5",
                         "is_default": False,
                     },
@@ -255,16 +247,16 @@ class TestUniqueAgentProviderPair:
 # TC-UT-AGR-009: Layer 2 arch-test reference — Agent rows registered
 # ---------------------------------------------------------------------------
 class TestArchTestRegistrationStructure:
-    """TC-UT-AGR-009: ``test_masking_columns.py`` parametrize lists include Agent.
+    """TC-UT-AGR-009: ``test_masking_columns.py`` の parametrize リストが Agent を含む。
 
-    Cross-checks that the CI Layer 2 arch test was extended to cover
-    the 3 Agent tables. A future PR that drops these registrations
-    (e.g. by accident during a refactor) would let an over-masking
-    or under-masking change land silently — this test catches it.
+    CI Layer 2 arch test が 3 つの Agent テーブルをカバーするよう拡張されたかを
+    相互チェックする。これらの登録を落とす将来の PR（例: リファクタ中の事故）は
+    過剰マスキング / 不足マスキングの変更を静かに着地させてしまう ──
+    本テストがそれを捕捉する。
     """
 
     async def test_agents_prompt_body_in_masking_contract(self) -> None:
-        """``agents.prompt_body`` is registered as MaskedText in the contract list."""
+        """``agents.prompt_body`` が contract リストに MaskedText として登録されている。"""
         from bakufu.infrastructure.persistence.sqlite.base import MaskedText
 
         from tests.architecture.test_masking_columns import (
@@ -278,7 +270,7 @@ class TestArchTestRegistrationStructure:
         )
 
     async def test_agent_providers_and_skills_in_no_mask_list(self) -> None:
-        """``agent_providers`` / ``agent_skills`` are no-mask tables."""
+        """``agent_providers`` / ``agent_skills`` は no-mask テーブル。"""
         from tests.architecture.test_masking_columns import (
             _NO_MASK_TABLES,  # pyright: ignore[reportPrivateUsage]
         )
@@ -287,7 +279,7 @@ class TestArchTestRegistrationStructure:
         assert "agent_skills" in _NO_MASK_TABLES
 
     async def test_agents_partial_mask_template_registered(self) -> None:
-        """``agents`` is registered in the partial-mask template list."""
+        """``agents`` が partial-mask テンプレートリストに登録されている。"""
         from tests.architecture.test_masking_columns import (
             _PARTIAL_MASK_TABLES,  # pyright: ignore[reportPrivateUsage]
         )

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_agent_repository/test_masking_persona.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_agent_repository/test_masking_persona.py
@@ -1,25 +1,24 @@
-"""Agent Repository: §確定 H — MaskedText wiring on agents.prompt_body.
+"""Agent Repository: §確定 H — agents.prompt_body への MaskedText 配線。
 
-**Schneier 申し送り #3 实適用の物理保証**. This module is the core test
-file for PR #45 — the persistence-foundation #23 hook structure is
-finally exercised end-to-end against a real SQLite DB, against 7
-secret-bearing prompt-body shapes:
+**Schneier 申し送り #3 の物理保証**。本モジュールは PR #45 の中核テストファイルであり、
+persistence-foundation #23 のフック構造が、実際の SQLite DB 上で
+secret を含む 7 種類の prompt-body 形状に対しエンドツーエンドで動作することを検証する:
 
 1. **anthropic** — ``ANTHROPIC_API_KEY=sk-ant-api03-XXX...`` → ``<REDACTED:ANTHROPIC_KEY>``
 2. **github** — ``ghp_XXX...`` → ``<REDACTED:GITHUB_PAT>``
 3. **openai** — ``sk-XXX...`` → ``<REDACTED:OPENAI_KEY>``
 4. **bearer** — ``Authorization: Bearer XXX`` → ``<REDACTED:BEARER>``
-5. **no-secret** — plain prompt → unchanged (passthrough)
-6. **roundtrip** — §確定 H §不可逆性: ``find_by_id`` returns the masked
-   form (raw token unrecoverable from DB).
-7. **multiple** — 3+ secret types in one prompt → all redacted.
+5. **no-secret** — secret を含まない prompt → 変更されない（passthrough）
+6. **roundtrip** — §確定 H §不可逆性: ``find_by_id`` はマスク済み形式を返す
+   （生トークンは DB から復元不能）
+7. **multiple** — 1 つの prompt 中の 3 種以上の secret がすべて redact される。
 
-Each verification reads the persisted ``agents.prompt_body`` value via
-**raw SQL SELECT** so we observe the literal bytes that hit the disk
-(bypassing ``MaskedText.process_result_value`` is fine; the column is
-TEXT-typed, so the raw bind side IS the on-disk side).
+各検証は **raw SQL SELECT** で永続化された ``agents.prompt_body`` を読み取り、
+ディスクに到達した literal バイトを観測する
+（``MaskedText.process_result_value`` を迂回しても問題ない ── このフックは恒等関数
+であり、ストアした文字列をそのまま返すため、ここで読む値はディスク上の値そのものとなる）。
 
-Per ``docs/features/agent-repository/test-design.md`` TC-IT-AGR-006-masking-*.
+``docs/features/agent-repository/test-design.md`` TC-IT-AGR-006-masking-* 準拠。
 """
 
 from __future__ import annotations
@@ -42,16 +41,15 @@ if TYPE_CHECKING:
 pytestmark = pytest.mark.asyncio
 
 
-# Real-shape (synthetic) secret tokens. Pattern lengths must match
-# the masking gateway's regex (masking.py L62-93) so the token is
-# actually redacted; otherwise the test would pass for the wrong
-# reason (token is plain text → grep finds no token → false negative).
+# 実形（合成）secret トークン。パターン長は masking gateway の正規表現
+# (masking.py L62-93) と一致させる必要がある ── でなければトークンが redact されず、
+# テストが誤った理由で pass してしまう（生 → grep がトークンを見つけない → false negative）。
 _ANTHROPIC_TOKEN = "sk-ant-api03-" + "A" * 60
 _GITHUB_TOKEN = "ghp_" + "X" * 40
-_OPENAI_TOKEN = "sk-" + "B" * 50  # 20+ chars after sk-, not sk-ant- (negative lookahead)
+_OPENAI_TOKEN = "sk-" + "B" * 50  # sk- 後に 20 文字以上、かつ sk-ant- 以外（negative lookahead）
 _BEARER_TOKEN = "eyJhbGciOi.tokenpart.signature"
 
-# Redaction sentinels (masking.py L62-93).
+# Redaction sentinel (masking.py L62-93)。
 _ANTHROPIC_SENTINEL = "<REDACTED:ANTHROPIC_KEY>"
 _GITHUB_SENTINEL = "<REDACTED:GITHUB_PAT>"
 _OPENAI_SENTINEL = "<REDACTED:OPENAI_KEY>"
@@ -59,12 +57,11 @@ _BEARER_SENTINEL = "<REDACTED:BEARER>"
 
 
 def _make_agent_with_prompt(prompt_body: str, *, empire_id: UUID) -> Agent:
-    """Build an Agent whose Persona carries ``prompt_body``.
+    """Persona に ``prompt_body`` を持たせた Agent を構築する。
 
-    The default factory keeps every other field synthetic-but-valid;
-    we override only ``persona.prompt_body`` to inject the secret
-    pattern under test. ``empire_id`` is required so the FK to
-    ``empires.id`` resolves at INSERT time.
+    デフォルト factory は他のフィールドを合成だが妥当な値で埋め、
+    ここでは ``persona.prompt_body`` のみ上書きしてテスト対象の secret パターンを注入する。
+    ``empire_id`` は INSERT 時に ``empires.id`` への FK を解決するために必須。
     """
     persona = Persona(
         display_name="masking-probe",
@@ -78,18 +75,16 @@ async def _read_persisted_prompt(
     session_factory: async_sessionmaker[AsyncSession],
     agent_id: UUID,
 ) -> str:
-    """Raw-SQL SELECT to fetch ``agents.prompt_body`` literal bytes.
+    """Raw-SQL SELECT で ``agents.prompt_body`` の literal バイトを取得する。
 
-    Bypasses ``MaskedText.process_result_value`` is unnecessary —
-    that hook is identity (just returns the stored string), so what
-    we read here IS what is on disk. We use ``text()`` to make the
-    intent explicit and to keep the test independent of the ORM-
-    declarative metadata.
+    ``MaskedText.process_result_value`` を迂回する必要はない ── このフックは恒等関数
+    （ストアされた文字列をそのまま返す）であるため、ここで読む値はディスク上の値と一致する。
+    意図を明示的にし、ORM-declarative metadata から独立させるために ``text()`` を用いる。
     """
     async with session_factory() as session:
         stmt = text("SELECT prompt_body FROM agents WHERE id = :id")
-        # SQLAlchemy's UUIDStr TypeDecorator stores as ``.hex``; we
-        # match that here so the WHERE clause hits the row.
+        # SQLAlchemy の UUIDStr TypeDecorator は ``.hex`` で格納するため、
+        # WHERE 句がレコードに当たるよう ``.hex`` で照合する。
         row = (await session.execute(stmt, {"id": agent_id.hex})).first()
     assert row is not None, f"agents row not found for id={agent_id}"
     persisted = row[0]
@@ -101,14 +96,14 @@ async def _read_persisted_prompt(
 # TC-IT-AGR-006-masking-anthropic
 # ---------------------------------------------------------------------------
 class TestAnthropicKeyMasked:
-    """TC-IT-AGR-006-masking-anthropic: Anthropic API key redacted on save."""
+    """TC-IT-AGR-006-masking-anthropic: save 時に Anthropic API key が redact される。"""
 
     async def test_anthropic_key_redacted_in_persisted_prompt(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_empire_id: UUID,
     ) -> None:
-        """Raw-SQL SELECT shows ``<REDACTED:ANTHROPIC_KEY>``; raw token absent."""
+        """Raw-SQL SELECT が ``<REDACTED:ANTHROPIC_KEY>`` を返し、生トークンが含まれない。"""
         prompt = f"Use ANTHROPIC_API_KEY={_ANTHROPIC_TOKEN} when calling Claude."
         agent = _make_agent_with_prompt(prompt, empire_id=seeded_empire_id)
         async with session_factory() as session, session.begin():
@@ -132,14 +127,14 @@ class TestAnthropicKeyMasked:
 # TC-IT-AGR-006-masking-github
 # ---------------------------------------------------------------------------
 class TestGitHubPatMasked:
-    """TC-IT-AGR-006-masking-github: GitHub PAT redacted on save."""
+    """TC-IT-AGR-006-masking-github: save 時に GitHub PAT が redact される。"""
 
     async def test_github_pat_redacted_in_persisted_prompt(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_empire_id: UUID,
     ) -> None:
-        """Raw-SQL SELECT shows ``<REDACTED:GITHUB_PAT>``; raw PAT absent."""
+        """Raw-SQL SELECT が ``<REDACTED:GITHUB_PAT>`` を返し、生 PAT が含まれない。"""
         prompt = f"Use {_GITHUB_TOKEN} for git push."
         agent = _make_agent_with_prompt(prompt, empire_id=seeded_empire_id)
         async with session_factory() as session, session.begin():
@@ -160,18 +155,18 @@ class TestGitHubPatMasked:
 # TC-IT-AGR-006-masking-openai
 # ---------------------------------------------------------------------------
 class TestOpenAiKeyMasked:
-    """TC-IT-AGR-006-masking-openai: OpenAI API key redacted on save."""
+    """TC-IT-AGR-006-masking-openai: save 時に OpenAI API key が redact される。"""
 
     async def test_openai_key_redacted_in_persisted_prompt(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_empire_id: UUID,
     ) -> None:
-        """Raw-SQL SELECT shows ``<REDACTED:OPENAI_KEY>``; raw token absent.
+        """Raw-SQL SELECT が ``<REDACTED:OPENAI_KEY>`` を返し、生トークンが含まれない。
 
-        Note the masking gateway uses a **negative lookahead** so
-        Anthropic's ``sk-ant-`` prefix is NOT mis-classified as
-        OpenAI. We feed a non-Anthropic ``sk-...`` here.
+        masking gateway は **negative lookahead** を用いるため、Anthropic の
+        ``sk-ant-`` プレフィックスは OpenAI と誤分類されない。ここでは
+        Anthropic ではない ``sk-...`` を渡している。
         """
         prompt = f"Use OPENAI_API_KEY={_OPENAI_TOKEN} for fallback."
         agent = _make_agent_with_prompt(prompt, empire_id=seeded_empire_id)
@@ -192,14 +187,14 @@ class TestOpenAiKeyMasked:
 # TC-IT-AGR-006-masking-bearer
 # ---------------------------------------------------------------------------
 class TestBearerTokenMasked:
-    """TC-IT-AGR-006-masking-bearer: Authorization: Bearer XXX redacted."""
+    """TC-IT-AGR-006-masking-bearer: Authorization: Bearer XXX が redact される。"""
 
     async def test_bearer_token_redacted_in_persisted_prompt(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_empire_id: UUID,
     ) -> None:
-        """Raw-SQL SELECT shows ``<REDACTED:BEARER>``; raw token absent."""
+        """Raw-SQL SELECT が ``<REDACTED:BEARER>`` を返し、生トークンが含まれない。"""
         prompt = f"Set header `Authorization: Bearer {_BEARER_TOKEN}`."
         agent = _make_agent_with_prompt(prompt, empire_id=seeded_empire_id)
         async with session_factory() as session, session.begin():
@@ -219,20 +214,19 @@ class TestBearerTokenMasked:
 # TC-IT-AGR-006-masking-no-secret (passthrough)
 # ---------------------------------------------------------------------------
 class TestNoSecretPassthrough:
-    """TC-IT-AGR-006-masking-no-secret: plain prompt is stored unchanged."""
+    """TC-IT-AGR-006-masking-no-secret: 平文 prompt は変更されずに保存される。"""
 
     async def test_plain_prompt_is_passthrough(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_empire_id: UUID,
     ) -> None:
-        """A prompt with no Schneier-#6 secrets is persisted byte-identical.
+        """Schneier-#6 の secret を含まない prompt はバイト等価で永続化される。
 
-        Confirms masking is **scoped** — only known secret patterns
-        get redacted; the masking gateway is not over-aggressive on
-        plain text. Without this check, a regression that replaces
-        the masking gateway with ``str.replace_all('a', '<X>')``
-        would silently corrupt prompts.
+        マスキングが **限定的** であることを確認する ── 既知の secret パターンのみ
+        redact され、masking gateway は平文に対し過剰反応しない。このチェックがないと、
+        masking gateway を ``str.replace_all('a', '<X>')`` に置き換えた回帰により
+        prompt が静かに破壊されてしまう。
         """
         plain = "You are a thorough reviewer who checks PRs carefully."
         agent = _make_agent_with_prompt(plain, empire_id=seeded_empire_id)
@@ -251,15 +245,13 @@ class TestNoSecretPassthrough:
 # TC-IT-AGR-006-masking-roundtrip (§確定 H §不可逆性)
 # ---------------------------------------------------------------------------
 class TestRoundTripIsIrreversible:
-    """TC-IT-AGR-006-masking-roundtrip: §確定 H §不可逆性 — find_by_id returns masked.
+    """TC-IT-AGR-006-masking-roundtrip: §確定 H §不可逆性 ── find_by_id はマスク済みを返す。
 
-    Once a secret is masked at save time, the raw token is
-    **physically unrecoverable** from the DB. ``find_by_id`` must
-    therefore return a Persona whose ``prompt_body`` carries the
-    redaction sentinel rather than the original token. Detecting
-    masked prompts and refusing to dispatch them to the LLM is
-    ``feature/llm-adapter``'s job (申し送り #1) — the Repository
-    contract is "the masked form is what you get back".
+    一度 secret が save 時にマスクされたら、生トークンは DB から **物理的に復元不能**
+    である。したがって ``find_by_id`` は redaction sentinel を持つ Persona を返す
+    べきであり、元のトークンを返してはならない。マスクされた prompt を検出して
+    LLM へのディスパッチを拒否することは ``feature/llm-adapter`` の責務（申し送り #1）であり、
+    Repository の契約は「戻ってくるのはマスク済みの形式」である。
     """
 
     async def test_find_by_id_returns_masked_prompt_body(
@@ -267,7 +259,7 @@ class TestRoundTripIsIrreversible:
         session_factory: async_sessionmaker[AsyncSession],
         seeded_empire_id: UUID,
     ) -> None:
-        """Save raw → find_by_id → persona.prompt_body == masked form."""
+        """生で save → find_by_id → persona.prompt_body == マスク済み形式。"""
         raw = f"ANTHROPIC_API_KEY={_ANTHROPIC_TOKEN}"
         agent = _make_agent_with_prompt(raw, empire_id=seeded_empire_id)
         async with session_factory() as session, session.begin():
@@ -285,9 +277,8 @@ class TestRoundTripIsIrreversible:
             f"[FAIL] §確定 H §不可逆性 violated: raw token recovered after round-trip.\n"
             f"Restored: {restored.persona.prompt_body!r}"
         )
-        # And of course the round-tripped Agent does NOT compare equal
-        # to the original Agent (since prompt_body changed) — pin
-        # this asymmetry as the documented design contract.
+        # ラウンドトリップした Agent は元の Agent と等価ではない（prompt_body が変わるため）。
+        # この非対称性を文書化された設計契約として固定する。
         assert restored != agent, (
             "[FAIL] round-trip equality should not hold for masked prompts; "
             "if this passes, masking might be a no-op."
@@ -298,18 +289,18 @@ class TestRoundTripIsIrreversible:
 # TC-IT-AGR-006-masking-multiple
 # ---------------------------------------------------------------------------
 class TestMultipleSecretsAllRedacted:
-    """TC-IT-AGR-006-masking-multiple: 3+ secret types in one prompt all redacted."""
+    """TC-IT-AGR-006-masking-multiple: 1 prompt 中の 3 種以上の secret がすべて redact される。"""
 
     async def test_multiple_secrets_all_redacted_in_one_pass(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_empire_id: UUID,
     ) -> None:
-        """A prompt with anthropic + github + bearer all gets fully redacted.
+        """anthropic + github + bearer を含む prompt がすべて完全に redact される。
 
-        Confirms masking is **comprehensive** — applying one redaction
-        does not short-circuit the others. The gateway iterates all
-        regex patterns; this test pins that behaviour.
+        マスキングが **包括的** であることを確認する ── 1 つの redaction を適用しても
+        他の redaction が短絡されない。gateway はすべての正規表現パターンを反復処理する。
+        本テストはこの動作を固定する。
         """
         prompt = (
             f"Multiple secrets in one prompt:\n"
@@ -323,11 +314,11 @@ class TestMultipleSecretsAllRedacted:
 
         persisted = await _read_persisted_prompt(session_factory, agent.id)
 
-        # All 3 sentinels present.
+        # 3 種の sentinel がすべて含まれる。
         assert _ANTHROPIC_SENTINEL in persisted
         assert _GITHUB_SENTINEL in persisted
         assert _BEARER_SENTINEL in persisted
-        # All 3 raw tokens absent.
+        # 3 種の生トークンはいずれも含まれない。
         assert _ANTHROPIC_TOKEN not in persisted, (
             f"[FAIL] Anthropic token survived multi-secret masking. Persisted: {persisted!r}"
         )

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_agent_repository/test_protocol_crud.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_agent_repository/test_protocol_crud.py
@@ -1,11 +1,10 @@
-"""Agent Repository: Protocol surface + basic CRUD coverage.
+"""Agent Repository: Protocol サーフェス + 基本 CRUD カバレッジ。
 
-TC-UT-AGR-001 / 004 / 005 — the entry-point behaviors plus the
-**4-method Protocol surface** (the agent-repository is the first
-Repository to add ``find_by_name`` on top of the empire / workflow
-3-method template, §確定 F).
+TC-UT-AGR-001 / 004 / 005 ── エントリポイント挙動と
+**4 メソッドの Protocol サーフェス**（agent-repository は empire / workflow の
+3 メソッドテンプレートに ``find_by_name`` を加える最初の Repository。§確定 F）。
 
-Per ``docs/features/agent-repository/test-design.md``.
+``docs/features/agent-repository/test-design.md`` 準拠。
 """
 
 from __future__ import annotations
@@ -32,30 +31,30 @@ pytestmark = pytest.mark.asyncio
 
 
 # ---------------------------------------------------------------------------
-# REQ-AGR-001: Protocol definition + 4-method surface (§確定 A + F)
+# REQ-AGR-001: Protocol 定義 + 4 メソッドサーフェス (§確定 A + F)
 # ---------------------------------------------------------------------------
 class TestAgentRepositoryProtocol:
-    """TC-UT-AGR-001: Protocol declares 4 async methods incl. ``find_by_name``."""
+    """TC-UT-AGR-001: Protocol が ``find_by_name`` を含む 4 つの async メソッドを宣言する。"""
 
     async def test_protocol_declares_four_async_methods(self) -> None:
-        """TC-UT-AGR-001: ``AgentRepository`` has find_by_id / count / save / find_by_name."""
-        # Marked async so module-level pytestmark = asyncio does not warn.
+        """TC-UT-AGR-001: ``AgentRepository`` が
+        find_by_id / count / save / find_by_name を持つ。"""
+        # モジュールレベルの pytestmark = asyncio が警告しないよう async を付ける。
         assert hasattr(AgentRepository, "find_by_id")
         assert hasattr(AgentRepository, "count")
         assert hasattr(AgentRepository, "save")
-        # ``find_by_name`` is the 4th method introduced by §確定 F —
-        # the first M2 Repository PR to extend the 3-method template.
+        # ``find_by_name`` は §確定 F で導入された 4 番目のメソッド ──
+        # 3 メソッドテンプレートを最初に拡張する M2 Repository PR。
         assert hasattr(AgentRepository, "find_by_name")
 
     async def test_sqlite_repository_satisfies_protocol(
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """TC-UT-AGR-001: ``SqliteAgentRepository`` is assignable to ``AgentRepository``.
+        """TC-UT-AGR-001: ``SqliteAgentRepository`` を ``AgentRepository`` に代入できる。
 
-        The variable annotation acts as a static-type assertion; pyright
-        strict will reject the assignment if any of the 4 Protocol
-        methods is missing or has a wrong signature.
+        変数アノテーションが静的型アサーションとして機能する。pyright strict は、
+        Protocol メソッドが欠落または誤シグネチャの場合に代入を拒否する。
         """
         async with session_factory() as session:
             repo: AgentRepository = SqliteAgentRepository(session)
@@ -66,21 +65,21 @@ class TestAgentRepositoryProtocol:
 
 
 # ---------------------------------------------------------------------------
-# REQ-AGR-002 (find_by_id basic round-trip)
+# REQ-AGR-002 (find_by_id の基本ラウンドトリップ)
 # ---------------------------------------------------------------------------
 class TestFindById:
-    """find_by_id retrieves saved Agents; returns None for unknown."""
+    """find_by_id は保存済み Agent を取得する。未知の id は None を返す。"""
 
     async def test_find_by_id_returns_saved_agent(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_empire_id: UUID,
     ) -> None:
-        """``find_by_id(agent.id)`` returns a structurally-equal Agent (no secrets in default)."""
-        # Default factory ``prompt_body='You are a thorough reviewer.'``
-        # contains no Schneier-#6 secrets, so masking is a no-op and
-        # round-trip equality holds. Secret-bearing prompt round-trip
-        # lives in :mod:`...test_masking_persona` (§確定 H §不可逆性).
+        """``find_by_id(agent.id)`` が構造的に等価な Agent を返す（デフォルトでは secret なし）。"""
+        # デフォルト factory の ``prompt_body='You are a thorough reviewer.'`` には
+        # Schneier-#6 の secret が含まれないため、マスキングは no-op となり
+        # ラウンドトリップ等価性が成立する。secret を含む prompt のラウンドトリップは
+        # :mod:`...test_masking_persona` (§確定 H §不可逆性) で扱う。
         agent = make_agent(empire_id=seeded_empire_id)
         async with session_factory() as session, session.begin():
             await SqliteAgentRepository(session).save(agent)
@@ -95,7 +94,7 @@ class TestFindById:
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """``find_by_id(uuid4())`` returns ``None`` without raising."""
+        """``find_by_id(uuid4())`` は例外を投げず ``None`` を返す。"""
         unknown_id = uuid4()
         async with session_factory() as session:
             fetched = await SqliteAgentRepository(session).find_by_id(unknown_id)
@@ -106,7 +105,7 @@ class TestFindById:
 # TC-UT-AGR-004: count() must issue SQL-level COUNT(*)
 # ---------------------------------------------------------------------------
 class TestCountIssuesScalarCount:
-    """TC-UT-AGR-004: ``count()`` issues ``SELECT COUNT(*)``, not a full row scan."""
+    """TC-UT-AGR-004: ``count()`` は ``SELECT COUNT(*)`` を発行し、行を全件スキャンしない。"""
 
     async def test_count_emits_select_count_not_full_load(
         self,
@@ -114,12 +113,11 @@ class TestCountIssuesScalarCount:
         app_engine: AsyncEngine,
         seeded_empire_id: UUID,
     ) -> None:
-        """SQL log shows ``SELECT count(*)`` for ``count()``.
+        """SQL ログが ``count()`` に対し ``SELECT count(*)`` を示す。
 
-        The empire-repository §確定 D 補強 contract continued — Agent
-        provider / skill rows can hold hundreds of records once the
-        preset library lands, so the COUNT(*) pattern matters even
-        more than for Empire.
+        empire-repository §確定 D 補強の契約を継続する ── Agent の
+        provider / skill 行は preset ライブラリ着地後は数百レコードを保持しうるため、
+        COUNT(*) パターンが Empire 以上に重要となる。
         """
         async with session_factory() as session, session.begin():
             await SqliteAgentRepository(session).save(make_agent(empire_id=seeded_empire_id))
@@ -160,23 +158,22 @@ class TestCountIssuesScalarCount:
 # TC-UT-AGR-005: find_by_name Empire-scoped (§確定 F)
 # ---------------------------------------------------------------------------
 class TestFindByNameEmpireScoped:
-    """TC-UT-AGR-005: ``find_by_name`` enforces Empire scoping.
+    """TC-UT-AGR-005: ``find_by_name`` が Empire スコープを強制する。
 
-    Three orthogonal cases per §確定 F:
+    §確定 F に沿う 3 つの直交ケース:
 
-    1. **Hit**: Agent named ``foo`` inside ``empire_a`` is returned.
-    2. **Miss in same Empire**: name ``bar`` under ``empire_a`` returns None.
-    3. **Cross-Empire isolation**: name ``foo`` under ``empire_b`` returns None
-       even though ``foo`` exists in ``empire_a``. This is the IDOR
-       guard — without ``WHERE empire_id=:empire_id`` an attacker
-       could read another tenant's Agent by guessing the name.
+    1. **ヒット**: ``empire_a`` 内の ``foo`` という名前の Agent が返る。
+    2. **同 Empire 内ミス**: ``empire_a`` 配下の ``bar`` という名前は None を返す。
+    3. **Empire 間隔離**: ``foo`` が ``empire_a`` に存在しても、``empire_b`` 配下の
+       ``foo`` 検索は None を返す。これが IDOR ガード ── ``WHERE empire_id=:empire_id``
+       がなければ攻撃者が名前を推測して別テナントの Agent を読み取れる。
     """
 
     async def test_find_by_name_returns_agent_when_present(
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """Hit path: name + empire_id pair returns the Agent."""
+        """ヒット経路: name + empire_id ペアが Agent を返す。"""
         empire_a = await seed_empire(session_factory)
         agent = make_agent(empire_id=empire_a, name="agent_a")
         async with session_factory() as session, session.begin():
@@ -194,7 +191,7 @@ class TestFindByNameEmpireScoped:
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """Miss path: unknown name in known Empire returns None."""
+        """ミス経路: 既知 Empire 内の未知の名前は None を返す。"""
         empire_a = await seed_empire(session_factory)
         async with session_factory() as session, session.begin():
             await SqliteAgentRepository(session).save(
@@ -209,12 +206,11 @@ class TestFindByNameEmpireScoped:
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """**IDOR guard**: same name under different Empire returns None.
+        """**IDOR ガード**: 別 Empire 配下の同名は None を返す。
 
-        This is the test-design.md §確定 F core contract. A regression
-        that drops the ``WHERE empire_id`` clause (e.g. by globally
-        searching by name) would let an attacker read cross-tenant
-        Agents — this assertion fires loudly in that case.
+        本テストは test-design.md §確定 F の中核契約。``WHERE empire_id`` 句を落とす
+        回帰（例: 全 Empire 横断で name 検索）は、攻撃者がテナント越境で Agent を
+        読めてしまう ── このアサーションは即座にそれを表面化させる。
         """
         empire_a = await seed_empire(session_factory)
         empire_b = await seed_empire(session_factory)
@@ -223,8 +219,8 @@ class TestFindByNameEmpireScoped:
             await SqliteAgentRepository(session).save(agent_in_a)
 
         async with session_factory() as session:
-            # Look up the same name but in a DIFFERENT empire — must
-            # return None even though "shared_name" exists in empire_a.
+            # 同じ名前を別の empire で検索する ── empire_a に "shared_name" が
+            # 存在しても、None を返さねばならない。
             fetched = await SqliteAgentRepository(session).find_by_name(empire_b, "shared_name")
         assert fetched is None, (
             "[FAIL] find_by_name leaked an Agent across Empire boundaries.\n"
@@ -237,13 +233,11 @@ class TestFindByNameEmpireScoped:
         session_factory: async_sessionmaker[AsyncSession],
         app_engine: AsyncEngine,
     ) -> None:
-        """SQL log shows ``WHERE agents.empire_id = ?`` and ``LIMIT 1``.
+        """SQL ログに ``WHERE agents.empire_id = ?`` と ``LIMIT 1`` が含まれる。
 
-        Defense-in-depth on top of the behavioural test above: even if
-        the cross-Empire test happens to pass via row-coincidence
-        (e.g. name conflict in seed data), the SQL itself must carry
-        the scope clause. We attach a ``before_cursor_execute``
-        listener and grep for the empire_id predicate.
+        上の振る舞いテストに対する多層防御: クロス Empire テストが seed の名前衝突など
+        行偶発で pass してしまっても、SQL 自体がスコープ句を持たねばならない。
+        ``before_cursor_execute`` リスナを取り付け、empire_id 述語を grep する。
         """
         empire_a = await seed_empire(session_factory)
         async with session_factory() as session, session.begin():
@@ -271,11 +265,11 @@ class TestFindByNameEmpireScoped:
         finally:
             event.remove(sync_engine, "before_cursor_execute", _on_execute)
 
-        # Locate the SELECT that hit ``agents`` to look up the AgentId.
+        # AgentId を検索するために ``agents`` を叩いた SELECT を探す。
         agent_id_selects = [s for s in captured if "FROM agents" in s and "SELECT" in s.upper()]
         assert agent_id_selects, "find_by_name must SELECT from agents"
-        # The first such SELECT must carry both the empire_id predicate
-        # and a LIMIT clause to avoid full-table scans.
+        # 該当する最初の SELECT は、フルテーブルスキャンを避けるため、
+        # empire_id 述語と LIMIT 句の両方を持たねばならない。
         target_stmt = agent_id_selects[0]
         assert "empire_id" in target_stmt, (
             f"[FAIL] find_by_name SQL missing empire_id predicate.\nCaptured: {target_stmt!r}"
@@ -286,20 +280,19 @@ class TestFindByNameEmpireScoped:
 
 
 # ---------------------------------------------------------------------------
-# Lifecycle integration: save → find_by_name → find_by_id → save (update)
+# ライフサイクル統合: save → find_by_name → find_by_id → save (更新)
 # ---------------------------------------------------------------------------
 class TestLifecycleIntegration:
-    """TC-IT-AGR-LIFECYCLE: full save → lookup → update flow."""
+    """TC-IT-AGR-LIFECYCLE: save → 検索 → 更新の完全フロー。"""
 
     async def test_full_lifecycle_with_persona_update(
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """Save → find_by_name → find_by_id → update persona → save.
+        """Save → find_by_name → find_by_id → persona 更新 → save。
 
-        Verifies the 4 Protocol methods cooperate end-to-end and that
-        a persona update via re-save reaches the DB through the
-        UPSERT path (Step 1 of §確定 B 5-step).
+        4 つの Protocol メソッドがエンドツーエンドで協調し、再 save 経由の
+        persona 更新が UPSERT 経路（§確定 B 5 ステップの Step 1）で DB に到達することを検証する。
         """
         from bakufu.domain.agent import Persona
 
@@ -328,7 +321,7 @@ class TestLifecycleIntegration:
         assert via_id is not None
         assert via_id == via_name
 
-        # Update: change the persona display_name and re-save.
+        # 更新: persona display_name を変更して再 save。
         updated = original.model_copy(
             update={
                 "persona": Persona(

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_agent_repository/test_save_semantics.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_agent_repository/test_save_semantics.py
@@ -1,10 +1,9 @@
-"""Agent Repository: save() semantics — delete-then-insert + ORDER BY + Tx boundary.
+"""Agent Repository: save() のセマンティクス ── delete-then-insert + ORDER BY + Tx 境界。
 
-TC-UT-AGR-002 / 003 / 010 / 011 — the §確定 B / §BUG-EMR-001 inheritance
-contracts that back the ``save()`` flow + ORDER BY observation +
-Tx boundary + round-trip equality.
+TC-UT-AGR-002 / 003 / 010 / 011 ── §確定 B / §BUG-EMR-001 を踏襲して ``save()`` フローを
+裏付ける契約 + ORDER BY 観測 + Tx 境界 + ラウンドトリップ等価性。
 
-Per ``docs/features/agent-repository/test-design.md``.
+``docs/features/agent-repository/test-design.md`` 準拠。
 """
 
 from __future__ import annotations
@@ -41,11 +40,11 @@ pytestmark = pytest.mark.asyncio
 # TC-UT-AGR-002: 5-step delete-then-insert SQL order (§確定 B)
 # ---------------------------------------------------------------------------
 class TestSaveSqlOrder:
-    """TC-UT-AGR-002: ``save`` issues the §確定 B 5-step DML sequence.
+    """TC-UT-AGR-002: ``save`` が §確定 B の 5 ステップ DML シーケンスを発行する。
 
-    Same harness as empire-repository TC-IT-EMR-011 / workflow-
-    repository TC-IT-WFR-010 — observe SQL via
-    ``before_cursor_execute`` listener and assert prefixes:
+    empire-repository TC-IT-EMR-011 / workflow-repository TC-IT-WFR-010 と
+    同じハーネスで ``before_cursor_execute`` リスナにより SQL を観測し、
+    プレフィックスを assert する:
 
     1. ``INSERT INTO agents`` (UPSERT)
     2. ``DELETE FROM agent_providers``
@@ -60,7 +59,7 @@ class TestSaveSqlOrder:
         app_engine: AsyncEngine,
         seeded_empire_id: UUID,
     ) -> None:
-        """5-step DML order matches §確定 B."""
+        """5 ステップの DML 順序が §確定 B に一致する。"""
         captured: list[str] = []
 
         def _on_execute(
@@ -76,9 +75,8 @@ class TestSaveSqlOrder:
         sync_engine = app_engine.sync_engine
         event.listen(sync_engine, "before_cursor_execute", _on_execute)
         try:
-            # Build an Agent with non-empty providers + skills so all
-            # 5 DML statements actually fire (empty side-tables would
-            # skip the INSERT).
+            # 5 つの DML がすべて発火するよう、providers と skills を持つ Agent を構築する
+            # （side-table が空だと INSERT がスキップされる）。
             agent = make_agent(
                 empire_id=seeded_empire_id,
                 providers=[make_provider_config()],
@@ -116,13 +114,12 @@ class TestSaveSqlOrder:
 # TC-UT-AGR-003: ORDER BY contract (§BUG-EMR-001 inherited from day 1)
 # ---------------------------------------------------------------------------
 class TestFindByIdOrderByContract:
-    """TC-UT-AGR-003: ``ORDER BY provider_kind`` / ``ORDER BY skill_id`` are emitted.
+    """TC-UT-AGR-003: ``ORDER BY provider_kind`` / ``ORDER BY skill_id`` が発行される。
 
-    The empire-repository BUG-EMR-001 closure froze the ORDER BY
-    contract; the agent Repository adopts it from PR #1. Without
-    these clauses, SQLite returns rows in internal-scan order which
-    would break ``Agent == Agent`` round-trip equality (the
-    Aggregate compares list-by-list).
+    empire-repository BUG-EMR-001 のクロージャが ORDER BY 契約を凍結し、
+    agent Repository は PR #1 から踏襲する。これらの句がないと SQLite は
+    内部スキャン順で行を返し、``Agent == Agent`` ラウンドトリップ等価性
+    （Aggregate がリスト同士で比較する）が壊れる。
     """
 
     async def test_find_by_id_emits_order_by_provider_kind(
@@ -131,7 +128,7 @@ class TestFindByIdOrderByContract:
         app_engine: AsyncEngine,
         seeded_empire_id: UUID,
     ) -> None:
-        """``find_by_id`` emits ``ORDER BY agent_providers.provider_kind``."""
+        """``find_by_id`` が ``ORDER BY agent_providers.provider_kind`` を発行する。"""
         agent = make_agent(
             empire_id=seeded_empire_id,
             providers=[
@@ -179,7 +176,7 @@ class TestFindByIdOrderByContract:
         app_engine: AsyncEngine,
         seeded_empire_id: UUID,
     ) -> None:
-        """``find_by_id`` emits ``ORDER BY agent_skills.skill_id``."""
+        """``find_by_id`` が ``ORDER BY agent_skills.skill_id`` を発行する。"""
         agent = make_agent(
             empire_id=seeded_empire_id,
             providers=[make_provider_config()],
@@ -222,15 +219,15 @@ class TestFindByIdOrderByContract:
 # TC-UT-AGR-002 (delete-then-insert replacement semantics)
 # ---------------------------------------------------------------------------
 class TestSaveReplacesSideTableRows:
-    """``save`` replaces side-table rows wholesale (§確定 B)."""
+    """``save`` が side-table 行を丸ごと置換する (§確定 B)。"""
 
     async def test_save_replaces_skill_rows(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_empire_id: UUID,
     ) -> None:
-        """Skills 2 → 1 reflects as 1 row in agent_skills (no residue)."""
-        # Two skills initially.
+        """skills 2 → 1 が agent_skills で 1 行として反映される（残骸なし）。"""
+        # 初期状態は 2 skill。
         original = make_agent(
             empire_id=seeded_empire_id,
             skills=[make_skill_ref(name="skill_a"), make_skill_ref(name="skill_b")],
@@ -238,7 +235,7 @@ class TestSaveReplacesSideTableRows:
         async with session_factory() as session, session.begin():
             await SqliteAgentRepository(session).save(original)
 
-        # Re-save with one skill — same agent_id.
+        # 同じ agent_id で skill 1 件にして再 save。
         replacement = make_agent(
             agent_id=original.id,
             empire_id=original.empire_id,
@@ -266,12 +263,12 @@ class TestSaveReplacesSideTableRows:
 # TC-UT-AGR-011: round-trip equality (_to_row / _from_row via DB)
 # ---------------------------------------------------------------------------
 class TestRoundTripEquality:
-    """TC-UT-AGR-011: save → find_by_id round-trip preserves Agent identity.
+    """TC-UT-AGR-011: save → find_by_id ラウンドトリップで Agent の同一性が保たれる。
 
-    Note: this test uses default ``prompt_body`` (no secrets) so
-    masking is a no-op and full ``==`` holds. Secret-bearing
-    round-trip is non-equal due to §確定 H §不可逆性 — that path lives
-    in :mod:`...test_masking_persona`.
+    本テストはデフォルトの ``prompt_body``（secret なし）を使うため、マスキングは
+    no-op となり full ``==`` が成立する。secret を含むラウンドトリップは
+    §確定 H §不可逆性 により非等価になる ── その経路は
+    :mod:`...test_masking_persona` で扱う。
     """
 
     async def test_agent_with_providers_and_skills_round_trips(
@@ -279,7 +276,7 @@ class TestRoundTripEquality:
         session_factory: async_sessionmaker[AsyncSession],
         seeded_empire_id: UUID,
     ) -> None:
-        """Agent with 1 provider + 1 skill round-trips structurally."""
+        """provider 1 + skill 1 を持つ Agent が構造的にラウンドトリップする。"""
         agent = make_agent(
             empire_id=seeded_empire_id,
             providers=[make_provider_config()],
@@ -296,8 +293,8 @@ class TestRoundTripEquality:
         assert restored.empire_id == agent.empire_id
         assert restored.name == agent.name
         assert restored.role == agent.role
-        # ORDER BY-aware comparisons (single-element here, but the
-        # contract is "list order matches the SQL ORDER BY key").
+        # ORDER BY を考慮した比較（ここでは要素 1 つだが、契約は
+        # 「リスト順序が SQL の ORDER BY キーに一致する」）。
         assert restored.providers == sorted(agent.providers, key=lambda p: p.provider_kind.value)
         assert restored.skills == sorted(agent.skills, key=lambda s: s.skill_id)
 
@@ -306,14 +303,14 @@ class TestRoundTripEquality:
 # TC-UT-AGR-010: Tx boundary responsibility separation (§確定 B)
 # ---------------------------------------------------------------------------
 class TestTxBoundaryRespectedByRepository:
-    """TC-UT-AGR-010: Repository never calls commit / rollback (§確定 B)."""
+    """TC-UT-AGR-010: Repository は commit / rollback を呼ばない (§確定 B)。"""
 
     async def test_commit_path_persists_via_outer_block(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_empire_id: UUID,
     ) -> None:
-        """Outer ``async with session.begin()`` commits the save."""
+        """外側の ``async with session.begin()`` が save を commit する。"""
         agent = make_agent(empire_id=seeded_empire_id)
         async with session_factory() as session, session.begin():
             await SqliteAgentRepository(session).save(agent)
@@ -327,15 +324,14 @@ class TestTxBoundaryRespectedByRepository:
         session_factory: async_sessionmaker[AsyncSession],
         seeded_empire_id: UUID,
     ) -> None:
-        """An exception inside ``begin()`` rolls back ALL 5 DML steps.
+        """``begin()`` 内の例外が 5 ステップの DML すべてをロールバックする。
 
-        The Agent row + providers + skills all participate in the
-        same caller-managed transaction. A single uncaught exception
-        inside the ``begin()`` block must purge **all** of them.
+        Agent 行 + providers + skills は同一の呼び出し側管理トランザクションに参加する。
+        ``begin()`` ブロック内の単一の未捕捉例外が **すべて** を破棄せねばならない。
         """
 
         class _BoomError(Exception):
-            """Synthetic exception used to drive the rollback path."""
+            """ロールバック経路を駆動する合成例外。"""
 
         agent = make_agent(
             empire_id=seeded_empire_id,
@@ -352,9 +348,8 @@ class TestTxBoundaryRespectedByRepository:
             fetched = await SqliteAgentRepository(session).find_by_id(agent.id)
         assert fetched is None
 
-        # Side tables also empty — the §確定 B contract is that the
-        # 5-step sequence is **one** logical operation under the
-        # caller's UoW.
+        # side-table も空 ── §確定 B の契約により、5 ステップは
+        # 呼び出し側 UoW 下で **1 つ** の論理操作として扱われる。
         async with session_factory() as session:
             provider_rows = (
                 await session.execute(
@@ -374,11 +369,11 @@ class TestTxBoundaryRespectedByRepository:
         session_factory: async_sessionmaker[AsyncSession],
         seeded_empire_id: UUID,
     ) -> None:
-        """``save`` outside ``begin()`` does not auto-commit (§確定 B)."""
+        """``begin()`` の外側での ``save`` は自動 commit しない (§確定 B)。"""
         agent = make_agent(empire_id=seeded_empire_id)
         async with session_factory() as session:
             await SqliteAgentRepository(session).save(agent)
-            # AsyncSession's __aexit__ rolls back any in-flight tx.
+            # AsyncSession の __aexit__ が処理中の tx をロールバックする。
 
         async with session_factory() as session:
             fetched = await SqliteAgentRepository(session).find_by_id(agent.id)

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_directive_repository/test_find_by_room.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_directive_repository/test_find_by_room.py
@@ -37,14 +37,14 @@ pytestmark = pytest.mark.asyncio
 # TC-UT-DRR-004: ORDER BY created_at DESC, id DESC + SQL log (§確定 R1-D)
 # ---------------------------------------------------------------------------
 class TestFindByRoomOrderBy:
-    """TC-UT-DRR-004: find_by_room returns newest first with id DESC tiebreaker."""
+    """TC-UT-DRR-004: find_by_room は id DESC タイブレーカーで最新優先を返す。"""
 
     async def test_find_by_room_returns_directives_newest_first(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_room_id: UUID,
     ) -> None:
-        """Directives are returned newest first (created_at DESC)."""
+        """Directive は最新優先 (created_at DESC) で返される。"""
         oldest = make_directive(
             target_room_id=seeded_room_id,
             created_at=datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC),
@@ -57,7 +57,7 @@ class TestFindByRoomOrderBy:
             target_room_id=seeded_room_id,
             created_at=datetime(2026, 1, 3, 0, 0, 0, tzinfo=UTC),
         )
-        # save in non-chronological order to prove sorting is not insert-order
+        # 非時系列順で save し、ソートが挿入順ではないことを示す
         for d in (middle, oldest, newest):
             async with session_factory() as session, session.begin():
                 await SqliteDirectiveRepository(session).save(d)
@@ -76,10 +76,10 @@ class TestFindByRoomOrderBy:
         app_engine: AsyncEngine,
         seeded_room_id: UUID,
     ) -> None:
-        """SQL log contains ORDER BY created_at DESC, id DESC (§確定 R1-D).
+        """SQL ログに ORDER BY created_at DESC, id DESC が含まれる (§確定 R1-D)。
 
-        This is the regression-detection anchor for BUG-EMR-001 規約:
-        if the implementation drops ``id DESC``, this test fails.
+        BUG-EMR-001 規約の回帰検知の基点: 実装が ``id DESC`` を削除したら
+        このテストは失敗する。
         """
         directive = make_directive(target_room_id=seeded_room_id)
         async with session_factory() as session, session.begin():
@@ -108,7 +108,7 @@ class TestFindByRoomOrderBy:
         directive_selects = [
             s for s in captured if "FROM directives" in s and "SELECT" in s.upper()
         ]
-        assert directive_selects, "find_by_room must SELECT from directives"
+        assert directive_selects, "find_by_room は directives から SELECT しなければならない"
         target_stmt = directive_selects[0].lower()
         assert "order by" in target_stmt and "created_at" in target_stmt, (
             f"[FAIL] find_by_room SQL missing ORDER BY created_at.\n"
@@ -125,7 +125,7 @@ class TestFindByRoomOrderBy:
         session_factory: async_sessionmaker[AsyncSession],
         seeded_room_id: UUID,
     ) -> None:
-        """find_by_room returns exactly the number of saved Directives."""
+        """find_by_room は保存した Directive の正確な数を返す。"""
         for _ in range(4):
             async with session_factory() as session, session.begin():
                 await SqliteDirectiveRepository(session).save(
@@ -138,17 +138,17 @@ class TestFindByRoomOrderBy:
 
 
 # ---------------------------------------------------------------------------
-# TC-UT-DRR-004b: empty Room returns [] (not None)
+# TC-UT-DRR-004b: 空の Room は [] を返す (None ではなく)
 # ---------------------------------------------------------------------------
 class TestFindByRoomEmpty:
-    """TC-UT-DRR-004b: find_by_room returns [] for a Room with no Directives."""
+    """TC-UT-DRR-004b: find_by_room は Directive がない Room に対して [] を返す。"""
 
     async def test_find_by_room_empty_room_returns_empty_list(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_room_id: UUID,
     ) -> None:
-        """A Room with zero Directives → [] (empty list, not None)."""
+        """Directive がない Room → [] (空リスト、None ではない)。"""
         async with session_factory() as session:
             results = await SqliteDirectiveRepository(session).find_by_room(seeded_room_id)
         assert results == [], (
@@ -160,7 +160,7 @@ class TestFindByRoomEmpty:
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """An unknown room_id (no rows exist) → [] (not None, not an error)."""
+        """未知の room_id (行が存在しない) → [] (None ではなく、エラーでもない)。"""
         unknown_room_id = uuid4()
         async with session_factory() as session:
             results = await SqliteDirectiveRepository(session).find_by_room(unknown_room_id)
@@ -168,19 +168,19 @@ class TestFindByRoomEmpty:
 
 
 # ---------------------------------------------------------------------------
-# TC-UT-DRR-004c: Room scope isolation (IDOR guard)
+# TC-UT-DRR-004c: Room スコープ隔離 (IDOR 防止)
 # ---------------------------------------------------------------------------
 class TestFindByRoomScopeIsolation:
-    """TC-UT-DRR-004c: find_by_room strictly applies Room scope."""
+    """TC-UT-DRR-004c: find_by_room は Room スコープを厳密に適用する。"""
 
     async def test_find_by_room_isolates_directives_by_room(
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """Directives from room_a are NOT returned when querying room_b.
+        """room_a からの Directive は room_b のクエリで返されない。
 
-        Cross-Room isolation: without WHERE target_room_id = :room_id
-        scoping, room_a's Directives could leak into room_b's query.
+        Room 間の隔離: WHERE target_room_id = :room_id スコープなしであれば、
+        room_a の Directive が room_b のクエリに漏洩する可能性がある。
         """
         room_a = await seed_room(session_factory)
         room_b = await seed_room(session_factory)
@@ -205,17 +205,17 @@ class TestFindByRoomScopeIsolation:
 
 
 # ---------------------------------------------------------------------------
-# TC-UT-DRR-004d: _from_row full attribute restoration
+# TC-UT-DRR-004d: _from_row 全属性復元
 # ---------------------------------------------------------------------------
 class TestFindByRoomFromRowRestoration:
-    """TC-UT-DRR-004d: find_by_room hydrates Directives via _from_row correctly."""
+    """TC-UT-DRR-004d: find_by_room は _from_row で Directive を正しく補水する。"""
 
     async def test_find_by_room_restores_all_attributes(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_room_id: UUID,
     ) -> None:
-        """All Directive attributes (id/text/target_room_id/created_at/task_id) restored."""
+        """すべての Directive 属性 (id/text/target_room_id/created_at/task_id) が復元される。"""
         directive = make_directive(
             target_room_id=seeded_room_id,
             text="テスト用ディレクティブ",
@@ -239,18 +239,17 @@ class TestFindByRoomFromRowRestoration:
 
 
 # ---------------------------------------------------------------------------
-# TC-UT-DRR-004e: id DESC tiebreaker — same created_at (BUG-EMR-001 規約)
+# TC-UT-DRR-004e: id DESC タイブレーカー — 同一 created_at (BUG-EMR-001 規約)
 # ---------------------------------------------------------------------------
 class TestFindByRoomTiebreaker:
-    """TC-UT-DRR-004e: id DESC tiebreaker when created_at is identical.
+    """TC-UT-DRR-004e: created_at が同一のときの id DESC タイブレーカー。
 
-    BUG-EMR-001 規約: ORDER BY created_at DESC alone is non-deterministic
-    when multiple Directives share the same timestamp. id DESC (PK, UUID)
-    must be the tiebreaker.
+    BUG-EMR-001 規約: ORDER BY created_at DESC だけでは複数の Directive が
+    同じタイムスタンプを共有する場合に非決定的。id DESC (PK, UUID) が
+    タイブレーカーでなければならない。
 
-    This test is the **regression-detection path**: if the implementation
-    removes ``id DESC`` from the ORDER BY clause, this test will fail
-    because the returned order becomes engine-dependent (arbitrary).
+    このテストは **回帰検知パス**: 実装が ORDER BY 句から ``id DESC`` を削除した場合、
+    返却順がエンジン依存（任意）になるためこのテストは失敗する。
     """
 
     async def test_same_created_at_ordered_by_id_desc(
@@ -258,15 +257,14 @@ class TestFindByRoomTiebreaker:
         session_factory: async_sessionmaker[AsyncSession],
         seeded_room_id: UUID,
     ) -> None:
-        """3 Directives with identical created_at → returned in id DESC order.
+        """同一 created_at の Directive 3 つ → id DESC 順で返される。
 
-        UUID strings (hex form) compare lexicographically. We save 3
-        Directives with the exact same created_at timestamp and verify
-        the result order matches id DESC — proving the tiebreaker is
-        active. If id DESC is removed, the order becomes unpredictable
-        and this assertion will intermittently fail.
+        UUID 文字列 (hex 形式) は辞書順比較。同じ created_at タイムスタンプで
+        Directive 3 つを保存し、結果順が id DESC と一致することを検証 ——
+        タイブレーカーが活作していることを証明。id DESC が削除されたら、
+        順序が予測不可能になり、このアサーションは断続的に失敗する。
         """
-        # Use a fixed identical timestamp so created_at cannot differentiate.
+        # created_at が区別できないよう固定の同一タイムスタンプを使用。
         shared_ts = datetime(9999, 1, 1, 0, 0, 0, tzinfo=UTC)
 
         d1 = make_directive(target_room_id=seeded_room_id, created_at=shared_ts)
@@ -284,15 +282,16 @@ class TestFindByRoomTiebreaker:
 
         assert len(results) == 3
 
-        # Build expected order: id DESC (UUID hex string descending)
+        # 期待順序を構築: id DESC (UUID hex 文字列降順)
         ids = [d1.id, d2.id, d3.id]
         expected_order = sorted(ids, key=lambda uid: uid.hex, reverse=True)
         actual_order = [r.id for r in results]
 
         assert actual_order == expected_order, (
-            f"[FAIL] find_by_room did not apply id DESC tiebreaker (BUG-EMR-001 規約).\n"
-            f"All 3 Directives have identical created_at={shared_ts.isoformat()}.\n"
-            f"Expected id order (desc): {[uid.hex for uid in expected_order]}\n"
-            f"Actual id order:          {[uid.hex for uid in actual_order]}\n"
-            f"Next: add .order_by(DirectiveRow.created_at.desc(), DirectiveRow.id.desc())"
+            f"[FAIL] find_by_room が id DESC タイブレーカーを適用していない"
+            f"(BUG-EMR-001 規約)。\n"
+            f"3 つの Directive すべてが同一 created_at={shared_ts.isoformat()}。\n"
+            f"期待される id 順 (desc): {[uid.hex for uid in expected_order]}\n"
+            f"実際の id 順:          {[uid.hex for uid in actual_order]}\n"
+            f"次: .order_by(DirectiveRow.created_at.desc(), DirectiveRow.id.desc()) を追加"
         )

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_directive_repository/test_find_by_room.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_directive_repository/test_find_by_room.py
@@ -1,13 +1,13 @@
-"""Directive Repository: find_by_room ORDER BY + Room scoping tests.
+"""Directive Repository: find_by_room ORDER BY + ルームスコーピングテスト。
 
-TC-UT-DRR-004 / 004b / 004c / 004d / 004e.
+TC-UT-DRR-004 / 004b / 004c / 004d / 004e。
 
-§確定 R1-D: find_by_room returns Directives newest-first with a tiebreaker
-on id DESC (BUG-EMR-001 規約 — ORDER BY created_at DESC alone is
-non-deterministic when multiple Directives share the same timestamp).
+§確定 R1-D: find_by_room は最新優先で Directive を返し、id DESC でタイブレーク
+(BUG-EMR-001 規約 — ORDER BY created_at DESC のみは複数の Directive が
+同じタイムスタンプを共有する場合、非決定的)。
 
-Per ``docs/features/directive-repository/test-design.md``.
-Issue #34 — M2 0006.
+``docs/features/directive-repository/test-design.md`` 準拠。
+Issue #34 — M2 0006。
 """
 
 from __future__ import annotations

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_directive_repository/test_masking_text.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_directive_repository/test_masking_text.py
@@ -61,7 +61,7 @@ _GITHUB_TOKEN = "ghp_" + "X" * 40
 # Bearer token ── Authorization: Bearer <token> に一致。
 _BEARER_TOKEN = "eyJhbGciOi.tokenpart.signature"
 
-# Redaction sentinel
+# Redaction センチネル
 _DISCORD_SENTINEL = "<REDACTED:DISCORD_TOKEN>"
 _ANTHROPIC_SENTINEL = "<REDACTED:ANTHROPIC_KEY>"
 _GITHUB_SENTINEL = "<REDACTED:GITHUB_PAT>"

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_directive_repository/test_masking_text.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_directive_repository/test_masking_text.py
@@ -1,31 +1,29 @@
-"""Directive Repository: §確定 G 実適用 — MaskedText wiring on directives.text.
+"""Directive Repository: §確定 G 実適用 ── directives.text への MaskedText 配線。
 
-TC-IT-DRR-010-masking-* (7 paths).
+TC-IT-DRR-010-masking-* (7 経路)。
 
-**directive §確定 G 実適用の物理保証**: This module is the core masking
-test file for PR #34 — the MaskedText TypeDecorator on ``directives.text``
-is exercised end-to-end against a real SQLite DB, against 7 secret-bearing
-directive text shapes:
+**directive §確定 G 実適用の物理保証**: 本モジュールは PR #34 のマスキング核となるテストファイル。
+``directives.text`` の MaskedText TypeDecorator が、実際の SQLite DB に対して
+secret を含む 7 種類の directive text 形状でエンドツーエンドに動作することを検証する:
 
-1. **discord** — Discord Bot Token in webhook URL context →
-   ``<REDACTED:DISCORD_TOKEN>`` (primary irreversibility case).
+1. **discord** — webhook URL 文脈の Discord Bot Token →
+   ``<REDACTED:DISCORD_TOKEN>``（主要な不可逆性ケース）。
 2. **anthropic** — ``ANTHROPIC_API_KEY=sk-ant-api03-XXX...`` →
-   ``<REDACTED:ANTHROPIC_KEY>``.
-3. **github** — ``ghp_XXX...`` → ``<REDACTED:GITHUB_PAT>``.
-4. **bearer** — ``Authorization: Bearer XXX`` → ``<REDACTED:BEARER>``.
-5. **no-secret** — plain text → unchanged (passthrough).
-6. **roundtrip** — §確定 G §不可逆性: find_by_id returns masked form
-   (raw token unrecoverable from DB).
-7. **multiple** — 3 secret types in one directive text → all redacted.
+   ``<REDACTED:ANTHROPIC_KEY>``。
+3. **github** — ``ghp_XXX...`` → ``<REDACTED:GITHUB_PAT>``。
+4. **bearer** — ``Authorization: Bearer XXX`` → ``<REDACTED:BEARER>``。
+5. **no-secret** — 平文 → 変更されない（passthrough）。
+6. **roundtrip** — §確定 G §不可逆性: find_by_id はマスク済み形式を返す
+   （生トークンは DB から復元不能）。
+7. **multiple** — 1 つの directive text 内の 3 種の secret すべてが redact される。
 
-Each verification reads ``directives.text`` via **raw SQL SELECT** so we
-observe the literal bytes that hit the disk (bypassing
-``MaskedText.process_result_value`` on the read side).
+各検証は **raw SQL SELECT** で ``directives.text`` を読み取り、ディスクに到達した
+literal バイトを観測する（読み出し側で ``MaskedText.process_result_value`` を迂回）。
 
-Room-repo ``test_masking_prompt_kit.py`` pattern inherited 100%.
+Room-repo ``test_masking_prompt_kit.py`` のパターンを 100% 踏襲。
 
-Per ``docs/features/directive-repository/test-design.md`` TC-IT-DRR-010-*.
-Issue #34 — M2 0006.
+``docs/features/directive-repository/test-design.md`` TC-IT-DRR-010-* 準拠。
+Issue #34 — M2 0006。
 """
 
 from __future__ import annotations
@@ -47,23 +45,23 @@ if TYPE_CHECKING:
 pytestmark = pytest.mark.asyncio
 
 
-# Real-shape (synthetic) secret tokens. Pattern lengths must match
-# the masking gateway's regex (masking.py _REGEX_PATTERNS).
+# 実形（合成）secret トークン。パターン長は masking gateway の正規表現
+# (masking.py _REGEX_PATTERNS) に一致させる必要がある。
 
-# Discord Bot Token — matches [MN][A-Za-z\d]{23,}\.[\w-]{6}\.[\w-]{27,}
-# Constructed via concatenation to prevent GitHub push-protection false positives.
+# Discord Bot Token ── [MN][A-Za-z\d]{23,}\.[\w-]{6}\.[\w-]{27,} に一致。
+# GitHub push-protection の false positive を避けるため連結で構築。
 _DISCORD_TOKEN = "MTk4NjIyNDgz" + "NDcxOTI1MjQ4.ClFDg_." + "A" * 27
 
-# Anthropic API key — matches sk-ant-(?:api03-)?[A-Za-z0-9_\-]{40,}
+# Anthropic API key ── sk-ant-(?:api03-)?[A-Za-z0-9_\-]{40,} に一致。
 _ANTHROPIC_TOKEN = "sk-ant-api03-" + "A" * 60
 
-# GitHub PAT — matches (?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36,}
+# GitHub PAT ── (?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36,} に一致。
 _GITHUB_TOKEN = "ghp_" + "X" * 40
 
-# Bearer token — matches Authorization: Bearer <token>
+# Bearer token ── Authorization: Bearer <token> に一致。
 _BEARER_TOKEN = "eyJhbGciOi.tokenpart.signature"
 
-# Redaction sentinels
+# Redaction sentinel
 _DISCORD_SENTINEL = "<REDACTED:DISCORD_TOKEN>"
 _ANTHROPIC_SENTINEL = "<REDACTED:ANTHROPIC_KEY>"
 _GITHUB_SENTINEL = "<REDACTED:GITHUB_PAT>"
@@ -74,11 +72,10 @@ async def _read_persisted_text(
     session_factory: async_sessionmaker[AsyncSession],
     directive_id: UUID,
 ) -> str:
-    """Raw-SQL SELECT to fetch ``directives.text`` literal bytes from disk.
+    """Raw-SQL SELECT で ``directives.text`` の literal バイトをディスクから取得する。
 
-    Bypasses ``MaskedText.process_result_value`` so we observe the value
-    physically stored in SQLite. Uses ``.hex`` for the UUID parameter
-    to match ``UUIDStr`` TypeDecorator storage format.
+    ``MaskedText.process_result_value`` を迂回して SQLite に物理的に保存されている値を観測する。
+    UUID パラメータは ``UUIDStr`` TypeDecorator のストレージ形式に合わせて ``.hex`` を用いる。
     """
     async with session_factory() as session:
         stmt = text("SELECT text FROM directives WHERE id = :id")
@@ -90,17 +87,17 @@ async def _read_persisted_text(
 
 
 # ---------------------------------------------------------------------------
-# TC-IT-DRR-010-masking-discord (primary case, directive §確定 G 不可逆性)
+# TC-IT-DRR-010-masking-discord (主要ケース、directive §確定 G 不可逆性)
 # ---------------------------------------------------------------------------
 class TestDiscordTokenMasked:
-    """TC-IT-DRR-010-masking-discord: Discord Bot Token in directive text redacted."""
+    """TC-IT-DRR-010-masking-discord: directive text 中の Discord Bot Token が redact される。"""
 
     async def test_discord_token_in_webhook_url_redacted(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_room_id: UUID,
     ) -> None:
-        """Raw-SQL SELECT shows <REDACTED:DISCORD_TOKEN>; raw token absent from disk."""
+        """Raw-SQL SELECT が <REDACTED:DISCORD_TOKEN> を返し、生トークンがディスク上に残らない。"""
         directive_text = (
             f"配信先: https://discord.com/api/webhooks/123456789012345678/{_DISCORD_TOKEN}\n"
             f"通知プレフィックス: CEO 指令"
@@ -126,14 +123,14 @@ class TestDiscordTokenMasked:
 # TC-IT-DRR-010-masking-anthropic
 # ---------------------------------------------------------------------------
 class TestAnthropicKeyMasked:
-    """TC-IT-DRR-010-masking-anthropic: Anthropic API key redacted on save."""
+    """TC-IT-DRR-010-masking-anthropic: save 時に Anthropic API key が redact される。"""
 
     async def test_anthropic_key_redacted(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_room_id: UUID,
     ) -> None:
-        """Raw-SQL SELECT shows <REDACTED:ANTHROPIC_KEY>; raw key absent."""
+        """Raw-SQL SELECT が <REDACTED:ANTHROPIC_KEY> を返し、生 key が含まれない。"""
         directive_text = f"ANTHROPIC_API_KEY={_ANTHROPIC_TOKEN} を使ってClaude APIを呼ぶこと"
         directive = make_directive(target_room_id=seeded_room_id, text=directive_text)
         async with session_factory() as session, session.begin():
@@ -153,14 +150,14 @@ class TestAnthropicKeyMasked:
 # TC-IT-DRR-010-masking-github
 # ---------------------------------------------------------------------------
 class TestGitHubPatMasked:
-    """TC-IT-DRR-010-masking-github: GitHub PAT redacted on save."""
+    """TC-IT-DRR-010-masking-github: save 時に GitHub PAT が redact される。"""
 
     async def test_github_pat_redacted(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_room_id: UUID,
     ) -> None:
-        """Raw-SQL SELECT shows <REDACTED:GITHUB_PAT>; raw PAT absent."""
+        """Raw-SQL SELECT が <REDACTED:GITHUB_PAT> を返し、生 PAT が含まれない。"""
         directive_text = f"git push には {_GITHUB_TOKEN} を使うこと"
         directive = make_directive(target_room_id=seeded_room_id, text=directive_text)
         async with session_factory() as session, session.begin():
@@ -181,14 +178,14 @@ class TestGitHubPatMasked:
 # TC-IT-DRR-010-masking-bearer
 # ---------------------------------------------------------------------------
 class TestBearerTokenMasked:
-    """TC-IT-DRR-010-masking-bearer: Authorization: Bearer XXX redacted."""
+    """TC-IT-DRR-010-masking-bearer: Authorization: Bearer XXX が redact される。"""
 
     async def test_bearer_token_redacted(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_room_id: UUID,
     ) -> None:
-        """Raw-SQL SELECT shows <REDACTED:BEARER>; raw Bearer token absent."""
+        """Raw-SQL SELECT が <REDACTED:BEARER> を返し、生 Bearer トークンが含まれない。"""
         directive_text = f"APIコール時は Authorization: Bearer {_BEARER_TOKEN} を使うこと"
         directive = make_directive(target_room_id=seeded_room_id, text=directive_text)
         async with session_factory() as session, session.begin():
@@ -208,17 +205,17 @@ class TestBearerTokenMasked:
 # TC-IT-DRR-010-masking-no-secret (passthrough)
 # ---------------------------------------------------------------------------
 class TestNoSecretPassthrough:
-    """TC-IT-DRR-010-masking-no-secret: plain directive text is stored unchanged."""
+    """TC-IT-DRR-010-masking-no-secret: 平文 directive text は変更されずに保存される。"""
 
     async def test_plain_text_is_passthrough(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_room_id: UUID,
     ) -> None:
-        """A directive text with no secrets is persisted byte-identical.
+        """secret を含まない directive text はバイト等価で永続化される。
 
-        Confirms masking is scoped — only known secret patterns get
-        redacted; the gateway is not over-aggressive on plain text.
+        マスキングが限定的であること（既知の secret パターンのみ redact、
+        gateway は平文に過剰反応しない）を確認する。
         """
         plain_text = "チームAにタスクXを割り当て、Vモデル設計工程に入ること。"
         directive = make_directive(target_room_id=seeded_room_id, text=plain_text)
@@ -237,11 +234,11 @@ class TestNoSecretPassthrough:
 # TC-IT-DRR-010-masking-roundtrip (directive §確定 G §不可逆性)
 # ---------------------------------------------------------------------------
 class TestRoundTripIsIrreversible:
-    """TC-IT-DRR-010-masking-roundtrip: §確定 G §不可逆性 — find_by_id returns masked.
+    """TC-IT-DRR-010-masking-roundtrip: §確定 G §不可逆性 ── find_by_id はマスク済みを返す。
 
-    Once a Discord Bot Token is masked at save time, the raw token is
-    physically unrecoverable from DB. find_by_id must return a Directive
-    whose text carries the redaction sentinel rather than the original token.
+    一度 Discord Bot Token が save 時にマスクされたら、生トークンは DB から
+    物理的に復元不能。find_by_id は redaction sentinel を持つ Directive を返さねばならず、
+    元のトークンを返してはならない。
     """
 
     async def test_find_by_id_returns_masked_text(
@@ -249,7 +246,7 @@ class TestRoundTripIsIrreversible:
         session_factory: async_sessionmaker[AsyncSession],
         seeded_room_id: UUID,
     ) -> None:
-        """Save raw Discord webhook URL → find_by_id → text == masked form."""
+        """生の Discord webhook URL を save → find_by_id → text == マスク済み形式。"""
         raw_text = f"配信先: https://discord.com/api/webhooks/12345/{_DISCORD_TOKEN}"
         directive = make_directive(target_room_id=seeded_room_id, text=raw_text)
         async with session_factory() as session, session.begin():
@@ -266,7 +263,7 @@ class TestRoundTripIsIrreversible:
             f"[FAIL] directive §確定 G §不可逆性 violated: raw Discord token recovered after "
             f"round-trip.\nRestored text: {restored.text!r}"
         )
-        # Round-tripped Directive must NOT equal the original (masking changed it)
+        # ラウンドトリップした Directive は元と等価ではない（マスキングで変わるため）
         assert restored != directive, (
             "[FAIL] round-trip equality should not hold for masked directive text; "
             "masking might be a no-op."
@@ -277,14 +274,15 @@ class TestRoundTripIsIrreversible:
 # TC-IT-DRR-010-masking-multiple
 # ---------------------------------------------------------------------------
 class TestMultipleSecretsAllRedacted:
-    """TC-IT-DRR-010-masking-multiple: 3+ secret types in one directive all redacted."""
+    """TC-IT-DRR-010-masking-multiple: 1 directive 内の
+    3 種以上の secret すべてが redact される。"""
 
     async def test_multiple_secrets_all_redacted_in_one_pass(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_room_id: UUID,
     ) -> None:
-        """Discord + Anthropic + GitHub all redacted in a single directive text."""
+        """1 つの directive text 中の Discord + Anthropic + GitHub すべてが redact される。"""
         directive_text = (
             f"複数シークレットを含む指令:\n"
             f"  Discord: https://discord.com/api/webhooks/123/{_DISCORD_TOKEN}\n"
@@ -297,7 +295,7 @@ class TestMultipleSecretsAllRedacted:
 
         persisted = await _read_persisted_text(session_factory, directive.id)
 
-        # All 3 sentinels present
+        # 3 種の sentinel すべてが含まれる
         assert _DISCORD_SENTINEL in persisted, (
             f"[FAIL] Discord sentinel missing in multi-secret directive. Persisted: {persisted!r}"
         )
@@ -307,7 +305,7 @@ class TestMultipleSecretsAllRedacted:
         assert _GITHUB_SENTINEL in persisted, (
             f"[FAIL] GitHub sentinel missing in multi-secret directive. Persisted: {persisted!r}"
         )
-        # All 3 raw tokens absent
+        # 3 種の生トークンはいずれも含まれない
         assert _DISCORD_TOKEN not in persisted, (
             f"[FAIL] Discord token survived multi-secret masking. Persisted: {persisted!r}"
         )

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_directive_repository/test_protocol_crud.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_directive_repository/test_protocol_crud.py
@@ -1,12 +1,12 @@
-"""Directive Repository: Protocol surface + basic CRUD + Lifecycle coverage.
+"""Directive Repository: Protocol サーフェス + 基本 CRUD + ライフサイクルカバレッジ。
 
 TC-UT-DRR-001〜009 + TC-IT-DRR-LIFECYCLE.
 
-REQ-DRR-001 / REQ-DRR-002 — 4-method Protocol surface (§確定 R1-A) +
-basic CRUD (find_by_id / count / save / Tx boundary) + Lifecycle.
+REQ-DRR-001 / REQ-DRR-002 ── 4 メソッドの Protocol サーフェス (§確定 R1-A) +
+基本 CRUD (find_by_id / count / save / Tx 境界) + ライフサイクル。
 
-Per ``docs/features/directive-repository/test-design.md``.
-Issue #34 — M2 0006.
+``docs/features/directive-repository/test-design.md`` 準拠。
+Issue #34 — M2 0006。
 """
 
 from __future__ import annotations
@@ -31,25 +31,25 @@ pytestmark = pytest.mark.asyncio
 
 
 # ---------------------------------------------------------------------------
-# TC-UT-DRR-001: Protocol definition + 4-method surface (§確定 R1-A)
+# TC-UT-DRR-001: Protocol 定義 + 4 メソッドサーフェス (§確定 R1-A)
 # ---------------------------------------------------------------------------
 class TestDirectiveRepositoryProtocol:
-    """TC-UT-DRR-001: Protocol declares 4 async methods (§確定 R1-A)."""
+    """TC-UT-DRR-001: Protocol が 4 つの async メソッドを宣言する (§確定 R1-A)。"""
 
     async def test_protocol_declares_four_async_methods(self) -> None:
-        """TC-UT-DRR-001: DirectiveRepository has find_by_id/count/save/find_by_room."""
+        """TC-UT-DRR-001: DirectiveRepository が find_by_id/count/save/find_by_room を持つ。"""
         assert hasattr(DirectiveRepository, "find_by_id")
         assert hasattr(DirectiveRepository, "count")
         assert hasattr(DirectiveRepository, "save")
         assert hasattr(DirectiveRepository, "find_by_room")
 
     async def test_protocol_does_not_have_find_by_task_id(self) -> None:
-        """TC-UT-DRR-001: find_by_task_id is NOT part of the Protocol (YAGNI).
+        """TC-UT-DRR-001: find_by_task_id は Protocol に含まれない（YAGNI）。
 
-        §確定 R1-D 後続申し送り: find_by_task_id is deferred to the
-        task-repository PR (method + INDEX + FK closure simultaneously).
-        If it reappears here, the YAGNI decision in detailed-design.md
-        was reversed without updating the design doc first.
+        §確定 R1-D 後続申し送り: find_by_task_id は task-repository PR
+        （メソッド + INDEX + FK のクロージャを同時に行う）に先送り。
+        ここに再出現したら、detailed-design.md の YAGNI 判断を
+        設計ドキュメントを更新せずに反転させたことになる。
         """
         assert not hasattr(DirectiveRepository, "find_by_task_id"), (
             "[FAIL] DirectiveRepository.find_by_task_id must not exist (YAGNI).\n"
@@ -61,11 +61,10 @@ class TestDirectiveRepositoryProtocol:
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """TC-UT-DRR-001: SqliteDirectiveRepository satisfies DirectiveRepository.
+        """TC-UT-DRR-001: SqliteDirectiveRepository が DirectiveRepository を満たす。
 
-        The variable annotation acts as a static-type assertion; pyright
-        strict will reject the assignment if any of the 4 Protocol
-        methods is missing or has a wrong signature.
+        変数アノテーションが静的型アサーションとして機能する。pyright strict は、
+        Protocol の 4 メソッドのいずれかが欠落または誤シグネチャの場合、代入を拒否する。
         """
         async with session_factory() as session:
             repo: DirectiveRepository = SqliteDirectiveRepository(session)
@@ -78,7 +77,7 @@ class TestDirectiveRepositoryProtocol:
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """TC-UT-DRR-001: duck-typing confirms all 4 methods present on the impl."""
+        """TC-UT-DRR-001: ダックタイピングで実装に 4 メソッドすべてが存在することを確認する。"""
         async with session_factory() as session:
             repo = SqliteDirectiveRepository(session)
             for method_name in ("find_by_id", "count", "save", "find_by_room"):
@@ -92,14 +91,14 @@ class TestDirectiveRepositoryProtocol:
 # TC-UT-DRR-002: find_by_id (REQ-DRR-002, 受入基準 3)
 # ---------------------------------------------------------------------------
 class TestFindById:
-    """TC-UT-DRR-002: find_by_id retrieves saved Directives; None for unknown."""
+    """TC-UT-DRR-002: find_by_id は保存済み Directive を取得する。未知の id は None。"""
 
     async def test_find_by_id_returns_saved_directive(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_room_id: UUID,
     ) -> None:
-        """find_by_id(directive.id) returns the saved Directive."""
+        """find_by_id(directive.id) が保存済み Directive を返す。"""
         directive = make_directive(target_room_id=seeded_room_id)
         async with session_factory() as session, session.begin():
             await SqliteDirectiveRepository(session).save(directive)
@@ -115,26 +114,26 @@ class TestFindById:
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """find_by_id(uuid4()) returns None without raising."""
+        """find_by_id(uuid4()) は例外を投げず None を返す。"""
         async with session_factory() as session:
             fetched = await SqliteDirectiveRepository(session).find_by_id(uuid4())
         assert fetched is None
 
 
 # ---------------------------------------------------------------------------
-# TC-UT-DRR-003: save round-trip equality (REQ-DRR-002, 受入基準 4, §確定 R1-G)
+# TC-UT-DRR-003: save ラウンドトリップ等価性 (REQ-DRR-002, 受入基準 4, §確定 R1-G)
 # ---------------------------------------------------------------------------
 class TestSaveRoundTrip:
-    """TC-UT-DRR-003: save → find_by_id round-trip preserves all attributes."""
+    """TC-UT-DRR-003: save → find_by_id ラウンドトリップで全属性が保たれる。"""
 
     async def test_save_find_by_id_round_trip_all_attributes(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_room_id: UUID,
     ) -> None:
-        """All attributes (id/text/target_room_id/created_at/task_id) survive round-trip.
+        """全属性 (id/text/target_room_id/created_at/task_id) がラウンドトリップで保たれる。
 
-        §確定 R1-G: created_at must remain UTC tz-aware after SQLite storage.
+        §確定 R1-G: created_at は SQLite ストア後も UTC tz-aware を維持しなければならない。
         """
         directive = make_directive(target_room_id=seeded_room_id)
         async with session_factory() as session, session.begin():
@@ -154,7 +153,7 @@ class TestSaveRoundTrip:
         session_factory: async_sessionmaker[AsyncSession],
         seeded_room_id: UUID,
     ) -> None:
-        """§確定 R1-G: created_at survives round-trip as UTC tz-aware datetime."""
+        """§確定 R1-G: created_at がラウンドトリップで UTC tz-aware datetime のまま残る。"""
         directive = make_directive(target_room_id=seeded_room_id)
         async with session_factory() as session, session.begin():
             await SqliteDirectiveRepository(session).save(directive)
@@ -173,7 +172,7 @@ class TestSaveRoundTrip:
         session_factory: async_sessionmaker[AsyncSession],
         seeded_room_id: UUID,
     ) -> None:
-        """§確定 R1-G: task_id=None round-trips correctly."""
+        """§確定 R1-G: task_id=None が正しくラウンドトリップする。"""
         directive = make_directive(target_room_id=seeded_room_id, task_id=None)
         async with session_factory() as session, session.begin():
             await SqliteDirectiveRepository(session).save(directive)
@@ -186,10 +185,10 @@ class TestSaveRoundTrip:
 
 
 # ---------------------------------------------------------------------------
-# TC-UT-DRR-006: count() SQL COUNT(*) contract (受入基準 8, §確定 R1-A D補強)
+# TC-UT-DRR-006: count() の SQL COUNT(*) 契約 (受入基準 8, §確定 R1-A D 補強)
 # ---------------------------------------------------------------------------
 class TestCountIssuesScalarCount:
-    """TC-UT-DRR-006: count() issues SELECT COUNT(*), not a full row scan."""
+    """TC-UT-DRR-006: count() は SELECT COUNT(*) を発行し、行を全件スキャンしない。"""
 
     async def test_count_emits_select_count_not_full_load(
         self,
@@ -197,10 +196,10 @@ class TestCountIssuesScalarCount:
         app_engine: AsyncEngine,
         seeded_room_id: UUID,
     ) -> None:
-        """SQL log shows SELECT count(*) FROM directives for count().
+        """SQL ログが count() に対し SELECT count(*) FROM directives を示す。
 
-        empire-repository §確定 D 補強 contract: count() must never
-        stream full Directive rows back to Python.
+        empire-repository §確定 D 補強の契約: count() は Directive 行を Python へ
+        全件ストリームしてはならない。
         """
         for _ in range(2):
             directive = make_directive(target_room_id=seeded_room_id)
@@ -238,17 +237,17 @@ class TestCountIssuesScalarCount:
 
 
 # ---------------------------------------------------------------------------
-# TC-UT-DRR-007: save UPSERT update semantics (受入基準 4)
+# TC-UT-DRR-007: save の UPSERT 更新セマンティクス (受入基準 4)
 # ---------------------------------------------------------------------------
 class TestSaveUpsertSemantics:
-    """TC-UT-DRR-007: re-save with same id updates the row (UPSERT)."""
+    """TC-UT-DRR-007: 同一 id での再 save は行を更新する（UPSERT）。"""
 
     async def test_resave_updates_text(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_room_id: UUID,
     ) -> None:
-        """Same directive.id with changed text → latest text returned."""
+        """同じ directive.id で text を変更 → 最新の text が返る。"""
         original = make_directive(target_room_id=seeded_room_id, text="初期テキスト")
         async with session_factory() as session, session.begin():
             await SqliteDirectiveRepository(session).save(original)
@@ -271,7 +270,7 @@ class TestSaveUpsertSemantics:
         session_factory: async_sessionmaker[AsyncSession],
         seeded_room_id: UUID,
     ) -> None:
-        """UPSERT ensures count stays 1 after multiple saves of same id."""
+        """UPSERT により、同じ id を複数回 save しても件数は 1 のまま。"""
         directive = make_directive(target_room_id=seeded_room_id)
         for _ in range(3):
             async with session_factory() as session, session.begin():
@@ -283,20 +282,20 @@ class TestSaveUpsertSemantics:
 
 
 # ---------------------------------------------------------------------------
-# TC-UT-DRR-008: save after link_task — task_id update (§確定 R1-G)
+# TC-UT-DRR-008: link_task 後の save ── task_id 更新 (§確定 R1-G)
 # ---------------------------------------------------------------------------
 class TestSaveAfterLinkTask:
-    """TC-UT-DRR-008: link_task → re-save updates task_id column."""
+    """TC-UT-DRR-008: link_task → 再 save で task_id カラムが更新される。"""
 
     async def test_link_task_and_resave_updates_task_id(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_room_id: UUID,
     ) -> None:
-        """directive.link_task(task_id) → save → find_by_id returns updated task_id.
+        """directive.link_task(task_id) → save → find_by_id が更新後 task_id を返す。
 
-        BUG-DRR-001 closure (0007): directives.task_id → tasks.id RESTRICT FK
-        is now active. A real tasks row must exist before setting directive.task_id.
+        BUG-DRR-001 クロージャ (0007): directives.task_id → tasks.id RESTRICT FK が
+        有効。directive.task_id を設定する前に実 tasks 行が存在しなければならない。
         """
         from bakufu.infrastructure.persistence.sqlite.repositories.task_repository import (
             SqliteTaskRepository,
@@ -308,7 +307,7 @@ class TestSaveAfterLinkTask:
         async with session_factory() as session, session.begin():
             await SqliteDirectiveRepository(session).save(original)
 
-        # BUG-DRR-001 closure: save a real Task referencing this Directive first.
+        # BUG-DRR-001 クロージャ: 先にこの Directive を参照する実 Task を save する。
         real_task = make_task(room_id=seeded_room_id, directive_id=original.id)
         async with session_factory() as session, session.begin():
             await SqliteTaskRepository(session).save(real_task)
@@ -330,17 +329,17 @@ class TestSaveAfterLinkTask:
 
 
 # ---------------------------------------------------------------------------
-# TC-UT-DRR-009: Tx boundary (§確定 R1-B, empire §確定 B 踏襲)
+# TC-UT-DRR-009: Tx 境界 (§確定 R1-B, empire §確定 B 踏襲)
 # ---------------------------------------------------------------------------
 class TestTxBoundary:
-    """TC-UT-DRR-009: Repository does not auto-commit; caller owns UoW boundary."""
+    """TC-UT-DRR-009: Repository は自動 commit せず、UoW 境界は呼び出し側が所有する。"""
 
     async def test_save_within_begin_persists(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_room_id: UUID,
     ) -> None:
-        """save inside async with session.begin() persists the row."""
+        """async with session.begin() 内の save は行を永続化する。"""
         directive = make_directive(target_room_id=seeded_room_id)
         async with session_factory() as session, session.begin():
             await SqliteDirectiveRepository(session).save(directive)
@@ -354,17 +353,17 @@ class TestTxBoundary:
         session_factory: async_sessionmaker[AsyncSession],
         seeded_room_id: UUID,
     ) -> None:
-        """save without session.begin() leaves row absent after session close.
+        """session.begin() なしの save は session クローズ後に行が残らない。
 
-        Without begin(), SQLAlchemy async session defaults to autobegin
-        but does NOT auto-commit on session exit. The implicit transaction
-        rolls back when the session context manager exits without commit.
+        begin() なしの場合、SQLAlchemy async session はデフォルトで autobegin するが、
+        session 終了時に自動 commit はしない。暗黙トランザクションは、commit せず
+        session コンテキストマネージャを抜けた時点でロールバックされる。
         """
         directive = make_directive(target_room_id=seeded_room_id)
         async with session_factory() as session:
-            # No session.begin() → auto-rollback on __aexit__
+            # session.begin() なし → __aexit__ で自動ロールバック
             await SqliteDirectiveRepository(session).save(directive)
-            # Do NOT commit
+            # commit しない
 
         async with session_factory() as session:
             fetched = await SqliteDirectiveRepository(session).find_by_id(directive.id)
@@ -375,22 +374,23 @@ class TestTxBoundary:
 
 
 # ---------------------------------------------------------------------------
-# TC-IT-DRR-LIFECYCLE: 4-method full lifecycle (§確定 R1-F + R1-G)
+# TC-IT-DRR-LIFECYCLE: 4 メソッドのフルライフサイクル (§確定 R1-F + R1-G)
 # ---------------------------------------------------------------------------
 class TestLifecycleIntegration:
-    """TC-IT-DRR-LIFECYCLE: save → find_by_room → save(update) → count → find_by_id."""
+    """TC-IT-DRR-LIFECYCLE: save → find_by_room → save(更新) → count → find_by_id。"""
 
     async def test_full_lifecycle_4_method(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_room_id: UUID,
     ) -> None:
-        """4-method full lifecycle: save x3 → find_by_room → link_task+resave → count → find_by_id.
+        """4 メソッドのフルライフサイクル: save x3 → find_by_room →
+        link_task+resave → count → find_by_id。
 
-        Validates §確定 R1-F (save 1引数) and §確定 R1-G (task_id update)
-        in a real end-to-end sequence without any mocking.
+        §確定 R1-F (save 1 引数) と §確定 R1-G (task_id 更新) を、
+        モックなしのリアルな end-to-end シーケンスで検証する。
         """
-        # Step 1: save 3 directives
+        # Step 1: 3 件の directive を save
         now = datetime.now(UTC)
         d1 = make_directive(
             target_room_id=seeded_room_id,
@@ -399,7 +399,7 @@ class TestLifecycleIntegration:
         )
         import asyncio
 
-        await asyncio.sleep(0)  # yield to ensure ordering
+        await asyncio.sleep(0)  # 順序保証のため yield
         d2 = make_directive(
             target_room_id=seeded_room_id,
             text="ディレクティブ2",
@@ -417,14 +417,14 @@ class TestLifecycleIntegration:
             await repo.save(d2)
             await repo.save(d3)
 
-        # Step 2: find_by_room returns 3 directives
+        # Step 2: find_by_room が 3 件の directive を返す
         async with session_factory() as session:
             results = await SqliteDirectiveRepository(session).find_by_room(seeded_room_id)
         assert len(results) == 3
 
-        # Step 3: link_task → re-save
-        # BUG-DRR-001 closure (0007): directives.task_id → tasks.id RESTRICT FK.
-        # Must save a real Task referencing d1 before setting directive.task_id.
+        # Step 3: link_task → 再 save
+        # BUG-DRR-001 クロージャ (0007): directives.task_id → tasks.id RESTRICT FK。
+        # directive.task_id を設定する前に d1 を参照する実 Task を save しなければならない。
         from bakufu.infrastructure.persistence.sqlite.repositories.task_repository import (
             SqliteTaskRepository,
         )
@@ -440,18 +440,18 @@ class TestLifecycleIntegration:
         async with session_factory() as session, session.begin():
             await SqliteDirectiveRepository(session).save(d1_updated)
 
-        # Step 4: count → 3 (re-save is UPSERT, not INSERT)
+        # Step 4: count → 3（再 save は UPSERT であり INSERT ではない）
         async with session_factory() as session:
             count = await SqliteDirectiveRepository(session).count()
         assert count == 3
 
-        # Step 5: find_by_id(d2.id) → d2 attributes
+        # Step 5: find_by_id(d2.id) → d2 の属性
         async with session_factory() as session:
             via_id = await SqliteDirectiveRepository(session).find_by_id(d2.id)
         assert via_id is not None
         assert via_id.text == d2.text
 
-        # Step 6: d1_updated has task_id set
+        # Step 6: d1_updated に task_id が設定されている
         async with session_factory() as session:
             d1_restored = await SqliteDirectiveRepository(session).find_by_id(d1.id)
         assert d1_restored is not None
@@ -462,15 +462,14 @@ class TestLifecycleIntegration:
         session_factory: async_sessionmaker[AsyncSession],
         seeded_room_id: UUID,
     ) -> None:
-        """§確定 R1-F: save(directive) reads FK from directive.target_room_id.
+        """§確定 R1-F: save(directive) は directive.target_room_id から FK を読み取る。
 
-        The 1-argument save pattern: Directive carries target_room_id
-        as its own attribute, so the Repository reads it directly.
-        Saving should succeed without an extra empire_id argument.
+        1 引数 save パターン: Directive は target_room_id を自身の属性として持つため、
+        Repository はそれを直接読み取る。追加の empire_id 引数なしで save が成功するべき。
         """
         directive = make_directive(target_room_id=seeded_room_id)
         async with session_factory() as session, session.begin():
-            # No second argument needed — §確定 R1-F standard pattern
+            # 第二引数不要 ── §確定 R1-F の標準パターン
             await SqliteDirectiveRepository(session).save(directive)
 
         async with session_factory() as session:

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_empire_repository/__init__.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_empire_repository/__init__.py
@@ -1,15 +1,15 @@
-"""Empire Repository integration tests, split by topic.
+"""トピックごとに分割された Empire Repository の統合テスト群。
 
-Per ``docs/features/empire-repository/test-design.md`` and Norman's
-500-line rule: the original ``test_empire_repository.py`` (506 lines)
-is split into three siblings so each file stays under the readability
-budget and the next 6 Repository PRs can extend the pattern without
-inheriting a 500+ line monolith:
+``docs/features/empire-repository/test-design.md`` および Norman の
+500 行ルールに従い、元の ``test_empire_repository.py``（506 行）を
+3 つの兄弟ファイルに分割している。各ファイルは可読性の閾値を超えず、
+後続の 6 Repository PR が 500+ 行のモノリスを継承することなく
+同じパターンを拡張できる:
 
-* :mod:`...test_protocol_crud` — Protocol surface + ``find_by_id`` /
-  ``count`` / ``save`` basic CRUD (TC-IT-EMR-001〜005, 010, 018).
-* :mod:`...test_save_semantics` — delete-then-insert + Tx boundary
-  + round-trip equality (TC-IT-EMR-006, 007, 011, 012 + TC-UT-EMR-003).
-* :mod:`...test_constraints_arch` — DB-level FK CASCADE + UNIQUE +
-  CI three-layer-defense template structure (TC-IT-EMR-013, 014, 017).
+* :mod:`...test_protocol_crud` — Protocol 面 + ``find_by_id`` /
+  ``count`` / ``save`` の基本 CRUD（TC-IT-EMR-001〜005, 010, 018）。
+* :mod:`...test_save_semantics` — delete-then-insert + Tx 境界
+  + ラウンドトリップ等価性（TC-IT-EMR-006, 007, 011, 012 + TC-UT-EMR-003）。
+* :mod:`...test_constraints_arch` — DB レベルの FK CASCADE + UNIQUE +
+  CI 三層防衛テンプレート構造（TC-IT-EMR-013, 014, 017）。
 """

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_empire_repository/conftest.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_empire_repository/conftest.py
@@ -39,35 +39,35 @@ async def seed_rooms(
     *,
     workflow_id: UUID | None = None,
 ) -> UUID:
-    """Seed ``workflows`` + ``rooms`` rows to satisfy ``empire_room_refs`` FK.
+    """``empire_room_refs`` FK を満たすため ``workflows`` + ``rooms`` 行をシードする。
 
-    ``empire_room_refs.room_id → rooms.id`` FK (ON DELETE CASCADE) was added
-    in Alembic 0005 as BUG-EMR-001 FK closure. This helper inserts the
-    minimal prerequisite rows so tests that populate an Empire's ``rooms``
-    list can call ``SqliteEmpireRepository.save()`` without hitting
-    ``FOREIGN KEY constraint failed``.
+    ``empire_room_refs.room_id → rooms.id`` FK (ON DELETE CASCADE) は
+    Alembic 0005 で BUG-EMR-001 FK クロージャとして追加。
+    このヘルパーは最小限の前提条件行を挿入し、Empire の ``rooms`` リストを
+    設定するテストが ``FOREIGN KEY constraint failed`` を発生させずに
+    ``SqliteEmpireRepository.save()`` を呼び出せるようにする。
 
-    Steps:
-    1. Ensure the Empire row exists (``INSERT OR IGNORE`` — idempotent so
-       the caller can seed before or after the first ``save()``).
-    2. Seed one ``workflows`` row that the rooms can reference via FK.
-    3. Seed one ``rooms`` row per ``room_id`` with ``empire_id`` and
-       ``workflow_id`` as foreign keys.
+    ステップ:
+    1. Empire 行が存在することを確認する (``INSERT OR IGNORE`` ——
+       呼び出し元が最初の ``save()`` の前後どちらでシードできるよう冪等)。
+    2. rooms が FK 経由で参照できる ``workflows`` 行をシードする。
+    3. ``empire_id`` と ``workflow_id`` を外部キーとして、
+       ``room_id`` ごとに 1 つの ``rooms`` 行をシードする。
 
-    Returns the ``workflow_id`` that was used (generated fresh if not passed).
+    使用した ``workflow_id`` を返す (渡されない場合は新規生成)。
     """
     wf_id = workflow_id if workflow_id is not None else uuid4()
 
     async with session_factory() as session, session.begin():
-        # Step 1: ensure the empire row exists so rooms.empire_id FK resolves.
-        # INSERT OR IGNORE is safe even after SqliteEmpireRepository.save()
-        # has already created the empire row via UPSERT.
+        # ステップ 1: rooms.empire_id FK が解決するよう Empire 行が存在することを確認。
+        # INSERT OR IGNORE は SqliteEmpireRepository.save() が既に UPSERT 経由で
+        # Empire 行を作成していても安全。
         await session.execute(
             text("INSERT OR IGNORE INTO empires (id, name) VALUES (:id, :name)"),
             {"id": empire_id.hex, "name": "seed-empire"},
         )
 
-        # Step 2: seed a minimal workflow row so rooms.workflow_id FK resolves.
+        # ステップ 2: rooms.workflow_id FK が解決するよう最小限の workflow 行をシード。
         await session.execute(
             text(
                 "INSERT INTO workflows (id, name, entry_stage_id) "
@@ -80,7 +80,7 @@ async def seed_rooms(
             },
         )
 
-        # Step 3: seed one rooms row per room_id.
+        # ステップ 3: room_id ごとに 1 つの rooms 行をシード。
         for room_id in room_ids:
             await session.execute(
                 text(

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_empire_repository/conftest.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_empire_repository/conftest.py
@@ -1,16 +1,16 @@
-"""Pytest fixtures for empire-repository integration tests.
+"""empire-repository 統合テスト用の Pytest フィクスチャ。
 
-Provides seed helpers to satisfy the ``empire_room_refs.room_id → rooms.id``
-FK constraint added by Alembic 0005_room_aggregate (BUG-EMR-001 FK closure).
+``empire_room_refs.room_id → rooms.id`` FK制約を満たすセッドヘルパーを提供
+(Alembic 0005_room_aggregate により追加、BUG-EMR-001 FK クロージャ)。
 
-Background: before Alembic 0005, ``empire_room_refs.room_id`` had **no** FK
-onto ``rooms.id`` (the rooms table didn't exist yet). After 0005 the FK is
-wired with ``ON DELETE CASCADE`` so any INSERT into ``empire_room_refs`` now
-requires a matching row in ``rooms``. Tests that call
-``SqliteEmpireRepository.save(empire)`` with a populated Empire, or that
-issue raw SQL into ``empire_room_refs``, must seed the ``rooms`` table first.
+背景: Alembic 0005 より前、``empire_room_refs.room_id`` は rooms.id への
+**FK を持たなかった** (rooms テーブルがまだ存在しなかった)。0005 の後、
+FK は ``ON DELETE CASCADE`` で配線されるため、empire_room_refs への任意の
+INSERT は rooms の一致する行を要求する。``SqliteEmpireRepository.save(empire)``
+を完全に充実した Empire で呼び出すテスト、または empire_room_refs に
+生 SQL を発行するテストは、最初に rooms テーブルをシードする必要。
 
-Usage::
+使用法::
 
     from tests.infrastructure.persistence.sqlite.repositories.\
         test_empire_repository.conftest import seed_rooms

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_empire_repository/test_constraints_arch.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_empire_repository/test_constraints_arch.py
@@ -1,9 +1,8 @@
-"""Empire Repository: DB constraints + arch-test template structure.
+"""Empire Repository: DB制約 + アーキテクチャテストテンプレート構造。
 
-TC-IT-EMR-013 / 014 / 017 — FK CASCADE, UNIQUE pair enforcement, and
-the CI three-layer-defense template the next 6 Repository PRs will
-extend. Split out from the original ``test_empire_repository.py`` per
-Norman's 500-line rule.
+TC-IT-EMR-013 / 014 / 017 — FK CASCADE、UNIQUE ペア強制実行、および
+次の 6 つの Repository PR が拡張する CI 3層防御テンプレート。
+Norman の500行ルールに従い元の ``test_empire_repository.py`` から分割。
 """
 
 from __future__ import annotations

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_empire_repository/test_constraints_arch.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_empire_repository/test_constraints_arch.py
@@ -90,8 +90,8 @@ class TestUniqueConstraintViolation:
             await SqliteEmpireRepository(session).save(empire)
 
         room_id = uuid4()
-        # Alembic 0005 added empire_room_refs.room_id → rooms.id FK (BUG-EMR-001
-        # closure). Seed the room row before inserting into empire_room_refs.
+        # Alembic 0005 で empire_room_refs.room_id → rooms.id FK が追加された（BUG-EMR-001
+        # クローズ）。empire_room_refs に挿入する前に room 行を seed する。
         await seed_rooms(session_factory, empire.id, [room_id])
         async with session_factory() as session, session.begin():
             await session.execute(
@@ -142,12 +142,12 @@ class TestNoMaskTemplateStructure:
             _NO_MASK_TABLES,  # pyright: ignore[reportPrivateUsage]
         )
 
-        # Empire 3 tables must be in the no-mask list.
+        # Empire の 3 テーブルは no-mask リストに含まれる必要がある。
         assert "empires" in _NO_MASK_TABLES
         assert "empire_room_refs" in _NO_MASK_TABLES
         assert "empire_agent_refs" in _NO_MASK_TABLES
-        # Empire columns must NOT appear in the masking-contract list
-        # (positive contract).
+        # Empire のカラムは masking 契約リストに **現れない** こと
+        # （ポジティブ契約）。
         empire_table_names = {"empires", "empire_room_refs", "empire_agent_refs"}
         contract_tables = {tbl for tbl, _, _ in _MASKING_CONTRACT}
         assert contract_tables.isdisjoint(empire_table_names)

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_empire_repository/test_protocol_crud.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_empire_repository/test_protocol_crud.py
@@ -1,9 +1,9 @@
-"""Empire Repository: Protocol surface + basic CRUD coverage.
+"""Empire Repository: プロトコルサーフェス + 基本 CRUD カバレッジ。
 
-TC-IT-EMR-001 / 002 / 003 / 004 / 005 / 010 / 018 — the entry-point
-behaviors every Aggregate Repository must satisfy. Split out from
-the original ``test_empire_repository.py`` per Norman's 500-line rule
-(see :mod:`...test_empire_repository.__init__`).
+TC-IT-EMR-001 / 002 / 003 / 004 / 005 / 010 / 018 — すべての Aggregate Repository
+が満たさねばならないエントリポイント動作。Norman の500行ルールに従い
+元の ``test_empire_repository.py`` から分割
+(参照: :mod:`...test_empire_repository.__init__`)。
 """
 
 from __future__ import annotations

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_empire_repository/test_protocol_crud.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_empire_repository/test_protocol_crud.py
@@ -44,10 +44,10 @@ class TestEmpireRepositoryProtocol:
 
     async def test_protocol_declares_three_async_methods(self) -> None:
         """TC-IT-EMR-001: ``EmpireRepository`` has find_by_id / count / save."""
-        # Protocol classes don't expose the methods at instance level
-        # but at class level. Assert each method is callable on the
-        # Protocol type itself. Marked ``async`` purely so the
-        # module-level ``pytestmark = asyncio`` does not warn.
+        # Protocol クラスはメソッドをインスタンスレベルではなく
+        # クラスレベルで公開する。各メソッドが Protocol 型自体で
+        # callable であることをアサートする。``async`` を付けているのは
+        # モジュールレベルの ``pytestmark = asyncio`` が warn しないようにするため。
         assert hasattr(EmpireRepository, "find_by_id")
         assert hasattr(EmpireRepository, "count")
         assert hasattr(EmpireRepository, "save")
@@ -133,8 +133,8 @@ class TestCount:
         async with session_factory() as session, session.begin():
             await SqliteEmpireRepository(session).save(make_empire())
         async with session_factory() as session, session.begin():
-            # Different id — the FK constraints accept it; the
-            # Repository must not throw a singleton-enforcement error.
+            # 異なる id — FK 制約は受け入れる;
+            # Repository はシングルトン強制エラーを送出してはならない。
             await SqliteEmpireRepository(session).save(make_empire())
 
         async with session_factory() as session:
@@ -151,8 +151,8 @@ class TestSaveInsertsAllThreeTables:
     ) -> None:
         """TC-IT-EMR-005: 2 rooms + 3 agents land in their respective side tables."""
         empire = make_populated_empire(n_rooms=2, n_agents=3)
-        # Alembic 0005 added empire_room_refs.room_id → rooms.id FK (BUG-EMR-001
-        # closure). Seed rooms rows before save() so the FK resolves.
+        # Alembic 0005 で empire_room_refs.room_id → rooms.id FK が追加された（BUG-EMR-001
+        # クローズ）。FK を解決するため save() 前に rooms 行を seed する。
         await seed_rooms(session_factory, empire.id, [r.room_id for r in empire.rooms])
         async with session_factory() as session, session.begin():
             await SqliteEmpireRepository(session).save(empire)

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_empire_repository/test_save_semantics.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_empire_repository/test_save_semantics.py
@@ -1,9 +1,8 @@
-"""Empire Repository: save() semantics — delete-then-insert + Tx boundary.
+"""Empire Repository: save() の挙動 ── delete-then-insert + Tx 境界.
 
-TC-IT-EMR-006 / 007 / 011 / 012 + TC-UT-EMR-003 — the §確定 B
-contract that backs the ``save()`` flow plus round-trip equality.
-Split out from the original ``test_empire_repository.py`` per
-Norman's 500-line rule.
+TC-IT-EMR-006 / 007 / 011 / 012 + TC-UT-EMR-003 ── ``save()`` フローを
+裏付ける §確定 B 契約とラウンドトリップ等価性。
+Norman の 500 行ルールに従い、元の ``test_empire_repository.py`` から分割。
 """
 
 from __future__ import annotations
@@ -31,26 +30,26 @@ pytestmark = pytest.mark.asyncio
 
 
 class TestSaveDeleteThenInsert:
-    """TC-IT-EMR-006: ``save`` replaces side-table rows wholesale (§確定 B)."""
+    """TC-IT-EMR-006: ``save`` は side-table 行を一括置換する (§確定 B)。"""
 
     async def test_save_replaces_room_refs(
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """TC-IT-EMR-006: 2 rooms → 1 room is reflected as 1 row in empire_room_refs."""
+        """TC-IT-EMR-006: 2 rooms → 1 room は empire_room_refs で 1 行として反映される。"""
         original = make_populated_empire(n_rooms=2, n_agents=3)
-        # Create the replacement room ref upfront so we can seed it before save.
+        # save 前に seed できるよう、置換用 room ref を先行生成する。
         replacement_room = make_room_ref(name="残った部屋")
 
-        # Alembic 0005 added empire_room_refs.room_id → rooms.id FK (BUG-EMR-001
-        # closure). Seed all room_ids that will ever appear in empire_room_refs.
+        # Alembic 0005 で empire_room_refs.room_id → rooms.id FK が追加された
+        # (BUG-EMR-001 閉鎖)。empire_room_refs に登場し得る全 room_id を seed する。
         all_room_ids = [r.room_id for r in original.rooms] + [replacement_room.room_id]
         await seed_rooms(session_factory, original.id, all_room_ids)
 
         async with session_factory() as session, session.begin():
             await SqliteEmpireRepository(session).save(original)
 
-        # Build a new Empire with the same id but only 1 room.
+        # 同じ id で 1 room だけの新しい Empire を構築する。
         replacement = make_empire(
             empire_id=original.id,
             name=original.name,
@@ -60,7 +59,7 @@ class TestSaveDeleteThenInsert:
         async with session_factory() as session, session.begin():
             await SqliteEmpireRepository(session).save(replacement)
 
-        # Side tables must show the new state, not the merged old + new.
+        # side テーブルは古い + 新しいの merge ではなく新状態を反映せねばならない。
         async with session_factory() as session:
             room_rows = list(
                 (
@@ -74,28 +73,27 @@ class TestSaveDeleteThenInsert:
 
 
 class TestRoundTripStructuralEquality:
-    """TC-IT-EMR-007 + TC-UT-EMR-003: save → find_by_id round-trip preserves equality.
+    """TC-IT-EMR-007 + TC-UT-EMR-003: save → find_by_id ラウンドトリップで等価性が保たれる。
 
-    BUG-EMR-001 closure: :meth:`SqliteEmpireRepository.find_by_id` now
-    issues ``ORDER BY room_id`` / ``ORDER BY agent_id`` per
-    ``basic-design.md`` L127-128 and ``detailed-design.md`` §クラス設計.
-    The hydrated lists are deterministic, so the previous set-based
-    workaround is removed and replaced with the contracted list-order
-    comparison.
+    BUG-EMR-001 閉鎖: :meth:`SqliteEmpireRepository.find_by_id` は
+    ``basic-design.md`` L127-128 と ``detailed-design.md`` §クラス設計 に従い、
+    ``ORDER BY room_id`` / ``ORDER BY agent_id`` を発行する。
+    ハイドレートされたリストは決定的になるため、以前の set ベースの
+    ワークアラウンドは外し、契約に沿ったリスト順比較に置き換えた。
 
-    Test contract (ORDER BY 物理保証): the Repository's
-    ``ORDER BY room_id`` / ``ORDER BY agent_id`` design contract is
-    asserted by sorting the input Empire's collections by the same
-    key and demanding list equality. Failing this assertion means
-    the SQL contract regressed (either the ``ORDER BY`` was dropped
-    or the column changed).
+    テスト契約 (ORDER BY 物理保証): Repository の
+    ``ORDER BY room_id`` / ``ORDER BY agent_id`` 設計契約を、入力 Empire の
+    コレクションを同じキーでソートしてリスト等価を要求する形でアサートする。
+    本アサートが失敗すれば SQL 契約のリグレッション (``ORDER BY`` が
+    落ちた、もしくはカラムが変わった) を意味する。
     """
 
     async def test_populated_empire_round_trip(
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """TC-IT-EMR-007: round-trip preserves Empire identity + membership in ORDER BY order."""
+        """TC-IT-EMR-007: ラウンドトリップが Empire アイデンティティと
+        メンバーシップを ORDER BY 順で保持する。"""
         empire = make_populated_empire(n_rooms=2, n_agents=3)
         await seed_rooms(session_factory, empire.id, [r.room_id for r in empire.rooms])
         async with session_factory() as session, session.begin():
@@ -106,10 +104,9 @@ class TestRoundTripStructuralEquality:
         assert restored is not None
         assert restored.id == empire.id
         assert restored.name == empire.name
-        # ORDER BY room_id / agent_id 物理保証: restored side-table
-        # lists are deterministic, so list-order equality is the
-        # contract. The expected lists are sorted by the same key
-        # the Repository used in its ``ORDER BY``.
+        # ORDER BY room_id / agent_id 物理保証: 復元される side-table
+        # リストは決定的なので、リスト順等価が契約。期待リストは
+        # Repository の ``ORDER BY`` と同じキーでソートしておく。
         assert restored.rooms == sorted(empire.rooms, key=lambda r: r.room_id)
         assert restored.agents == sorted(empire.agents, key=lambda a: a.agent_id)
 
@@ -117,22 +114,22 @@ class TestRoundTripStructuralEquality:
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """TC-IT-EMR-007: round-trip an Empire with zero rooms / agents."""
-        empire = make_empire()  # rooms=[] agents=[] by default
+        """TC-IT-EMR-007: rooms / agents 空の Empire をラウンドトリップする。"""
+        empire = make_empire()  # デフォルトで rooms=[] agents=[]
         async with session_factory() as session, session.begin():
             await SqliteEmpireRepository(session).save(empire)
 
         async with session_factory() as session:
             restored = await SqliteEmpireRepository(session).find_by_id(empire.id)
         assert restored is not None
-        # Empty case: no list-order ambiguity, full ``==`` is fine.
+        # 空ケース: リスト順の曖昧さは無いので完全な ``==`` で良い。
         assert restored == empire
 
     async def test_to_row_then_from_row_round_trip(
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """TC-UT-EMR-003: ``_to_row`` → save + find_by_id (≡ ``_from_row``) preserves equality."""
+        """TC-UT-EMR-003: ``_to_row`` → save + find_by_id (≡ ``_from_row``) で等価性が保たれる。"""
         empire = make_populated_empire(n_rooms=2, n_agents=3)
         await seed_rooms(session_factory, empire.id, [r.room_id for r in empire.rooms])
         async with session_factory() as session, session.begin():
@@ -143,9 +140,8 @@ class TestRoundTripStructuralEquality:
         assert restored is not None
         assert restored.id == empire.id
         assert restored.name == empire.name
-        # Same ORDER BY-aware list comparison as
-        # test_populated_empire_round_trip — see class docstring for
-        # the BUG-EMR-001 closure rationale.
+        # test_populated_empire_round_trip と同じ ORDER BY 認識のリスト比較 ──
+        # BUG-EMR-001 閉鎖の根拠はクラス docstring を参照。
         assert restored.rooms == sorted(empire.rooms, key=lambda r: r.room_id)
         assert restored.agents == sorted(empire.agents, key=lambda a: a.agent_id)
 
@@ -154,22 +150,21 @@ class TestRoundTripStructuralEquality:
 # 確定 B: delete-then-insert 5 段階順序 + Tx 境界
 # ---------------------------------------------------------------------------
 class TestSaveSqlOrder:
-    """TC-IT-EMR-011: ``save`` issues SQL in the §確定 B 5-step order.
+    """TC-IT-EMR-011: ``save`` は §確定 B の 5 ステップ順で SQL を発行する。
 
-    We attach a ``before_cursor_execute`` listener on the **sync**
-    engine so we observe the actual SQL strings the dialect emits. The
-    listener appends each statement to a captured list; we then assert
-    the prefix sequence matches the design's 5 steps. The dispatcher /
-    ORM may issue extra SAVEPOINT / BEGIN statements which we filter
-    out — the contract is on the *DML* prefix.
+    **sync** エンジンに ``before_cursor_execute`` リスナを付け、方言が
+    実際に発行する SQL 文字列を観察する。リスナは各文をキャプチャ用リストに
+    append し、プレフィックス列が設計の 5 ステップに一致することをアサートする。
+    ディスパッチャ / ORM は追加で SAVEPOINT / BEGIN を発行し得るので
+    フィルタする ── 契約は *DML* のプレフィックスに対する。
     """
 
     async def test_save_emits_upsert_then_delete_insert_pairs(
         self,
         session_factory: async_sessionmaker[AsyncSession],
-        app_engine: object,  # AsyncEngine; typed loosely so listener API works
+        app_engine: object,  # AsyncEngine; リスナ API のため緩く型付け
     ) -> None:
-        """TC-IT-EMR-011: empires UPSERT → empire_room_refs DEL+INS → empire_agent_refs DEL+INS."""
+        """TC-IT-EMR-011: empires UPSERT → empire_room_refs DEL+INS → empire_agent_refs DEL+INS。"""
         from sqlalchemy import event
 
         captured: list[str] = []
@@ -194,8 +189,8 @@ class TestSaveSqlOrder:
         finally:
             event.remove(sync_engine, "before_cursor_execute", _on_execute)
 
-        # Filter to the 5 DML statements we care about (BEGIN /
-        # SAVEPOINT / RELEASE / COMMIT noise removed).
+        # 注目したい 5 件の DML 文に絞る (BEGIN /
+        # SAVEPOINT / RELEASE / COMMIT のノイズを除去)。
         dml = [
             s
             for s in captured
@@ -206,7 +201,7 @@ class TestSaveSqlOrder:
         ]
         # Step 1 (UPSERT empires) → Step 2 (DELETE empire_room_refs) →
         # Step 3 (INSERT empire_room_refs) → Step 4 (DELETE
-        # empire_agent_refs) → Step 5 (INSERT empire_agent_refs).
+        # empire_agent_refs) → Step 5 (INSERT empire_agent_refs)。
         assert len(dml) >= 5
         assert dml[0].upper().startswith("INSERT INTO EMPIRES")
         assert dml[1].upper().startswith("DELETE FROM EMPIRE_ROOM_REFS")
@@ -216,13 +211,14 @@ class TestSaveSqlOrder:
 
 
 class TestTxBoundaryRespectedByRepository:
-    """TC-IT-EMR-012: Repository never calls commit / rollback (§確定 B)."""
+    """TC-IT-EMR-012: Repository は commit / rollback を呼ばない (§確定 B)。"""
 
     async def test_commit_path_persists_via_outer_block(
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """TC-IT-EMR-012 (commit): outer ``async with session.begin()`` commits the save."""
+        """TC-IT-EMR-012 (commit): 外側の ``async with session.begin()``
+        で save がコミットされる。"""
         empire = make_empire()
         async with session_factory() as session, session.begin():
             await SqliteEmpireRepository(session).save(empire)
@@ -235,10 +231,10 @@ class TestTxBoundaryRespectedByRepository:
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """TC-IT-EMR-012 (rollback): an exception inside ``begin()`` rolls back the save."""
+        """TC-IT-EMR-012 (rollback): ``begin()`` 内の例外で save がロールバックされる。"""
 
         class _BoomError(Exception):
-            """Synthetic exception used to drive the rollback path."""
+            """ロールバック経路を駆動するための合成例外。"""
 
         empire = make_empire()
         with pytest.raises(_BoomError):
@@ -248,5 +244,5 @@ class TestTxBoundaryRespectedByRepository:
 
         async with session_factory() as session:
             fetched = await SqliteEmpireRepository(session).find_by_id(empire.id)
-        # Rollback must have been atomic — no row survives.
+        # ロールバックはアトミックでなければならない ── 行は残らない。
         assert fetched is None

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_empire_repository/test_save_semantics.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_empire_repository/test_save_semantics.py
@@ -199,8 +199,8 @@ class TestSaveSqlOrder:
                 for prefix in ("INSERT INTO EMPIRES", "DELETE FROM EMPIRE", "INSERT INTO EMPIRE")
             )
         ]
-        # Step 1 (UPSERT empires) → Step 2 (DELETE empire_room_refs) →
-        # Step 3 (INSERT empire_room_refs) → Step 4 (DELETE
+        # Step 1（UPSERT empires）→ Step 2（DELETE empire_room_refs）→
+        # Step 3（INSERT empire_room_refs）→ Step 4（DELETE
         # empire_agent_refs) → Step 5 (INSERT empire_agent_refs)。
         assert len(dml) >= 5
         assert dml[0].upper().startswith("INSERT INTO EMPIRES")

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_external_review_gate_repository/test_count_by_decision.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_external_review_gate_repository/test_count_by_decision.py
@@ -1,14 +1,14 @@
-"""ExternalReviewGate Repository: count_by_decision SQL guarantee.
+"""ExternalReviewGate Repository: count_by_decision SQL 保証。
 
-TC-UT-ERGR-008 — §確定 R1-D count_by_decision.
+TC-UT-ERGR-008 — §確定 R1-D count_by_decision。
 
-Verifies:
-* count_by_decision(PENDING) returns correct count.
-* SQL log contains WHERE decision = filter (not a full-table-scan aggregate).
-* All decision values (PENDING / APPROVED / REJECTED / CANCELLED) isolated.
+検証:
+* count_by_decision(PENDING) は正しいカウントを返す。
+* SQL ログは WHERE decision = フィルタを含む (フルテーブルスキャン集計ではない)。
+* すべての decision 値 (PENDING / APPROVED / REJECTED / CANCELLED) が隔離。
 
-Per ``docs/features/external-review-gate-repository/test-design.md`` TC-UT-ERGR-008.
-Issue #36 — M2 0008.
+``docs/features/external-review-gate-repository/test-design.md`` TC-UT-ERGR-008 準拠。
+Issue #36 — M2 0008。
 """
 
 from __future__ import annotations

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_external_review_gate_repository/test_find_methods.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_external_review_gate_repository/test_find_methods.py
@@ -1,14 +1,14 @@
-"""ExternalReviewGate Repository: find_pending_by_reviewer / find_by_task_id.
+"""ExternalReviewGate Repository: find_pending_by_reviewer / find_by_task_id。
 
-TC-UT-ERGR-006/006b/006c/006d/007/007b/007c — §確定 R1-D / §確定 R1-H ORDER BY.
+TC-UT-ERGR-006/006b/006c/006d/007/007b/007c — §確定 R1-D / §確定 R1-H ORDER BY。
 
-Tests ORDER BY determinism (BUG-EMR-001 準拠) for both query methods:
-* find_pending_by_reviewer: created_at DESC, id DESC tiebreaker
-* find_by_task_id: created_at ASC, id ASC (chronological review history)
+両クエリメソッドの ORDER BY 決定性をテスト (BUG-EMR-001 準拠):
+* find_pending_by_reviewer: created_at DESC, id DESC タイブレーカ
+* find_by_task_id: created_at ASC, id ASC (時系列レビュー履歴)
 
-Per ``docs/features/external-review-gate-repository/test-design.md``
-TC-UT-ERGR-006〜007c.
-Issue #36 — M2 0008.
+``docs/features/external-review-gate-repository/test-design.md``
+TC-UT-ERGR-006〜007c 準拠。
+Issue #36 — M2 0008。
 """
 
 from __future__ import annotations

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_external_review_gate_repository/test_masking_fields.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_external_review_gate_repository/test_masking_fields.py
@@ -1,22 +1,22 @@
-"""ExternalReviewGate Repository: MaskedText wiring on 3 columns (TC-IT-ERGR-020-masking-*).
+"""ExternalReviewGate Repository: 3 カラムへの MaskedText 配線 (TC-IT-ERGR-020-masking-*).
 
-RQ-ERGR-006 / §確定 R1-E — 3 MaskedText columns physical verification:
+RQ-ERGR-006 / §確定 R1-E ── 3 つの MaskedText カラムの物理検証:
   * external_review_gates.snapshot_body_markdown
   * external_review_gates.feedback_text
   * external_review_audit_entries.comment
 
-Each column is verified via **raw SQL SELECT** so the observation bypasses
-``MaskedText.process_result_value`` and confirms the literal bytes on disk.
+各カラムは **raw SQL SELECT** で検証する ──
+``MaskedText.process_result_value`` を迂回し、ディスク上の実バイトを確認するため。
 
-9 test cases:
-  snapshot_body_markdown: masked / plain / roundtrip (3 cases)
-  feedback_text: masked / plain / roundtrip (3 cases)
-  comment: masked / plain (2 cases)
-  3-column simultaneous: 1 case
+テストケース 9 件:
+  snapshot_body_markdown: masked / plain / roundtrip (3 件)
+  feedback_text: masked / plain / roundtrip (3 件)
+  comment: masked / plain (2 件)
+  3 カラム同時: 1 件
 
-Per ``docs/features/external-review-gate-repository/test-design.md``
-TC-IT-ERGR-020-masking-*.
-Issue #36 — M2 0008.
+``docs/features/external-review-gate-repository/test-design.md``
+TC-IT-ERGR-020-masking-* 準拠。
+Issue #36 ── M2 0008。
 """
 
 from __future__ import annotations
@@ -47,30 +47,30 @@ pytestmark = pytest.mark.asyncio
 
 
 # ---------------------------------------------------------------------------
-# Secret token constants (real-shape, constructed to avoid push-protection)
+# secret トークン定数 (push-protection 回避のため実形を分割構築)
 # ---------------------------------------------------------------------------
 
-# Discord Bot Token — [MN][A-Za-z\d]{23,}\.[\w-]{6}\.[\w-]{27,}
+# Discord Bot Token ── [MN][A-Za-z\d]{23,}\.[\w-]{6}\.[\w-]{27,}
 _DISCORD_TOKEN = "MTk4NjIyNDgz" + "NDcxOTI1MjQ4.ClFDg_." + "A" * 27
 _DISCORD_SENTINEL = "<REDACTED:DISCORD_TOKEN>"
 
-# GitHub PAT — (?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36,}
+# GitHub PAT ── (?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36,}
 _GITHUB_TOKEN = "ghp_" + "X" * 40
 _GITHUB_SENTINEL = "<REDACTED:GITHUB_PAT>"
 
-# Slack Bot Token — xoxb-[0-9]{10,13}-[0-9]{10,13}-[a-zA-Z0-9]{24}
+# Slack Bot Token ── xoxb-[0-9]{10,13}-[0-9]{10,13}-[a-zA-Z0-9]{24}
 _SLACK_TOKEN = "xoxb-" + "1" * 11 + "-" + "2" * 11 + "-" + "A" * 24
 _SLACK_SENTINEL = "<REDACTED:SLACK_TOKEN>"
 
 
 # ---------------------------------------------------------------------------
-# Raw-SQL helpers (bypass TypeDecorator.process_result_value)
+# Raw-SQL ヘルパ (TypeDecorator.process_result_value を迂回)
 # ---------------------------------------------------------------------------
 async def _read_persisted_snapshot_body(
     session_factory: async_sessionmaker[AsyncSession],
     gate_id: UUID,
 ) -> str:
-    """Fetch external_review_gates.snapshot_body_markdown literal bytes."""
+    """external_review_gates.snapshot_body_markdown の実バイトを取得する。"""
     async with session_factory() as session:
         row = (
             await session.execute(
@@ -87,7 +87,7 @@ async def _read_persisted_feedback_text(
     session_factory: async_sessionmaker[AsyncSession],
     gate_id: UUID,
 ) -> str:
-    """Fetch external_review_gates.feedback_text literal bytes."""
+    """external_review_gates.feedback_text の実バイトを取得する。"""
     async with session_factory() as session:
         row = (
             await session.execute(
@@ -104,7 +104,7 @@ async def _read_persisted_audit_comment(
     session_factory: async_sessionmaker[AsyncSession],
     gate_id: UUID,
 ) -> str:
-    """Fetch external_review_audit_entries.comment literal bytes (first entry)."""
+    """external_review_audit_entries.comment の実バイトを取得する (最初のエントリ)。"""
     async with session_factory() as session:
         row = (
             await session.execute(
@@ -124,14 +124,15 @@ async def _read_persisted_audit_comment(
 # TC-IT-ERGR-020-masking-snapshot-masked
 # ---------------------------------------------------------------------------
 class TestSnapshotBodyMarkdownDiscordTokenMasked:
-    """TC-IT-ERGR-020-masking-snapshot-masked: Discord token in snapshot_body_markdown redacted."""
+    """TC-IT-ERGR-020-masking-snapshot-masked: snapshot_body_markdown
+    の Discord トークンが redact される。"""
 
     async def test_discord_token_in_snapshot_body_redacted_on_disk(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_gate_context: tuple[UUID, UUID, UUID],
     ) -> None:
-        """Raw-SQL SELECT shows <REDACTED:DISCORD_TOKEN>; raw token absent from disk."""
+        """Raw-SQL SELECT が <REDACTED:DISCORD_TOKEN> を返し、生トークンはディスク上に残らない。"""
         task_id, stage_id, reviewer_id = seeded_gate_context
         body = (
             f"# 設計書\nDiscord webhook: https://discord.com/api/webhooks/123/{_DISCORD_TOKEN}\n"
@@ -151,11 +152,12 @@ class TestSnapshotBodyMarkdownDiscordTokenMasked:
         persisted = await _read_persisted_snapshot_body(session_factory, gate.id)
 
         assert _DISCORD_SENTINEL in persisted, (
-            f"[FAIL] snapshot_body_markdown missing Discord sentinel.\nPersisted: {persisted!r}"
+            "[FAIL] snapshot_body_markdown に Discord sentinel が"
+            f"含まれない。\nPersisted: {persisted!r}"
         )
         assert _DISCORD_TOKEN not in persisted, (
-            f"[FAIL] Raw Discord token leaked into snapshot_body_markdown.\n"
-            f"Violates §確定 R1-E §不可逆性. Persisted: {persisted!r}"
+            f"[FAIL] 生 Discord トークンが snapshot_body_markdown に漏洩した。\n"
+            f"§確定 R1-E §不可逆性 違反。Persisted: {persisted!r}"
         )
 
 
@@ -163,14 +165,14 @@ class TestSnapshotBodyMarkdownDiscordTokenMasked:
 # TC-IT-ERGR-020-masking-snapshot-plain
 # ---------------------------------------------------------------------------
 class TestSnapshotBodyMarkdownPlainPassthrough:
-    """TC-IT-ERGR-020-masking-snapshot-plain: plain text stored unchanged."""
+    """TC-IT-ERGR-020-masking-snapshot-plain: 平文は変更なしで保存される。"""
 
     async def test_plain_snapshot_body_is_passthrough(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_gate_context: tuple[UUID, UUID, UUID],
     ) -> None:
-        """snapshot_body_markdown without secrets stored byte-identical."""
+        """secret を含まない snapshot_body_markdown はバイト等価で保存される。"""
         task_id, stage_id, reviewer_id = seeded_gate_context
         plain_body = "タスク設計が完成した。レビューをお願いします。"
         snapshot = make_deliverable(body_markdown=plain_body)
@@ -186,7 +188,7 @@ class TestSnapshotBodyMarkdownPlainPassthrough:
 
         persisted = await _read_persisted_snapshot_body(session_factory, gate.id)
         assert persisted == plain_body, (
-            f"[FAIL] Plain snapshot_body_markdown was modified.\n"
+            f"[FAIL] 平文 snapshot_body_markdown が変更されている。\n"
             f"Expected: {plain_body!r}\nGot: {persisted!r}"
         )
 
@@ -195,14 +197,15 @@ class TestSnapshotBodyMarkdownPlainPassthrough:
 # TC-IT-ERGR-020-masking-snapshot-roundtrip
 # ---------------------------------------------------------------------------
 class TestSnapshotBodyMarkdownRoundtripIrreversible:
-    """TC-IT-ERGR-020-masking-snapshot-roundtrip: find_by_id returns masked body."""
+    """TC-IT-ERGR-020-masking-snapshot-roundtrip: find_by_id はマスク済み body を返す。"""
 
     async def test_find_by_id_returns_masked_snapshot_body(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_gate_context: tuple[UUID, UUID, UUID],
     ) -> None:
-        """Save raw Discord token in snapshot_body_markdown → find_by_id → body == masked."""
+        """snapshot_body_markdown に生 Discord トークンを保存 →
+        find_by_id → body がマスクされている。"""
         task_id, stage_id, reviewer_id = seeded_gate_context
         body = f"設計書: auth={_DISCORD_TOKEN} for Discord integration"
         snapshot = make_deliverable(body_markdown=body)
@@ -222,27 +225,28 @@ class TestSnapshotBodyMarkdownRoundtripIrreversible:
         assert restored is not None
         restored_body = restored.deliverable_snapshot.body_markdown
         assert _DISCORD_SENTINEL in restored_body, (
-            f"[FAIL] find_by_id returned unmasked snapshot_body_markdown.\n"
+            f"[FAIL] find_by_id がマスクされていない snapshot_body_markdown を返した。\n"
             f"Restored: {restored_body!r}"
         )
         assert _DISCORD_TOKEN not in restored_body, (
-            f"[FAIL] §確定 R1-E §不可逆性 violated: raw Discord token recovered.\n"
+            f"[FAIL] §確定 R1-E §不可逆性 違反: 生 Discord トークンが復元された。\n"
             f"Restored: {restored_body!r}"
         )
 
 
 # ---------------------------------------------------------------------------
 # TC-IT-ERGR-020-masking-feedback-masked
-# ---------------------------------------------------------------------------
+# -------------------------------------------------------------------
 class TestFeedbackTextSlackTokenMasked:
-    """TC-IT-ERGR-020-masking-feedback-masked: Slack token in feedback_text redacted."""
+    """TC-IT-ERGR-020-masking-feedback-masked: feedback_text
+    中の Slack トークンが redact される。"""
 
     async def test_slack_token_in_feedback_text_redacted_on_disk(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_gate_context: tuple[UUID, UUID, UUID],
     ) -> None:
-        """Raw-SQL SELECT shows <REDACTED:SLACK_TOKEN>; raw token absent from disk."""
+        """Raw-SQL SELECT が <REDACTED:SLACK_TOKEN> を返し、生トークンはディスク上に残らない。"""
         task_id, stage_id, reviewer_id = seeded_gate_context
         feedback = f"レビュー承認。Slack通知: token={_SLACK_TOKEN}"
         decided_at = datetime.now(UTC)
@@ -260,11 +264,11 @@ class TestFeedbackTextSlackTokenMasked:
         persisted = await _read_persisted_feedback_text(session_factory, gate.id)
 
         assert _SLACK_SENTINEL in persisted, (
-            f"[FAIL] feedback_text missing Slack sentinel.\nPersisted: {persisted!r}"
+            f"[FAIL] feedback_text に Slack sentinel が含まれない。\nPersisted: {persisted!r}"
         )
         assert _SLACK_TOKEN not in persisted, (
-            f"[FAIL] Raw Slack token leaked into feedback_text.\n"
-            f"Violates §確定 R1-E (§設計決定 ERGR-002). Persisted: {persisted!r}"
+            f"[FAIL] 生 Slack トークンが feedback_text に漏洩した。\n"
+            f"§確定 R1-E (§設計決定 ERGR-002) 違反。Persisted: {persisted!r}"
         )
 
 
@@ -272,14 +276,14 @@ class TestFeedbackTextSlackTokenMasked:
 # TC-IT-ERGR-020-masking-feedback-plain
 # ---------------------------------------------------------------------------
 class TestFeedbackTextPlainPassthrough:
-    """TC-IT-ERGR-020-masking-feedback-plain: plain feedback text stored unchanged."""
+    """TC-IT-ERGR-020-masking-feedback-plain: 平文 feedback は変更なしで保存される。"""
 
     async def test_plain_feedback_text_is_passthrough(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_gate_context: tuple[UUID, UUID, UUID],
     ) -> None:
-        """feedback_text without secrets stored byte-identical."""
+        """secret を含まない feedback_text はバイト等価で保存される。"""
         task_id, stage_id, reviewer_id = seeded_gate_context
         plain_feedback = "設計品質が基準を満たしていない。再提出を求める。"
         decided_at = datetime.now(UTC)
@@ -296,7 +300,7 @@ class TestFeedbackTextPlainPassthrough:
 
         persisted = await _read_persisted_feedback_text(session_factory, gate.id)
         assert persisted == plain_feedback, (
-            f"[FAIL] plain feedback_text was modified.\n"
+            f"[FAIL] 平文 feedback_text が変更されている。\n"
             f"Expected: {plain_feedback!r}\nGot: {persisted!r}"
         )
 
@@ -305,14 +309,15 @@ class TestFeedbackTextPlainPassthrough:
 # TC-IT-ERGR-020-masking-feedback-roundtrip
 # ---------------------------------------------------------------------------
 class TestFeedbackTextRoundtripIrreversible:
-    """TC-IT-ERGR-020-masking-feedback-roundtrip: find_by_id returns masked feedback."""
+    """TC-IT-ERGR-020-masking-feedback-roundtrip: find_by_id はマスク済み feedback を返す。"""
 
     async def test_find_by_id_returns_masked_feedback_text(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_gate_context: tuple[UUID, UUID, UUID],
     ) -> None:
-        """Save Slack token in feedback_text → find_by_id → feedback_text == masked."""
+        """feedback_text に Slack トークンを保存 → find_by_id →
+        feedback_text がマスクされている。"""
         task_id, stage_id, reviewer_id = seeded_gate_context
         feedback = f"Slack auth: {_SLACK_TOKEN} で通知を送る"
         decided_at = datetime.now(UTC)
@@ -332,11 +337,11 @@ class TestFeedbackTextRoundtripIrreversible:
 
         assert restored is not None
         assert _SLACK_SENTINEL in restored.feedback_text, (
-            f"[FAIL] find_by_id returned unmasked feedback_text.\n"
+            f"[FAIL] find_by_id がマスクされていない feedback_text を返した。\n"
             f"Restored: {restored.feedback_text!r}"
         )
         assert _SLACK_TOKEN not in restored.feedback_text, (
-            f"[FAIL] §確定 R1-E §不可逆性 violated: raw Slack token recovered.\n"
+            f"[FAIL] §確定 R1-E §不可逆性 違反: 生 Slack トークンが復元された。\n"
             f"Restored: {restored.feedback_text!r}"
         )
 
@@ -345,14 +350,14 @@ class TestFeedbackTextRoundtripIrreversible:
 # TC-IT-ERGR-020-masking-comment-masked
 # ---------------------------------------------------------------------------
 class TestAuditCommentGithubPatMasked:
-    """TC-IT-ERGR-020-masking-comment-masked: GitHub PAT in audit comment redacted."""
+    """TC-IT-ERGR-020-masking-comment-masked: 監査コメント中の GitHub PAT が redact される。"""
 
     async def test_github_pat_in_audit_comment_redacted_on_disk(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_gate_context: tuple[UUID, UUID, UUID],
     ) -> None:
-        """Raw-SQL SELECT shows <REDACTED:GITHUB_PAT>; raw PAT absent from disk."""
+        """Raw-SQL SELECT が <REDACTED:GITHUB_PAT> を返し、生 PAT はディスク上に残らない。"""
         task_id, stage_id, reviewer_id = seeded_gate_context
         comment = f"承認します。GitHub PAT: {_GITHUB_TOKEN} で変更を確認。"
         decided_at = datetime.now(UTC)
@@ -375,11 +380,11 @@ class TestAuditCommentGithubPatMasked:
         persisted = await _read_persisted_audit_comment(session_factory, gate.id)
 
         assert _GITHUB_SENTINEL in persisted, (
-            f"[FAIL] audit comment missing GitHub PAT sentinel.\nPersisted: {persisted!r}"
+            f"[FAIL] 監査コメントに GitHub PAT sentinel が含まれない。\nPersisted: {persisted!r}"
         )
         assert _GITHUB_TOKEN not in persisted, (
-            f"[FAIL] Raw GitHub PAT leaked into audit_entries.comment.\n"
-            f"Violates §確定 R1-E. Persisted: {persisted!r}"
+            f"[FAIL] 生 GitHub PAT が audit_entries.comment に漏洩した。\n"
+            f"§確定 R1-E 違反。Persisted: {persisted!r}"
         )
 
 
@@ -387,14 +392,14 @@ class TestAuditCommentGithubPatMasked:
 # TC-IT-ERGR-020-masking-comment-plain
 # ---------------------------------------------------------------------------
 class TestAuditCommentPlainPassthrough:
-    """TC-IT-ERGR-020-masking-comment-plain: plain comment stored unchanged."""
+    """TC-IT-ERGR-020-masking-comment-plain: 平文コメントは変更なしで保存される。"""
 
     async def test_plain_audit_comment_is_passthrough(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_gate_context: tuple[UUID, UUID, UUID],
     ) -> None:
-        """audit_entries.comment without secrets stored byte-identical."""
+        """secret を含まない audit_entries.comment はバイト等価で保存される。"""
         task_id, stage_id, reviewer_id = seeded_gate_context
         plain_comment = "設計品質が基準を満たしている。承認する。"
         decided_at = datetime.now(UTC)
@@ -416,33 +421,35 @@ class TestAuditCommentPlainPassthrough:
 
         persisted = await _read_persisted_audit_comment(session_factory, gate.id)
         assert persisted == plain_comment, (
-            f"[FAIL] plain audit comment was modified.\n"
+            f"[FAIL] 平文監査コメントが変更されている。\n"
             f"Expected: {plain_comment!r}\nGot: {persisted!r}"
         )
 
 
-# ---------------------------------------------------------------------------
-# TC-IT-ERGR-020-masking-3columns: 3 columns simultaneous masking
-# ---------------------------------------------------------------------------
+# -------------------------------------------------------------------
+# TC-IT-ERGR-020-masking-3columns: 3 カラム同時 masking
+# -------------------------------------------------------------------
 class TestThreeColumnSimultaneousMasking:
-    """TC-IT-ERGR-020-masking-3columns: All 3 MaskedText columns redacted in one save."""
+    """TC-IT-ERGR-020-masking-3columns: 1 回の save で
+    3 つの MaskedText カラム全てが redact される。"""
 
     async def test_three_masked_text_columns_redacted_simultaneously(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_gate_context: tuple[UUID, UUID, UUID],
     ) -> None:
-        """Discord + Slack + GitHub all redacted across 3 separate MaskedText columns."""
+        """別個の 3 つの MaskedText カラム全てで
+        Discord + Slack + GitHub がいずれも redact される。"""
         task_id, stage_id, reviewer_id = seeded_gate_context
 
-        # snapshot_body_markdown: Discord token
+        # snapshot_body_markdown: Discord トークン
         body = f"# 設計書\nDiscord token={_DISCORD_TOKEN} for webhook"
         snapshot = make_deliverable(body_markdown=body)
 
-        # feedback_text: Slack token
+        # feedback_text: Slack トークン
         feedback = f"レビュー拒否。Slack: {_SLACK_TOKEN}"
 
-        # audit comment: GitHub PAT
+        # 監査コメント: GitHub PAT
         comment = f"却下理由: GitHub PAT {_GITHUB_TOKEN} が混入していた"
         decided_at = datetime.now(UTC)
         audit_entry = make_audit_entry(
@@ -468,19 +475,19 @@ class TestThreeColumnSimultaneousMasking:
         persisted_feedback = await _read_persisted_feedback_text(session_factory, gate.id)
         persisted_comment = await _read_persisted_audit_comment(session_factory, gate.id)
 
-        # snapshot_body_markdown — Discord
+        # snapshot_body_markdown ── Discord
         assert _DISCORD_SENTINEL in persisted_snapshot, (
             "[FAIL] snapshot_body_markdown missing Discord sentinel in 3-column test."
         )
         assert _DISCORD_TOKEN not in persisted_snapshot
 
-        # feedback_text — Slack
+        # feedback_text ── Slack
         assert _SLACK_SENTINEL in persisted_feedback, (
             "[FAIL] feedback_text missing Slack sentinel in 3-column test."
         )
         assert _SLACK_TOKEN not in persisted_feedback
 
-        # audit comment — GitHub
+        # 監査コメント ── GitHub
         assert _GITHUB_SENTINEL in persisted_comment, (
             "[FAIL] audit_entries.comment missing GitHub PAT sentinel in 3-column test."
         )

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_external_review_gate_repository/test_masking_fields.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_external_review_gate_repository/test_masking_fields.py
@@ -475,13 +475,13 @@ class TestThreeColumnSimultaneousMasking:
         persisted_feedback = await _read_persisted_feedback_text(session_factory, gate.id)
         persisted_comment = await _read_persisted_audit_comment(session_factory, gate.id)
 
-        # snapshot_body_markdown ── Discord
+        # snapshot_body_markdown フィールドの Discord トークン検査
         assert _DISCORD_SENTINEL in persisted_snapshot, (
             "[FAIL] snapshot_body_markdown missing Discord sentinel in 3-column test."
         )
         assert _DISCORD_TOKEN not in persisted_snapshot
 
-        # feedback_text ── Slack
+        # feedback_text フィールドの Slack トークン検査
         assert _SLACK_SENTINEL in persisted_feedback, (
             "[FAIL] feedback_text missing Slack sentinel in 3-column test."
         )

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_external_review_gate_repository/test_protocol_crud.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_external_review_gate_repository/test_protocol_crud.py
@@ -383,13 +383,13 @@ class TestLifecycle:
         assert len(pending) == 1
         assert pending[0].id == gate1.id
 
-        # (3) find_by_task_id
+        # (3) find_by_task_id の検証
         async with session_factory() as session:
             by_task = await SqliteExternalReviewGateRepository(session).find_by_task_id(task_id)
         assert len(by_task) == 1
         assert by_task[0].id == gate1.id
 
-        # (4) find_by_id
+        # (4) find_by_id の検証
         async with session_factory() as session:
             single = await SqliteExternalReviewGateRepository(session).find_by_id(gate1.id)
         assert single is not None

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_external_review_gate_repository/test_protocol_crud.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_external_review_gate_repository/test_protocol_crud.py
@@ -1,18 +1,18 @@
-"""ExternalReviewGate Repository: Protocol surface + basic CRUD + Lifecycle.
+"""ExternalReviewGate Repository: Protocol サーフェス + 基本 CRUD + ライフサイクル。
 
 TC-UT-ERGR-001〜004/009 + TC-IT-ERGR-LIFECYCLE.
 
-RQ-ERGR-001 / RQ-ERGR-002 — 6-method Protocol (§確定 R1-A / §確定 R1-D) +
-CRUD (find_by_id / count / save / Tx boundary) + Lifecycle.
+RQ-ERGR-001 / RQ-ERGR-002 ── 6 メソッドの Protocol (§確定 R1-A / §確定 R1-D) +
+CRUD (find_by_id / count / save / Tx 境界) + ライフサイクル。
 
-save() 5-step child-table semantics (TC-UT-ERGR-005/005b/005c) live in
-``test_save_child_tables.py``.  find_pending_by_reviewer + find_by_task_id
-(TC-UT-ERGR-006/007) live in ``test_find_methods.py``.
-count_by_decision (TC-UT-ERGR-008) lives in ``test_count_by_decision.py``.
-masking (TC-IT-ERGR-020-masking-*) lives in ``test_masking_fields.py``.
+save() の 5 ステップ子テーブルセマンティクス (TC-UT-ERGR-005/005b/005c) は
+``test_save_child_tables.py`` に置く。find_pending_by_reviewer + find_by_task_id
+(TC-UT-ERGR-006/007) は ``test_find_methods.py`` に置く。
+count_by_decision (TC-UT-ERGR-008) は ``test_count_by_decision.py`` に置く。
+masking (TC-IT-ERGR-020-masking-*) は ``test_masking_fields.py`` に置く。
 
-Per ``docs/features/external-review-gate-repository/test-design.md``.
-Issue #36 — M2 0008.
+``docs/features/external-review-gate-repository/test-design.md`` 準拠。
+Issue #36 — M2 0008。
 """
 
 from __future__ import annotations
@@ -53,10 +53,10 @@ pytestmark = pytest.mark.asyncio
 # TC-UT-ERGR-001: Protocol definition + 6-method surface (§確定 R1-A / §確定 R1-D)
 # ---------------------------------------------------------------------------
 class TestExternalReviewGateRepositoryProtocol:
-    """TC-UT-ERGR-001: Protocol declares 6 async methods."""
+    """TC-UT-ERGR-001: Protocol が 6 つの async メソッドを宣言する。"""
 
     async def test_protocol_declares_six_async_methods(self) -> None:
-        """TC-UT-ERGR-001: ExternalReviewGateRepository has all 6 required methods."""
+        """TC-UT-ERGR-001: ExternalReviewGateRepository が必須 6 メソッドをすべて持つ。"""
         for method_name in (
             "find_by_id",
             "count",
@@ -71,9 +71,9 @@ class TestExternalReviewGateRepositoryProtocol:
             )
 
     async def test_protocol_does_not_have_yagni_methods(self) -> None:
-        """TC-UT-ERGR-001: YAGNI methods absent from Protocol.
+        """TC-UT-ERGR-001: YAGNI メソッドは Protocol に含まれない。
 
-        §確定 R1-D YAGNI 拒否済み: find_all_pending / find_by_id_all_including_decided.
+        §確定 R1-D で YAGNI 拒否済み: find_all_pending / find_by_id_all_including_decided。
         """
         for banned_method in ("find_all_pending", "find_by_id_all_including_decided"):
             assert not hasattr(ExternalReviewGateRepository, banned_method), (
@@ -85,7 +85,7 @@ class TestExternalReviewGateRepositoryProtocol:
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """TC-UT-ERGR-001: SqliteExternalReviewGateRepository satisfies Protocol."""
+        """TC-UT-ERGR-001: SqliteExternalReviewGateRepository が Protocol を満たす。"""
         async with session_factory() as session:
             repo: ExternalReviewGateRepository = SqliteExternalReviewGateRepository(session)
             for method_name in (
@@ -102,7 +102,7 @@ class TestExternalReviewGateRepositoryProtocol:
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """TC-UT-ERGR-001: duck-typing confirms all 6 methods present on impl."""
+        """TC-UT-ERGR-001: ダックタイピングで実装に 6 メソッドすべての存在を確認する。"""
         async with session_factory() as session:
             repo = SqliteExternalReviewGateRepository(session)
             for method_name in (
@@ -122,14 +122,14 @@ class TestExternalReviewGateRepositoryProtocol:
 # TC-UT-ERGR-002: find_by_id 存在 / 不在
 # ---------------------------------------------------------------------------
 class TestFindById:
-    """TC-UT-ERGR-002: find_by_id returns Gate or None correctly."""
+    """TC-UT-ERGR-002: find_by_id が Gate または None を正しく返す。"""
 
     async def test_find_by_id_returns_saved_gate(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_gate_context: tuple[UUID, UUID, UUID],
     ) -> None:
-        """TC-UT-ERGR-002: find_by_id returns the Gate after save."""
+        """TC-UT-ERGR-002: save 後に find_by_id が Gate を返す。"""
         task_id, stage_id, reviewer_id = seeded_gate_context
         gate = make_gate(task_id=task_id, stage_id=stage_id, reviewer_id=reviewer_id)
 
@@ -146,7 +146,7 @@ class TestFindById:
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """TC-UT-ERGR-002: find_by_id returns None for a non-existent id."""
+        """TC-UT-ERGR-002: 存在しない id に対し find_by_id は None を返す。"""
         async with session_factory() as session:
             result = await SqliteExternalReviewGateRepository(session).find_by_id(uuid4())
         assert result is None
@@ -156,14 +156,14 @@ class TestFindById:
 # TC-UT-ERGR-003: save → find_by_id round-trip 全属性 (§確定 R1-C)
 # ---------------------------------------------------------------------------
 class TestSaveRoundTrip:
-    """TC-UT-ERGR-003: Full attribute round-trip including child tables."""
+    """TC-UT-ERGR-003: 子テーブルを含む全属性のラウンドトリップ。"""
 
     async def test_roundtrip_all_scalar_fields(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_gate_context: tuple[UUID, UUID, UUID],
     ) -> None:
-        """TC-UT-ERGR-003: save + find_by_id restores all Gate scalar fields."""
+        """TC-UT-ERGR-003: save + find_by_id が Gate のスカラーフィールドを全て復元する。"""
         task_id, stage_id, reviewer_id = seeded_gate_context
         snapshot_stage_id = uuid4()
         committed_by = uuid4()
@@ -207,7 +207,7 @@ class TestSaveRoundTrip:
         session_factory: async_sessionmaker[AsyncSession],
         seeded_gate_context: tuple[UUID, UUID, UUID],
     ) -> None:
-        """TC-UT-ERGR-003: Attachment + AuditEntry child tables survive round-trip."""
+        """TC-UT-ERGR-003: Attachment + AuditEntry 子テーブルがラウンドトリップを生き残る。"""
         task_id, stage_id, reviewer_id = seeded_gate_context
         sha256 = "a" * 64
         attachment = Attachment(
@@ -244,14 +244,14 @@ class TestSaveRoundTrip:
 # TC-UT-ERGR-004: count() SQL COUNT(*) 契約
 # ---------------------------------------------------------------------------
 class TestCount:
-    """TC-UT-ERGR-004: count() issues SELECT COUNT(*) without full-row load."""
+    """TC-UT-ERGR-004: count() は全行ロード無しに SELECT COUNT(*) を発行する。"""
 
     async def test_count_returns_correct_total(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_gate_context: tuple[UUID, UUID, UUID],
     ) -> None:
-        """TC-UT-ERGR-004: count() returns the total number of gates."""
+        """TC-UT-ERGR-004: count() が gate の総数を返す。"""
         task_id, stage_id, reviewer_id = seeded_gate_context
         gate1 = make_gate(task_id=task_id, stage_id=stage_id, reviewer_id=reviewer_id)
         gate2 = make_gate(task_id=task_id, stage_id=stage_id, reviewer_id=reviewer_id)
@@ -294,7 +294,7 @@ class TestCount:
         assert any("COUNT" in s for s in sql_log), (
             f"[FAIL] count() did not issue COUNT(*) SQL.\nCaptured SQL: {sql_log}"
         )
-        # No SELECT * or full-row load
+        # SELECT * や全行ロードなし
         assert not any("SELECT external_review_gate" in s.lower() for s in sql_log), (
             f"[FAIL] count() triggered full-row load.\nCaptured SQL: {sql_log}"
         )
@@ -304,14 +304,14 @@ class TestCount:
 # TC-UT-ERGR-009: Tx 境界の責務分離 (empire §確定 B 踏襲)
 # ---------------------------------------------------------------------------
 class TestTransactionBoundary:
-    """TC-UT-ERGR-009: Repository never commits; caller-side UoW owns the boundary."""
+    """TC-UT-ERGR-009: Repository は commit しない。境界は呼び出し側 UoW が所有する。"""
 
     async def test_save_within_begin_is_committed(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_gate_context: tuple[UUID, UUID, UUID],
     ) -> None:
-        """TC-UT-ERGR-009: save inside session.begin() is visible across sessions."""
+        """TC-UT-ERGR-009: session.begin() 内の save は別 session からも見える。"""
         task_id, stage_id, reviewer_id = seeded_gate_context
         gate = make_gate(task_id=task_id, stage_id=stage_id, reviewer_id=reviewer_id)
 
@@ -328,14 +328,14 @@ class TestTransactionBoundary:
         session_factory: async_sessionmaker[AsyncSession],
         seeded_gate_context: tuple[UUID, UUID, UUID],
     ) -> None:
-        """TC-UT-ERGR-009: save without session.begin() → not persisted (no auto-commit)."""
+        """TC-UT-ERGR-009: session.begin() なしの save → 永続化されない（自動 commit なし）。"""
         task_id, stage_id, reviewer_id = seeded_gate_context
         gate = make_gate(task_id=task_id, stage_id=stage_id, reviewer_id=reviewer_id)
 
         async with session_factory() as session:
-            # No session.begin() — no explicit transaction context
+            # session.begin() なし ── 明示的なトランザクション文脈なし
             await SqliteExternalReviewGateRepository(session).save(gate)
-            # Session closed without commit
+            # Session は commit せずに閉じる
 
         async with session_factory() as session:
             restored = await SqliteExternalReviewGateRepository(session).find_by_id(gate.id)
@@ -349,7 +349,7 @@ class TestTransactionBoundary:
 # TC-IT-ERGR-LIFECYCLE: 6 method 全経路連携
 # ---------------------------------------------------------------------------
 class TestLifecycle:
-    """TC-IT-ERGR-LIFECYCLE: All 6 Protocol methods interact correctly end-to-end."""
+    """TC-IT-ERGR-LIFECYCLE: 6 つの Protocol メソッドすべてが end-to-end で正しく協調する。"""
 
     async def test_full_lifecycle_six_methods(
         self,
@@ -357,25 +357,25 @@ class TestLifecycle:
         seeded_gate_context: tuple[UUID, UUID, UUID],
     ) -> None:
         """TC-IT-ERGR-LIFECYCLE: save → find_pending → find_by_task_id → find_by_id
-        → count_by_decision → approve → re-save → verify counts updated."""
+        → count_by_decision → approve → 再 save → カウント更新の検証。"""
         from tests.infrastructure.persistence.sqlite.repositories.test_external_review_gate_repository.conftest import (  # noqa: E501
             seed_gate_context,
         )
 
         task_id, stage_id, reviewer_id = seeded_gate_context
-        # Second task for isolation
+        # 隔離のための 2 つ目の task
         task_id2, stage_id2, reviewer_id2 = await seed_gate_context(session_factory)
 
         gate1 = make_gate(task_id=task_id, stage_id=stage_id, reviewer_id=reviewer_id)
         gate2 = make_gate(task_id=task_id2, stage_id=stage_id2, reviewer_id=reviewer_id2)
 
-        # (1) save both gates
+        # (1) 両 gate を save
         async with session_factory() as session, session.begin():
             repo = SqliteExternalReviewGateRepository(session)
             await repo.save(gate1)
             await repo.save(gate2)
 
-        # (2) find_pending_by_reviewer: only gate1 for reviewer
+        # (2) find_pending_by_reviewer: reviewer に対しては gate1 のみ
         async with session_factory() as session:
             pending = await SqliteExternalReviewGateRepository(session).find_pending_by_reviewer(
                 reviewer_id
@@ -395,14 +395,14 @@ class TestLifecycle:
         assert single is not None
         assert single.id == gate1.id
 
-        # (5) count_by_decision: 2 PENDING total
+        # (5) count_by_decision: 全体で 2 件の PENDING
         async with session_factory() as session:
             pending_count = await SqliteExternalReviewGateRepository(session).count_by_decision(
                 ReviewDecision.PENDING
             )
         assert pending_count == 2
 
-        # (6) approve gate1 → re-save
+        # (6) gate1 を approve → 再 save
         approved_gate1 = make_approved_gate(
             gate_id=gate1.id,
             task_id=task_id,
@@ -413,7 +413,7 @@ class TestLifecycle:
         async with session_factory() as session, session.begin():
             await SqliteExternalReviewGateRepository(session).save(approved_gate1)
 
-        # (7) counts updated
+        # (7) カウントが更新されている
         async with session_factory() as session:
             repo = SqliteExternalReviewGateRepository(session)
             pending_count_after = await repo.count_by_decision(ReviewDecision.PENDING)

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_external_review_gate_repository/test_save_child_tables.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_external_review_gate_repository/test_save_child_tables.py
@@ -1,16 +1,16 @@
-"""ExternalReviewGate Repository: 5-step save() physical verification.
+"""ExternalReviewGate Repository: 5 ステップ save() 物理検証。
 
-TC-UT-ERGR-005 / 005b / 005c — §確定 R1-B save() 5段階の物理確認.
+TC-UT-ERGR-005 / 005b / 005c — §確定 R1-B save() 5 段階の物理確認。
 
-Tests that:
-* DELETE child tables (steps 1+2) prevent duplicate rows on re-save.
-* UPSERT gate (step 3) + INSERT attachments (step 4) + INSERT audit_entries (step 5).
-* UNIQUE(gate_id, sha256) constraint satisfied on every re-save cycle.
-* Empty gate upgraded to full gate (all 5 steps exercised).
+テスト対象:
+* DELETE child tables (steps 1+2) が re-save で重複行を防止。
+* UPSERT gate (step 3) + INSERT attachments (step 4) + INSERT audit_entries (step 5)。
+* UNIQUE(gate_id, sha256) 制約が re-save サイクル毎に満たされる。
+* Empty gate が full gate にアップグレード (すべての 5 ステップを実行)。
 
-Per ``docs/features/external-review-gate-repository/test-design.md``
-TC-UT-ERGR-005/005b/005c.
-Issue #36 — M2 0008.
+``docs/features/external-review-gate-repository/test-design.md``
+TC-UT-ERGR-005/005b/005c に従う。
+Issue #36 — M2 0008。
 """
 
 from __future__ import annotations
@@ -43,7 +43,7 @@ async def _count_attachments(
     session_factory: async_sessionmaker[AsyncSession],
     gate_id: UUID,
 ) -> int:
-    """Count external_review_gate_attachments rows for gate_id via raw SQL."""
+    """gate_id 用 external_review_gate_attachments 行をカウント (raw SQL)。"""
     async with session_factory() as session:
         row = (
             await session.execute(
@@ -60,7 +60,7 @@ async def _count_audit_entries(
     session_factory: async_sessionmaker[AsyncSession],
     gate_id: UUID,
 ) -> int:
-    """Count external_review_audit_entries rows for gate_id via raw SQL."""
+    """gate_id 用 external_review_audit_entries 行をカウント (raw SQL)。"""
     async with session_factory() as session:
         row = (
             await session.execute(
@@ -75,17 +75,17 @@ async def _count_audit_entries(
 # TC-UT-ERGR-005: audit_entries DELETE + re-INSERT on re-save
 # ---------------------------------------------------------------------------
 class TestSaveChildTableSemantics:
-    """TC-UT-ERGR-005: §確定 R1-B DELETE → UPSERT → INSERT 5-step order."""
+    """TC-UT-ERGR-005: §確定 R1-B DELETE → UPSERT → INSERT 5 ステップ順序。"""
 
     async def test_resave_updates_decision_and_replaces_audit_entries(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_gate_context: tuple[UUID, UUID, UUID],
     ) -> None:
-        """TC-UT-ERGR-005: re-save after approve replaces audit_entries (DELETE + re-INSERT)."""
+        """TC-UT-ERGR-005: approve 後 re-save が audit_entries を置換 (DELETE + re-INSERT)。"""
         task_id, stage_id, reviewer_id = seeded_gate_context
 
-        # First save: PENDING gate, no audit entries
+        # 最初の save: PENDING gate、audit entries なし
         gate = make_gate(task_id=task_id, stage_id=stage_id, reviewer_id=reviewer_id)
         async with session_factory() as session, session.begin():
             await SqliteExternalReviewGateRepository(session).save(gate)
@@ -93,7 +93,7 @@ class TestSaveChildTableSemantics:
         count_before = await _count_audit_entries(session_factory, gate.id)
         assert count_before == 0
 
-        # Re-save as APPROVED with 1 audit entry
+        # APPROVED で re-save (1 audit entry)
         decided_at = datetime.now(UTC)
         approved = make_approved_gate(
             gate_id=gate.id,
@@ -106,9 +106,9 @@ class TestSaveChildTableSemantics:
             await SqliteExternalReviewGateRepository(session).save(approved)
 
         count_after = await _count_audit_entries(session_factory, gate.id)
-        assert count_after == 1, f"[FAIL] expected 1 audit entry after re-save, got {count_after}"
+        assert count_after == 1, f"[FAIL] re-save 後 1 audit entry を期待、{count_after} 得た"
 
-        # Decision updated via UPSERT
+        # Decision が UPSERT で更新される
         async with session_factory() as session:
             restored = await SqliteExternalReviewGateRepository(session).find_by_id(gate.id)
 
@@ -122,7 +122,7 @@ class TestSaveChildTableSemantics:
         session_factory: async_sessionmaker[AsyncSession],
         seeded_gate_context: tuple[UUID, UUID, UUID],
     ) -> None:
-        """TC-UT-ERGR-005: UPSERT ensures only 1 row in external_review_gates per id."""
+        """TC-UT-ERGR-005: UPSERT が id ごとの external_review_gates の 1 行を保証。"""
         task_id, stage_id, reviewer_id = seeded_gate_context
         gate = make_gate(task_id=task_id, stage_id=stage_id, reviewer_id=reviewer_id)
 
@@ -139,7 +139,7 @@ class TestSaveChildTableSemantics:
                 )
             ).first()
         assert row is not None and row[0] == 1, (
-            f"[FAIL] UPSERT produced {row[0] if row else 'None'} rows, expected 1."
+            f"[FAIL] UPSERT が {row[0] if row else 'None'} 行を生成、1 を期待。"
         )
 
 
@@ -147,14 +147,15 @@ class TestSaveChildTableSemantics:
 # TC-UT-ERGR-005b: UNIQUE(gate_id, sha256) no duplicate on re-save
 # ---------------------------------------------------------------------------
 class TestAttachmentUniqueConstraintOnReSave:
-    """TC-UT-ERGR-005b: Step 1 DELETE prevents UNIQUE(gate_id, sha256) violation."""
+    """TC-UT-ERGR-005b: Step 1 DELETE が UNIQUE(gate_id, sha256) 違反を防ぐ。"""
 
     async def test_resave_with_same_attachments_no_unique_violation(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_gate_context: tuple[UUID, UUID, UUID],
     ) -> None:
-        """TC-UT-ERGR-005b: re-save with same sha256 attachment does not raise IntegrityError."""
+        """TC-UT-ERGR-005b: 同じ sha256 attachment での re-save が
+        IntegrityError を raise しない。"""
         task_id, stage_id, reviewer_id = seeded_gate_context
         sha256 = "b" * 64
         attachment = Attachment(
@@ -171,20 +172,20 @@ class TestAttachmentUniqueConstraintOnReSave:
             deliverable_snapshot=snapshot,
         )
 
-        # First save
+        # 最初の save
         async with session_factory() as session, session.begin():
             await SqliteExternalReviewGateRepository(session).save(gate)
         count_after_first = await _count_attachments(session_factory, gate.id)
         assert count_after_first == 1
 
-        # Re-save (step 1 DELETE + step 4 INSERT — must not fail)
+        # Re-save (step 1 DELETE + step 4 INSERT — 失敗してはならない)
         async with session_factory() as session, session.begin():
             await SqliteExternalReviewGateRepository(session).save(gate)
         count_after_second = await _count_attachments(session_factory, gate.id)
 
         assert count_after_second == 1, (
-            f"[FAIL] Expected 1 attachment after re-save, got {count_after_second}. "
-            f"Duplicate row created — step 1 DELETE not working."
+            f"[FAIL] re-save 後 1 attachment を期待、{count_after_second} 得た。 "
+            f"重複行が作成 — step 1 DELETE が動作していない。"
         )
 
     async def test_resave_with_two_attachments_count_is_correct(
@@ -192,7 +193,7 @@ class TestAttachmentUniqueConstraintOnReSave:
         session_factory: async_sessionmaker[AsyncSession],
         seeded_gate_context: tuple[UUID, UUID, UUID],
     ) -> None:
-        """TC-UT-ERGR-005b: re-save with 2 attachments yields exactly 2 rows."""
+        """TC-UT-ERGR-005b: 2 attachments での re-save がちょうど 2 行を返す。"""
         task_id, stage_id, reviewer_id = seeded_gate_context
         att1 = Attachment(
             sha256="c" * 64, filename="a.pdf", mime_type="application/pdf", size_bytes=100
@@ -214,31 +215,31 @@ class TestAttachmentUniqueConstraintOnReSave:
             await SqliteExternalReviewGateRepository(session).save(gate)
 
         count = await _count_attachments(session_factory, gate.id)
-        assert count == 2, f"[FAIL] Expected 2 attachments, got {count}."
+        assert count == 2, f"[FAIL] 2 attachments を期待、{count} 得た。"
 
 
 # ---------------------------------------------------------------------------
-# TC-UT-ERGR-005c: Empty gate → full gate update (all 5 steps)
+# TC-UT-ERGR-005c: Empty gate → full gate update (すべての 5 ステップ)
 # ---------------------------------------------------------------------------
 class TestEmptyToFullGateUpdate:
-    """TC-UT-ERGR-005c: Empty gate (no children) → gate with audit_trail (steps 3-5)."""
+    """TC-UT-ERGR-005c: Empty gate (no children) → gate with audit_trail (steps 3-5)。"""
 
     async def test_resave_empty_to_full_gate_all_child_tables(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_gate_context: tuple[UUID, UUID, UUID],
     ) -> None:
-        """TC-UT-ERGR-005c: Empty gate upgraded to APPROVED gate with audit entries."""
+        """TC-UT-ERGR-005c: Empty gate が audit entries を持つ APPROVED gate にアップグレード。"""
         task_id, stage_id, reviewer_id = seeded_gate_context
 
-        # Save empty gate (PENDING, no audit_trail)
+        # Empty gate save (PENDING, no audit_trail)
         gate = make_gate(task_id=task_id, stage_id=stage_id, reviewer_id=reviewer_id)
         async with session_factory() as session, session.begin():
             await SqliteExternalReviewGateRepository(session).save(gate)
 
         assert await _count_audit_entries(session_factory, gate.id) == 0
 
-        # Re-save as APPROVED with 1 entry
+        # APPROVED で re-save (1 entry)
         decided = datetime.now(UTC)
         audit_entry = make_audit_entry(action=AuditAction.APPROVED, occurred_at=decided)
         approved = make_approved_gate(

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_external_review_gate_repository/test_save_child_tables.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_external_review_gate_repository/test_save_child_tables.py
@@ -232,7 +232,7 @@ class TestEmptyToFullGateUpdate:
         """TC-UT-ERGR-005c: Empty gate が audit entries を持つ APPROVED gate にアップグレード。"""
         task_id, stage_id, reviewer_id = seeded_gate_context
 
-        # Empty gate save (PENDING, no audit_trail)
+        # 空 gate の保存（PENDING、audit_trail 空）
         gate = make_gate(task_id=task_id, stage_id=stage_id, reviewer_id=reviewer_id)
         async with session_factory() as session, session.begin():
             await SqliteExternalReviewGateRepository(session).save(gate)

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_room_repository/test_constraints_arch.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_room_repository/test_constraints_arch.py
@@ -201,7 +201,7 @@ class TestWorkflowFkRestrict:
         seeded_empire_id: UUID,
         seeded_workflow_id: UUID,
     ) -> None:
-        """DELETE workflow while room references it → IntegrityError."""
+        """Room が参照中に workflow を DELETE → IntegrityError。"""
         from sqlalchemy.exc import IntegrityError
 
         room_id = uuid4()
@@ -224,8 +224,8 @@ class TestWorkflowFkRestrict:
                 },
             )
 
-        # Now try to delete the workflow that the room references —
-        # RESTRICT must fire.
+        # 次に、room が参照している workflow を削除しようとする ──
+        # RESTRICT が発動しなければならない。
         with pytest.raises(IntegrityError):
             async with session_factory() as session, session.begin():
                 await session.execute(
@@ -238,11 +238,11 @@ class TestWorkflowFkRestrict:
 # TC-IT-RR-009 補強: room_members CASCADE DELETE (§確定 R1-C)
 # ---------------------------------------------------------------------------
 class TestRoomMembersCascadeOnRoomDelete:
-    """room_members rows are deleted when the parent Room is deleted.
+    """親 Room 削除時に room_members 行が削除される。
 
-    ``room_members.room_id REFERENCES rooms.id ON DELETE CASCADE`` —
-    deleting a Room row must cascade to its member rows. This prevents
-    orphan room_members rows from accumulating after Room deletion.
+    ``room_members.room_id REFERENCES rooms.id ON DELETE CASCADE`` ——
+    Room 行削除はメンバー行にカスケードする必須。Room 削除後に
+    孤立 room_members 行が蓄積することを防ぐ。
     """
 
     async def test_cascade_deletes_member_rows(
@@ -251,7 +251,7 @@ class TestRoomMembersCascadeOnRoomDelete:
         seeded_empire_id: UUID,
         seeded_workflow_id: UUID,
     ) -> None:
-        """DELETE rooms row cascades to all room_members rows for that room."""
+        """rooms 行削除時に該当 room_members 行すべてにカスケードする。"""
         from datetime import UTC, datetime
 
         room_id = uuid4()
@@ -311,16 +311,16 @@ class TestRoomMembersCascadeOnRoomDelete:
 # TC-IT-RR-013-arch: Layer 2 arch-test reference — Room rows registered
 # ---------------------------------------------------------------------------
 class TestArchTestRegistrationStructure:
-    """TC-IT-RR-013-arch: ``test_masking_columns.py`` parametrize lists include Room.
+    """TC-IT-RR-013-arch: ``test_masking_columns.py`` parametrize リストが Room を含む。
 
-    Cross-checks that the CI Layer 2 arch test was extended to cover
-    Room tables (§確定 R1-E). A future PR that drops these registrations
-    (e.g. by accident during a refactor) would let an over-masking
-    or under-masking change land silently — this test catches it.
+    CI レイヤー2 アーキテクチャテストが Room テーブルをカバーするよう
+    拡張されたことを交差検証（§確定 R1-E）。将来の PR が
+    これらの登録を削除した場合（例：リファクタリング中の誤削除）、
+    過剰/過少 masking 変更がサイレントに落ちるが、本テストが検出。
     """
 
     async def test_rooms_prompt_kit_prefix_markdown_in_masking_contract(self) -> None:
-        """``rooms.prompt_kit_prefix_markdown`` is registered as MaskedText."""
+        """``rooms.prompt_kit_prefix_markdown`` は MaskedText で登録される。"""
         from bakufu.infrastructure.persistence.sqlite.base import MaskedText
 
         from tests.architecture.test_masking_columns import (
@@ -334,7 +334,7 @@ class TestArchTestRegistrationStructure:
         )
 
     async def test_room_members_in_no_mask_list(self) -> None:
-        """``room_members`` is a no-mask table (agent_id is not secret)."""
+        """``room_members`` は no-mask テーブル（agent_id は secret ではない）。"""
         from tests.architecture.test_masking_columns import (
             _NO_MASK_TABLES,  # pyright: ignore[reportPrivateUsage]
         )
@@ -345,7 +345,7 @@ class TestArchTestRegistrationStructure:
         )
 
     async def test_rooms_partial_mask_template_registered(self) -> None:
-        """``rooms`` is registered in the partial-mask template list."""
+        """``rooms`` は partial-mask テンプレートリストに登録される。"""
         from tests.architecture.test_masking_columns import (
             _PARTIAL_MASK_TABLES,  # pyright: ignore[reportPrivateUsage]
         )

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_room_repository/test_constraints_arch.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_room_repository/test_constraints_arch.py
@@ -288,7 +288,7 @@ class TestRoomMembersCascadeOnRoomDelete:
                 },
             )
 
-        # Delete the parent room — member rows must cascade.
+        # 親 room を削除 — member 行が CASCADE で削除されるはず。
         async with session_factory() as session, session.begin():
             await session.execute(
                 text("DELETE FROM rooms WHERE id = :id"),

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_room_repository/test_constraints_arch.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_room_repository/test_constraints_arch.py
@@ -1,27 +1,25 @@
-"""Room Repository: DB constraints + arch-test reference.
+"""Room Repository: DB制約 + アーキテクチャテスト参照。
 
-TC-IT-RR-009 / TC-IT-RR-013-arch — the **UNIQUE(room_id, agent_id, role)
-二重防衛** (§確定 R1-D) and the CI Layer 2 arch-test cross-reference.
+TC-IT-RR-009 / TC-IT-RR-013-arch — **UNIQUE(room_id, agent_id, role)
+二重防衛** (§確定 R1-D) と CI レイヤー2 アーキテクチャテスト相互参照。
 
-§確定 R1-D: duplicate (room_id, agent_id, role) triplets are forbidden
-by **two layers**:
+§確定 R1-D: 重複 (room_id, agent_id, role) トリプレットは **2つのレイヤー** で禁止:
 
-1. **Aggregate-level**: Room construction validates member uniqueness at
-   construction time.
-2. **DB-level**: explicit ``UniqueConstraint("room_id", "agent_id", "role",
-   name="uq_room_members_triplet")`` physically rejects the INSERT — the
-   final defense line for code paths that bypass the Aggregate (raw SQL,
-   future Repository implementations, dump/restore migrations, etc.).
+1. **Aggregate レベル**: Room 構築時にメンバー一意性を検証。
+2. **DB レベル**: 明示的 ``UniqueConstraint("room_id", "agent_id", "role",
+   name="uq_room_members_triplet")`` が INSERT を物理的に拒否 —
+   Aggregate をバイパスするコードパス（生 SQL、将来の Repository 実装、
+   ダンプ/リストア移行など）の最終防衛線。
 
-This test exercises **layer 2 in isolation** by writing raw SQL that
-sidesteps the Aggregate. A regression that drops the UniqueConstraint
-DDL would let the second INSERT succeed silently.
+このテストは Aggregate を迂回する生 SQL を書いて **レイヤー2を単独で** 実行。
+UniqueConstraint DDL をドロップするリグレッションは 2 番目の INSERT を
+サイレントに成功させてしまう。
 
-Also tests:
-* ``rooms.workflow_id FK RESTRICT``: DELETE a workflow while a room
-  references it must raise ``IntegrityError`` (§確定 R1-I).
-* ``room_members.room_id FK CASCADE``: DELETE a room cascades to
-  room_members rows (§確定 R1-C Room entity cascade).
+また以下もテスト:
+* ``rooms.workflow_id FK RESTRICT``: Workflow を削除するもルームがそれを
+  参照 → ``IntegrityError`` を発生させる必要 (§確定 R1-I)。
+* ``room_members.room_id FK CASCADE``: ルームを削除するとカスケードして
+  room_members 行に伝播 (§確定 R1-C Room エンティティカスケード)。
 """
 
 from __future__ import annotations
@@ -42,12 +40,11 @@ pytestmark = pytest.mark.asyncio
 # TC-IT-RR-009: UNIQUE(room_id, agent_id, role) 二重防衛 (§確定 R1-D)
 # ---------------------------------------------------------------------------
 class TestUniqueRoomMemberTripletDoubleDefense:
-    """TC-IT-RR-009: duplicate (room_id, agent_id, role) raises IntegrityError.
+    """TC-IT-RR-009: 重複 (room_id, agent_id, role) は IntegrityError を発生させる。
 
-    The Aggregate's member validation is the first layer; this test
-    bypasses it by writing raw SQL directly so the DB constraint is the
-    only thing standing between us and a silent duplicate. The first
-    INSERT must succeed; the second must raise ``IntegrityError``.
+    Aggregate のメンバー検証が第1層；このテストは生 SQL を直接書いて
+    バイパスするため DB制約が唯一つのサイレント重複を防ぐもの。
+    最初の INSERT は成功する必要；2番目は ``IntegrityError`` を発生させる必要。
     """
 
     async def test_duplicate_triplet_raises_integrity_error(
@@ -56,7 +53,7 @@ class TestUniqueRoomMemberTripletDoubleDefense:
         seeded_empire_id: UUID,
         seeded_workflow_id: UUID,
     ) -> None:
-        """TC-IT-RR-009: same (room_id, agent_id, role) inserted twice → IntegrityError."""
+        """TC-IT-RR-009: 同じ (room_id, agent_id, role) を2回 INSERT → IntegrityError。"""
         from datetime import UTC, datetime
 
         from sqlalchemy.exc import IntegrityError
@@ -66,7 +63,7 @@ class TestUniqueRoomMemberTripletDoubleDefense:
         empire_id = seeded_empire_id
         workflow_id = seeded_workflow_id
 
-        # Seed the rooms row first so room_members FK resolves.
+        # room_members FK が解決するよう、最初に rooms 行をシード。
         async with session_factory() as session, session.begin():
             await session.execute(
                 text(
@@ -89,7 +86,7 @@ class TestUniqueRoomMemberTripletDoubleDefense:
 
         joined_at = datetime.now(UTC).isoformat()
 
-        # First member INSERT — must succeed.
+        # 最初のメンバー INSERT — 成功する必要。
         async with session_factory() as session, session.begin():
             await session.execute(
                 text(
@@ -104,8 +101,8 @@ class TestUniqueRoomMemberTripletDoubleDefense:
                 },
             )
 
-        # Second INSERT with the same (room_id, agent_id, role) triplet —
-        # the uq_room_members_triplet constraint must reject it.
+        # 同じ (room_id, agent_id, role) トリプレットでの 2 番目 INSERT —
+        # uq_room_members_triplet 制約が拒否する必要。
         with pytest.raises(IntegrityError):
             async with session_factory() as session, session.begin():
                 await session.execute(
@@ -116,7 +113,7 @@ class TestUniqueRoomMemberTripletDoubleDefense:
                     {
                         "room_id": room_id.hex,
                         "agent_id": agent_id.hex,
-                        "role": "LEADER",  # same role → same triplet
+                        "role": "LEADER",  # 同じロール → 同じトリプレット
                         "joined_at": joined_at,
                     },
                 )
@@ -127,11 +124,11 @@ class TestUniqueRoomMemberTripletDoubleDefense:
         seeded_empire_id: UUID,
         seeded_workflow_id: UUID,
     ) -> None:
-        """Same (room_id, agent_id) with different roles must NOT raise.
+        """同じ (room_id, agent_id) で異なるロールは例外を発生させる必要なし。
 
-        Confirms the uniqueness is scoped to the **triplet** — different
-        roles on the same (room_id, agent_id) represent distinct membership
-        records (e.g. an agent who is both DEVELOPER and REVIEWER).
+        一意性は **トリプレット** にスコープされることを確認 —
+        同じ (room_id, agent_id) の異なるロールは異なるメンバーシップ
+        レコードを表す（例：DEVELOPER と REVIEWER の両方であるエージェント）。
         """
         from datetime import UTC, datetime
 
@@ -173,7 +170,7 @@ class TestUniqueRoomMemberTripletDoubleDefense:
                     },
                 )
 
-        # Both rows present; triplet uniqueness did not fire.
+        # 両方の行が存在; トリプレット一意性は発動しなかった。
         async with session_factory() as session:
             result = await session.execute(
                 text("SELECT COUNT(*) FROM room_members WHERE room_id = :room_id"),
@@ -187,15 +184,15 @@ class TestUniqueRoomMemberTripletDoubleDefense:
 # TC-IT-RR-009 補強: workflow_id FK RESTRICT (§確定 R1-I)
 # ---------------------------------------------------------------------------
 class TestWorkflowFkRestrict:
-    """``rooms.workflow_id`` FK RESTRICT prevents orphan Rooms on Workflow delete.
+    """``rooms.workflow_id`` FK RESTRICT は Workflow 削除時の孤立 Room を防ぐ。
 
-    §確定 R1-I: Workflow is a *reference* target for Room, not an owner.
-    Deleting a Workflow while Rooms still reference it is a hard failure
-    at the DB level — the application layer check alone would be
-    insufficient for raw-SQL paths.
+    §確定 R1-I: Workflow は Room の*参照*ターゲット、所有者ではない。
+    Workflow が削除される一方でルームがそれをまだ参照することは
+    DB レベルのハード失敗 — アプリケーションレイヤーのチェックのみでは
+    生 SQL パスに対して不十分。
 
-    Note: SQLite FK enforcement requires ``PRAGMA foreign_keys = ON``,
-    which the production engine enables at connect time.
+    注: SQLite FK の強制実行は ``PRAGMA foreign_keys = ON`` を要求し、
+    本番エンジンは接続時に有効化。
     """
 
     async def test_delete_referenced_workflow_raises_integrity_error(

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_room_repository/test_masking_prompt_kit.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_room_repository/test_masking_prompt_kit.py
@@ -1,27 +1,27 @@
-"""Room Repository: §確定 R1-J — MaskedText wiring on rooms.prompt_kit_prefix_markdown.
+"""Room Repository: §確定 R1-J ── rooms.prompt_kit_prefix_markdown への MaskedText 配線.
 
-**Schneier 申し送り #3 实適用の物理保証 (Room 適用)**. This module is the core
-masking test file for PR #33 — the MaskedText TypeDecorator on
-``rooms.prompt_kit_prefix_markdown`` is exercised end-to-end against a real
-SQLite DB, against 7 secret-bearing prompt-prefix shapes:
+**Schneier 申し送り #3 実適用の物理保証 (Room 適用)**.
+本モジュールは PR #33 の masking テスト中核 ──
+``rooms.prompt_kit_prefix_markdown`` 上の MaskedText TypeDecorator を
+実 SQLite DB に対して端から端まで動かし、secret を含む 7 種類の
+prompt prefix 形に対して検証する:
 
-1. **discord** — Discord Bot Token in webhook URL context →
-   ``<REDACTED:DISCORD_TOKEN>`` (primary case from test instruction,
-   §確定 R1-J 不可逆性).
-2. **anthropic** — ``ANTHROPIC_API_KEY=sk-ant-api03-XXX...`` →
-   ``<REDACTED:ANTHROPIC_KEY>``.
-3. **github** — ``ghp_XXX...`` → ``<REDACTED:GITHUB_PAT>``.
-4. **bearer** — ``Authorization: Bearer XXX`` → ``<REDACTED:BEARER>``.
-5. **no-secret** — plain prefix → unchanged (passthrough).
-6. **roundtrip** — §確定 R1-J §不可逆性: ``find_by_id`` returns the masked
-   form (raw token unrecoverable from DB).
-7. **multiple** — 3+ secret types in one prefix → all redacted.
+1. **discord** ── webhook URL 文脈中の Discord Bot Token →
+   ``<REDACTED:DISCORD_TOKEN>`` (テスト指示の主要ケース、§確定 R1-J 不可逆性)。
+2. **anthropic** ── ``ANTHROPIC_API_KEY=sk-ant-api03-XXX...`` →
+   ``<REDACTED:ANTHROPIC_KEY>``。
+3. **github** ── ``ghp_XXX...`` → ``<REDACTED:GITHUB_PAT>``。
+4. **bearer** ── ``Authorization: Bearer XXX`` → ``<REDACTED:BEARER>``。
+5. **no-secret** ── 平文 prefix → 変更なし (passthrough)。
+6. **roundtrip** ── §確定 R1-J §不可逆性: ``find_by_id`` は masking 済み形を
+   返す (生トークンは DB から復元不能)。
+7. **multiple** ── 1 つの prefix に 3 種以上の secret → 全て redact される。
 
-Each verification reads ``rooms.prompt_kit_prefix_markdown`` via **raw SQL
-SELECT** so we observe the literal bytes that hit the disk (bypassing
-``MaskedText.process_result_value`` on the read side).
+各検証は ``rooms.prompt_kit_prefix_markdown`` を **raw SQL SELECT** で
+読む ── ディスクに書き込まれた実バイトを観察するため (読み取り側で
+``MaskedText.process_result_value`` を迂回)。
 
-Per ``docs/features/room-repository/test-design.md`` TC-IT-RR-008-masking-*.
+``docs/features/room-repository/test-design.md`` TC-IT-RR-008-masking-* 準拠。
 """
 
 from __future__ import annotations
@@ -44,26 +44,25 @@ if TYPE_CHECKING:
 pytestmark = pytest.mark.asyncio
 
 
-# Real-shape (synthetic) secret tokens. Pattern lengths must match
-# the masking gateway's regex (masking.py _REGEX_PATTERNS) so the
-# token is actually redacted.
+# 実形 (合成) の secret トークン。パターン長は masking ゲートウェイの正規表現
+# (masking.py _REGEX_PATTERNS) に一致させなければ redact されない。
 
-# Discord Bot Token — matches [MN][A-Za-z\d]{23,}\.[\w-]{6}\.[\w-]{27,}
-# Used in a webhook URL context per test instruction.
-# Constructed via concatenation (same pattern as _ANTHROPIC_TOKEN) to prevent
-# GitHub push-protection false positives on a clearly synthetic test fixture.
+# Discord Bot Token ── [MN][A-Za-z\d]{23,}\.[\w-]{6}\.[\w-]{27,} に一致。
+# テスト指示に従い webhook URL 文脈で使用。
+# 明らかに合成テストフィクスチャに対する GitHub push-protection の誤検知を
+# 避けるため、_ANTHROPIC_TOKEN と同じく連結で構築する。
 _DISCORD_TOKEN = "MTk4NjIyNDgz" + "NDcxOTI1MjQ4.ClFDg_." + "A" * 27
 
-# Anthropic API key — matches sk-ant-(?:api03-)?[A-Za-z0-9_\-]{40,}
+# Anthropic API キー ── sk-ant-(?:api03-)?[A-Za-z0-9_\-]{40,} に一致。
 _ANTHROPIC_TOKEN = "sk-ant-api03-" + "A" * 60
 
-# GitHub PAT — matches (?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36,}
+# GitHub PAT ── (?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36,} に一致。
 _GITHUB_TOKEN = "ghp_" + "X" * 40
 
-# Bearer token — matches Authorization: Bearer <token>
+# Bearer トークン ── Authorization: Bearer <token> に一致。
 _BEARER_TOKEN = "eyJhbGciOi.tokenpart.signature"
 
-# Redaction sentinels (masking.py _REGEX_PATTERNS).
+# redaction sentinel (masking.py _REGEX_PATTERNS)。
 _DISCORD_SENTINEL = "<REDACTED:DISCORD_TOKEN>"
 _ANTHROPIC_SENTINEL = "<REDACTED:ANTHROPIC_KEY>"
 _GITHUB_SENTINEL = "<REDACTED:GITHUB_PAT>"
@@ -74,11 +73,11 @@ async def _read_persisted_prefix(
     session_factory: async_sessionmaker[AsyncSession],
     room_id: UUID,
 ) -> str:
-    """Raw-SQL SELECT to fetch ``rooms.prompt_kit_prefix_markdown`` literal bytes.
+    """``rooms.prompt_kit_prefix_markdown`` の実バイトを raw-SQL SELECT で取得する。
 
-    Bypasses ``MaskedText.process_result_value`` so we observe the value
-    that is physically stored on disk. Uses ``.hex`` for the UUID parameter
-    to match ``UUIDStr`` TypeDecorator storage format.
+    ``MaskedText.process_result_value`` を迂回して、ディスクに物理的に
+    保存された値を観察する。``UUIDStr`` TypeDecorator の保存形式と
+    合わせるため、UUID パラメータは ``.hex`` を使う。
     """
     async with session_factory() as session:
         stmt = text("SELECT prompt_kit_prefix_markdown FROM rooms WHERE id = :id")
@@ -94,7 +93,7 @@ def _make_room_with_prefix(
     *,
     workflow_id: UUID,
 ) -> Room:
-    """Build a Room whose PromptKit carries ``prefix_markdown``."""
+    """``prefix_markdown`` を持つ PromptKit を備えた Room を構築する。"""
     return make_room(
         workflow_id=workflow_id,
         prompt_kit=make_prompt_kit(prefix_markdown=prefix_markdown),
@@ -105,14 +104,14 @@ def _make_room_with_prefix(
 # TC-IT-RR-008-masking-discord (primary case, §確定 R1-J)
 # ---------------------------------------------------------------------------
 class TestDiscordTokenMasked:
-    """TC-IT-RR-008-masking-discord: Discord Bot Token in webhook URL redacted.
+    """TC-IT-RR-008-masking-discord: webhook URL 中の Discord Bot Token が redact される。
 
-    This is the **primary case** from the test instruction:
+    テスト指示の **主要ケース**:
     ``prompt_kit_prefix_markdownにDiscord webhook URLを渡した時DB上で
     <REDACTED:DISCORD_TOKEN>になること(不可逆性確認)``.
 
-    A prompt-kit prefix that contains a Discord Bot Token embedded in a
-    webhook URL must be masked before it hits SQLite disk.
+    webhook URL に埋め込まれた Discord Bot Token を含む prompt kit prefix は、
+    SQLite ディスクに到達する前に masking されねばならない。
     """
 
     async def test_discord_token_in_webhook_url_redacted(
@@ -121,7 +120,7 @@ class TestDiscordTokenMasked:
         seeded_empire_id: UUID,
         seeded_workflow_id: UUID,
     ) -> None:
-        """Raw-SQL SELECT shows ``<REDACTED:DISCORD_TOKEN>``; raw token absent."""
+        """Raw-SQL SELECT が ``<REDACTED:DISCORD_TOKEN>`` を返し、生トークンは残らない。"""
         prefix = (
             f"通知先: https://discord.com/api/webhooks/123456789012345678/{_DISCORD_TOKEN}\n"
             f"このURLを使ってワークフロー完了を通知する。"
@@ -147,7 +146,7 @@ class TestDiscordTokenMasked:
 # TC-IT-RR-008-masking-anthropic
 # ---------------------------------------------------------------------------
 class TestAnthropicKeyMasked:
-    """TC-IT-RR-008-masking-anthropic: Anthropic API key redacted on save."""
+    """TC-IT-RR-008-masking-anthropic: save 時に Anthropic API キーが redact される。"""
 
     async def test_anthropic_key_redacted_in_persisted_prefix(
         self,
@@ -155,7 +154,7 @@ class TestAnthropicKeyMasked:
         seeded_empire_id: UUID,
         seeded_workflow_id: UUID,
     ) -> None:
-        """Raw-SQL SELECT shows ``<REDACTED:ANTHROPIC_KEY>``; raw token absent."""
+        """Raw-SQL SELECT が ``<REDACTED:ANTHROPIC_KEY>`` を返し、生トークンは残らない。"""
         prefix = f"ANTHROPIC_API_KEY={_ANTHROPIC_TOKEN} を使ってClaude APIを呼ぶこと。"
         room = _make_room_with_prefix(prefix, workflow_id=seeded_workflow_id)
         async with session_factory() as session, session.begin():
@@ -177,7 +176,7 @@ class TestAnthropicKeyMasked:
 # TC-IT-RR-008-masking-github
 # ---------------------------------------------------------------------------
 class TestGitHubPatMasked:
-    """TC-IT-RR-008-masking-github: GitHub PAT redacted on save."""
+    """TC-IT-RR-008-masking-github: save 時に GitHub PAT が redact される。"""
 
     async def test_github_pat_redacted_in_persisted_prefix(
         self,
@@ -185,7 +184,7 @@ class TestGitHubPatMasked:
         seeded_empire_id: UUID,
         seeded_workflow_id: UUID,
     ) -> None:
-        """Raw-SQL SELECT shows ``<REDACTED:GITHUB_PAT>``; raw PAT absent."""
+        """Raw-SQL SELECT が ``<REDACTED:GITHUB_PAT>`` を返し、生 PAT は残らない。"""
         prefix = f"git push には {_GITHUB_TOKEN} を使うこと。"
         room = _make_room_with_prefix(prefix, workflow_id=seeded_workflow_id)
         async with session_factory() as session, session.begin():
@@ -207,7 +206,7 @@ class TestGitHubPatMasked:
 # TC-IT-RR-008-masking-bearer
 # ---------------------------------------------------------------------------
 class TestBearerTokenMasked:
-    """TC-IT-RR-008-masking-bearer: Authorization: Bearer XXX redacted."""
+    """TC-IT-RR-008-masking-bearer: Authorization: Bearer XXX が redact される。"""
 
     async def test_bearer_token_redacted_in_persisted_prefix(
         self,
@@ -215,7 +214,7 @@ class TestBearerTokenMasked:
         seeded_empire_id: UUID,
         seeded_workflow_id: UUID,
     ) -> None:
-        """Raw-SQL SELECT shows ``<REDACTED:BEARER>``; raw token absent."""
+        """Raw-SQL SELECT が ``<REDACTED:BEARER>`` を返し、生トークンは残らない。"""
         prefix = f"APIコール時は ``Authorization: Bearer {_BEARER_TOKEN}`` を使うこと。"
         room = _make_room_with_prefix(prefix, workflow_id=seeded_workflow_id)
         async with session_factory() as session, session.begin():
@@ -237,7 +236,7 @@ class TestBearerTokenMasked:
 # TC-IT-RR-008-masking-no-secret (passthrough)
 # ---------------------------------------------------------------------------
 class TestNoSecretPassthrough:
-    """TC-IT-RR-008-masking-no-secret: plain prefix is stored unchanged."""
+    """TC-IT-RR-008-masking-no-secret: 平文 prefix は変更なしで保存される。"""
 
     async def test_plain_prefix_is_passthrough(
         self,
@@ -245,11 +244,10 @@ class TestNoSecretPassthrough:
         seeded_empire_id: UUID,
         seeded_workflow_id: UUID,
     ) -> None:
-        """A prefix with no Schneier-#6 secrets is persisted byte-identical.
+        """Schneier #6 secret を含まない prefix はバイト等価で保存される。
 
-        Confirms masking is **scoped** — only known secret patterns
-        get redacted; the masking gateway is not over-aggressive on
-        plain text.
+        masking が **適用範囲限定** であることを確認 ── 既知の secret
+        パターンのみ redact され、平文に対して過敏に反応しない。
         """
         plain = (
             "あなたはコードレビューを担当する開発者です。"
@@ -271,16 +269,15 @@ class TestNoSecretPassthrough:
 # TC-IT-RR-008-masking-roundtrip (§確定 R1-J §不可逆性)
 # ---------------------------------------------------------------------------
 class TestRoundTripIsIrreversible:
-    """TC-IT-RR-008-masking-roundtrip: §確定 R1-J §不可逆性 — find_by_id returns masked.
+    """TC-IT-RR-008-masking-roundtrip: §確定 R1-J §不可逆性 ── find_by_id は masking 形を返す。
 
-    Once a Discord Bot Token is masked at save time, the raw token is
-    **physically unrecoverable** from the DB. ``find_by_id`` must
-    therefore return a Room whose ``prompt_kit.prefix_markdown`` carries
-    the redaction sentinel rather than the original token.
+    save 時に一度 Discord Bot Token が masking されると、生トークンは
+    DB から **物理的に復元不能** となる。``find_by_id`` は
+    ``prompt_kit.prefix_markdown`` に元トークンではなく redaction sentinel
+    を含む Room を返さねばならない。
 
-    This is the primary irreversibility test specifically requested in
-    the task instruction: "Discord webhook URLを渡した時DB上でになること
-    (不可逆性確認)".
+    タスク指示に明示要求された主要 irreversibility テスト:
+    「Discord webhook URLを渡した時DB上でになること(不可逆性確認)」。
     """
 
     async def test_find_by_id_returns_masked_prefix_markdown(
@@ -289,7 +286,7 @@ class TestRoundTripIsIrreversible:
         seeded_empire_id: UUID,
         seeded_workflow_id: UUID,
     ) -> None:
-        """Save raw Discord webhook URL → find_by_id → prefix == masked form."""
+        """生 Discord webhook URL を保存 → find_by_id → prefix が masking 形。"""
         raw_prefix = f"Notify via https://discord.com/api/webhooks/12345/{_DISCORD_TOKEN}"
         room = _make_room_with_prefix(raw_prefix, workflow_id=seeded_workflow_id)
         async with session_factory() as session, session.begin():
@@ -307,7 +304,7 @@ class TestRoundTripIsIrreversible:
             f"[FAIL] §確定 R1-J §不可逆性 violated: raw Discord token recovered after "
             f"round-trip.\nRestored: {restored.prompt_kit.prefix_markdown!r}"
         )
-        # The round-tripped Room must NOT equal the original (masking changed the value).
+        # ラウンドトリップ済み Room は元と等価であってはならない (masking が値を変更している)。
         assert restored != room, (
             "[FAIL] round-trip equality should not hold for masked prompts; "
             "if this passes, masking might be a no-op."
@@ -318,7 +315,7 @@ class TestRoundTripIsIrreversible:
 # TC-IT-RR-008-masking-multiple
 # ---------------------------------------------------------------------------
 class TestMultipleSecretsAllRedacted:
-    """TC-IT-RR-008-masking-multiple: 3+ secret types in one prefix all redacted."""
+    """TC-IT-RR-008-masking-multiple: 1 つの prefix に 3 種以上の secret → 全て redact。"""
 
     async def test_multiple_secrets_all_redacted_in_one_pass(
         self,
@@ -326,11 +323,11 @@ class TestMultipleSecretsAllRedacted:
         seeded_empire_id: UUID,
         seeded_workflow_id: UUID,
     ) -> None:
-        """A prefix with discord + anthropic + github all gets fully redacted.
+        """discord + anthropic + github を含む prefix は全て完全に redact される。
 
-        Confirms masking is **comprehensive** — applying one redaction
-        does not short-circuit the others. The gateway iterates all
-        regex patterns; this test pins that behaviour.
+        masking が **網羅的** であることを確認 ── 1 つの redaction が
+        他を短絡しない。ゲートウェイは全正規表現パターンを反復する ──
+        本テストでその挙動を固定する。
         """
         prefix = (
             f"複数シークレットを含むプレフィックス:\n"
@@ -344,7 +341,7 @@ class TestMultipleSecretsAllRedacted:
 
         persisted = await _read_persisted_prefix(session_factory, room.id)
 
-        # All 3 sentinels present.
+        # 3 つの sentinel が全て存在する。
         assert _DISCORD_SENTINEL in persisted, (
             f"[FAIL] Discord sentinel missing in multi-secret prefix. Persisted: {persisted!r}"
         )
@@ -354,7 +351,7 @@ class TestMultipleSecretsAllRedacted:
         assert _GITHUB_SENTINEL in persisted, (
             f"[FAIL] GitHub sentinel missing in multi-secret prefix. Persisted: {persisted!r}"
         )
-        # All 3 raw tokens absent.
+        # 3 つの生トークンは全て消えている。
         assert _DISCORD_TOKEN not in persisted, (
             f"[FAIL] Discord token survived multi-secret masking. Persisted: {persisted!r}"
         )

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_room_repository/test_protocol_crud.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_room_repository/test_protocol_crud.py
@@ -1,10 +1,10 @@
-"""Room Repository: Protocol surface + basic CRUD coverage.
+"""Room Repository: Protocol サーフェス + 基本 CRUD カバレッジ。
 
-TC-UT-RR-001 / 004 / 005 / 006 — the entry-point behaviors plus the
-**4-method Protocol surface** (``find_by_id`` / ``count`` / ``save`` /
-``find_by_name``, §確定 R1-A + R1-F).
+TC-UT-RR-001 / 004 / 005 / 006 ── エントリポイント挙動と
+**4 メソッドの Protocol サーフェス** (``find_by_id`` / ``count`` / ``save`` /
+``find_by_name``、§確定 R1-A + R1-F)。
 
-Per ``docs/features/room-repository/test-design.md``.
+``docs/features/room-repository/test-design.md`` 準拠。
 """
 
 from __future__ import annotations
@@ -35,10 +35,10 @@ pytestmark = pytest.mark.asyncio
 # REQ-RR-001: Protocol definition + 4-method surface (§確定 R1-A)
 # ---------------------------------------------------------------------------
 class TestRoomRepositoryProtocol:
-    """TC-UT-RR-001: Protocol declares 4 async methods."""
+    """TC-UT-RR-001: Protocol が 4 つの async メソッドを宣言する。"""
 
     async def test_protocol_declares_four_async_methods(self) -> None:
-        """TC-UT-RR-001: ``RoomRepository`` has find_by_id / count / save / find_by_name."""
+        """TC-UT-RR-001: ``RoomRepository`` が find_by_id / count / save / find_by_name を持つ。"""
         assert hasattr(RoomRepository, "find_by_id")
         assert hasattr(RoomRepository, "count")
         assert hasattr(RoomRepository, "save")
@@ -48,11 +48,10 @@ class TestRoomRepositoryProtocol:
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """TC-UT-RR-001: ``SqliteRoomRepository`` is assignable to ``RoomRepository``.
+        """TC-UT-RR-001: ``SqliteRoomRepository`` を ``RoomRepository`` に代入できる。
 
-        The variable annotation acts as a static-type assertion; pyright
-        strict will reject the assignment if any of the 4 Protocol
-        methods is missing or has a wrong signature.
+        変数アノテーションが静的型アサーションとして機能する。pyright strict は、
+        Protocol メソッドが欠落または誤シグネチャの場合に代入を拒否する。
         """
         async with session_factory() as session:
             repo: RoomRepository = SqliteRoomRepository(session)
@@ -62,11 +61,11 @@ class TestRoomRepositoryProtocol:
             assert hasattr(repo, "find_by_name")
 
     async def test_protocol_does_not_expose_count_by_empire(self) -> None:
-        """TC-UT-RR-001: ``count_by_empire`` is NOT part of the Protocol (YAGNI).
+        """TC-UT-RR-001: ``count_by_empire`` は Protocol に含まれない（YAGNI）。
 
-        §確定 R1-A froze ``count_by_empire`` as YAGNI — the method must not
-        appear on the public Protocol surface. A future PR that re-adds it
-        must update §確定 R1-A first; otherwise this assertion fires.
+        §確定 R1-A が ``count_by_empire`` を YAGNI として凍結したため、
+        メソッドは公開 Protocol サーフェスに現れてはならない。再追加する将来の
+        PR は §確定 R1-A の更新を先に行う必要がある。さもなくば本アサーションが発火する。
         """
         assert not hasattr(RoomRepository, "count_by_empire"), (
             "[FAIL] RoomRepository.count_by_empire must not exist (YAGNI, §確定 R1-A).\n"
@@ -78,7 +77,7 @@ class TestRoomRepositoryProtocol:
 # REQ-RR-002 (find_by_id basic round-trip)
 # ---------------------------------------------------------------------------
 class TestFindById:
-    """find_by_id retrieves saved Rooms; returns None for unknown."""
+    """find_by_id は保存済み Room を取得する。未知の id は None を返す。"""
 
     async def test_find_by_id_returns_saved_room(
         self,
@@ -86,12 +85,12 @@ class TestFindById:
         seeded_empire_id: UUID,
         seeded_workflow_id: UUID,
     ) -> None:
-        """``find_by_id(room.id)`` returns a structurally-equal Room (no secrets in default).
+        """``find_by_id(room.id)`` が構造的に等価な Room を返す（デフォルトでは secret なし）。
 
-        Default factory ``prompt_kit.prefix_markdown=''`` contains no
-        Schneier-#6 secrets, so masking is a no-op and round-trip
-        equality holds. Secret-bearing prefix round-trip lives in
-        :mod:`...test_masking_prompt_kit` (§確定 R1-J §不可逆性).
+        デフォルト factory の ``prompt_kit.prefix_markdown=''`` には
+        Schneier-#6 の secret が含まれないため、マスキングは no-op となり
+        ラウンドトリップ等価性が成立する。secret を含む prefix のラウンドトリップは
+        :mod:`...test_masking_prompt_kit` (§確定 R1-J §不可逆性) で扱う。
         """
         room = make_room(workflow_id=seeded_workflow_id)
         async with session_factory() as session, session.begin():
@@ -107,7 +106,7 @@ class TestFindById:
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """``find_by_id(uuid4())`` returns ``None`` without raising."""
+        """``find_by_id(uuid4())`` は例外を投げず ``None`` を返す。"""
         unknown_id = uuid4()
         async with session_factory() as session:
             fetched = await SqliteRoomRepository(session).find_by_id(unknown_id)
@@ -119,7 +118,7 @@ class TestFindById:
         seeded_empire_id: UUID,
         seeded_workflow_id: UUID,
     ) -> None:
-        """``find_by_id`` returns a Room with its members hydrated."""
+        """``find_by_id`` がメンバを hydrate した Room を返す。"""
         room = make_populated_room(workflow_id=seeded_workflow_id)
         async with session_factory() as session, session.begin():
             await SqliteRoomRepository(session).save(room, seeded_empire_id)
@@ -128,14 +127,14 @@ class TestFindById:
             fetched = await SqliteRoomRepository(session).find_by_id(room.id)
 
         assert fetched is not None
-        assert len(fetched.members) == 2  # LEADER + DEVELOPER from make_populated_room
+        assert len(fetched.members) == 2  # make_populated_room による LEADER + DEVELOPER
 
 
 # ---------------------------------------------------------------------------
 # TC-UT-RR-004: count() must issue SQL-level COUNT(*)
 # ---------------------------------------------------------------------------
 class TestCountIssuesScalarCount:
-    """TC-UT-RR-004: ``count()`` issues ``SELECT COUNT(*)``, not a full row scan."""
+    """TC-UT-RR-004: ``count()`` は ``SELECT COUNT(*)`` を発行し、行を全件スキャンしない。"""
 
     async def test_count_emits_select_count_not_full_load(
         self,
@@ -144,11 +143,11 @@ class TestCountIssuesScalarCount:
         seeded_empire_id: UUID,
         seeded_workflow_id: UUID,
     ) -> None:
-        """SQL log shows ``SELECT count(*)`` for ``count()``.
+        """SQL ログが ``count()`` に対し ``SELECT count(*)`` を示す。
 
-        Follows empire-repository §確定 D 補強 contract — ``count()`` must
-        never stream full Room rows back to Python, especially once Rooms
-        carry large ``prompt_kit_prefix_markdown`` content.
+        empire-repository §確定 D 補強の契約に従う ── ``count()`` は Python へ
+        Room 行を全件ストリームしてはならない。Room が大きな
+        ``prompt_kit_prefix_markdown`` を持つようになると特に重要。
         """
         async with session_factory() as session, session.begin():
             await SqliteRoomRepository(session).save(
@@ -193,23 +192,22 @@ class TestCountIssuesScalarCount:
 # TC-UT-RR-005: find_by_name Empire-scoped (§確定 R1-F)
 # ---------------------------------------------------------------------------
 class TestFindByNameEmpireScoped:
-    """TC-UT-RR-005: ``find_by_name`` enforces Empire scoping.
+    """TC-UT-RR-005: ``find_by_name`` が Empire スコープを強制する。
 
-    Three orthogonal cases per §確定 R1-F:
+    §確定 R1-F に沿う 3 つの直交ケース:
 
-    1. **Hit**: Room named ``foo`` inside ``empire_a`` is returned.
-    2. **Miss in same Empire**: name ``bar`` under ``empire_a`` returns None.
-    3. **Cross-Empire isolation**: name ``foo`` under ``empire_b`` returns None
-       even though ``foo`` exists in ``empire_a``. This is the IDOR
-       guard — without ``WHERE empire_id=:empire_id`` an attacker
-       could read another tenant's Room by guessing the name.
+    1. **ヒット**: ``empire_a`` 内の ``foo`` という名前の Room が返る。
+    2. **同 Empire 内ミス**: ``empire_a`` 配下の ``bar`` という名前は None を返す。
+    3. **Empire 間隔離**: ``foo`` が ``empire_a`` に存在しても、``empire_b`` 配下の
+       ``foo`` 検索は None を返す。これが IDOR ガード ── ``WHERE empire_id=:empire_id``
+       がなければ攻撃者が名前を推測して別テナントの Room を読み取れる。
     """
 
     async def test_find_by_name_returns_room_when_present(
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """Hit path: name + empire_id pair returns the Room."""
+        """ヒット経路: name + empire_id ペアが Room を返す。"""
         empire_a = await seed_empire(session_factory)
         wf = await seed_workflow(session_factory)
         room = make_room(name="room_a", workflow_id=wf)
@@ -227,7 +225,7 @@ class TestFindByNameEmpireScoped:
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """Miss path: unknown name in known Empire returns None."""
+        """ミス経路: 既知 Empire 内の未知の名前は None を返す。"""
         empire_a = await seed_empire(session_factory)
         wf = await seed_workflow(session_factory)
         async with session_factory() as session, session.begin():
@@ -243,11 +241,11 @@ class TestFindByNameEmpireScoped:
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """**IDOR guard**: same name under different Empire returns None.
+        """**IDOR ガード**: 別 Empire 配下の同名は None を返す。
 
-        This is the test-design.md §確定 R1-F core contract. A regression
-        that drops the ``WHERE empire_id`` clause would let an attacker
-        read cross-tenant Rooms — this assertion fires loudly in that case.
+        本テストは test-design.md §確定 R1-F の中核契約。``WHERE empire_id`` 句を
+        落とす回帰は攻撃者にテナント越境で Room を読ませてしまう ──
+        本アサーションがそれを即座に表面化させる。
         """
         empire_a = await seed_empire(session_factory)
         empire_b = await seed_empire(session_factory)
@@ -257,8 +255,8 @@ class TestFindByNameEmpireScoped:
             await SqliteRoomRepository(session).save(room_in_a, empire_a)
 
         async with session_factory() as session:
-            # Look up the same name but in a DIFFERENT empire — must
-            # return None even though "shared_name" exists in empire_a.
+            # 同じ名前を別の empire で検索する ── empire_a に "shared_name" が
+            # 存在しても None を返さなければならない。
             fetched = await SqliteRoomRepository(session).find_by_name(empire_b, "shared_name")
         assert fetched is None, (
             "[FAIL] find_by_name leaked a Room across Empire boundaries.\n"
@@ -271,13 +269,11 @@ class TestFindByNameEmpireScoped:
         session_factory: async_sessionmaker[AsyncSession],
         app_engine: AsyncEngine,
     ) -> None:
-        """SQL log shows ``WHERE rooms.empire_id = ?`` and ``LIMIT 1``.
+        """SQL ログに ``WHERE rooms.empire_id = ?`` と ``LIMIT 1`` が含まれる。
 
-        Defense-in-depth on top of the behavioural test above: even if
-        the cross-Empire test happens to pass via row-coincidence,
-        the SQL itself must carry the scope clause. We attach a
-        ``before_cursor_execute`` listener and grep for the empire_id
-        predicate.
+        上の振る舞いテストに対する多層防御: クロス Empire テストが行偶発で
+        pass してしまっても、SQL 自体がスコープ句を持たねばならない。
+        ``before_cursor_execute`` リスナを取り付け、empire_id 述語を grep する。
         """
         empire_a = await seed_empire(session_factory)
         wf = await seed_workflow(session_factory)
@@ -306,10 +302,10 @@ class TestFindByNameEmpireScoped:
         finally:
             event.remove(sync_engine, "before_cursor_execute", _on_execute)
 
-        # Locate the SELECT that hit ``rooms`` to look up the RoomId.
+        # RoomId を検索するために ``rooms`` を叩いた SELECT を探す。
         room_id_selects = [s for s in captured if "FROM rooms" in s and "SELECT" in s.upper()]
         assert room_id_selects, "find_by_name must SELECT from rooms"
-        # The SELECT must carry both the empire_id predicate and LIMIT.
+        # SELECT は empire_id 述語と LIMIT の両方を持たねばならない。
         target_stmt = room_id_selects[0]
         assert "empire_id" in target_stmt, (
             f"[FAIL] find_by_name SQL missing empire_id predicate.\nCaptured: {target_stmt!r}"
@@ -323,17 +319,17 @@ class TestFindByNameEmpireScoped:
 # TC-UT-RR-006: Lifecycle integration (§確定 R1-B)
 # ---------------------------------------------------------------------------
 class TestLifecycleIntegration:
-    """TC-UT-RR-006: full save → lookup → update flow."""
+    """TC-UT-RR-006: save → 検索 → 更新の完全フロー。"""
 
     async def test_full_lifecycle_with_description_update(
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """Save → find_by_name → find_by_id → update description → save.
+        """Save → find_by_name → find_by_id → description 更新 → save。
 
-        Verifies the 4 Protocol methods cooperate end-to-end and that
-        a description update via re-save reaches the DB through the
-        UPSERT path (Step 1 of §確定 R1-B 3-step).
+        4 つの Protocol メソッドがエンドツーエンドで協調し、再 save 経由の
+        description 更新が UPSERT 経路（§確定 R1-B 3 ステップの Step 1）で
+        DB に到達することを検証する。
         """
         empire_a = await seed_empire(session_factory)
         wf = await seed_workflow(session_factory)
@@ -355,7 +351,7 @@ class TestLifecycleIntegration:
         assert via_id is not None
         assert via_id == via_name
 
-        # Update: change description and re-save.
+        # 更新: description を変更して再 save。
         updated = original.model_copy(update={"description": "更新後の説明"})
         async with session_factory() as session, session.begin():
             await SqliteRoomRepository(session).save(updated, empire_a)

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_room_repository/test_save_semantics.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_room_repository/test_save_semantics.py
@@ -1,18 +1,18 @@
-"""Room Repository: save() semantics — delete-then-insert + ORDER BY + Tx boundary.
+"""Room Repository: save() のセマンティクス ── delete-then-insert + ORDER BY + Tx 境界。
 
-TC-UT-RR-002 / 003 / 010 / 011 — the §確定 R1-B 3-step save flow contract +
-ORDER BY observation + Tx boundary + round-trip equality.
+TC-UT-RR-002 / 003 / 010 / 011 ── §確定 R1-B の 3 ステップ save フロー契約 +
+ORDER BY 観測 + Tx 境界 + ラウンドトリップ等価性。
 
-§確定 R1-B 3-step:
-    1. ``rooms`` UPSERT (id PK, ON CONFLICT update 5 scalar columns)
+§確定 R1-B の 3 ステップ:
+    1. ``rooms`` UPSERT (id PK, ON CONFLICT で 5 スカラーカラムを更新)
     2. ``room_members`` DELETE WHERE room_id = ?
-    3. ``room_members`` bulk INSERT (skipped when members is empty)
+    3. ``room_members`` 一括 INSERT（members が空のときはスキップ）
 
-ORDER BY (§BUG-EMR-001 inherited from day 1):
-    ``find_by_id`` must ORDER BY ``agent_id, role`` on room_members so the
-    hydrated member list is deterministic across SQLite internal-scan order.
+ORDER BY（day 1 から踏襲する §BUG-EMR-001）:
+    ``find_by_id`` は room_members に ``ORDER BY agent_id, role`` を発行し、
+    SQLite の内部スキャン順に左右されない決定性を持つメンバリストとする。
 
-Per ``docs/features/room-repository/test-design.md``.
+``docs/features/room-repository/test-design.md`` 準拠。
 """
 
 from __future__ import annotations
@@ -45,11 +45,11 @@ pytestmark = pytest.mark.asyncio
 # TC-UT-RR-002: 3-step delete-then-insert SQL order (§確定 R1-B)
 # ---------------------------------------------------------------------------
 class TestSaveSqlOrder:
-    """TC-UT-RR-002: ``save`` issues the §確定 R1-B 3-step DML sequence.
+    """TC-UT-RR-002: ``save`` が §確定 R1-B の 3 ステップ DML シーケンスを発行する。
 
-    Observed via ``before_cursor_execute`` listener and asserted:
+    ``before_cursor_execute`` リスナで観測し、以下を assert する:
 
-    1. ``INSERT INTO rooms`` (UPSERT via ON CONFLICT DO UPDATE)
+    1. ``INSERT INTO rooms`` (ON CONFLICT DO UPDATE による UPSERT)
     2. ``DELETE FROM room_members``
     3. ``INSERT INTO room_members``
     """
@@ -61,7 +61,7 @@ class TestSaveSqlOrder:
         seeded_empire_id: UUID,
         seeded_workflow_id: UUID,
     ) -> None:
-        """3-step DML order matches §確定 R1-B."""
+        """3 ステップの DML 順序が §確定 R1-B に一致する。"""
         captured: list[str] = []
 
         def _on_execute(
@@ -77,8 +77,8 @@ class TestSaveSqlOrder:
         sync_engine = app_engine.sync_engine
         event.listen(sync_engine, "before_cursor_execute", _on_execute)
         try:
-            # Build a Room with non-empty members so all 3 DML steps fire.
-            # An empty room would skip step 3 (INSERT room_members).
+            # 3 ステップの DML すべてが発火するよう、メンバを持つ Room を構築する。
+            # 空 Room ではステップ 3（INSERT room_members）がスキップされる。
             room = make_populated_room(workflow_id=seeded_workflow_id)
             async with session_factory() as session, session.begin():
                 await SqliteRoomRepository(session).save(room, seeded_empire_id)
@@ -118,13 +118,11 @@ class TestSaveSqlOrder:
         seeded_empire_id: UUID,
         seeded_workflow_id: UUID,
     ) -> None:
-        """A Room with no members skips step 3 (INSERT room_members).
+        """メンバなしの Room はステップ 3（INSERT room_members）をスキップする。
 
-        ``save()`` has an explicit ``if member_rows:`` guard (§確定 R1-B).
-        An empty INSERT would still be a no-op in SQL, but this confirms
-        the short-circuit path — a regression that removes the guard and
-        issues an empty INSERT would not be caught by a behavioural test
-        alone.
+        ``save()`` には明示的な ``if member_rows:`` ガードがある (§確定 R1-B)。
+        SQL 的には空 INSERT も no-op だが、本テストは短絡経路を確認する ──
+        ガードを除去して空 INSERT を発行する回帰は、振る舞いテストだけでは捕まえられない。
         """
         captured: list[str] = []
 
@@ -141,7 +139,7 @@ class TestSaveSqlOrder:
         sync_engine = app_engine.sync_engine
         event.listen(sync_engine, "before_cursor_execute", _on_execute)
         try:
-            # Explicitly empty members list.
+            # 明示的に空 members リスト。
             room = make_room(members=[], workflow_id=seeded_workflow_id)
             async with session_factory() as session, session.begin():
                 await SqliteRoomRepository(session).save(room, seeded_empire_id)
@@ -162,13 +160,12 @@ class TestSaveSqlOrder:
 # TC-UT-RR-003: ORDER BY contract (§BUG-EMR-001 inherited from day 1)
 # ---------------------------------------------------------------------------
 class TestFindByIdOrderByContract:
-    """TC-UT-RR-003: ``find_by_id`` emits ``ORDER BY agent_id, role`` on room_members.
+    """TC-UT-RR-003: ``find_by_id`` が room_members に ``ORDER BY agent_id, role`` を発行する。
 
-    The empire-repository BUG-EMR-001 closure froze the ORDER BY
-    contract; the Room Repository adopts it from PR #33.  Without
-    these clauses, SQLite returns rows in internal-scan order which
-    would break ``Room == Room`` round-trip equality (the Aggregate
-    compares member list-by-list).
+    empire-repository BUG-EMR-001 のクロージャが ORDER BY 契約を凍結し、
+    Room Repository は PR #33 から踏襲する。これらの句がないと SQLite は
+    内部スキャン順で行を返し、``Room == Room`` ラウンドトリップ等価性
+    （Aggregate がメンバリスト同士で比較する）が壊れる。
     """
 
     async def test_find_by_id_emits_order_by_agent_id_role(
@@ -178,7 +175,7 @@ class TestFindByIdOrderByContract:
         seeded_empire_id: UUID,
         seeded_workflow_id: UUID,
     ) -> None:
-        """``find_by_id`` emits ``ORDER BY room_members.agent_id, room_members.role``."""
+        """``find_by_id`` が ``ORDER BY room_members.agent_id, room_members.role`` を発行する。"""
         room = make_populated_room(workflow_id=seeded_workflow_id)
         async with session_factory() as session, session.begin():
             await SqliteRoomRepository(session).save(room, seeded_empire_id)
@@ -222,16 +219,16 @@ class TestFindByIdOrderByContract:
         seeded_empire_id: UUID,
         seeded_workflow_id: UUID,
     ) -> None:
-        """Multiple find_by_id calls return members in the same ORDER BY order.
+        """複数回 find_by_id を呼んでも同じ ORDER BY 順でメンバが返る。
 
-        Seeds a Room with 3 members (different agent_ids) and verifies
-        that two successive find_by_id calls produce identical member
-        lists — proving ORDER BY is deterministic across SQLite pages.
+        異なる agent_id を持つメンバ 3 件で Room を seed し、find_by_id を
+        2 回連続で呼んだ結果が同一のメンバリストになることを確認する ──
+        ORDER BY が SQLite ページをまたいで決定的であることを示す。
         """
         from uuid import UUID as _UUID
 
-        # Three distinct agent IDs; deliberately not in ascending UUIDhex
-        # order so we can detect if ORDER BY is absent.
+        # 別個の 3 つの agent ID。ORDER BY 不在を検出できるよう、
+        # 意図的に UUID hex の昇順にはしない。
         a1 = _UUID("aaaaaaaa-0000-0000-0000-000000000001")
         a2 = _UUID("aaaaaaaa-0000-0000-0000-000000000002")
         a3 = _UUID("aaaaaaaa-0000-0000-0000-000000000003")
@@ -264,7 +261,7 @@ class TestFindByIdOrderByContract:
 # TC-UT-RR-002 (delete-then-insert replacement semantics)
 # ---------------------------------------------------------------------------
 class TestSaveReplacesMemberRows:
-    """``save`` replaces room_members wholesale (§確定 R1-B step 2-3)."""
+    """``save`` が room_members を丸ごと置換する (§確定 R1-B ステップ 2-3)。"""
 
     async def test_save_replaces_member_rows(
         self,
@@ -272,12 +269,12 @@ class TestSaveReplacesMemberRows:
         seeded_empire_id: UUID,
         seeded_workflow_id: UUID,
     ) -> None:
-        """Members 2 → 1 reflects as 1 row in room_members (no residue).
+        """メンバ 2 → 1 が room_members で 1 行として反映される（残骸なし）。
 
-        Verifies the DELETE-then-INSERT pattern: a re-save with fewer
-        members must not leave stale rows in room_members.
+        DELETE-then-INSERT パターンを検証する: メンバを減らして再 save しても、
+        room_members に古い行が残ってはならない。
         """
-        # Two members initially.
+        # 初期状態は 2 メンバ。
         original = make_room(
             workflow_id=seeded_workflow_id,
             members=[
@@ -288,7 +285,7 @@ class TestSaveReplacesMemberRows:
         async with session_factory() as session, session.begin():
             await SqliteRoomRepository(session).save(original, seeded_empire_id)
 
-        # Re-save with only one member.
+        # メンバ 1 名で再 save。
         solo_member = make_leader_membership()
         replacement = original.model_copy(update={"members": [solo_member]})
         async with session_factory() as session, session.begin():
@@ -310,12 +307,12 @@ class TestSaveReplacesMemberRows:
 # TC-UT-RR-011: round-trip equality (_to_row / _from_row via DB)
 # ---------------------------------------------------------------------------
 class TestRoundTripEquality:
-    """TC-UT-RR-011: save → find_by_id round-trip preserves Room identity.
+    """TC-UT-RR-011: save → find_by_id ラウンドトリップで Room の同一性が保たれる。
 
-    Note: this test uses default ``prompt_kit.prefix_markdown=''`` (no
-    secrets) so masking is a no-op and full ``==`` holds. Secret-bearing
-    round-trip is non-equal due to §確定 R1-J §不可逆性 — that path lives
-    in :mod:`...test_masking_prompt_kit`.
+    本テストはデフォルトの ``prompt_kit.prefix_markdown=''``（secret なし）を使うため、
+    マスキングは no-op となり full ``==`` が成立する。secret を含むラウンドトリップは
+    §確定 R1-J §不可逆性 により非等価になる ── その経路は
+    :mod:`...test_masking_prompt_kit` で扱う。
     """
 
     async def test_populated_room_round_trips(
@@ -324,7 +321,7 @@ class TestRoundTripEquality:
         seeded_empire_id: UUID,
         seeded_workflow_id: UUID,
     ) -> None:
-        """Room with 2 members round-trips structurally (ORDER BY aware)."""
+        """メンバ 2 名の Room が構造的にラウンドトリップする（ORDER BY を考慮）。"""
         room = make_populated_room(workflow_id=seeded_workflow_id)
         async with session_factory() as session, session.begin():
             await SqliteRoomRepository(session).save(room, seeded_empire_id)
@@ -339,9 +336,8 @@ class TestRoundTripEquality:
         assert restored.archived == room.archived
         assert restored.workflow_id == room.workflow_id
         assert restored.prompt_kit == room.prompt_kit
-        # Members are returned in ORDER BY (agent_id, role) — compare
-        # after sorting by (agent_id, role) on the original side so the
-        # assertion is ORDER BY-aware.
+        # メンバは ORDER BY (agent_id, role) で返るため、
+        # 元側を (agent_id, role) で sort してから比較する（ORDER BY を意識した assertion）。
         original_sorted = sorted(room.members, key=lambda m: (str(m.agent_id), m.role.value))
         assert len(restored.members) == len(original_sorted)
         for got, want in zip(restored.members, original_sorted, strict=True):
@@ -353,7 +349,7 @@ class TestRoundTripEquality:
 # TC-UT-RR-010: Tx boundary responsibility separation (§確定 R1-B)
 # ---------------------------------------------------------------------------
 class TestTxBoundaryRespectedByRepository:
-    """TC-UT-RR-010: Repository never calls commit / rollback (§確定 R1-B)."""
+    """TC-UT-RR-010: Repository は commit / rollback を呼ばない (§確定 R1-B)。"""
 
     async def test_commit_path_persists_via_outer_block(
         self,
@@ -361,7 +357,7 @@ class TestTxBoundaryRespectedByRepository:
         seeded_empire_id: UUID,
         seeded_workflow_id: UUID,
     ) -> None:
-        """Outer ``async with session.begin()`` commits the save."""
+        """外側の ``async with session.begin()`` が save を commit する。"""
         room = make_room(workflow_id=seeded_workflow_id)
         async with session_factory() as session, session.begin():
             await SqliteRoomRepository(session).save(room, seeded_empire_id)
@@ -376,15 +372,14 @@ class TestTxBoundaryRespectedByRepository:
         seeded_empire_id: UUID,
         seeded_workflow_id: UUID,
     ) -> None:
-        """An exception inside ``begin()`` rolls back ALL 3 DML steps.
+        """``begin()`` 内の例外が 3 ステップの DML すべてをロールバックする。
 
-        The Room row + room_members all participate in the same
-        caller-managed transaction. A single uncaught exception must
-        purge **all** of them.
+        Room 行と room_members は同一の呼び出し側管理トランザクションに参加する。
+        単一の未捕捉例外が **すべて** を破棄せねばならない。
         """
 
         class _BoomError(Exception):
-            """Synthetic exception used to drive the rollback path."""
+            """ロールバック経路を駆動する合成例外。"""
 
         room = make_populated_room(workflow_id=seeded_workflow_id)
 
@@ -397,8 +392,8 @@ class TestTxBoundaryRespectedByRepository:
             fetched = await SqliteRoomRepository(session).find_by_id(room.id)
         assert fetched is None
 
-        # room_members also empty — the §確定 R1-B contract is that the
-        # 3-step sequence is one logical operation under the caller's UoW.
+        # room_members も空 ── §確定 R1-B の契約により、3 ステップは
+        # 呼び出し側 UoW 下で 1 つの論理操作として扱われる。
         async with session_factory() as session:
             member_rows = (
                 await session.execute(select(RoomMemberRow).where(RoomMemberRow.room_id == room.id))
@@ -411,11 +406,11 @@ class TestTxBoundaryRespectedByRepository:
         seeded_empire_id: UUID,
         seeded_workflow_id: UUID,
     ) -> None:
-        """``save`` outside ``begin()`` does not auto-commit (§確定 R1-B)."""
+        """``begin()`` の外側での ``save`` は自動 commit しない (§確定 R1-B)。"""
         room = make_room(workflow_id=seeded_workflow_id)
         async with session_factory() as session:
             await SqliteRoomRepository(session).save(room, seeded_empire_id)
-            # AsyncSession's __aexit__ rolls back any in-flight tx.
+            # AsyncSession の __aexit__ が処理中の tx をロールバックする。
 
         async with session_factory() as session:
             fetched = await SqliteRoomRepository(session).find_by_id(room.id)

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_task_repository/test_count_methods.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_task_repository/test_count_methods.py
@@ -1,11 +1,11 @@
-"""Task Repository: count_by_status / count_by_room (TC-UT-TR-006/007).
+"""Task Repository: count_by_status / count_by_room (TC-UT-TR-006/007)。
 
-REQ-TR-003 / §確定 R1-D — 2 COUNT query methods:
+REQ-TR-003 / §確定 R1-D — 2 つの COUNT クエリメソッド:
   * ``count_by_status(status)`` — COUNT(*) WHERE status = ?
   * ``count_by_room(room_id)``  — COUNT(*) WHERE room_id = ?
 
-Per ``docs/features/task-repository/test-design.md``.
-Issue #35 — M2 0007.
+``docs/features/task-repository/test-design.md`` 準拠。
+Issue #35 — M2 0007。
 """
 
 from __future__ import annotations
@@ -39,14 +39,14 @@ pytestmark = pytest.mark.asyncio
 # TC-UT-TR-006: count_by_status (§確定 R1-D)
 # ---------------------------------------------------------------------------
 class TestCountByStatus:
-    """TC-UT-TR-006: count_by_status counts Tasks by status; Room-isolation."""
+    """TC-UT-TR-006: count_by_status はステータス別に Task をカウント; ルーム隔離。"""
 
     async def test_count_by_status_pending(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_task_context: tuple[UUID, UUID],
     ) -> None:
-        """count_by_status(PENDING) returns only PENDING count."""
+        """count_by_status(PENDING) は PENDING カウントのみを返す。"""
         room_id, directive_id = seeded_task_context
         for _ in range(2):
             async with session_factory() as session, session.begin():
@@ -69,7 +69,7 @@ class TestCountByStatus:
         session_factory: async_sessionmaker[AsyncSession],
         seeded_task_context: tuple[UUID, UUID],
     ) -> None:
-        """count_by_status(BLOCKED) counts only BLOCKED tasks."""
+        """count_by_status(BLOCKED) は BLOCKED Task のみをカウント。"""
         room_id, directive_id = seeded_task_context
         async with session_factory() as session, session.begin():
             await SqliteTaskRepository(session).save(
@@ -91,7 +91,7 @@ class TestCountByStatus:
         session_factory: async_sessionmaker[AsyncSession],
         seeded_task_context: tuple[UUID, UUID],
     ) -> None:
-        """count_by_status returns 0 when no Tasks with that status exist."""
+        """そのステータスの Task が存在しない場合、count_by_status は 0 を返す。"""
         room_id, directive_id = seeded_task_context
         async with session_factory() as session, session.begin():
             await SqliteTaskRepository(session).save(
@@ -108,7 +108,7 @@ class TestCountByStatus:
         app_engine: AsyncEngine,
         seeded_task_context: tuple[UUID, UUID],
     ) -> None:
-        """count_by_status SQL log shows COUNT(*) WHERE status filter."""
+        """count_by_status SQL ログは COUNT(*) WHERE status フィルタを示す。"""
         room_id, directive_id = seeded_task_context
         async with session_factory() as session, session.begin():
             await SqliteTaskRepository(session).save(
@@ -137,7 +137,8 @@ class TestCountByStatus:
 
         count_stmts = [s for s in captured if "count" in s.lower() and "tasks" in s.lower()]
         assert count_stmts, (
-            f"[FAIL] count_by_status() did not emit COUNT(*) FROM tasks.\nCaptured: {captured}"
+            "[FAIL] count_by_status() が COUNT(*) FROM tasks を発行しなかった。"
+            f"\nキャプチャ: {captured}"
         )
 
 
@@ -145,14 +146,14 @@ class TestCountByStatus:
 # TC-UT-TR-007: count_by_room (§確定 R1-D)
 # ---------------------------------------------------------------------------
 class TestCountByRoom:
-    """TC-UT-TR-007: count_by_room counts Tasks per Room; cross-room isolation."""
+    """TC-UT-TR-007: count_by_room はルームごとに Task をカウント; ルーム間隔離。"""
 
     async def test_count_by_room_returns_correct_count(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_task_context: tuple[UUID, UUID],
     ) -> None:
-        """count_by_room returns only tasks in the specified room."""
+        """count_by_room は指定されたルーム内のタスクのみを返す。"""
         room_id, directive_id = seeded_task_context
         for _ in range(3):
             async with session_factory() as session, session.begin():
@@ -169,9 +170,9 @@ class TestCountByRoom:
         session_factory: async_sessionmaker[AsyncSession],
         seeded_task_context: tuple[UUID, UUID],
     ) -> None:
-        """count_by_room returns 0 for a room with no tasks."""
+        """タスクがないルームに対して count_by_room は 0 を返す。"""
         room_id, _directive_id = seeded_task_context
-        # Seed tasks in a different room
+        # 別のルームでタスクをシード
         room2_id, directive2_id = await seed_task_context(session_factory)
         async with session_factory() as session, session.begin():
             await SqliteTaskRepository(session).save(
@@ -180,18 +181,18 @@ class TestCountByRoom:
 
         async with session_factory() as session:
             count = await SqliteTaskRepository(session).count_by_room(room_id)  # type: ignore[arg-type]
-        assert count == 0, f"[FAIL] count_by_room leaked tasks from another room. count={count}"
+        assert count == 0, f"[FAIL] count_by_room が別のルームからタスクをリーク。 count={count}"
 
     async def test_count_by_room_cross_room_isolation(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_task_context: tuple[UUID, UUID],
     ) -> None:
-        """TC-UT-TR-007: count_by_room does not bleed across rooms."""
+        """TC-UT-TR-007: count_by_room はルーム間でリークしない。"""
         room_a_id, directive_a_id = seeded_task_context
         room_b_id, directive_b_id = await seed_task_context(session_factory)
 
-        # 2 tasks in room A, 3 tasks in room B
+        # ルーム A に 2 つのタスク、ルーム B に 3 つのタスク
         async with session_factory() as session, session.begin():
             await SqliteTaskRepository(session).save(
                 make_task(room_id=room_a_id, directive_id=directive_a_id)

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_task_repository/test_find_blocked.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_task_repository/test_find_blocked.py
@@ -1,13 +1,13 @@
-"""Task Repository: find_blocked (TC-UT-TR-008〜008e).
+"""Task Repository: find_blocked (TC-UT-TR-008〜008e)。
 
 REQ-TR-003 / §確定 R1-D:
   * ``find_blocked()`` — SELECT BLOCKED ORDER BY updated_at DESC, id DESC
 
-count_by_status (TC-UT-TR-006) and count_by_room (TC-UT-TR-007)
-live in ``test_count_methods.py``.
+count_by_status (TC-UT-TR-006) と count_by_room (TC-UT-TR-007) は
+``test_count_methods.py`` にある。
 
-Per ``docs/features/task-repository/test-design.md``.
-Issue #35 — M2 0007.
+``docs/features/task-repository/test-design.md`` 準拠。
+Issue #35 — M2 0007。
 """
 
 from __future__ import annotations
@@ -40,14 +40,14 @@ pytestmark = pytest.mark.asyncio
 # TC-UT-TR-008: find_blocked returns only BLOCKED Tasks (§確定 R1-D)
 # ---------------------------------------------------------------------------
 class TestFindBlocked:
-    """TC-UT-TR-008: find_blocked returns only BLOCKED Tasks; empty → []; tiebreaker."""
+    """TC-UT-TR-008: find_blocked は BLOCKED Task のみを返す; 空 → []; タイブレーカ。"""
 
     async def test_find_blocked_returns_only_blocked(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_task_context: tuple[UUID, UUID],
     ) -> None:
-        """TC-UT-TR-008: find_blocked returns BLOCKED tasks; skips PENDING/DONE."""
+        """TC-UT-TR-008: find_blocked は BLOCKED Task を返す; PENDING/DONE をスキップ。"""
         room_id, directive_id = seeded_task_context
         pending = make_task(room_id=room_id, directive_id=directive_id)
         blocked = make_blocked_task(
@@ -67,7 +67,7 @@ class TestFindBlocked:
             results = await SqliteTaskRepository(session).find_blocked()
 
         assert len(results) == 1, (
-            f"[FAIL] find_blocked returned {len(results)} tasks; expected 1 (only BLOCKED)."
+            f"[FAIL] find_blocked が {len(results)} タスクを返した; 期待値は 1 (BLOCKED のみ)。"
         )
         assert results[0].id == blocked.id
         assert results[0].status == TaskStatus.BLOCKED
@@ -77,7 +77,7 @@ class TestFindBlocked:
         session_factory: async_sessionmaker[AsyncSession],
         seeded_task_context: tuple[UUID, UUID],
     ) -> None:
-        """TC-UT-TR-008b: find_blocked returns [] when no BLOCKED Tasks exist."""
+        """TC-UT-TR-008b: BLOCKED Task がない場合、find_blocked は [] を返す。"""
         room_id, directive_id = seeded_task_context
         async with session_factory() as session, session.begin():
             await SqliteTaskRepository(session).save(
@@ -87,13 +87,13 @@ class TestFindBlocked:
         async with session_factory() as session:
             results = await SqliteTaskRepository(session).find_blocked()
 
-        assert results == [], f"[FAIL] find_blocked returned {results!r} but expected []."
+        assert results == [], f"[FAIL] find_blocked が {results!r} を返したが、[] が期待値。"
 
     async def test_find_blocked_returns_empty_from_empty_db(
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """TC-UT-TR-008b: find_blocked on empty DB returns []."""
+        """TC-UT-TR-008b: 空 DB での find_blocked は [] を返す。"""
         async with session_factory() as session:
             results = await SqliteTaskRepository(session).find_blocked()
         assert results == []
@@ -104,7 +104,7 @@ class TestFindBlocked:
         app_engine: AsyncEngine,
         seeded_task_context: tuple[UUID, UUID],
     ) -> None:
-        """TC-UT-TR-008c: find_blocked SQL log shows WHERE status = 'BLOCKED' ORDER BY."""
+        """TC-UT-TR-008c: find_blocked SQL ログは WHERE status = 'BLOCKED' ORDER BY を示す。"""
         room_id, directive_id = seeded_task_context
         async with session_factory() as session, session.begin():
             await SqliteTaskRepository(session).save(
@@ -131,16 +131,16 @@ class TestFindBlocked:
         finally:
             event.remove(sync_engine, "before_cursor_execute", _on_execute)
 
-        # The find_blocked statement must include tasks table with ORDER BY
+        # find_blocked statement は ORDER BY を伴う tasks テーブルを含む必要
         status_stmts = [s for s in captured if "tasks" in s.lower() and "status" in s.lower()]
         assert status_stmts, (
-            f"[FAIL] find_blocked() did not emit SQL with tasks + status filter.\n"
-            f"Captured: {captured}"
+            f"[FAIL] find_blocked() が tasks + status フィルタを伴う SQL を発行しなかった。\n"
+            f"キャプチャ: {captured}"
         )
-        # ORDER BY must be present (DESC ordering for recency-first)
+        # ORDER BY が存在する必要（最新優先の DESC 順）
         order_stmts = [s for s in status_stmts if "order by" in s.lower() or "ORDER BY" in s]
         assert order_stmts, (
-            f"[FAIL] find_blocked() SQL lacks ORDER BY clause.\nstatus_stmts: {status_stmts}"
+            f"[FAIL] find_blocked() SQL が ORDER BY 句を欠く。\nstatus_stmts: {status_stmts}"
         )
 
     async def test_find_blocked_restores_full_attributes(
@@ -148,9 +148,9 @@ class TestFindBlocked:
         session_factory: async_sessionmaker[AsyncSession],
         seeded_task_context: tuple[UUID, UUID],
     ) -> None:
-        """TC-UT-TR-008d: find_blocked hydrates complete BLOCKED task attributes.
+        """TC-UT-TR-008d: find_blocked は BLOCKED Task の完全な属性をハイドレート。
 
-        Includes assigned_agent_ids, deliverables, and all scalar fields.
+        assigned_agent_ids、deliverables、およびすべてのスカラーフィールドを含む。
         """
         room_id, directive_id = seeded_task_context
         agent_id = uuid4()
@@ -179,7 +179,7 @@ class TestFindBlocked:
         assert len(restored.assigned_agent_ids) == 1
         assert restored.assigned_agent_ids[0] == agent_id
         assert stage_id in restored.deliverables  # type: ignore[operator]
-        assert restored.last_error is not None  # last_error was masked at save time
+        assert restored.last_error is not None  # last_error は保存時にマスク
         assert restored.created_at.tzinfo is not None
         assert restored.updated_at.tzinfo is not None
 
@@ -188,22 +188,21 @@ class TestFindBlocked:
         session_factory: async_sessionmaker[AsyncSession],
         seeded_task_context: tuple[UUID, UUID],
     ) -> None:
-        """TC-UT-TR-008e: BUG-EMR-001規約 — same updated_at → ORDER BY id DESC tiebreaker.
+        """TC-UT-TR-008e: BUG-EMR-001 規約 — 同じ updated_at → ORDER BY id DESC タイブレーカ。
 
-        Two BLOCKED Tasks with identical updated_at timestamps must be
-        ordered id DESC. The task with the hex-greater UUID must appear
-        first in find_blocked() results.
+        同じ updated_at タイムスタンプを持つ 2 つの BLOCKED Task は
+        id DESC で順序付けされる必要。16進大の UUID を持つタスクは
+        find_blocked() 結果の最初に現れる必要。
 
-        This test physically asserts the tiebreaker from §確定 R1-K
-        ``ORDER BY updated_at DESC, id DESC`` by controlling both IDs and
-        timestamps at construction time.
+        このテストは§確定 R1-K ``ORDER BY updated_at DESC, id DESC`` から
+        タイブレーカを物理的にアサートし、構成時に ID とタイムスタンプを制御。
         """
         room_id, directive_id = seeded_task_context
 
-        # Pin a shared updated_at so the tiebreaker kicks in.
+        # 共有 updated_at をピンして、タイブレーカが発動するようにする。
         fixed_ts = datetime(9999, 1, 1, 0, 0, 0, tzinfo=UTC)
 
-        # UUID hex: "ffffffff..." > "00000000..." lexicographically.
+        # UUID hex: "ffffffff..." > "00000000..." 辞書順。
         id_high = UUID("ffffffff-ffff-4000-8000-000000000001")
         id_low = UUID("00000000-0000-4000-8000-000000000001")
 
@@ -229,13 +228,13 @@ class TestFindBlocked:
         async with session_factory() as session:
             results = await SqliteTaskRepository(session).find_blocked()
 
-        assert len(results) == 2, f"[FAIL] Expected 2 BLOCKED tasks, got {len(results)}"
-        # id DESC: id_high must come before id_low
+        assert len(results) == 2, f"[FAIL] 2 つの BLOCKED Task が期待値、 {len(results)} を取得"
+        # id DESC: id_high は id_low の前に来る必要
         assert results[0].id == id_high, (
-            f"[FAIL] Tiebreaker ORDER BY id DESC violated.\n"
-            f"Expected first: {id_high!r}\n"
-            f"Got first:      {results[0].id!r}\n"
-            f"BUG-EMR-001規約: find_blocked ORDER BY updated_at DESC, id DESC must "
-            f"produce deterministic ordering when updated_at is equal."
+            f"[FAIL] タイブレーカ ORDER BY id DESC が違反。\n"
+            f"期待値最初: {id_high!r}\n"
+            f"実際最初:      {results[0].id!r}\n"
+            f"BUG-EMR-001規約: find_blocked ORDER BY updated_at DESC, id DESC は "
+            f"updated_at が等しい場合に決定的な順序を生成する必要。"
         )
         assert results[1].id == id_low

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_task_repository/test_masking_fields.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_task_repository/test_masking_fields.py
@@ -1,19 +1,18 @@
-"""Task Repository: MaskedText wiring on 2 columns (TC-IT-TR-020-masking-*).
+"""Task Repository: 2 カラムへの MaskedText 配線 (TC-IT-TR-020-masking-*).
 
-REQ-TR-004 / §確定 G 実適用 — tasks.last_error / deliverables.body_markdown
-are ``MaskedText`` columns.
+REQ-TR-004 / §確定 G 実適用 ── tasks.last_error / deliverables.body_markdown
+は ``MaskedText`` カラム。
 
-``conversation_messages.body_markdown`` is excluded (§BUG-TR-002 凍結済み):
-Task domain currently has no ``conversations`` attribute. Tests for
-``conversation_messages.body_markdown`` will be added when that attribute is
-introduced.
+``conversation_messages.body_markdown`` は除外 (§BUG-TR-002 凍結済み):
+Task ドメインに現状 ``conversations`` 属性は存在しない。
+``conversation_messages.body_markdown`` のテストはその属性導入時に追加する。
 
 **Task §確定 G 実適用の物理保証**:
-2 columns must never let secret tokens reach SQLite. Each is verified via
-**raw SQL SELECT** so the observation bypasses ``MaskedText.process_result_value``
-and confirms the literal bytes on disk.
-Per ``docs/features/task-repository/test-design.md`` TC-IT-TR-020-masking-*.
-Issue #35 — M2 0007.
+2 カラムは secret トークンを SQLite まで通してはならない。各カラムは
+**raw SQL SELECT** で検証する ── ``MaskedText.process_result_value`` を
+迂回し、ディスク上の実バイトを観察するため。
+``docs/features/task-repository/test-design.md`` TC-IT-TR-020-masking-* 準拠。
+Issue #35 ── M2 0007。
 """
 
 from __future__ import annotations
@@ -41,28 +40,28 @@ pytestmark = pytest.mark.asyncio
 
 
 # ---------------------------------------------------------------------------
-# Secret token constants (real-shape, constructed to avoid push-protection)
+# secret トークン定数 (push-protection 回避のため実形を分割構築)
 # ---------------------------------------------------------------------------
 
-# Discord Bot Token — [MN][A-Za-z\d]{23,}\.[\w-]{6}\.[\w-]{27,}
+# Discord Bot Token ── [MN][A-Za-z\d]{23,}\.[\w-]{6}\.[\w-]{27,}
 _DISCORD_TOKEN = "MTk4NjIyNDgz" + "NDcxOTI1MjQ4.ClFDg_." + "A" * 27
 
-# GitHub PAT — (?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36,}
+# GitHub PAT ── (?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36,}
 _GITHUB_TOKEN = "ghp_" + "X" * 40
 
-# Redaction sentinels
+# redaction sentinel
 _DISCORD_SENTINEL = "<REDACTED:DISCORD_TOKEN>"
 _GITHUB_SENTINEL = "<REDACTED:GITHUB_PAT>"
 
 
 # ---------------------------------------------------------------------------
-# Raw-SQL helpers
+# Raw-SQL ヘルパ
 # ---------------------------------------------------------------------------
 async def _read_last_error(
     session_factory: async_sessionmaker[AsyncSession],
     task_id: UUID,
 ) -> str | None:
-    """Fetch tasks.last_error literal bytes via raw SQL (bypasses TypeDecorator read)."""
+    """tasks.last_error の実バイトを raw SQL で取得する (TypeDecorator 読み取りを迂回)。"""
     async with session_factory() as session:
         row = (
             await session.execute(
@@ -79,7 +78,7 @@ async def _read_deliverable_body(
     session_factory: async_sessionmaker[AsyncSession],
     task_id: UUID,
 ) -> str | None:
-    """Fetch deliverables.body_markdown literal bytes for the first deliverable."""
+    """deliverables.body_markdown の実バイトを取得する (最初の deliverable)。"""
     async with session_factory() as session:
         row = (
             await session.execute(
@@ -96,14 +95,14 @@ async def _read_deliverable_body(
 # TC-IT-TR-020-masking-discord: tasks.last_error Discord token redacted
 # ---------------------------------------------------------------------------
 class TestLastErrorDiscordTokenMasked:
-    """TC-IT-TR-020-masking-discord: Discord Bot Token in last_error is redacted."""
+    """TC-IT-TR-020-masking-discord: last_error 中の Discord Bot Token が redact される。"""
 
     async def test_discord_token_in_last_error_redacted_on_disk(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_task_context: tuple[UUID, UUID],
     ) -> None:
-        """Raw-SQL SELECT shows <REDACTED:DISCORD_TOKEN>; raw token absent from disk."""
+        """Raw-SQL SELECT が <REDACTED:DISCORD_TOKEN> を返し、生トークンはディスク上に残らない。"""
         room_id, directive_id = seeded_task_context
         last_error = (
             f"Discord webhook failed: https://discord.com/api/webhooks/123/{_DISCORD_TOKEN}\n"
@@ -133,14 +132,14 @@ class TestLastErrorDiscordTokenMasked:
 # TC-IT-TR-020-masking-passthrough: tasks.last_error plain text unchanged
 # ---------------------------------------------------------------------------
 class TestLastErrorNoSecretPassthrough:
-    """TC-IT-TR-020-masking-passthrough: plain error text stored byte-identical."""
+    """TC-IT-TR-020-masking-passthrough: 平文のエラーテキストはバイト等価で保存される。"""
 
     async def test_plain_error_text_is_passthrough(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_task_context: tuple[UUID, UUID],
     ) -> None:
-        """A last_error without secrets is stored unchanged (masking is scoped)."""
+        """secret を含まない last_error は変更なしで保存される (masking は適用範囲限定)。"""
         room_id, directive_id = seeded_task_context
         plain_error = "RateLimitExceeded: max 100 requests/min. Retry after 60s."
         blocked = make_blocked_task(
@@ -162,11 +161,11 @@ class TestLastErrorNoSecretPassthrough:
 # TC-IT-TR-020-masking-roundtrip: §確定 G §不可逆性
 # ---------------------------------------------------------------------------
 class TestLastErrorRoundTripIsIrreversible:
-    """TC-IT-TR-020-masking-roundtrip: find_by_id returns masked last_error.
+    """TC-IT-TR-020-masking-roundtrip: find_by_id はマスク済み last_error を返す。
 
-    Once a Discord token is masked at save(), the raw token is physically
-    unrecoverable from DB. find_by_id must return a Task whose last_error
-    carries the redaction sentinel rather than the original token.
+    save() 時に一度 Discord トークンが masking されると、生トークンは
+    DB から物理的に復元不能となる。find_by_id は last_error に元トークンではなく
+    redaction sentinel を含む Task を返さねばならない。
     """
 
     async def test_find_by_id_returns_masked_last_error(
@@ -174,7 +173,7 @@ class TestLastErrorRoundTripIsIrreversible:
         session_factory: async_sessionmaker[AsyncSession],
         seeded_task_context: tuple[UUID, UUID],
     ) -> None:
-        """Save raw Discord token in last_error → find_by_id → last_error == masked."""
+        """生 Discord トークンを last_error に保存 → find_by_id → last_error がマスクされている。"""
         room_id, directive_id = seeded_task_context
         raw_error = f"webhook auth={_DISCORD_TOKEN} rejected by Discord API"
         blocked = make_blocked_task(
@@ -204,14 +203,14 @@ class TestLastErrorRoundTripIsIrreversible:
 # TC-IT-TR-020-masking-null-safe: NULL last_error safe
 # ---------------------------------------------------------------------------
 class TestLastErrorNullSafe:
-    """TC-IT-TR-020-masking-null-safe: last_error=None stored as SQL NULL."""
+    """TC-IT-TR-020-masking-null-safe: last_error=None は SQL NULL として保存される。"""
 
     async def test_null_last_error_stored_as_null(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_task_context: tuple[UUID, UUID],
     ) -> None:
-        """PENDING task with last_error=None → raw SQL SELECT returns NULL."""
+        """PENDING task で last_error=None → raw SQL SELECT は NULL を返す。"""
         room_id, directive_id = seeded_task_context
         task = make_task(room_id=room_id, directive_id=directive_id, last_error=None)
         async with session_factory() as session, session.begin():
@@ -227,14 +226,15 @@ class TestLastErrorNullSafe:
 # TC-IT-TR-020-masking-deliverable: deliverables.body_markdown GitHub PAT
 # ---------------------------------------------------------------------------
 class TestDeliverableBodyMarkdownGitHubPatMasked:
-    """TC-IT-TR-020-masking-deliverable: GitHub PAT in deliverables.body_markdown redacted."""
+    """TC-IT-TR-020-masking-deliverable: deliverables.body_markdown
+    中の GitHub PAT が redact される。"""
 
     async def test_github_pat_in_deliverable_body_redacted(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_task_context: tuple[UUID, UUID],
     ) -> None:
-        """Raw-SQL SELECT shows <REDACTED:GITHUB_PAT>; raw PAT absent from disk."""
+        """Raw-SQL SELECT が <REDACTED:GITHUB_PAT> を返し、生 PAT はディスク上に残らない。"""
         room_id, directive_id = seeded_task_context
         stage_id = uuid4()
         body = f"## 成果物\nGitHub PAT: {_GITHUB_TOKEN}\nこのトークンでリポジトリを操作しました。"
@@ -264,7 +264,7 @@ class TestDeliverableBodyMarkdownGitHubPatMasked:
         session_factory: async_sessionmaker[AsyncSession],
         seeded_task_context: tuple[UUID, UUID],
     ) -> None:
-        """deliverables.body_markdown without secrets stored unchanged."""
+        """secret を含まない deliverables.body_markdown は変更なしで保存される。"""
         room_id, directive_id = seeded_task_context
         stage_id = uuid4()
         plain_body = "## 成果物\n\nタスク完了。特に問題なし。"
@@ -285,18 +285,18 @@ class TestDeliverableBodyMarkdownGitHubPatMasked:
 
 
 # ---------------------------------------------------------------------------
-# TC-IT-TR-020-masking-2columns: simultaneous masking (2 columns at once)
+# TC-IT-TR-020-masking-2columns: 同時 masking (2 カラム同時)
 #
 # §BUG-TR-002 凍結済みのため conversation_messages は除外。
 # tasks.last_error (Discord) + deliverables.body_markdown (GitHub PAT) のみ。
 # ---------------------------------------------------------------------------
 class TestTwoColumnSimultaneousMasking:
-    """TC-IT-TR-020-masking-2columns: 2 MaskedText columns redacted simultaneously.
+    """TC-IT-TR-020-masking-2columns: 2 つの MaskedText カラムが同時に redact される。
 
-    One Task with:
-      * tasks.last_error            → Discord token
+    1 つの Task で以下を持つ:
+      * tasks.last_error            → Discord トークン
       * deliverables.body_markdown  → GitHub PAT
-    Both must be redacted in a single save cycle.
+    両方とも 1 回の save サイクルで redact されねばならない。
     """
 
     async def test_two_masked_text_columns_redacted_simultaneously(
@@ -304,13 +304,13 @@ class TestTwoColumnSimultaneousMasking:
         session_factory: async_sessionmaker[AsyncSession],
         seeded_task_context: tuple[UUID, UUID],
     ) -> None:
-        """Discord + GitHub both redacted across 2 separate MaskedText columns."""
+        """別個の 2 つの MaskedText カラム全てで Discord + GitHub がいずれも redact される。"""
         room_id, directive_id = seeded_task_context
         stage_id = uuid4()
 
-        # last_error with Discord token
+        # last_error に Discord トークン
         last_error = f"Discord webhook error: {_DISCORD_TOKEN}"
-        # deliverable body with GitHub PAT
+        # deliverable body に GitHub PAT
         deliv_body = f"## 成果物\nGitHub clone with token {_GITHUB_TOKEN}"
         deliv = make_deliverable(stage_id=stage_id, body_markdown=deliv_body)
 
@@ -323,18 +323,18 @@ class TestTwoColumnSimultaneousMasking:
         async with session_factory() as session, session.begin():
             await SqliteTaskRepository(session).save(blocked)
 
-        # Verify both columns via raw SQL
+        # 両カラムを raw SQL で確認
         persisted_last_error = await _read_last_error(session_factory, blocked.id)
         persisted_deliv = await _read_deliverable_body(session_factory, blocked.id)
 
-        # tasks.last_error — Discord
+        # tasks.last_error ── Discord
         assert persisted_last_error is not None
         assert _DISCORD_SENTINEL in persisted_last_error, (
             "[FAIL] tasks.last_error missing Discord sentinel in 2-column test."
         )
         assert _DISCORD_TOKEN not in persisted_last_error
 
-        # deliverables.body_markdown — GitHub
+        # deliverables.body_markdown ── GitHub
         assert persisted_deliv is not None
         assert _GITHUB_SENTINEL in persisted_deliv, (
             "[FAIL] deliverables.body_markdown missing GitHub sentinel in 2-column test."

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_task_repository/test_masking_fields.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_task_repository/test_masking_fields.py
@@ -49,7 +49,7 @@ _DISCORD_TOKEN = "MTk4NjIyNDgz" + "NDcxOTI1MjQ4.ClFDg_." + "A" * 27
 # GitHub PAT ── (?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36,}
 _GITHUB_TOKEN = "ghp_" + "X" * 40
 
-# redaction sentinel
+# redaction センチネル
 _DISCORD_SENTINEL = "<REDACTED:DISCORD_TOKEN>"
 _GITHUB_SENTINEL = "<REDACTED:GITHUB_PAT>"
 
@@ -327,14 +327,14 @@ class TestTwoColumnSimultaneousMasking:
         persisted_last_error = await _read_last_error(session_factory, blocked.id)
         persisted_deliv = await _read_deliverable_body(session_factory, blocked.id)
 
-        # tasks.last_error ── Discord
+        # tasks.last_error フィールドの Discord トークン検査
         assert persisted_last_error is not None
         assert _DISCORD_SENTINEL in persisted_last_error, (
             "[FAIL] tasks.last_error missing Discord sentinel in 2-column test."
         )
         assert _DISCORD_TOKEN not in persisted_last_error
 
-        # deliverables.body_markdown ── GitHub
+        # deliverables.body_markdown フィールドの GitHub PAT 検査
         assert persisted_deliv is not None
         assert _GITHUB_SENTINEL in persisted_deliv, (
             "[FAIL] deliverables.body_markdown missing GitHub sentinel in 2-column test."

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_task_repository/test_protocol_crud.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_task_repository/test_protocol_crud.py
@@ -1,16 +1,16 @@
-"""Task Repository: Protocol surface + basic CRUD + Lifecycle.
+"""Task Repository: Protocol サーフェス + 基本 CRUD + ライフサイクル。
 
 TC-UT-TR-001〜004/009 + TC-IT-TR-LIFECYCLE.
 
-REQ-TR-001 / REQ-TR-002 — 6-method Protocol (§確定 R1-A / §確定 R1-D) +
-CRUD (find_by_id / count / save / Tx boundary) + Lifecycle.
+REQ-TR-001 / REQ-TR-002 ── 6 メソッドの Protocol (§確定 R1-A / §確定 R1-D) +
+CRUD (find_by_id / count / save / Tx 境界) + ライフサイクル。
 
-save() child-table semantics (TC-UT-TR-005/005b/005c) live in
-``test_save_child_tables.py``.  count_by_status / count_by_room
-(TC-UT-TR-006/007) live in ``test_count_methods.py``.
+save() の child-table セマンティクス (TC-UT-TR-005/005b/005c) は
+``test_save_child_tables.py`` に置く。count_by_status / count_by_room
+(TC-UT-TR-006/007) は ``test_count_methods.py`` に置く。
 
-Per ``docs/features/task-repository/test-design.md``.
-Issue #35 — M2 0007.
+``docs/features/task-repository/test-design.md`` 準拠。
+Issue #35 — M2 0007。
 """
 
 from __future__ import annotations
@@ -40,13 +40,13 @@ pytestmark = pytest.mark.asyncio
 
 
 # ---------------------------------------------------------------------------
-# TC-UT-TR-001: Protocol definition + 6-method surface (§確定 R1-A / §確定 R1-D)
+# TC-UT-TR-001: Protocol 定義 + 6 メソッドサーフェス (§確定 R1-A / §確定 R1-D)
 # ---------------------------------------------------------------------------
 class TestTaskRepositoryProtocol:
-    """TC-UT-TR-001: Protocol declares 6 async methods."""
+    """TC-UT-TR-001: Protocol が 6 つの async メソッドを宣言する。"""
 
     async def test_protocol_declares_six_async_methods(self) -> None:
-        """TC-UT-TR-001: TaskRepository has all 6 required methods."""
+        """TC-UT-TR-001: TaskRepository が必須 6 メソッドをすべて持つ。"""
         for method_name in (
             "find_by_id",
             "count",
@@ -61,12 +61,13 @@ class TestTaskRepositoryProtocol:
             )
 
     async def test_protocol_does_not_have_yagni_methods(self) -> None:
-        """TC-UT-TR-001: YAGNI methods (find_by_room, find_by_directive) absent.
+        """TC-UT-TR-001: YAGNI メソッド (find_by_room, find_by_directive) は不在。
 
-        §確定 R1-D YAGNI 拒否済み: find_by_room requires pagination spec
-        (未確定), find_by_directive has no callers. If these reappear, the
-        YAGNI decision in requirements-analysis §確定 R1-D was reversed
-        without updating the design doc first.
+        §確定 R1-D で YAGNI 拒否済み: find_by_room は
+        ページネーション仕様（未確定）が必要、find_by_directive は
+        呼び出し元なし。これらが再出現したら、requirements-analysis
+        §確定 R1-D の YAGNI 判断を設計ドキュメントを更新せず反転させた
+        ことになる。
         """
         for banned_method in ("find_by_room", "find_by_directive"):
             assert not hasattr(TaskRepository, banned_method), (
@@ -78,7 +79,7 @@ class TestTaskRepositoryProtocol:
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """TC-UT-TR-001: SqliteTaskRepository satisfies TaskRepository Protocol."""
+        """TC-UT-TR-001: SqliteTaskRepository が TaskRepository Protocol を満たす。"""
         async with session_factory() as session:
             repo: TaskRepository = SqliteTaskRepository(session)
             for method_name in (
@@ -95,7 +96,7 @@ class TestTaskRepositoryProtocol:
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """TC-UT-TR-001: duck-typing confirms all 6 methods present on impl."""
+        """TC-UT-TR-001: ダックタイピングで実装に 6 メソッドすべての存在を確認する。"""
         async with session_factory() as session:
             repo = SqliteTaskRepository(session)
             for method_name in (
@@ -115,14 +116,14 @@ class TestTaskRepositoryProtocol:
 # TC-UT-TR-002: find_by_id (REQ-TR-002)
 # ---------------------------------------------------------------------------
 class TestFindById:
-    """TC-UT-TR-002: find_by_id retrieves saved Tasks; None for unknown."""
+    """TC-UT-TR-002: find_by_id は保存済み Task を取得する。未知の id は None。"""
 
     async def test_find_by_id_returns_saved_task(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_task_context: tuple[UUID, UUID],
     ) -> None:
-        """save(task) → find_by_id(task.id) returns the Task."""
+        """save(task) → find_by_id(task.id) が Task を返す。"""
         room_id, directive_id = seeded_task_context
         task = make_task(room_id=room_id, directive_id=directive_id)
         async with session_factory() as session, session.begin():
@@ -137,28 +138,28 @@ class TestFindById:
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """find_by_id with unknown TaskId returns None."""
+        """未知 TaskId での find_by_id は None を返す。"""
         async with session_factory() as session:
             result = await SqliteTaskRepository(session).find_by_id(uuid4())  # type: ignore[arg-type]
         assert result is None
 
 
 # ---------------------------------------------------------------------------
-# TC-UT-TR-003: save round-trip — all attributes (§確定 R1-H / §確定 R1-J)
+# TC-UT-TR-003: save ラウンドトリップ ── 全属性 (§確定 R1-H / §確定 R1-J)
 # ---------------------------------------------------------------------------
 class TestSaveRoundTrip:
-    """TC-UT-TR-003: save → find_by_id round-trips all Task attributes."""
+    """TC-UT-TR-003: save → find_by_id ですべての Task 属性がラウンドトリップする。"""
 
     async def test_save_find_by_id_round_trip_all_attributes(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_task_context: tuple[UUID, UUID],
     ) -> None:
-        """All scalar + child attributes survive save → find_by_id round-trip.
+        """全スカラー + 子属性が save → find_by_id ラウンドトリップを生き残る。
 
-        §確定 R1-J: _from_rows reconstructs assigned_agent_ids (order_index order)
-        and deliverables (dict[StageId, Deliverable]). conversations are empty
-        because the Task domain model has no conversations attribute yet.
+        §確定 R1-J: _from_rows は assigned_agent_ids（order_index 順）と
+        deliverables (dict[StageId, Deliverable]) を再構成する。
+        Task ドメインモデルにまだ conversations 属性がないため conversations は空。
         """
         room_id, directive_id = seeded_task_context
         agent1_id = uuid4()
@@ -193,12 +194,12 @@ class TestSaveRoundTrip:
         assert restored.updated_at.tzinfo is not None, (
             "[FAIL] updated_at lost timezone info in round-trip."
         )
-        # §確定 R1-J: assigned_agent_ids preserved in order_index order
+        # §確定 R1-J: assigned_agent_ids は order_index 順で保持される
         assert restored.assigned_agent_ids == [agent1_id, agent2_id], (
             f"[FAIL] assigned_agent_ids order not preserved.\n"
             f"Expected: {[agent1_id, agent2_id]}\nGot: {restored.assigned_agent_ids}"
         )
-        # §確定 R1-J: deliverables dict keyed by stage_id
+        # §確定 R1-J: deliverables dict は stage_id をキーとする
         assert stage_id in restored.deliverables, (  # type: ignore[operator]
             f"[FAIL] deliverables dict missing stage_id={stage_id}"
         )
@@ -210,7 +211,7 @@ class TestSaveRoundTrip:
         session_factory: async_sessionmaker[AsyncSession],
         seeded_task_context: tuple[UUID, UUID],
     ) -> None:
-        """created_at / updated_at are UTC tz-aware after find_by_id."""
+        """find_by_id 後、created_at / updated_at が UTC tz-aware である。"""
         room_id, directive_id = seeded_task_context
         task = make_task(room_id=room_id, directive_id=directive_id)
         async with session_factory() as session, session.begin():
@@ -228,7 +229,7 @@ class TestSaveRoundTrip:
         session_factory: async_sessionmaker[AsyncSession],
         seeded_task_context: tuple[UUID, UUID],
     ) -> None:
-        """PENDING task with last_error=None round-trips as None."""
+        """last_error=None の PENDING task はラウンドトリップしても None のまま。"""
         room_id, directive_id = seeded_task_context
         task = make_task(room_id=room_id, directive_id=directive_id, last_error=None)
         async with session_factory() as session, session.begin():
@@ -245,7 +246,7 @@ class TestSaveRoundTrip:
         session_factory: async_sessionmaker[AsyncSession],
         seeded_task_context: tuple[UUID, UUID],
     ) -> None:
-        """Task with no assigned agents round-trips with empty list."""
+        """アサイン agent なしの Task は空リストでラウンドトリップする。"""
         room_id, directive_id = seeded_task_context
         task = make_task(room_id=room_id, directive_id=directive_id, assigned_agent_ids=[])
         async with session_factory() as session, session.begin():
@@ -262,7 +263,7 @@ class TestSaveRoundTrip:
         session_factory: async_sessionmaker[AsyncSession],
         seeded_task_context: tuple[UUID, UUID],
     ) -> None:
-        """Task with no deliverables round-trips with empty dict."""
+        """deliverable なしの Task は空 dict でラウンドトリップする。"""
         room_id, directive_id = seeded_task_context
         task = make_task(room_id=room_id, directive_id=directive_id, deliverables={})
         async with session_factory() as session, session.begin():
@@ -276,10 +277,10 @@ class TestSaveRoundTrip:
 
 
 # ---------------------------------------------------------------------------
-# TC-UT-TR-004: count() SQL COUNT(*) (empire §確定 D 踏襲)
+# TC-UT-TR-004: count() の SQL COUNT(*) (empire §確定 D 踏襲)
 # ---------------------------------------------------------------------------
 class TestCountScalar:
-    """TC-UT-TR-004: count() issues SELECT COUNT(*) without full row load."""
+    """TC-UT-TR-004: count() は全行ロード無しに SELECT COUNT(*) を発行する。"""
 
     async def test_count_emits_select_count_not_full_load(
         self,
@@ -287,7 +288,7 @@ class TestCountScalar:
         app_engine: AsyncEngine,
         seeded_task_context: tuple[UUID, UUID],
     ) -> None:
-        """count() SQL log contains COUNT(*); full-row SELECT is absent."""
+        """count() の SQL ログに COUNT(*) が含まれ、全行 SELECT が含まれない。"""
         room_id, directive_id = seeded_task_context
         for _ in range(3):
             async with session_factory() as session, session.begin():
@@ -320,7 +321,7 @@ class TestCountScalar:
         assert count_stmts, (
             f"[FAIL] count() did not emit SELECT count(*) FROM tasks.\nCaptured: {captured}"
         )
-        # Full-row load path must NOT appear
+        # 全行ロード経路は出現してはならない
         full_load_stmts = [
             s
             for s in captured
@@ -333,17 +334,17 @@ class TestCountScalar:
 
 
 # ---------------------------------------------------------------------------
-# TC-UT-TR-009: Tx boundary (empire §確定 B 踏襲)
+# TC-UT-TR-009: Tx 境界 (empire §確定 B 踏襲)
 # ---------------------------------------------------------------------------
 class TestTxBoundary:
-    """TC-UT-TR-009: Repository does not auto-commit; caller owns UoW boundary."""
+    """TC-UT-TR-009: Repository は自動 commit せず、UoW 境界は呼び出し側が所有する。"""
 
     async def test_save_within_begin_persists(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_task_context: tuple[UUID, UUID],
     ) -> None:
-        """save inside async with session.begin() persists the row."""
+        """async with session.begin() 内の save は行を永続化する。"""
         room_id, directive_id = seeded_task_context
         task = make_task(room_id=room_id, directive_id=directive_id)
         async with session_factory() as session, session.begin():
@@ -358,14 +359,14 @@ class TestTxBoundary:
         session_factory: async_sessionmaker[AsyncSession],
         seeded_task_context: tuple[UUID, UUID],
     ) -> None:
-        """save without session.begin() leaves row absent after session close.
+        """session.begin() なしの save は session クローズ後に行が残らない。
 
-        Without begin(), SQLAlchemy async session auto-rolls back on exit.
+        begin() がないと SQLAlchemy async session は終了時に自動ロールバックする。
         """
         room_id, directive_id = seeded_task_context
         task = make_task(room_id=room_id, directive_id=directive_id)
         async with session_factory() as session:
-            # No session.begin() → auto-rollback on __aexit__
+            # session.begin() なし → __aexit__ で自動ロールバック
             await SqliteTaskRepository(session).save(task)
 
         async with session_factory() as session:
@@ -377,20 +378,20 @@ class TestTxBoundary:
 
 
 # ---------------------------------------------------------------------------
-# TC-IT-TR-LIFECYCLE: 6-method full lifecycle
+# TC-IT-TR-LIFECYCLE: 6 メソッドのフルライフサイクル
 # ---------------------------------------------------------------------------
 class TestLifecycleIntegration:
-    """TC-IT-TR-LIFECYCLE: 6-method full lifecycle integration."""
+    """TC-IT-TR-LIFECYCLE: 6 メソッドのフルライフサイクル統合。"""
 
     async def test_full_lifecycle_6_method(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_task_context: tuple[UUID, UUID],
     ) -> None:
-        """save x2 → count_by_status → find_blocked → count_by_room → count → re-save → verify."""
+        """save x2 → count_by_status → find_blocked → count_by_room → count → 再 save → 検証。"""
         room_id, directive_id = seeded_task_context
 
-        # Step 1: save a PENDING task and a BLOCKED task
+        # Step 1: PENDING タスクと BLOCKED タスクを save
         pending = make_task(room_id=room_id, directive_id=directive_id)
         blocked = make_blocked_task(
             room_id=room_id,
@@ -407,7 +408,7 @@ class TestLifecycleIntegration:
             blocked_count = await SqliteTaskRepository(session).count_by_status(TaskStatus.BLOCKED)
         assert blocked_count == 1
 
-        # Step 3: find_blocked returns the blocked task
+        # Step 3: find_blocked が blocked タスクを返す
         async with session_factory() as session:
             blocked_tasks = await SqliteTaskRepository(session).find_blocked()
         assert len(blocked_tasks) == 1
@@ -423,7 +424,7 @@ class TestLifecycleIntegration:
             total = await SqliteTaskRepository(session).count()
         assert total == 2
 
-        # Step 6: re-save blocked with updated status (DONE)
+        # Step 6: blocked を更新後 status (DONE) で再 save
         done = make_done_task(
             task_id=blocked.id,
             room_id=room_id,
@@ -432,7 +433,7 @@ class TestLifecycleIntegration:
         async with session_factory() as session, session.begin():
             await SqliteTaskRepository(session).save(done)
 
-        # Step 7: find_blocked returns [] now
+        # Step 7: find_blocked が [] を返すようになる
         async with session_factory() as session:
             blocked_after = await SqliteTaskRepository(session).find_blocked()
         assert blocked_after == []

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_task_repository/test_protocol_crud.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_task_repository/test_protocol_crud.py
@@ -403,7 +403,7 @@ class TestLifecycleIntegration:
             await repo.save(pending)
             await repo.save(blocked)
 
-        # Step 2: count_by_status
+        # Step 2: count_by_status の検証
         async with session_factory() as session:
             blocked_count = await SqliteTaskRepository(session).count_by_status(TaskStatus.BLOCKED)
         assert blocked_count == 1
@@ -414,12 +414,12 @@ class TestLifecycleIntegration:
         assert len(blocked_tasks) == 1
         assert blocked_tasks[0].id == blocked.id
 
-        # Step 4: count_by_room
+        # Step 4: count_by_room の検証
         async with session_factory() as session:
             room_count = await SqliteTaskRepository(session).count_by_room(room_id)  # type: ignore[arg-type]
         assert room_count == 2
 
-        # Step 5: count
+        # Step 5: count の検証
         async with session_factory() as session:
             total = await SqliteTaskRepository(session).count()
         assert total == 2
@@ -438,7 +438,7 @@ class TestLifecycleIntegration:
             blocked_after = await SqliteTaskRepository(session).find_blocked()
         assert blocked_after == []
 
-        # Step 8: count_by_status(BLOCKED) == 0
+        # Step 8: count_by_status(BLOCKED) == 0 の検証
         async with session_factory() as session:
             blocked_count_after = await SqliteTaskRepository(session).count_by_status(
                 TaskStatus.BLOCKED

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_task_repository/test_save_child_tables.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_task_repository/test_save_child_tables.py
@@ -1,18 +1,18 @@
-"""Task Repository: save() child-table semantics (TC-UT-TR-005/005b/005c).
+"""Task Repository: save() 副テーブルセマンティクス (TC-UT-TR-005/005b/005c)。
 
-REQ-TR-001 / §確定 R1-B — 6-stage save() DELETE+UPSERT+INSERT semantics:
-  Stage 1: DELETE deliverables WHERE task_id = ?
-  Stage 2: DELETE task_assigned_agents WHERE task_id = ?
-  Stage 3: UPSERT tasks (ON CONFLICT DO UPDATE mutable fields)
-  Stage 4: INSERT task_assigned_agents (order_index)
-  Stage 5: INSERT deliverables
-  Stage 6: INSERT deliverable_attachments
+REQ-TR-001 / §確定 R1-B — 6段階 save() DELETE+UPSERT+INSERT セマンティクス:
+  段階 1: DELETE deliverables WHERE task_id = ?
+  段階 2: DELETE task_assigned_agents WHERE task_id = ?
+  段階 3: UPSERT tasks (ON CONFLICT DO UPDATE 可変フィールド)
+  段階 4: INSERT task_assigned_agents (order_index)
+  段階 5: INSERT deliverables
+  段階 6: INSERT deliverable_attachments
 
-Child tables are fully replaced on every save() call.
-UNIQUE(task_id, stage_id) on deliverables is safe because DELETE precedes INSERT.
+副テーブルは save() 呼び出しのたびに完全に置換される。
+deliverables の UNIQUE(task_id, stage_id) は DELETE が INSERT に先行するため安全。
 
-Per ``docs/features/task-repository/test-design.md`` TC-UT-TR-005/005b/005c.
-Issue #35 — M2 0007.
+``docs/features/task-repository/test-design.md`` TC-UT-TR-005/005b/005c 準拠。
+Issue #35 — M2 0007。
 """
 
 from __future__ import annotations
@@ -42,24 +42,24 @@ pytestmark = pytest.mark.asyncio
 # TC-UT-TR-005: save() 6-stage DELETE+UPSERT+INSERT semantics (§確定 R1-B)
 # ---------------------------------------------------------------------------
 class TestSaveChildTableSemantics:
-    """TC-UT-TR-005/005b/005c: save() 6-stage order and re-save UPSERT semantics."""
+    """TC-UT-TR-005/005b/005c: save() 6段階の順序と再保存 UPSERT セマンティクス。"""
 
     async def test_resave_updates_scalar_fields(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         seeded_task_context: tuple[UUID, UUID],
     ) -> None:
-        """Re-saving a Task updates mutable scalar fields (ON CONFLICT DO UPDATE).
+        """Task を再保存すると可変スカラーフィールドが更新される (ON CONFLICT DO UPDATE)。
 
-        Tests stage 3 (UPSERT): current_stage_id / status / last_error / updated_at
-        are updated; room_id / directive_id / created_at are NOT updated.
+        段階 3 (UPSERT) をテスト: current_stage_id / status / last_error / updated_at
+        は更新される; room_id / directive_id / created_at は更新されない。
         """
         room_id, directive_id = seeded_task_context
         original = make_task(room_id=room_id, directive_id=directive_id)
         async with session_factory() as session, session.begin():
             await SqliteTaskRepository(session).save(original)
 
-        # Re-save with different status (PENDING → IN_PROGRESS via factory bypass)
+        # 異なるステータスで再保存 (PENDING → IN_PROGRESS via factory bypass)
         updated = make_in_progress_task(
             task_id=original.id,
             room_id=room_id,
@@ -73,7 +73,7 @@ class TestSaveChildTableSemantics:
 
         assert restored is not None
         assert restored.status == TaskStatus.IN_PROGRESS
-        # room_id / directive_id / created_at remain from original (immutable)
+        # room_id / directive_id / created_at は元のまま (不変)
         assert restored.room_id == original.room_id
         assert restored.directive_id == original.directive_id
 
@@ -82,7 +82,7 @@ class TestSaveChildTableSemantics:
         session_factory: async_sessionmaker[AsyncSession],
         seeded_task_context: tuple[UUID, UUID],
     ) -> None:
-        """Re-saving same task_id does not duplicate the tasks row (UPSERT)."""
+        """同じ task_id の再保存は tasks 行を重複させない (UPSERT)。"""
         room_id, directive_id = seeded_task_context
         task = make_task(room_id=room_id, directive_id=directive_id)
         async with session_factory() as session, session.begin():
@@ -99,10 +99,10 @@ class TestSaveChildTableSemantics:
         session_factory: async_sessionmaker[AsyncSession],
         seeded_task_context: tuple[UUID, UUID],
     ) -> None:
-        """Re-save with different assigned_agents re-inserts task_assigned_agents.
+        """異なる assigned_agents での再保存は task_assigned_agents を再挿入。
 
-        Tests stages 2 (DELETE task_assigned_agents) + 4 (INSERT new agents).
-        Original agents are cleared, new agents are written.
+        段階 2 (DELETE task_assigned_agents) + 段階 4 (新しいエージェントを INSERT) をテスト。
+        元のエージェントがクリアされ、新しいエージェントが書き込まれる。
         """
         room_id, directive_id = seeded_task_context
         agent_a = uuid4()
@@ -115,7 +115,7 @@ class TestSaveChildTableSemantics:
         async with session_factory() as session, session.begin():
             await SqliteTaskRepository(session).save(original)
 
-        # Re-save with different agents
+        # 異なるエージェントで再保存
         updated = make_in_progress_task(
             task_id=original.id,
             room_id=room_id,
@@ -139,11 +139,11 @@ class TestSaveChildTableSemantics:
         session_factory: async_sessionmaker[AsyncSession],
         seeded_task_context: tuple[UUID, UUID],
     ) -> None:
-        """TC-UT-TR-005b: re-saving same stage_id deliverable does not violate UNIQUE.
+        """TC-UT-TR-005b: 同じ stage_id の納品物の再保存は UNIQUE 違反にならない。
 
-        UNIQUE(task_id, stage_id) constraint: stage 1 DELETEs old deliverable
-        rows, stage 5 INSERTs fresh ones. No UNIQUE violation occurs because
-        DELETE happens before INSERT.
+        UNIQUE(task_id, stage_id) 制約: 段階 1 は古い納品物行をDELETE、
+        段階 5 は新しい行をINSERT。DELETE が INSERT の前に行われるため
+        UNIQUE 違反は発生しない。
         """
         room_id, directive_id = seeded_task_context
         stage_id = uuid4()
@@ -163,7 +163,7 @@ class TestSaveChildTableSemantics:
             directive_id=directive_id,
             deliverables={stage_id: deliv_v2},  # type: ignore[dict-item]
         )
-        # Must not raise IntegrityError (UNIQUE constraint)
+        # IntegrityError (UNIQUE 制約) を発生させてはならない
         async with session_factory() as session, session.begin():
             await SqliteTaskRepository(session).save(task_v2)
 
@@ -172,7 +172,7 @@ class TestSaveChildTableSemantics:
 
         assert restored is not None
         assert restored.deliverables[stage_id].body_markdown == "# バージョン2", (  # type: ignore[index]
-            "[FAIL] Deliverable body_markdown not updated after re-save."
+            "[FAIL] 再保存後に Deliverable body_markdown が更新されていない。"
         )
 
     async def test_resave_empty_to_full_task_all_child_tables(
@@ -180,9 +180,9 @@ class TestSaveChildTableSemantics:
         session_factory: async_sessionmaker[AsyncSession],
         seeded_task_context: tuple[UUID, UUID],
     ) -> None:
-        """TC-UT-TR-005c: empty task → full task (agents + deliverables) on re-save."""
+        """TC-UT-TR-005c: 空 Task → 満杯 Task (エージェント + 納品物) の再保存。"""
         room_id, directive_id = seeded_task_context
-        # Initially empty
+        # 最初は空
         empty_task = make_task(
             room_id=room_id,
             directive_id=directive_id,
@@ -192,7 +192,7 @@ class TestSaveChildTableSemantics:
         async with session_factory() as session, session.begin():
             await SqliteTaskRepository(session).save(empty_task)
 
-        # Re-save with agents + deliverables
+        # エージェント + 納品物で再保存
         stage_id = uuid4()
         deliv = make_deliverable(stage_id=stage_id)
         full_task = make_in_progress_task(

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_workflow_repository/__init__.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_workflow_repository/__init__.py
@@ -1,22 +1,22 @@
-"""Workflow Repository integration tests, split by topic.
+"""トピックごとに分割された Workflow Repository の統合テスト群。
 
-Per ``docs/features/workflow-repository/test-design.md`` and Norman's
-500-line rule (established in empire-repository PR #25): the test
-surface is split into four siblings so each file stays under the
-readability budget and the next 5 Repository PRs can extend the
-pattern without inheriting a 500+ line monolith:
+``docs/features/workflow-repository/test-design.md`` および Norman の
+500 行ルール（empire-repository PR #25 で確立）に従い、各ファイルが
+可読性の閾値を超えず、後続の 5 Repository PR が 500+ 行のモノリスを
+継承することなくパターンを拡張できるよう、テスト面を 4 つの兄弟ファイル
+に分割している:
 
-* :mod:`...test_protocol_crud` — Protocol surface + ``find_by_id`` /
-  ``count`` / ``save`` basic CRUD + ORDER BY observation + COUNT(*) SQL
-  observation + singleton non-enforcement
-  (TC-IT-WFR-001〜007, 019).
-* :mod:`...test_save_semantics` — delete-then-insert + 5-step SQL
-  order + Tx boundary + roles_csv determinism + round-trip equality
-  (TC-IT-WFR-008〜012, 015, 016).
-* :mod:`...test_constraints_arch` — DB-level FK CASCADE + UNIQUE pair
-  enforcement + CI three-layer-defense partial-mask template
-  (TC-IT-WFR-017, 018, 023).
-* :mod:`...test_masking` — §確定 H 物理確認: ``MaskedJSONEncoded``
-  redaction at the SQLite layer + §不可逆性 (find_by_id raises on
-  masked notify_channels) (TC-IT-WFR-013, 014).
+* :mod:`...test_protocol_crud` — Protocol 面 + ``find_by_id`` /
+  ``count`` / ``save`` の基本 CRUD + ORDER BY 観察 + COUNT(*) SQL 観察
+  + シングルトン非強制
+  （TC-IT-WFR-001〜007, 019）。
+* :mod:`...test_save_semantics` — delete-then-insert + 5 ステップ SQL
+  順序 + Tx 境界 + roles_csv 決定性 + ラウンドトリップ等価性
+  （TC-IT-WFR-008〜012, 015, 016）。
+* :mod:`...test_constraints_arch` — DB レベルの FK CASCADE + UNIQUE
+  ペア強制 + CI 三層防衛部分マスクテンプレート
+  （TC-IT-WFR-017, 018, 023）。
+* :mod:`...test_masking` — §確定 H 物理確認: SQLite 層での
+  ``MaskedJSONEncoded`` 編集 + §不可逆性（マスクされた notify_channels で
+  find_by_id が例外を送出）（TC-IT-WFR-013, 014）。
 """

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_workflow_repository/test_constraints_arch.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_workflow_repository/test_constraints_arch.py
@@ -84,7 +84,7 @@ class TestForeignKeyCascade:
 
 # ---------------------------------------------------------------------------
 # TC-IT-WFR-018: UNIQUE制約 (workflow_id, stage_id) および
-#                                       (workflow_id, transition_id)
+#                                       （workflow_id, transition_id）の複合キー
 # ---------------------------------------------------------------------------
 class TestUniqueConstraintViolation:
     """TC-IT-WFR-018: 重複 (workflow_id, stage_id) / (..., transition_id) は例外を発生させる。"""

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_workflow_repository/test_constraints_arch.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_workflow_repository/test_constraints_arch.py
@@ -1,12 +1,12 @@
-"""Workflow Repository: DB constraints + arch-test partial-mask template.
+"""Workflow Repository: DB制約 + アーキテクチャテスト部分マスキングテンプレート.
 
-TC-IT-WFR-017 / 018 / 023 — FK CASCADE, UNIQUE pair enforcement, and
-the **partial-mask** CI three-layer-defense template the Workflow PR
-introduces (empire-repo froze the *no-mask* template; this PR freezes
-the *partial-mask* template — exactly one masked column on a table,
-every other column un-masked).
+TC-IT-WFR-017 / 018 / 023 — FK CASCADE、UNIQUE ペアの強制実行、および
+この Workflow PR が導入する**部分マスキング** CI 3層防御テンプレート
+（empire-repo は*マスキングなし*テンプレートをフリーズ；この PR は
+*部分マスキング*テンプレートをフリーズ — 正確に1列がマスキングされ、
+他の全列はマスキングされない）。
 
-Per ``docs/features/workflow-repository/test-design.md``.
+詳細は ``docs/features/workflow-repository/test-design.md`` を参照。
 """
 
 from __future__ import annotations
@@ -39,13 +39,14 @@ pytestmark = pytest.mark.asyncio
 # TC-IT-WFR-017: FK CASCADE
 # ---------------------------------------------------------------------------
 class TestForeignKeyCascade:
-    """TC-IT-WFR-017: ``DELETE FROM workflows`` cascades to side tables."""
+    """TC-IT-WFR-017: ``DELETE FROM workflows`` は副テーブルにカスケードする。"""
 
     async def test_delete_workflow_cascades_to_side_tables(
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """TC-IT-WFR-017: FK ON DELETE CASCADE empties workflow_stages / workflow_transitions."""
+        """TC-IT-WFR-017: FK ON DELETE CASCADE が
+        workflow_stages / workflow_transitions を空にする。"""
         stage_a = make_stage(name="A")
         stage_b = make_stage(name="B")
         transition_ab = make_transition(from_stage_id=stage_a.id, to_stage_id=stage_b.id)
@@ -82,22 +83,21 @@ class TestForeignKeyCascade:
 
 
 # ---------------------------------------------------------------------------
-# TC-IT-WFR-018: UNIQUE constraints on (workflow_id, stage_id) and
+# TC-IT-WFR-018: UNIQUE制約 (workflow_id, stage_id) および
 #                                       (workflow_id, transition_id)
 # ---------------------------------------------------------------------------
 class TestUniqueConstraintViolation:
-    """TC-IT-WFR-018: duplicate (workflow_id, stage_id) / (..., transition_id) raises."""
+    """TC-IT-WFR-018: 重複 (workflow_id, stage_id) / (..., transition_id) は例外を発生させる。"""
 
     async def test_duplicate_stage_pair_raises(
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """TC-IT-WFR-018a: same (workflow_id, stage_id) inserted twice → DB rejects.
+        """TC-IT-WFR-018a: 同じ (workflow_id, stage_id) を2回 INSERT → DB が拒否。
 
-        The Repository's delete-then-insert flow always wipes the side
-        tables before INSERT, so the constraint is never tripped
-        through the Repository API. To exercise the **DB-level**
-        UNIQUE contract we issue raw SQL that bypasses the Repository.
+        Repository の削除後挿入フロー は常に挿入前に副テーブルをクリアするため、
+        Repository API 経由では制約に引っかかることはない。**DB レベルの**
+        UNIQUE 契約を検証するために、Repository をバイパスする生 SQL を発行する。
         """
         from sqlalchemy.exc import IntegrityError
 
@@ -155,11 +155,10 @@ class TestUniqueConstraintViolation:
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """TC-IT-WFR-018b: same (workflow_id, transition_id) inserted twice → DB rejects."""
+        """TC-IT-WFR-018b: 同じ (workflow_id, transition_id) を2回 INSERT → DB が拒否。"""
         from sqlalchemy.exc import IntegrityError
 
-        # A 2-stage Workflow gives us legitimate from_stage_id / to_stage_id
-        # values for the raw INSERT that follows.
+        # 2段階 Workflow は以下の生 INSERT に対する正当な from_stage_id / to_stage_id 値を提供する。
         stage_a = make_stage(name="A")
         stage_b = make_stage(name="B")
         transition_ab = make_transition(from_stage_id=stage_a.id, to_stage_id=stage_b.id)
@@ -213,50 +212,50 @@ class TestUniqueConstraintViolation:
 
 
 # ---------------------------------------------------------------------------
-# TC-IT-WFR-023: Layer 2 arch-test partial-mask template structure
+# TC-IT-WFR-023: レイヤー2アーキテクチャテスト部分マスキングテンプレート構造
 # ---------------------------------------------------------------------------
 class TestPartialMaskTemplateStructure:
-    """TC-IT-WFR-023: arch-test exposes the partial-mask parametrize structure.
+    """TC-IT-WFR-023: アーキテクチャテストは部分マスキングのパラメータ化構造を公開する。
 
-    The Workflow PR introduces the **partial-mask** pattern alongside
-    empire-repository's no-mask pattern: ``workflow_stages`` carries
-    exactly one masked column (``notify_channels_json``) and zero on
-    every other column. The arch-test parametrizes
-    ``_PARTIAL_MASK_TABLES`` to assert this — a future PR that swaps
-    another column to a Masked* type without updating §逆引き表 first
-    must trip the arch-test.
+    Workflow PR は empire-repository のマスキングなしパターンと並んで
+    **部分マスキング**パターンを導入：``workflow_stages`` は正確に
+    1つのマスキング列（``notify_channels_json``）を持ち、他のすべての列は
+    0個。アーキテクチャテストは ``_PARTIAL_MASK_TABLES`` をパラメータ化
+    してこれをアサート — 今後のPRが§逆引き表を最初に更新せずに
+    他の列を Masked* 型に交換する場合、アーキテクチャテストに引っかかる。
 
-    Future Repository PRs add their own "partial-mask" rows for their
-    Aggregate's tables; the structural shape lets them extend without
-    rewriting the harness.
+    今後の Repository PR は、それぞれのAggregate のテーブルに対して
+    「部分マスキング」行を追加；構造的な形状により、ハーネスを
+    書き直さずに拡張できる。
     """
 
     async def test_arch_test_module_imports_partial_mask_table_list(self) -> None:
-        """TC-IT-WFR-023: ``_PARTIAL_MASK_TABLES`` lists ``workflow_stages``."""
+        """TC-IT-WFR-023: ``_PARTIAL_MASK_TABLES`` が ``workflow_stages`` をリストアップ。"""
         from tests.architecture.test_masking_columns import (
             _NO_MASK_TABLES,  # pyright: ignore[reportPrivateUsage]
             _PARTIAL_MASK_TABLES,  # pyright: ignore[reportPrivateUsage]
         )
 
-        # workflow_stages is the partial-mask table.
+        # workflow_stages は部分マスキングテーブル。
         partial_mask_table_names = {tbl for tbl, _ in _PARTIAL_MASK_TABLES}
         assert "workflow_stages" in partial_mask_table_names, (
-            "[FAIL] workflow_stages must be registered in _PARTIAL_MASK_TABLES.\n"
-            "Next: add ('workflow_stages', 'notify_channels_json') per "
-            "detailed-design.md §確定 H."
+            "[FAIL] workflow_stages は _PARTIAL_MASK_TABLES に"
+            "登録される必要があります。\n"
+            "次: detailed-design.md §確定 H. に従い\n"
+            "('workflow_stages', 'notify_channels_json') を追加。"
         )
-        # The allowed column on workflow_stages is exactly notify_channels_json.
+        # workflow_stages の許可される列は正確に notify_channels_json。
         allowed_columns = [col for tbl, col in _PARTIAL_MASK_TABLES if tbl == "workflow_stages"]
         assert allowed_columns == ["notify_channels_json"], (
-            f"[FAIL] workflow_stages partial-mask declared {allowed_columns!r}, "
-            f"expected ['notify_channels_json'].\n"
-            f"Next: §逆引き表 freezes notify_channels_json as the sole masked column."
+            f"[FAIL] workflow_stages 部分マスキングが {allowed_columns!r} と宣言、"
+            f"期待値は ['notify_channels_json']。\n"
+            f"次: §逆引き表 が notify_channels_json をマスキング対象の唯一の列としてフリーズ。"
         )
 
-        # workflows / workflow_transitions live in the no-mask list.
+        # workflows / workflow_transitions はマスキングなしリストに存在。
         assert "workflows" in _NO_MASK_TABLES, (
-            "[FAIL] workflows must be registered in _NO_MASK_TABLES."
+            "[FAIL] workflows は _NO_MASK_TABLES に登録される必要があります。"
         )
         assert "workflow_transitions" in _NO_MASK_TABLES, (
-            "[FAIL] workflow_transitions must be registered in _NO_MASK_TABLES."
+            "[FAIL] workflow_transitions は _NO_MASK_TABLES に登録される必要があります。"
         )

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_workflow_repository/test_masking.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_workflow_repository/test_masking.py
@@ -42,19 +42,19 @@ if TYPE_CHECKING:
 pytestmark = pytest.mark.asyncio
 
 
-# A real-shape (but synthetic) Discord webhook URL. The token segment
-# is intentionally something distinctive so the assertion can prove
-# the on-disk bytes do NOT carry it after masking.
+# 実際の形状 (ただし合成) の Discord webhook URL。トークンセグメントは
+# 意図的に特徴的なものを使用して、アサーションがマスク後
+# ディスク上バイトがそれを持たないことを証明できるようにする。
 _REAL_SHAPE_TOKEN = "JeffMaskingProbe_-9876543210xyzABCDEFGHIJ"
 _REAL_SHAPE_WEBHOOK = "https://discord.com/api/webhooks/1234567890123456789/" + _REAL_SHAPE_TOKEN
 _DISCORD_REDACT_SENTINEL = "<REDACTED:DISCORD_WEBHOOK>"
 
 
 def _make_external_review_workflow(*, target_url: str) -> Workflow:
-    """Build a Workflow whose entry Stage is ``EXTERNAL_REVIEW`` + given webhook.
+    """入口 Stage が ``EXTERNAL_REVIEW`` + 与えられた webhook の Workflow を構築。
 
-    Returned shape is the bare ``Workflow`` aggregate; the test bodies
-    save / re-fetch it and assert against the persisted bytes.
+    返される形状は bare な ``Workflow`` aggregate；テスト本体が
+    それを保存 / 再取得してディスク上バイトに対してアサート。
     """
     notify_channel = NotifyChannel(
         kind="discord",
@@ -81,28 +81,28 @@ def _make_external_review_workflow(*, target_url: str) -> Workflow:
 # TC-IT-WFR-013: MaskedJSONEncoded wiring (Schneier 申し送り #6 物理確認)
 # ---------------------------------------------------------------------------
 class TestNotifyChannelsJsonMaskedOnDisk:
-    """TC-IT-WFR-013: ``notify_channels_json`` carries ``<REDACTED:...>`` not the raw token."""
+    """TC-IT-WFR-013: ``notify_channels_json`` は raw token ではなく ``<REDACTED:...>`` を持つ。"""
 
     async def test_discord_webhook_token_redacted_in_persisted_json(
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """TC-IT-WFR-013: raw-SQL ``SELECT`` shows masked JSON, never the secret token.
+        """TC-IT-WFR-013: raw-SQL ``SELECT`` はマスク済み JSON を示し、secret token は表示しない。
 
-        Two assertions, in this order (positive before negative):
+        2 つのアサーション（ポジティブ優先）：
 
-        1. The redaction sentinel appears — proves the masking gateway
-           ran. A bug that silently dropped the masking step would
-           drop both the sentinel **and** leave the token in plaintext.
-        2. The original token does NOT appear anywhere in the JSON
-           string — the credential never lands on disk in any form.
+        1. redaction sentinel が現れる — masking gateway が実行されたことを証明。
+           masking ステップをサイレントにドロップするバグは
+           sentinel を **ドロップし** token を平文で残す。
+        2. 元の token は JSON 文字列内のどこにも現れない —
+           認証情報はディスク上にどのような形式でも格納されない。
         """
         workflow = _make_external_review_workflow(target_url=_REAL_SHAPE_WEBHOOK)
         async with session_factory() as session, session.begin():
             await SqliteWorkflowRepository(session).save(workflow)
 
-        # Raw SQL — bypass MaskedJSONEncoded.process_result_value so we
-        # see the literal bytes that hit the disk.
+        # Raw SQL — MaskedJSONEncoded.process_result_value を迂回して
+        # ディスク上の文字通りのバイトを見る。
         async with session_factory() as session:
             stmt = text(
                 "SELECT notify_channels_json FROM workflow_stages "
@@ -115,20 +115,20 @@ class TestNotifyChannelsJsonMaskedOnDisk:
         persisted_json = row[0]
         assert isinstance(persisted_json, str)
 
-        # Positive: redaction sentinel is present.
+        # ポジティブ: redaction sentinel が存在する。
         assert _DISCORD_REDACT_SENTINEL in persisted_json, (
-            f"[FAIL] notify_channels_json missing redaction sentinel.\n"
-            f"Next: verify workflow_stages.notify_channels_json column type is "
-            f"MaskedJSONEncoded; this is the §確定 H 物理保証. "
+            f"[FAIL] notify_channels_json が redaction sentinel がない。\n"
+            f"Next: workflow_stages.notify_channels_json カラム型が "
+            f"MaskedJSONEncoded であることを確認； これは §確定 H 物理保証。 "
             f"Persisted JSON: {persisted_json!r}"
         )
-        # Negative: raw token is absent.
+        # ネガティブ: raw token は不在。
         assert _REAL_SHAPE_TOKEN not in persisted_json, (
-            f"[FAIL] raw Discord webhook token leaked into notify_channels_json.\n"
-            f"Next: this is the catastrophic case the §確定 H + Schneier 申し送り #6 "
-            f"three-layer defense was designed to prevent. Verify "
+            f"[FAIL] raw Discord webhook token が notify_channels_json に漏洩。\n"
+            f"Next: これは §確定 H + Schneier 申し送り #6 "
+            f"3 層防御が防止するように設計された壊滅的なケース。"
             f"NotifyChannel.field_serializer (Layer 1) AND MaskedJSONEncoded "
-            f"(Layer 2 / TypeDecorator) are both still in place. "
+            f"(Layer 2 / TypeDecorator) 両方がまだ配置されていることを確認。 "
             f"Persisted JSON: {persisted_json!r}"
         )
 
@@ -136,13 +136,13 @@ class TestNotifyChannelsJsonMaskedOnDisk:
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """TC-IT-WFR-013 補強: a Stage with no notify_channels still persists cleanly.
+        """TC-IT-WFR-013 補強: notify_channels のない Stage も問題なく永続化。
 
-        ``WORK`` stages don't carry notify_channels by default. The
-        column is NOT NULL with server_default ``'[]'``; the
-        Repository's ``_to_row`` emits ``[]`` (empty list) which the
-        ``MaskedJSONEncoded.process_bind_param`` normalizes to
-        ``"[]"`` JSON. No masking artifacts on this path.
+        ``WORK`` stages はデフォルトで notify_channels を持たない。
+        カラムは NOT NULL で server_default は ``'[]'`` ；
+        Repository の ``_to_row`` は ``[]`` (空リスト) を発行し、
+        ``MaskedJSONEncoded.process_bind_param`` は
+        これを ``"[]"`` JSON に正規化。このパスではマスキングアーティファクトなし。
         """
         workflow = make_workflow()  # 1 WORK stage, empty notify_channels
         async with session_factory() as session, session.begin():
@@ -155,11 +155,11 @@ class TestNotifyChannelsJsonMaskedOnDisk:
             row = (await session.execute(stmt, {"workflow_id": workflow.id.hex})).first()
 
         assert row is not None
-        # Either ``"[]"`` (the explicit empty list JSON) or any other
-        # JSON-valid empty container — the contract is "no leakage" not
-        # "exact byte form". We assert both interpretations are safe.
+        # ``"[]"`` (明示的な空リスト JSON) または
+        # JSON-valid な空コンテナ — 契約は「漏洩なし」であり「正確なバイト形式」ではない。
+        # 両方の解釈が安全であることをアサート。
         assert _DISCORD_REDACT_SENTINEL not in str(row[0])
-        # Quick sanity that we got a string-shaped JSON value.
+        # 文字列型 JSON 値を取得したことの簡易チェック。
         assert str(row[0]).strip() in ("[]", "null", "")
 
 
@@ -167,36 +167,37 @@ class TestNotifyChannelsJsonMaskedOnDisk:
 # TC-IT-WFR-014: §確定 H §不可逆性 — find_by_id raises after mask
 # ---------------------------------------------------------------------------
 class TestFindByIdRaisesOnMaskedNotifyChannels:
-    """TC-IT-WFR-014: ``find_by_id`` on a masked Workflow raises ``ValidationError``.
+    """TC-IT-WFR-014: マスク済み Workflow の ``find_by_id`` は ``ValidationError`` を発生。
 
-    The §確定 H §不可逆性 contract: once notify_channels are masked
-    on disk, recovering the *typed* Workflow aggregate is impossible
-    because the masked URL fails the ``NotifyChannel`` G7 regex on
-    re-validate. This test pins that behavior so a hypothetical PR
-    that "rescued" the round-trip (e.g. by skipping invalid notify
-    channels silently) would fail loudly.
+    §確定 H §不可逆性 契約： notify_channels がディスク上でマスクされると、
+    *型付き* Workflow aggregate の回復は不可能。マスク済み URL は
+    ``NotifyChannel`` G7 regex の再検証に失敗するため。
+    このテストはその動作を確定させるため、「ラウンドトリップを救出」
+    しようとする hypothetical PR (例：invalid notify_channels を
+    サイレントにスキップ) は大きく失敗する。
     """
 
     async def test_find_by_id_raises_validation_error(
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """TC-IT-WFR-014: a save-then-find_by_id on a masked URL must raise.
+        """TC-IT-WFR-014: マスク済み URL での save-then-find_by_id は raise しなければならない。
 
-        The contract:
+        契約:
 
-        * ``save`` succeeds (the gateway produces well-formed JSON,
-          just with the token redacted).
-        * ``find_by_id`` raises because ``NotifyChannel.model_validate``
-          rejects the masked URL — the G7 regex requires the token
-          segment to match ``[A-Za-z0-9_\\-]+`` and the redaction
-          sentinel ``<REDACTED:DISCORD_WEBHOOK>`` is not in that set
-          (``<`` / ``>`` / ``:`` are excluded).
+        * ``save`` は成功 (gateway は well-formed JSON を生成、
+          token は redact済み)。
+        * ``find_by_id`` は raise （``NotifyChannel.model_validate``
+          はマスク済み URL を reject — G7 regex は token
+          セグメントが ``[A-Za-z0-9_\\-]+`` にマッチを要求し
+          redaction sentinel ``<REDACTED:DISCORD_WEBHOOK>`` は
+          そのセットにない (``<`` / ``>`` / ``:`` は除外))。
 
-        The Repository docstring (workflow_repository.py L44-48)
-        commits to "find_by_id may therefore raise ``pydantic.ValidationError``";
-        we pin the contract here so a swap to a different exception
-        class would force a docs update + design revisit.
+        Repository docstring (workflow_repository.py L44-48)
+        は「find_by_id は ``pydantic.ValidationError`` を raise
+        するかもしれない」をコミット；
+        ここで契約を確定させるため、別の exception クラスへのスワップは
+        docs update + design revisit を強制するだろう。
         """
         workflow = _make_external_review_workflow(target_url=_REAL_SHAPE_WEBHOOK)
         async with session_factory() as session, session.begin():

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_workflow_repository/test_protocol_crud.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_workflow_repository/test_protocol_crud.py
@@ -1,12 +1,11 @@
-"""Workflow Repository: Protocol surface + basic CRUD coverage.
+"""Workflow Repository: Protocol サーフェス + 基本 CRUD カバレッジ。
 
-TC-IT-WFR-001 / 002 / 003 / 004 / 005 / 006 / 007 / 019 — the
-entry-point behaviors empire-repository (PR #25) froze and that this
-PR inherits 100%, plus the Workflow-specific ``ORDER BY stage_id`` /
-``ORDER BY transition_id`` SQL log observation (BUG-EMR-001 from-day-1
-contract per detailed-design.md L51).
+TC-IT-WFR-001 / 002 / 003 / 004 / 005 / 006 / 007 / 019 ── empire-repository (PR #25)
+が固定したエントリポイント挙動を本 PR が 100% 踏襲することと、Workflow 固有の
+``ORDER BY stage_id`` / ``ORDER BY transition_id`` SQL ログ観測（detailed-design.md L51 の
+BUG-EMR-001 from-day-1 契約）を扱う。
 
-Per ``docs/features/workflow-repository/test-design.md`` matrix.
+``docs/features/workflow-repository/test-design.md`` のマトリクス準拠。
 """
 
 from __future__ import annotations
@@ -39,16 +38,15 @@ pytestmark = pytest.mark.asyncio
 
 
 # ---------------------------------------------------------------------------
-# REQ-WFR-001: Protocol definition + 充足 (§確定 A)
+# REQ-WFR-001: Protocol 定義 + 充足 (§確定 A)
 # ---------------------------------------------------------------------------
 class TestWorkflowRepositoryProtocol:
-    """TC-IT-WFR-001 / 002: Protocol surface + duck-typing 充足."""
+    """TC-IT-WFR-001 / 002: Protocol サーフェス + ダックタイピング充足。"""
 
     async def test_protocol_declares_three_async_methods(self) -> None:
-        """TC-IT-WFR-001: ``WorkflowRepository`` has find_by_id / count / save."""
-        # Protocol classes don't expose the methods at instance level
-        # but at class level. Marked ``async`` purely so the
-        # module-level ``pytestmark = asyncio`` does not warn.
+        """TC-IT-WFR-001: ``WorkflowRepository`` が find_by_id / count / save を持つ。"""
+        # Protocol class はインスタンスレベルではなくクラスレベルでメソッドを公開する。
+        # モジュールレベルの ``pytestmark = asyncio`` が警告しないよう ``async`` を付ける。
         assert hasattr(WorkflowRepository, "find_by_id")
         assert hasattr(WorkflowRepository, "count")
         assert hasattr(WorkflowRepository, "save")
@@ -57,12 +55,11 @@ class TestWorkflowRepositoryProtocol:
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """TC-IT-WFR-002: ``SqliteWorkflowRepository`` is assignable to ``WorkflowRepository``.
+        """TC-IT-WFR-002: ``SqliteWorkflowRepository`` を ``WorkflowRepository`` に代入できる。
 
-        The variable annotation acts as a static-type assertion; pyright
-        strict will reject the assignment if any Protocol method is
-        missing or has a wrong signature. Duck-typing at runtime
-        confirms the three methods exist on the instance too.
+        変数アノテーションが静的型アサーションとして機能する ── pyright strict は、
+        Protocol メソッドが欠落または誤シグネチャの場合に代入を拒否する。
+        ランタイムのダックタイピングでもインスタンスに 3 メソッドの存在を確認する。
         """
         async with session_factory() as session:
             repo: WorkflowRepository = SqliteWorkflowRepository(session)
@@ -72,21 +69,20 @@ class TestWorkflowRepositoryProtocol:
 
 
 # ---------------------------------------------------------------------------
-# REQ-WFR-002: find_by_id / count / save 基本 CRUD
+# REQ-WFR-002: find_by_id / count / save の基本 CRUD
 # ---------------------------------------------------------------------------
 class TestFindById:
-    """TC-IT-WFR-003 / 004: find_by_id retrieves saved Workflows; None for unknown."""
+    """TC-IT-WFR-003 / 004: find_by_id は保存済み Workflow を取得する。未知の id は None。"""
 
     async def test_find_by_id_returns_saved_workflow(
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """TC-IT-WFR-003: ``find_by_id(workflow.id)`` returns a structurally-equal Workflow.
+        """TC-IT-WFR-003: ``find_by_id(workflow.id)`` が構造的に等価な Workflow を返す。
 
-        Uses ``make_workflow()`` default (single ``WORK`` stage, no
-        ``EXTERNAL_REVIEW`` → no notify_channels) so §確定 H §不可逆性
-        does not bite. Round-trip equality of the irreversible-masking
-        path lives in :mod:`...test_masking`.
+        ``make_workflow()`` のデフォルト（単一 ``WORK`` ステージ、``EXTERNAL_REVIEW``
+        なし → notify_channels なし）を用いるため §確定 H §不可逆性 に引っかからない。
+        不可逆マスキング経路のラウンドトリップ等価性は :mod:`...test_masking` に持つ。
         """
         workflow = make_workflow()
         async with session_factory() as session, session.begin():
@@ -102,7 +98,7 @@ class TestFindById:
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """TC-IT-WFR-004: ``find_by_id(uuid4())`` returns ``None`` without raising."""
+        """TC-IT-WFR-004: ``find_by_id(uuid4())`` は例外を投げず ``None`` を返す。"""
         unknown_id = uuid4()
         async with session_factory() as session:
             fetched = await SqliteWorkflowRepository(session).find_by_id(unknown_id)
@@ -110,32 +106,29 @@ class TestFindById:
 
 
 # ---------------------------------------------------------------------------
-# REQ-WFR-002 (ORDER BY contract per BUG-EMR-001 inherited from day 1)
+# REQ-WFR-002 (BUG-EMR-001 から day 1 で受け継ぐ ORDER BY 契約)
 # ---------------------------------------------------------------------------
 class TestFindByIdOrderByContract:
-    """TC-IT-WFR-005 / 006: ``ORDER BY stage_id`` / ``ORDER BY transition_id`` are emitted.
+    """TC-IT-WFR-005 / 006: ``ORDER BY stage_id`` / ``ORDER BY transition_id`` が発行される。
 
-    The empire-repository BUG-EMR-001 closure froze the ORDER BY
-    contract; the workflow Repository adopts it from PR #1. Without
-    these clauses, SQLite returns rows in internal-scan order which
-    would break ``Workflow == Workflow`` round-trip equality (the
-    Aggregate compares list-by-list).
+    empire-repository BUG-EMR-001 のクロージャが ORDER BY 契約を凍結し、
+    workflow Repository は PR #1 から踏襲する。これらの句がないと SQLite は
+    内部スキャン順で行を返し、``Workflow == Workflow`` ラウンドトリップ等価性
+    （Aggregate がリスト同士で比較する）が壊れる。
 
-    We attach a ``before_cursor_execute`` listener on the **sync**
-    engine and observe the actual SQL strings the dialect emits so a
-    silent removal of ``ORDER BY`` is caught even if the round-trip
-    test happens to pass via row-order coincidence.
+    **sync** engine に ``before_cursor_execute`` リスナを取り付け、ダイアレクトが
+    実際に発行する SQL 文字列を観測する。これにより、行順序が偶然合致して
+    ラウンドトリップが pass しても、``ORDER BY`` の静かな除去を検出できる。
     """
 
     async def _build_multi_stage_workflow(
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> tuple[Workflow, WorkflowId]:
-        """Build + save a 3-stage / 2-transition Workflow without EXTERNAL_REVIEW.
+        """EXTERNAL_REVIEW なしで 3 ステージ / 2 トランジションの Workflow を構築 + save する。
 
-        Returns the constructed workflow plus its id so the caller can
-        round-trip it. ``WORK`` stages do not require notify_channels,
-        so no §確定 H §不可逆性 trap.
+        構築した workflow とその id を返し、呼び出し側でラウンドトリップさせる。
+        ``WORK`` ステージは notify_channels を要求しないため、§確定 H §不可逆性 の罠なし。
         """
         stage_a = make_stage(name="ステージA")
         stage_b = make_stage(name="ステージB")
@@ -162,7 +155,7 @@ class TestFindByIdOrderByContract:
         session_factory: async_sessionmaker[AsyncSession],
         app_engine: AsyncEngine,
     ) -> None:
-        """TC-IT-WFR-005: ``find_by_id`` emits ``ORDER BY workflow_stages.stage_id``."""
+        """TC-IT-WFR-005: ``find_by_id`` が ``ORDER BY workflow_stages.stage_id`` を発行する。"""
         _, workflow_id = await self._build_multi_stage_workflow(session_factory)
 
         captured: list[str] = []
@@ -185,9 +178,8 @@ class TestFindByIdOrderByContract:
         finally:
             event.remove(sync_engine, "before_cursor_execute", _on_execute)
 
-        # The Workflow's stage SELECT must carry an ``ORDER BY`` on the
-        # stage_id column. We accept any whitespace / fully-qualified
-        # variation that SQLAlchemy chooses to emit.
+        # Workflow の stage SELECT は stage_id カラムに ``ORDER BY`` を持たねばならない。
+        # SQLAlchemy が選んで発行する任意の空白 / 完全修飾の表記を許容する。
         stage_selects = [
             stmt for stmt in captured if "FROM workflow_stages" in stmt and "SELECT" in stmt.upper()
         ]
@@ -203,7 +195,8 @@ class TestFindByIdOrderByContract:
         session_factory: async_sessionmaker[AsyncSession],
         app_engine: AsyncEngine,
     ) -> None:
-        """TC-IT-WFR-006: ``find_by_id`` emits ``ORDER BY workflow_transitions.transition_id``."""
+        """TC-IT-WFR-006: ``find_by_id`` が
+        ``ORDER BY workflow_transitions.transition_id`` を発行する。"""
         _, workflow_id = await self._build_multi_stage_workflow(session_factory)
 
         captured: list[str] = []
@@ -242,25 +235,25 @@ class TestFindByIdOrderByContract:
 
 
 # ---------------------------------------------------------------------------
-# REQ-WFR-002 (count() must issue SQL-level COUNT(*))
+# REQ-WFR-002 (count() は SQL レベルの COUNT(*) を発行しなければならない)
 # ---------------------------------------------------------------------------
 class TestCountIssuesScalarCount:
-    """TC-IT-WFR-007: ``count()`` issues ``SELECT COUNT(*)``, not a full row scan."""
+    """TC-IT-WFR-007: ``count()`` は ``SELECT COUNT(*)`` を発行し、行を全件スキャンしない。"""
 
     async def test_count_emits_select_count_not_full_load(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         app_engine: AsyncEngine,
     ) -> None:
-        """TC-IT-WFR-007: SQL log shows ``SELECT count(*)`` for ``count()``.
+        """TC-IT-WFR-007: SQL ログが ``count()`` に対し ``SELECT count(*)`` を示す。
 
-        Empire-repository §確定 D 補強: ``count()`` must not stream
-        every row back to Python and call ``len()``. With Workflow
-        preset libraries we expect hundreds of rows, so the SQL-level
-        COUNT(*) pattern matters even more than for Empire.
+        Empire-repository §確定 D 補強: ``count()`` は全行を Python へ
+        ストリームして ``len()`` を呼んではならない。Workflow の preset
+        ライブラリでは数百行を想定するため、SQL レベルの COUNT(*) パターンが
+        Empire 以上に重要。
         """
-        # Save two workflows so a hypothetical full-row scan would
-        # materialize at least 2 rows — we'd see them in the log.
+        # 仮の全行スキャンで少なくとも 2 行がマテリアライズされるよう、
+        # 2 つの workflow を save する ── ログに見えるはず。
         async with session_factory() as session, session.begin():
             await SqliteWorkflowRepository(session).save(make_workflow())
         async with session_factory() as session, session.begin():
@@ -287,9 +280,10 @@ class TestCountIssuesScalarCount:
             event.remove(sync_engine, "before_cursor_execute", _on_execute)
 
         assert count == 2
-        # Workflow SELECTs touched during count() must all be
-        # ``count(*)`` shapes — never a full ``SELECT id FROM workflows``
-        # row stream that the Repository would then ``len()``.
+        # count() 中に発行される Workflow SELECT はすべて
+        # ``count(*)`` 形でなければならず、Repository が後で
+        # ``len()`` する全行 ``SELECT id FROM workflows``
+        # ストリームになってはならない。
         workflow_selects = [s for s in captured if "FROM workflows" in s]
         assert workflow_selects, "count() must issue at least one SELECT against workflows"
         for stmt in workflow_selects:
@@ -301,21 +295,20 @@ class TestCountIssuesScalarCount:
 
 
 # ---------------------------------------------------------------------------
-# §確定 D: Repository never enforces singleton invariants
+# §確定 D: Repository は singleton 不変条件を強制しない
 # ---------------------------------------------------------------------------
 class TestRepositoryDoesNotEnforceSingleton:
-    """TC-IT-WFR-019: Repository accepts multiple Workflow saves."""
+    """TC-IT-WFR-019: Repository は複数の Workflow save を受け入れる。"""
 
     async def test_two_workflows_saved_without_error(
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """TC-IT-WFR-019: 2 distinct Workflows save successfully; ``count()`` reports 2.
+        """TC-IT-WFR-019: 別個の 2 つの Workflow が save 成功し、``count()`` が 2 を返す。
 
-        Singleton enforcement (e.g. "only one preset Workflow per
-        empire") is the application service's job; the Repository
-        itself reports facts via ``count()`` and never raises just
-        because the cardinality grew above 1.
+        Singleton 強制（例: 「empire ごとに preset Workflow は 1 つだけ」）は
+        application service の責務。Repository は ``count()`` で事実を返すのみで、
+        cardinality が 1 を超えただけで例外を投げてはならない。
         """
         async with session_factory() as session, session.begin():
             await SqliteWorkflowRepository(session).save(make_workflow())
@@ -328,24 +321,24 @@ class TestRepositoryDoesNotEnforceSingleton:
 
 
 # ---------------------------------------------------------------------------
-# REQ-WFR-002: save inserts into all 3 tables (TC-IT-WFR-008)
+# REQ-WFR-002: save が 3 テーブルに INSERT する (TC-IT-WFR-008)
 # ---------------------------------------------------------------------------
 class TestSaveInsertsAllThreeTables:
-    """TC-IT-WFR-008: ``save`` writes the 3 Workflow tables.
+    """TC-IT-WFR-008: ``save`` が 3 つの Workflow テーブルへ書き込む。
 
-    ``workflows`` + ``workflow_stages`` + ``workflow_transitions`` all
-    receive rows in a single ``save`` call.
+    ``workflows`` + ``workflow_stages`` + ``workflow_transitions`` のすべてが
+    1 回の ``save`` 呼び出しで行を受け取る。
     """
 
     async def test_save_populates_three_tables(
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """TC-IT-WFR-008: 3 stages + 2 transitions land in their respective side tables.
+        """TC-IT-WFR-008: 3 ステージ + 2 トランジションが各テーブルに着地する。
 
-        We deliberately avoid V-model payload here because that has
-        EXTERNAL_REVIEW stages and would conflate this test with the
-        notify_channels masking concern (covered in test_masking).
+        ここでは V-model ペイロードを意図的に避ける ── EXTERNAL_REVIEW ステージを
+        持つため、本テストが notify_channels マスキングの関心事
+        （test_masking で扱う）と混同される恐れがあるから。
         """
         stage_a = make_stage(name="A")
         stage_b = make_stage(name="B")

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_workflow_repository/test_save_delete_then_insert.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_workflow_repository/test_save_delete_then_insert.py
@@ -159,8 +159,8 @@ class TestSaveSqlOrder:
                 )
             )
         ]
-        # Step 1 (UPSERT workflows) → Step 2 (DELETE workflow_stages) →
-        # Step 3 (INSERT workflow_stages) → Step 4 (DELETE workflow_transitions) →
+        # Step 1（UPSERT workflows）→ Step 2（DELETE workflow_stages）→
+        # Step 3（INSERT workflow_stages）→ Step 4（DELETE workflow_transitions）→
         # Step 5 (INSERT workflow_transitions)。
         assert len(dml) >= 5, (
             f"[FAIL] save emitted only {len(dml)} DML statements; expected ≥5.\n"

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_workflow_repository/test_save_delete_then_insert.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_workflow_repository/test_save_delete_then_insert.py
@@ -1,19 +1,17 @@
-"""Workflow Repository: save() — delete-then-insert + SQL order + isolation.
+"""Workflow Repository: save() ── delete-then-insert + SQL 順序 + 隔離。
 
-TC-IT-WFR-009 / 010 — the §確定 B contract that backs the ``save()``
-flow's wholesale row replacement and the 5-step DML sequence, plus
-the isolation-between-Workflows smoke (``DELETE`` is scoped to a
-single ``workflow_id``).
+TC-IT-WFR-009 / 010 ── ``save()`` フローの行丸ごと置換と 5 ステップ DML シーケンスを
+裏付ける §確定 B 契約と、Workflow 間の隔離スモーク（``DELETE`` は単一の
+``workflow_id`` にスコープされる）を扱う。
 
-Split out of ``test_save_semantics.py`` per Norman 500-line rule
-(file would land at 502 lines after BUG-WFR-001 fix). The two
-companion files cover the round-trip + Tx-boundary contracts:
+Norman 500 行ルールにより ``test_save_semantics.py`` から分割
+（BUG-WFR-001 修正後にファイルが 502 行に達するため）。残り 2 つの併設ファイルは
+ラウンドトリップ + Tx 境界の契約をカバーする:
 
-* :mod:`...test_workflow_repository.test_save_round_trip` —
-  ``roles_csv`` determinism + structural equality + Tx commit /
-  rollback.
+* :mod:`...test_workflow_repository.test_save_round_trip` ──
+  ``roles_csv`` の決定性 + 構造的等価性 + Tx commit / rollback。
 
-Per ``docs/features/workflow-repository/test-design.md``.
+``docs/features/workflow-repository/test-design.md`` 準拠。
 """
 
 from __future__ import annotations
@@ -47,18 +45,17 @@ pytestmark = pytest.mark.asyncio
 # §確定 B: delete-then-insert replacement semantics (TC-IT-WFR-009)
 # ---------------------------------------------------------------------------
 class TestSaveDeleteThenInsert:
-    """TC-IT-WFR-009: ``save`` replaces side-table rows wholesale (§確定 B)."""
+    """TC-IT-WFR-009: ``save`` が side-table 行を丸ごと置換する (§確定 B)。"""
 
     async def test_save_replaces_stage_rows(
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """TC-IT-WFR-009: 3 stages → 1 stage is reflected as 1 row in workflow_stages.
+        """TC-IT-WFR-009: 3 ステージ → 1 ステージが workflow_stages で 1 行として反映される。
 
-        We construct a fresh single-stage Workflow with the **same
-        workflow_id** and re-save. The §確定 B contract says the side
-        tables must end up reflecting only the new state; old stages
-        must not survive as residue.
+        **同じ workflow_id** を持つ新しい単一ステージ Workflow を構築して再 save する。
+        §確定 B 契約により、side-table は新しい状態のみを反映し、
+        古いステージが残骸として残ってはならない。
         """
         stage_a = make_stage(name="A")
         stage_b = make_stage(name="B")
@@ -73,7 +70,7 @@ class TestSaveDeleteThenInsert:
         async with session_factory() as session, session.begin():
             await SqliteWorkflowRepository(session).save(original)
 
-        # Build a new Workflow with the same id but only 1 stage.
+        # 同じ id で 1 ステージのみの新しい Workflow を構築。
         replacement_stage = make_stage(name="残ったステージ")
         replacement = make_workflow(
             workflow_id=original.id,
@@ -85,7 +82,7 @@ class TestSaveDeleteThenInsert:
         async with session_factory() as session, session.begin():
             await SqliteWorkflowRepository(session).save(replacement)
 
-        # Side tables must show the new state, not the merged old + new.
+        # side-table は新状態のみを示し、古い+新しいの混在ではないこと。
         async with session_factory() as session:
             stage_rows = list(
                 (
@@ -102,17 +99,16 @@ class TestSaveDeleteThenInsert:
 # §確定 B: 5-step SQL order (TC-IT-WFR-010)
 # ---------------------------------------------------------------------------
 class TestSaveSqlOrder:
-    """TC-IT-WFR-010: ``save`` issues SQL in the §確定 B 5-step order.
+    """TC-IT-WFR-010: ``save`` が §確定 B の 5 ステップ順序で SQL を発行する。
 
-    We attach a ``before_cursor_execute`` listener on the **sync**
-    engine so we observe the actual SQL strings the dialect emits. The
-    listener appends each statement to a captured list; we then assert
-    the prefix sequence matches the design's 5 steps. The dispatcher /
-    ORM may issue extra SAVEPOINT / BEGIN statements which we filter
-    out — the contract is on the *DML* prefix.
+    **sync** engine に ``before_cursor_execute`` リスナを取り付け、ダイアレクトが
+    実際に発行する SQL 文字列を観測する。リスナは各 statement をキャプチャ
+    リストに追加し、その後プレフィックスシーケンスが設計の 5 ステップと
+    一致することを assert する。dispatcher / ORM は余分な SAVEPOINT / BEGIN
+    を発行しうるため、それらを除外する ── 契約は *DML* プレフィックスにある。
 
-    Same harness as empire-repository TC-IT-EMR-011; the next 5
-    Repository PRs should re-use this template.
+    empire-repository TC-IT-EMR-011 と同じハーネス。後続 5 つの Repository PR は
+    本テンプレートを再利用すべき。
     """
 
     async def test_save_emits_upsert_then_delete_insert_pairs(
@@ -120,9 +116,9 @@ class TestSaveSqlOrder:
         session_factory: async_sessionmaker[AsyncSession],
         app_engine: AsyncEngine,
     ) -> None:
-        """TC-IT-WFR-010: 5-step DML order matches §確定 B.
+        """TC-IT-WFR-010: 5 ステップの DML 順序が §確定 B に一致する。
 
-        workflows UPSERT → workflow_stages DEL+INS → workflow_transitions DEL+INS.
+        workflows UPSERT → workflow_stages DEL+INS → workflow_transitions DEL+INS。
         """
         captured: list[str] = []
 
@@ -139,9 +135,8 @@ class TestSaveSqlOrder:
         sync_engine = app_engine.sync_engine
         event.listen(sync_engine, "before_cursor_execute", _on_execute)
         try:
-            # V-model payload exercises 13 stages + 15 transitions —
-            # the busiest possible ``save()`` shape and the right one
-            # for SQL-order observation.
+            # V-model ペイロードは 13 ステージ + 15 トランジションで動作する ──
+            # 最も忙しい ``save()`` 形状であり、SQL 順序観測に適している。
             from bakufu.domain.workflow import Workflow
 
             workflow = Workflow.from_dict(build_v_model_payload())
@@ -150,8 +145,8 @@ class TestSaveSqlOrder:
         finally:
             event.remove(sync_engine, "before_cursor_execute", _on_execute)
 
-        # Filter to the 5 DML statements we care about (BEGIN /
-        # SAVEPOINT / RELEASE / COMMIT noise removed).
+        # 注目する 5 つの DML statement のみにフィルタ（BEGIN / SAVEPOINT /
+        # RELEASE / COMMIT のノイズを除外）。
         dml = [
             s
             for s in captured
@@ -165,8 +160,8 @@ class TestSaveSqlOrder:
             )
         ]
         # Step 1 (UPSERT workflows) → Step 2 (DELETE workflow_stages) →
-        # Step 3 (INSERT workflow_stages) → Step 4 (DELETE
-        # workflow_transitions) → Step 5 (INSERT workflow_transitions).
+        # Step 3 (INSERT workflow_stages) → Step 4 (DELETE workflow_transitions) →
+        # Step 5 (INSERT workflow_transitions)。
         assert len(dml) >= 5, (
             f"[FAIL] save emitted only {len(dml)} DML statements; expected ≥5.\n"
             f"Next: verify save() executes the §確定 B 5-step sequence. "
@@ -180,32 +175,31 @@ class TestSaveSqlOrder:
 
 
 # ---------------------------------------------------------------------------
-# Smoke test: an unknown workflow_id never collides with an existing row
+# スモークテスト: 未知の workflow_id は既存の行と衝突しない
 # ---------------------------------------------------------------------------
 class TestSaveDistinctWorkflowsAreIndependent:
-    """Side-effect isolation between Workflows."""
+    """Workflow 間の副作用隔離。"""
 
     async def test_save_one_does_not_disturb_another(
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """Saving Workflow B must not delete Workflow A's stages.
+        """Workflow B を save しても Workflow A のステージは削除されない。
 
-        The ``DELETE WHERE workflow_id = ?`` step in §確定 B is
-        scoped to the workflow_id under save; a poorly-written
-        Repository that issued an un-scoped DELETE would corrupt every
-        other Workflow in the DB. We assert the scoping with a
-        before / after snapshot.
+        §確定 B の ``DELETE WHERE workflow_id = ?`` ステップは save 中の
+        workflow_id にスコープされる。スコープなし DELETE を発行する粗末な
+        Repository は DB 内の他のすべての Workflow を破壊しうる。
+        前後スナップショットでスコーピングを assert する。
         """
         workflow_a = make_workflow()
         workflow_b = make_workflow()
-        # Distinct ids — sanity.
+        # id が別個であることのサニティチェック。
         assert workflow_a.id != workflow_b.id
 
         async with session_factory() as session, session.begin():
             await SqliteWorkflowRepository(session).save(workflow_a)
 
-        # Save B → A must remain untouched.
+        # B を save → A は無傷でなければならない。
         async with session_factory() as session, session.begin():
             await SqliteWorkflowRepository(session).save(workflow_b)
 
@@ -232,7 +226,7 @@ class TestSaveDistinctWorkflowsAreIndependent:
         assert len(a_rows) == 1
         assert len(b_rows) == 1
 
-        # Sanity: the two Workflows did not share stage rows.
+        # サニティ: 2 つの Workflow がステージ行を共有していない。
         a_stage_ids = {row.stage_id for row in a_rows}
         b_stage_ids = {row.stage_id for row in b_rows}
         assert a_stage_ids.isdisjoint(b_stage_ids)
@@ -241,7 +235,7 @@ class TestSaveDistinctWorkflowsAreIndependent:
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """find_by_id of an unknown id still returns None even when DB is non-empty."""
+        """DB が空でなくても、未知 id の find_by_id は None を返す。"""
         async with session_factory() as session, session.begin():
             await SqliteWorkflowRepository(session).save(make_workflow())
 

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_workflow_repository/test_save_round_trip.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_workflow_repository/test_save_round_trip.py
@@ -1,16 +1,14 @@
-"""Workflow Repository: save() — roles_csv determinism + round-trip + Tx boundary.
+"""Workflow Repository: save() ── roles_csv 決定性 + ラウンドトリップ + Tx 境界.
 
-TC-IT-WFR-011 / 012 / 015 / 016 — the §確定 G "sorted CSV"
-determinism, the §確定 C round-trip structural equality, and the
-§確定 B Tx-boundary responsibility separation.
+TC-IT-WFR-011 / 012 / 015 / 016 ── §確定 G の "sorted CSV" 決定性、
+§確定 C のラウンドトリップ構造的等価、および §確定 B の Tx 境界責務分離。
 
-Split out of ``test_save_semantics.py`` per Norman 500-line rule.
-The companion file
-:mod:`...test_workflow_repository.test_save_delete_then_insert` covers
-the delete-then-insert + 5-step DML order + cross-workflow isolation
-smoke.
+Norman 500 行ルールに従い ``test_save_semantics.py`` から分割。
+姉妹ファイル
+:mod:`...test_workflow_repository.test_save_delete_then_insert` で
+delete-then-insert + 5 ステップ DML 順 + ワークフロー横断 isolation スモークを扱う。
 
-Per ``docs/features/workflow-repository/test-design.md``.
+``docs/features/workflow-repository/test-design.md`` 準拠。
 """
 
 from __future__ import annotations
@@ -40,34 +38,32 @@ pytestmark = pytest.mark.asyncio
 
 
 # ---------------------------------------------------------------------------
-# §確定 G: roles_csv sorted CSV determinism (TC-IT-WFR-011 / 012)
+# §確定 G: roles_csv の sorted CSV 決定性 (TC-IT-WFR-011 / 012)
 # ---------------------------------------------------------------------------
 class TestRolesCsvSortedDeterminism:
-    """TC-IT-WFR-011 / 012: ``roles_csv`` is sorted; equal frozensets → equal CSV.
+    """TC-IT-WFR-011 / 012: ``roles_csv`` はソート済。同値 frozenset → 同値 CSV。
 
-    §確定 G freezes "sorted CSV" specifically because Python
-    ``frozenset`` iteration order is implementation-defined. Without
-    sorting, two save() calls of the same Workflow could produce
-    different ``roles_csv`` byte sequences and trigger spurious
-    delete-then-insert diff noise (the row would *look* changed even
-    though the domain value is identical).
+    §確定 G が「sorted CSV」を凍結する理由は、Python ``frozenset`` の
+    iteration 順が実装依存だから。ソートしない場合、同一 Workflow を
+    2 回 save() すると ``roles_csv`` のバイト列が異なってしまい、
+    delete-then-insert の差分ノイズが発生する (ドメイン値は同一なのに
+    行が *見かけ上* 変わる)。
 
-    We exercise:
+    検証項目:
 
-    1. **Round-trip restore** — frozenset → CSV → frozenset preserves
-       the role set (no roles dropped, no extras introduced).
-    2. **Byte-determinism** — two Workflows whose Stage's
-       ``required_role`` was constructed with **different insertion
-       order** (e.g. ``frozenset({DEVELOPER, REVIEWER})`` vs.
-       ``frozenset({REVIEWER, DEVELOPER})``) produce byte-identical
-       ``roles_csv`` rows in DB.
+    1. **ラウンドトリップ復元** ── frozenset → CSV → frozenset で
+       role 集合が保たれる (欠落も追加もない)。
+    2. **バイト決定性** ── Stage の ``required_role`` を **異なる挿入順**
+       (例: ``frozenset({DEVELOPER, REVIEWER})`` vs.
+       ``frozenset({REVIEWER, DEVELOPER})``) で構築した 2 つの Workflow
+       がバイト等価な ``roles_csv`` を DB に書く。
     """
 
     async def test_required_role_round_trips_via_roles_csv(
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """TC-IT-WFR-011: ``frozenset[Role]`` survives the CSV round-trip."""
+        """TC-IT-WFR-011: ``frozenset[Role]`` は CSV ラウンドトリップに耐える。"""
         roles = frozenset({Role.DEVELOPER, Role.TESTER, Role.REVIEWER})
         stage = make_stage(required_role=roles)
         workflow = make_workflow(stages=[stage], entry_stage_id=stage.id)
@@ -87,17 +83,16 @@ class TestRolesCsvSortedDeterminism:
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """TC-IT-WFR-012: Same ``frozenset`` produces byte-identical ``roles_csv``.
+        """TC-IT-WFR-012: 同じ ``frozenset`` はバイト等価な ``roles_csv`` を生む。
 
-        Build two stages whose ``required_role`` was constructed from
-        differently-ordered iterables but yield the same ``frozenset``.
-        The persisted ``roles_csv`` strings must match byte-for-byte —
-        otherwise delete-then-insert would re-write the same row over
-        and over (diff noise) on every save.
+        ``required_role`` を異なる順の iterable から構築した 2 つの Stage
+        だが、同一 ``frozenset`` を返す ── 永続化された ``roles_csv``
+        文字列はバイト等価でなければならない。さもないと
+        delete-then-insert が同じ行を毎回書き直す (差分ノイズ)。
         """
         roles_forward = frozenset({Role.DEVELOPER, Role.REVIEWER, Role.TESTER})
         roles_reverse = frozenset([Role.TESTER, Role.REVIEWER, Role.DEVELOPER])
-        # frozenset equality is set equality — sanity check our setup.
+        # frozenset の等価は集合等価 ── セットアップの確認。
         assert roles_forward == roles_reverse
 
         stage_a = make_stage(required_role=roles_forward)
@@ -109,10 +104,9 @@ class TestRolesCsvSortedDeterminism:
             await SqliteWorkflowRepository(session).save(workflow_a)
             await SqliteWorkflowRepository(session).save(workflow_b)
 
-        # Raw-SQL fetch of the two ``roles_csv`` cells; SQLAlchemy
-        # would hide the literal byte content behind type decorators
-        # (it doesn't here, but the explicit raw form documents the
-        # intent for follow-up Repository PRs).
+        # 2 つの ``roles_csv`` セルを raw SQL で取得 ── SQLAlchemy は
+        # 通常 TypeDecorator で実バイトを隠す (ここでは隠していないが、
+        # 後続の Repository PR のために明示的な raw 形で意図を残す)。
         async with session_factory() as session:
             stmt = text(
                 "SELECT roles_csv FROM workflow_stages "
@@ -133,28 +127,27 @@ class TestRolesCsvSortedDeterminism:
 
 
 # ---------------------------------------------------------------------------
-# §確定 C: round-trip structural equality (TC-IT-WFR-015)
+# §確定 C: ラウンドトリップ構造的等価 (TC-IT-WFR-015)
 # ---------------------------------------------------------------------------
 class TestRoundTripStructuralEquality:
-    """TC-IT-WFR-015: save → find_by_id round-trip preserves Workflow identity.
+    """TC-IT-WFR-015: save → find_by_id ラウンドトリップで Workflow アイデンティティが保たれる。
 
-    The Workflow Repository inherits empire-repository's ``ORDER BY
-    stage_id`` / ``ORDER BY transition_id`` contract from PR #1
-    (BUG-EMR-001 lesson applied at design time, not after the fact).
-    We sort the *expected* lists by the same key the Repository
-    sorted on so list-order equality is the contract.
+    Workflow Repository は PR #1 から empire-repository の ``ORDER BY
+    stage_id`` / ``ORDER BY transition_id`` 契約を継承している
+    (BUG-EMR-001 の教訓を後追いではなく設計時に適用した)。Repository が
+    ソートしたのと同じキーで *期待* リストをソートし、リスト順等価を
+    契約とする。
 
-    We deliberately avoid ``EXTERNAL_REVIEW`` stages in this round-trip
-    test because §確定 H §不可逆性 makes ``find_by_id`` raise on those;
-    the irreversibility is verified separately in
-    :mod:`...test_masking`.
+    本ラウンドトリップテストは ``EXTERNAL_REVIEW`` ステージを意図的に
+    避ける ── §確定 H §不可逆性 により ``find_by_id`` がそれらに対して
+    raise するため。irreversibility は別途 :mod:`...test_masking` で検証。
     """
 
     async def test_multi_stage_workflow_round_trip(
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """TC-IT-WFR-015: 3 stages + 2 transitions round-trip with list-order equality."""
+        """TC-IT-WFR-015: 3 stage + 2 transition がリスト順等価でラウンドトリップ。"""
         stage_a = make_stage(name="A")
         stage_b = make_stage(name="B")
         stage_c = make_stage(name="C")
@@ -176,9 +169,8 @@ class TestRoundTripStructuralEquality:
         assert restored.id == workflow.id
         assert restored.name == workflow.name
         assert restored.entry_stage_id == workflow.entry_stage_id
-        # ORDER BY stage_id / transition_id 物理保証: restored side-table
-        # lists are deterministic, so list-order equality is the
-        # contract.
+        # ORDER BY stage_id / transition_id 物理保証: 復元される side-table
+        # リストは決定的なので、リスト順等価が契約。
         assert restored.stages == sorted(workflow.stages, key=lambda s: s.id)
         assert restored.transitions == sorted(workflow.transitions, key=lambda t: t.id)
 
@@ -186,29 +178,30 @@ class TestRoundTripStructuralEquality:
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """TC-IT-WFR-015: a single-stage Workflow (entry == sink) round-trips with full ``==``."""
-        workflow = make_workflow()  # default = 1 WORK stage, 0 transitions
+        """TC-IT-WFR-015: 単一ステージ Workflow (entry == sink)
+        は完全 ``==`` でラウンドトリップ。"""
+        workflow = make_workflow()  # デフォルト = 1 WORK stage、0 transition
         async with session_factory() as session, session.begin():
             await SqliteWorkflowRepository(session).save(workflow)
 
         async with session_factory() as session:
             restored = await SqliteWorkflowRepository(session).find_by_id(workflow.id)
         assert restored is not None
-        # No list-order ambiguity — full ``==`` is fine.
+        # リスト順の曖昧さなし ── 完全 ``==`` で良い。
         assert restored == workflow
 
 
 # ---------------------------------------------------------------------------
-# §確定 B: Tx boundary responsibility separation (TC-IT-WFR-016)
+# §確定 B: Tx 境界責務分離 (TC-IT-WFR-016)
 # ---------------------------------------------------------------------------
 class TestTxBoundaryRespectedByRepository:
-    """TC-IT-WFR-016: Repository never calls commit / rollback (§確定 B)."""
+    """TC-IT-WFR-016: Repository は commit / rollback を呼ばない (§確定 B)。"""
 
     async def test_commit_path_persists_via_outer_block(
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """TC-IT-WFR-016 (commit): outer ``async with session.begin()`` commits the save."""
+        """TC-IT-WFR-016 (commit): 外側 ``async with session.begin()`` で save がコミットされる。"""
         workflow = make_workflow()
         async with session_factory() as session, session.begin():
             await SqliteWorkflowRepository(session).save(workflow)
@@ -221,20 +214,19 @@ class TestTxBoundaryRespectedByRepository:
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """TC-IT-WFR-016 (rollback): an exception inside ``begin()`` rolls back the save.
+        """TC-IT-WFR-016 (rollback): ``begin()`` 内の例外で save がロールバックされる。
 
-        The Workflow row + its (potentially non-empty) stages /
-        transitions all participate in the same caller-managed
-        transaction. A single uncaught exception inside the ``begin()``
-        block must purge **all** of them — Repository did not commit
-        anything itself.
+        Workflow 行と (空でない可能性のある) stages / transitions は
+        全て呼び出し側管理の同一トランザクションに参加する。``begin()``
+        ブロック内の未捕捉例外 1 つで **全て** が消えなければならない ──
+        Repository 自身は何もコミットしていないから。
         """
 
         class _BoomError(Exception):
-            """Synthetic exception used to drive the rollback path."""
+            """ロールバック経路を駆動するための合成例外。"""
 
-        # Use a 3-stage Workflow so rollback has stages + transitions
-        # to demonstrably purge alongside the workflow row.
+        # 3 stage Workflow を使い、ロールバック対象として stages + transitions
+        # も Workflow 行と一緒に消えることを実証する。
         stage_a = make_stage(name="A")
         stage_b = make_stage(name="B")
         transition_ab = make_transition(from_stage_id=stage_a.id, to_stage_id=stage_b.id)
@@ -251,12 +243,11 @@ class TestTxBoundaryRespectedByRepository:
 
         async with session_factory() as session:
             fetched = await SqliteWorkflowRepository(session).find_by_id(workflow.id)
-        # Rollback must have been atomic — no row survives.
+        # ロールバックはアトミックでなければならない ── 行は残らない。
         assert fetched is None
 
-        # Side tables also empty — the §確定 B contract is that the
-        # 5-step sequence is **one** logical operation under the
-        # caller's UoW, not five separate persistences.
+        # side テーブルも空 ── §確定 B 契約は、5 ステップ列が呼び出し側 UoW
+        # 配下の **1 つ** の論理操作であり、5 つの別個の永続化ではない。
         async with session_factory() as session:
             stage_count = (
                 await session.execute(
@@ -269,26 +260,25 @@ class TestTxBoundaryRespectedByRepository:
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """TC-IT-WFR-016 補強: ``save`` outside ``begin()`` does not auto-commit.
+        """TC-IT-WFR-016 補強: ``begin()`` 外の ``save`` は自動コミットしない。
 
-        If the Repository contained a stray ``await session.commit()``,
-        a save without ``async with session.begin()`` would still
-        persist — and a subsequent fresh-session read would see it.
-        SQLAlchemy AsyncSession default is autobegin=True with a
-        transactional SELECT, so we open a session and call save
-        directly without an outer ``begin()`` block, then expire +
-        re-read in a fresh session. The Repository's contract is that
-        the row does **not** persist, because no commit fired.
+        Repository に紛れ込んだ ``await session.commit()`` があれば、
+        ``async with session.begin()`` 無しの save が永続化されてしまい、
+        後続の新規セッション読み取りで観測される。SQLAlchemy AsyncSession
+        の既定は autobegin=True でトランザクショナル SELECT。本テストは
+        ``begin()`` ブロックなしでセッションを開いて save を直接呼び、
+        新規セッションで expire + 再読する。Repository の契約は ──
+        コミットが発火しないので ── 行が **永続化されない**。
         """
         workflow = make_workflow()
         async with session_factory() as session:
             await SqliteWorkflowRepository(session).save(workflow)
-            # Intentionally exit without ``commit()`` — AsyncSession's
-            # ``__aexit__`` will rollback any in-flight transaction.
+            # ``commit()`` を呼ばずに意図的に終了 ── AsyncSession の
+            # ``__aexit__`` が in-flight トランザクションをロールバックする。
 
         async with session_factory() as session:
             fetched = await SqliteWorkflowRepository(session).find_by_id(workflow.id)
-        # The Repository must NOT have committed implicitly.
+        # Repository は暗黙コミットしてはならない。
         assert fetched is None, (
             "[FAIL] Workflow row persisted without an outer commit.\n"
             "Next: SqliteWorkflowRepository.save() must not call "

--- a/backend/tests/infrastructure/persistence/sqlite/test_alembic_agent.py
+++ b/backend/tests/infrastructure/persistence/sqlite/test_alembic_agent.py
@@ -33,7 +33,7 @@ pytestmark = pytest.mark.asyncio
 
 
 # ---------------------------------------------------------------------------
-# Fixtures
+# フィクスチャ
 # ---------------------------------------------------------------------------
 @pytest_asyncio.fixture
 async def empty_engine(tmp_path: Path) -> AsyncIterator[AsyncEngine]:

--- a/backend/tests/infrastructure/persistence/sqlite/test_alembic_agent.py
+++ b/backend/tests/infrastructure/persistence/sqlite/test_alembic_agent.py
@@ -1,14 +1,14 @@
-"""Alembic 4th revision tests (TC-IT-AGR-008 — chain + DDL + idempotency).
+"""Alembic 4 番目リビジョンテスト (TC-IT-AGR-008 — チェーン + DDL + べき等性)。
 
-Per ``docs/features/agent-repository/test-design.md``. Real Alembic
-upgrade / downgrade against a real SQLite file, plus a chain
-integrity check that makes sure
+``docs/features/agent-repository/test-design.md`` に従う。実際の SQLite ファイルに対する
+実際の Alembic upgrade / downgrade、および
 ``0001_init`` → ``0002_empire_aggregate`` → ``0003_workflow_aggregate``
-→ ``0004_agent_aggregate`` stays linear (no head fork).
+→ ``0004_agent_aggregate`` が線形（head fork なし）であることを確認する
+チェーン完全性チェック。
 
-The conftest from ``tests/infrastructure/`` patches Alembic's
-``fileConfig`` so log capture survives migration; same workaround the
-M2 persistence-foundation tests rely on.
+``tests/infrastructure/`` の conftest は Alembic の ``fileConfig`` をパッチして、
+ログキャプチャがマイグレーション中も生き残るようにする；
+M2 persistence-foundation テストが依存している同じ回避策。
 """
 
 from __future__ import annotations

--- a/backend/tests/infrastructure/persistence/sqlite/test_alembic_agent.py
+++ b/backend/tests/infrastructure/persistence/sqlite/test_alembic_agent.py
@@ -37,7 +37,7 @@ pytestmark = pytest.mark.asyncio
 # ---------------------------------------------------------------------------
 @pytest_asyncio.fixture
 async def empty_engine(tmp_path: Path) -> AsyncIterator[AsyncEngine]:
-    """Bring up a fresh app engine without running any migrations."""
+    """マイグレーションを実行せずに新規 app エンジンを起動。"""
     url = f"sqlite+aiosqlite:///{tmp_path / 'bakufu.db'}"
     engine = engine_mod.create_engine(url)
     try:
@@ -47,7 +47,7 @@ async def empty_engine(tmp_path: Path) -> AsyncIterator[AsyncEngine]:
 
 
 def _alembic_config() -> Config:
-    """Resolve the bakufu Alembic config for ScriptDirectory inspection."""
+    """ScriptDirectory inspection 用に bakufu Alembic config を解決。"""
     backend_root = Path(__file__).resolve().parents[4]
     cfg = Config(str(backend_root / "alembic.ini"))
     cfg.set_main_option("script_location", str(backend_root / "alembic"))
@@ -58,13 +58,13 @@ def _alembic_config() -> Config:
 # TC-IT-AGR-008: 4th revision creates the 3 Agent tables + indexes
 # ---------------------------------------------------------------------------
 class TestFourthRevisionApplied:
-    """TC-IT-AGR-008: ``alembic upgrade head`` adds the Agent schema."""
+    """TC-IT-AGR-008: ``alembic upgrade head`` が Agent スキーマを追加。"""
 
     async def test_three_agent_tables_present_after_upgrade(
         self,
         empty_engine: AsyncEngine,
     ) -> None:
-        """agents / agent_providers / agent_skills exist after upgrade head."""
+        """upgrade head 後に agents / agent_providers / agent_skills が存在。"""
         await run_upgrade_head(empty_engine)
         async with empty_engine.connect() as conn:
             result = await conn.execute(text("SELECT name FROM sqlite_master WHERE type='table'"))
@@ -75,12 +75,12 @@ class TestFourthRevisionApplied:
         self,
         empty_engine: AsyncEngine,
     ) -> None:
-        """``uq_agent_providers_default`` partial unique index is created.
+        """``uq_agent_providers_default`` partial unique index が作成される。
 
-        SQLite stores partial-index DDL in ``sqlite_master.sql``; we
-        grep for the ``WHERE`` clause to confirm the partial nature
-        (a plain unique index would not block ``is_default=0``
-        duplicates).
+        SQLite は partial-index DDL を ``sqlite_master.sql`` に格納；
+        partial 性を確認するため ``WHERE`` 句を grep
+        (通常の unique index は ``is_default=0``
+        重複をブロックしない)。
         """
         await run_upgrade_head(empty_engine)
         async with empty_engine.connect() as conn:
@@ -95,13 +95,13 @@ class TestFourthRevisionApplied:
             (name, sql) for name, sql in rows if sql is not None and "WHERE" in sql.upper()
         ]
         assert partial_indexes, (
-            "[FAIL] agent_providers must declare a partial unique index "
-            "with a WHERE clause for §確定 G 二重防衛.\n"
-            f"All indexes on agent_providers: {rows}"
+            "[FAIL] agent_providers は §確定 G 二重防衛のため"
+            "WHERE 句を含む partial unique index を宣言する必要がある。\n"
+            f"agent_providers のすべてのインデックス: {rows}"
         )
-        # And the predicate must reference is_default = 1.
+        # 述語は is_default = 1 を参照する必要がある。
         assert any("is_default" in sql and "1" in sql for _, sql in partial_indexes), (
-            f"Partial index does not target is_default = 1: {partial_indexes}"
+            f"Partial index が is_default = 1 をターゲットにしていない: {partial_indexes}"
         )
 
 
@@ -109,15 +109,15 @@ class TestFourthRevisionApplied:
 # TC-IT-AGR-008 補強: upgrade / downgrade are idempotent
 # ---------------------------------------------------------------------------
 class TestUpgradeDowngradeIdempotent:
-    """upgrade head → downgrade base → upgrade head again all green."""
+    """upgrade head → downgrade base → upgrade head 再び全て成功。"""
 
     async def test_full_cycle_leaves_agent_tables_present(
         self,
         empty_engine: AsyncEngine,
     ) -> None:
-        """upgrade head → downgrade base → upgrade head again."""
+        """upgrade head → downgrade base → upgrade head 再び。"""
         await run_upgrade_head(empty_engine)
-        from alembic import command  # local import to avoid global side effects
+        from alembic import command  # グローバルサイドエフェクトを回避するためのローカルインポート
 
         cfg = _alembic_config()
         url = str(empty_engine.url)
@@ -144,20 +144,20 @@ class TestUpgradeDowngradeIdempotent:
 # TC-IT-AGR-008: revision chain is linear (no head fork)
 # ---------------------------------------------------------------------------
 class TestRevisionChainLinear:
-    """0001 → 0002 → 0003 → 0004 single-head chain."""
+    """0001 → 0002 → 0003 → 0004 単一-head チェーン。"""
 
     async def test_alembic_heads_returns_single_revision(self) -> None:
-        """``ScriptDirectory.get_heads()`` returns exactly one revision."""
+        """``ScriptDirectory.get_heads()`` が正確に 1 つの revision を返す。"""
         cfg = _alembic_config()
         script = ScriptDirectory.from_config(cfg)
         heads = script.get_heads()
         assert len(heads) == 1, (
-            f"Alembic head must be linear; got branched heads {heads}.\n"
-            f"Each Aggregate Repository PR appends a single revision."
+            f"Alembic head は線形である必要があります；分岐した heads {heads} を得た。\n"
+            f"各アグリゲートリポジトリ PR は単一 revision を追加します。"
         )
 
     async def test_0004_revision_has_correct_down_revision(self) -> None:
-        """``0004_agent_aggregate.down_revision == "0003_workflow_aggregate"``."""
+        """``0004_agent_aggregate.down_revision == "0003_workflow_aggregate"``。"""
         cfg = _alembic_config()
         script = ScriptDirectory.from_config(cfg)
         rev = script.get_revision("0004_agent_aggregate")
@@ -165,20 +165,20 @@ class TestRevisionChainLinear:
         assert rev.down_revision == "0003_workflow_aggregate"
 
     async def test_chain_walks_from_0004_back_to_base(self) -> None:
-        """Walking ``down_revision`` reaches base in 4 hops (no branching)."""
+        """``down_revision`` を走査すると 4 ホップで base に到達 (分岐なし)。"""
         cfg = _alembic_config()
         script = ScriptDirectory.from_config(cfg)
         chain: list[str] = []
         current_id: str | None = "0004_agent_aggregate"
-        for _ in range(10):  # generous bound for safety
+        for _ in range(10):  # 安全性のための余裕のある境界
             if current_id is None:
                 break
             rev = script.get_revision(current_id)
-            assert rev is not None, f"Revision {current_id!r} not found"
+            assert rev is not None, f"Revision {current_id!r} が見つかりません"
             chain.append(rev.revision)
             down = rev.down_revision
             if isinstance(down, tuple | list):
-                pytest.fail(f"Revision {rev.revision!r} has multiple down_revisions {down}")
+                pytest.fail(f"Revision {rev.revision!r} は複数の down_revisions {down} を持つ")
             current_id = down  # pyright: ignore[reportAssignmentType]
 
         assert chain == [
@@ -186,4 +186,4 @@ class TestRevisionChainLinear:
             "0003_workflow_aggregate",
             "0002_empire_aggregate",
             "0001_init",
-        ], f"Unexpected revision chain: {chain}"
+        ], f"予期しない revision chain: {chain}"

--- a/backend/tests/infrastructure/persistence/sqlite/test_alembic_directive.py
+++ b/backend/tests/infrastructure/persistence/sqlite/test_alembic_directive.py
@@ -41,7 +41,7 @@ pytestmark = pytest.mark.asyncio
 # ---------------------------------------------------------------------------
 @pytest_asyncio.fixture
 async def empty_engine(tmp_path: Path) -> AsyncIterator[AsyncEngine]:
-    """Bring up a fresh app engine without running any migrations."""
+    """マイグレーションを実行せずに新規 app エンジンを起動。"""
     url = f"sqlite+aiosqlite:///{tmp_path / 'bakufu.db'}"
     engine = engine_mod.create_engine(url)
     try:
@@ -51,7 +51,7 @@ async def empty_engine(tmp_path: Path) -> AsyncIterator[AsyncEngine]:
 
 
 def _alembic_config() -> Config:
-    """Resolve bakufu Alembic config for ScriptDirectory inspection."""
+    """ScriptDirectory inspection 用に bakufu Alembic config を解決。"""
     backend_root = Path(__file__).resolve().parents[4]
     cfg = Config(str(backend_root / "alembic.ini"))
     cfg.set_main_option("script_location", str(backend_root / "alembic"))
@@ -62,13 +62,13 @@ def _alembic_config() -> Config:
 # TC-IT-DRR-001: 0006 creates directives table + INDEX + FK (受入基準 9)
 # ---------------------------------------------------------------------------
 class TestSixthRevisionApplied:
-    """TC-IT-DRR-001: alembic upgrade head adds the Directive schema."""
+    """TC-IT-DRR-001: alembic upgrade head が Directive スキーマを追加。"""
 
     async def test_directives_table_present_after_upgrade(
         self,
         empty_engine: AsyncEngine,
     ) -> None:
-        """``directives`` table exists after upgrade head."""
+        """upgrade head 後に ``directives`` テーブルが存在。"""
         await run_upgrade_head(empty_engine)
         async with empty_engine.connect() as conn:
             result = await conn.execute(text("SELECT name FROM sqlite_master WHERE type='table'"))
@@ -81,7 +81,7 @@ class TestSixthRevisionApplied:
         self,
         empty_engine: AsyncEngine,
     ) -> None:
-        """``ix_directives_target_room_id_created_at`` composite index exists (§確定 R1-D)."""
+        """``ix_directives_target_room_id_created_at`` コンポジットインデックスが存在 (§確定 R1-D)。"""
         await run_upgrade_head(empty_engine)
         async with empty_engine.connect() as conn:
             result = await conn.execute(
@@ -98,7 +98,7 @@ class TestSixthRevisionApplied:
         self,
         empty_engine: AsyncEngine,
     ) -> None:
-        """PRAGMA foreign_key_list('directives') shows FK → rooms (§確定 R1-B)."""
+        """PRAGMA foreign_key_list('directives') が rooms への FK を表示 (§確定 R1-B)。"""
         await run_upgrade_head(empty_engine)
         async with empty_engine.connect() as conn:
             result = await conn.execute(text("PRAGMA foreign_key_list('directives')"))
@@ -116,16 +116,16 @@ class TestSixthRevisionApplied:
 # TC-IT-DRR-002: Alembic chain 0001→...→0006 single head (分岐なし)
 # ---------------------------------------------------------------------------
 class TestRevisionChainLinear:
-    """TC-IT-DRR-002: 0001→0002→0003→0004→0005→0006 single-head chain."""
+    """TC-IT-DRR-002: 0001→0002→0003→0004→0005→0006 単一-head チェーン。"""
 
     async def test_alembic_heads_returns_single_revision(self) -> None:
-        """ScriptDirectory.get_heads() returns exactly one revision."""
+        """ScriptDirectory.get_heads() が正確に 1 つの revision を返す。"""
         cfg = _alembic_config()
         script = ScriptDirectory.from_config(cfg)
         heads = script.get_heads()
         assert len(heads) == 1, (
-            f"[FAIL] Alembic head must be linear; got branched heads {heads}.\n"
-            f"Each Aggregate Repository PR appends a single revision."
+            f"[FAIL] Alembic head は線形である必要があります；分岐した heads {heads} を得た。\n"
+            f"各アグリゲートリポジトリ PR は単一 revision を追加します。"
         )
 
 
@@ -133,16 +133,16 @@ class TestRevisionChainLinear:
 # TC-IT-DRR-003: upgrade/downgrade idempotent (受入基準 9)
 # ---------------------------------------------------------------------------
 class TestUpgradeDowngradeIdempotent:
-    """TC-IT-DRR-003: upgrade head → downgrade base → upgrade head again."""
+    """TC-IT-DRR-003: upgrade head → downgrade base → upgrade head 再び。"""
 
     async def test_full_cycle_leaves_directives_present(
         self,
         empty_engine: AsyncEngine,
     ) -> None:
-        """upgrade head → downgrade base → upgrade head — directives survives."""
+        """upgrade head → downgrade base → upgrade head — directives が生き残る。"""
         await run_upgrade_head(empty_engine)
 
-        from alembic import command  # local import to avoid global side effects
+        from alembic import command  # グローバルサイドエフェクトを回避するためのローカルインポート
 
         cfg = _alembic_config()
         url = str(empty_engine.url)
@@ -173,21 +173,21 @@ class TestUpgradeDowngradeIdempotent:
 # TC-IT-DRR-004: 0006.down_revision == "0005_room_aggregate"
 # ---------------------------------------------------------------------------
 class TestDownRevision:
-    """TC-IT-DRR-004: 0006_directive_aggregate chains onto 0005_room_aggregate."""
+    """TC-IT-DRR-004: 0006_directive_aggregate が 0005_room_aggregate にチェーン。"""
 
     async def test_0006_revision_has_correct_down_revision(self) -> None:
-        """0006_directive_aggregate.down_revision == '0005_room_aggregate'."""
+        """0006_directive_aggregate.down_revision == '0005_room_aggregate'。"""
         cfg = _alembic_config()
         script = ScriptDirectory.from_config(cfg)
         rev = script.get_revision("0006_directive_aggregate")
         assert rev is not None
         assert rev.down_revision == "0005_room_aggregate", (
-            f"[FAIL] 0006_directive_aggregate.down_revision is {rev.down_revision!r}; "
-            f"expected '0005_room_aggregate'."
+            f"[FAIL] 0006_directive_aggregate.down_revision は {rev.down_revision!r} ；"
+            f"'0005_room_aggregate' を期待。"
         )
 
     async def test_chain_walks_from_0006_back_to_base(self) -> None:
-        """Walking down_revision from 0006 reaches base in 6 hops."""
+        """0006 から down_revision を走査すると 6 ホップで base に到達。"""
         cfg = _alembic_config()
         script = ScriptDirectory.from_config(cfg)
         chain: list[str] = []
@@ -196,11 +196,11 @@ class TestDownRevision:
             if current_id is None:
                 break
             rev = script.get_revision(current_id)
-            assert rev is not None, f"Revision {current_id!r} not found"
+            assert rev is not None, f"Revision {current_id!r} が見つかりません"
             chain.append(rev.revision)
             down = rev.down_revision
             if isinstance(down, tuple | list):
-                pytest.fail(f"Revision {rev.revision!r} has multiple down_revisions {down}")
+                pytest.fail(f"Revision {rev.revision!r} は複数の down_revisions {down} を持つ")
             current_id = down  # pyright: ignore[reportAssignmentType]
 
         assert chain == [
@@ -210,24 +210,24 @@ class TestDownRevision:
             "0003_workflow_aggregate",
             "0002_empire_aggregate",
             "0001_init",
-        ], f"Unexpected revision chain: {chain}"
+        ], f"予期しない revision chain: {chain}"
 
 
 # ---------------------------------------------------------------------------
 # TC-IT-DRR-005: target_room_id FK ON DELETE CASCADE (§確定 R1-B, 受入基準 10)
 # ---------------------------------------------------------------------------
 class TestCascadeDeleteOnRoomDeletion:
-    """TC-IT-DRR-005: Deleting a Room auto-deletes its Directives (CASCADE)."""
+    """TC-IT-DRR-005: Room を削除すると Directives が自動削除される (CASCADE)。"""
 
     async def test_room_deletion_cascades_to_directives(
         self,
         empty_engine: AsyncEngine,
     ) -> None:
-        """DELETE FROM rooms → Directive rows automatically deleted (CASCADE).
+        """DELETE FROM rooms → Directive 行が自動削除される (CASCADE)。
 
-        Inserts empire → workflow → room → directive via raw SQL to avoid
-        Repository layer dependencies. Then DELETEs the room and verifies
-        the directive row disappears due to ON DELETE CASCADE.
+        リポジトリ層の依存性を避けるために、生 SQL 経由で
+        empire → workflow → room → directive を挿入。次に room を
+        DELETE して、ON DELETE CASCADE により directive 行が消えることを検証。
         """
         from uuid import uuid4
 
@@ -275,16 +275,16 @@ class TestCascadeDeleteOnRoomDeletion:
                 },
             )
 
-        # Verify directive exists before delete
+        # delete 前に directive が存在することを確認
         async with empty_engine.connect() as conn:
             await conn.execute(text("PRAGMA foreign_keys = ON"))
             result = await conn.execute(
                 text("SELECT id FROM directives WHERE id = :id"),
                 {"id": directive_id},
             )
-            assert result.first() is not None, "Directive must exist before CASCADE test"
+            assert result.first() is not None, "CASCADE テスト前に Directive が存在する必要がある"
 
-        # Delete the room — CASCADE should remove the directive
+        # room を削除 — CASCADE が directive を削除すべき
         async with empty_engine.begin() as conn:
             await conn.execute(text("PRAGMA foreign_keys = ON"))
             await conn.execute(
@@ -299,9 +299,9 @@ class TestCascadeDeleteOnRoomDeletion:
             )
             remaining = result.first()
         assert remaining is None, (
-            "[FAIL] Directive row still exists after Room deletion.\n"
-            "directives.target_room_id → rooms.id ON DELETE CASCADE is not working.\n"
-            "Next: verify ForeignKey('rooms.id', ondelete='CASCADE') in tables/directives.py."
+            "[FAIL] Directive 行が Room 削除後も存在します。\n"
+            "directives.target_room_id → rooms.id ON DELETE CASCADE が動作していません。\n"
+            "次：tables/directives.py で ForeignKey('rooms.id', ondelete='CASCADE') を検証。"
         )
 
 
@@ -309,53 +309,54 @@ class TestCascadeDeleteOnRoomDeletion:
 # TC-IT-DRR-006: §BUG-DRR-001 — task_id FK does NOT exist at 0006 (受入基準 11)
 # ---------------------------------------------------------------------------
 class TestBugDrr001TaskIdFkClosure:
-    """TC-IT-DRR-006: BUG-DRR-001 closure confirmed — directives.task_id FK now present.
+    """TC-IT-DRR-006: BUG-DRR-001 closure 確認 — directives.task_id FK が現在存在。
 
-    §BUG-DRR-001 (BUG-EMR-001 パターン): was OPEN at 0006 level (tasks table did
-    not exist). Alembic revision 0007_task_aggregate closed this by adding
+    §BUG-DRR-001 (BUG-EMR-001 パターン): 0006 レベルで OPEN であった (tasks テーブルが
+    存在しなかった)。Alembic revision 0007_task_aggregate は
+    ``op.batch_alter_table('directives')`` 経由で
     ``fk_directives_task_id`` (``directives.task_id → tasks.id`` ON DELETE RESTRICT)
-    via ``op.batch_alter_table('directives')``.
+    を追加することで、これを閉じた。
 
-    This test physically confirms the closure: at HEAD (0007), the FK IS present.
-    TC-IT-TR-008 in test_alembic_task.py is the canonical closure test; this test
-    confirms the directive side is consistent with that assertion.
+    このテストは物理的に closure を確認：HEAD (0007) で FK が存在。
+    test_alembic_task.py の TC-IT-TR-008 が正規の closure テスト；
+    このテストは directive 側が当該アサーションと一致することを確認。
     """
 
     async def test_task_id_fk_present_in_directives_at_head(
         self,
         empty_engine: AsyncEngine,
     ) -> None:
-        """PRAGMA foreign_key_list('directives') has reference to 'tasks' at HEAD.
+        """PRAGMA foreign_key_list('directives') が HEAD で 'tasks' への参照を持つ。
 
-        BUG-DRR-001 closure: 0007_task_aggregate added the FK via batch_alter_table.
-        At upgrade head (0007), directives.task_id → tasks.id FK must exist.
+        BUG-DRR-001 closure: 0007_task_aggregate が batch_alter_table 経由で FK を追加。
+        upgrade head (0007) では、directives.task_id → tasks.id FK が存在する必要がある。
         """
         await run_upgrade_head(empty_engine)
         async with empty_engine.connect() as conn:
             result = await conn.execute(text("PRAGMA foreign_key_list('directives')"))
             fk_rows = list(result)
-        # PRAGMA foreign_key_list columns: id, seq, table, from, to, ...
+        # PRAGMA foreign_key_list カラム: id, seq, table, from, to, ...
         referenced_tables = {row[2] for row in fk_rows}
         assert "tasks" in referenced_tables, (
-            f"[FAIL] directives.task_id FK to 'tasks' missing at HEAD level.\n"
-            f"BUG-DRR-001 closure requires 0007_task_aggregate to add FK via "
+            f"[FAIL] directives.task_id FK to 'tasks' が HEAD レベルで不足。\n"
+            f"BUG-DRR-001 closure は 0007_task_aggregate が "
             f"op.batch_alter_table('directives') + create_foreign_key('fk_directives_task_id', "
-            f"'tasks', ['task_id'], ['id'], ondelete='RESTRICT').\n"
-            f"FK references found: {referenced_tables}"
+            f"'tasks', ['task_id'], ['id'], ondelete='RESTRICT') 経由で FK を追加することを必要とする。\n"
+            f"FK 参照が見つかりました: {referenced_tables}"
         )
 
     async def test_task_id_column_exists_as_nullable(
         self,
         empty_engine: AsyncEngine,
     ) -> None:
-        """task_id column exists in directives but is nullable with no FK."""
+        """task_id カラムが directives に存在するが、FK なしで nullable。"""
         await run_upgrade_head(empty_engine)
         async with empty_engine.connect() as conn:
             result = await conn.execute(text("PRAGMA table_info('directives')"))
             columns = {row[1]: {"notnull": row[3], "dflt": row[4]} for row in result}
         assert "task_id" in columns, (
-            f"[FAIL] task_id column missing from directives.\nColumns found: {list(columns.keys())}"
+            f"[FAIL] task_id カラムが directives から不足。\nカラムが見つかりました: {list(columns.keys())}"
         )
         assert columns["task_id"]["notnull"] == 0, (
-            "[FAIL] task_id must be nullable at 0006 level (§BUG-DRR-001)."
+            "[FAIL] task_id は 0006 レベルで nullable である必要があります (§BUG-DRR-001)。"
         )

--- a/backend/tests/infrastructure/persistence/sqlite/test_alembic_directive.py
+++ b/backend/tests/infrastructure/persistence/sqlite/test_alembic_directive.py
@@ -38,7 +38,7 @@ pytestmark = pytest.mark.asyncio
 
 
 # ---------------------------------------------------------------------------
-# Fixtures
+# フィクスチャ
 # ---------------------------------------------------------------------------
 @pytest_asyncio.fixture
 async def empty_engine(tmp_path: Path) -> AsyncIterator[AsyncEngine]:
@@ -106,7 +106,7 @@ class TestSixthRevisionApplied:
         async with empty_engine.connect() as conn:
             result = await conn.execute(text("PRAGMA foreign_key_list('directives')"))
             fk_rows = list(result)
-        # PRAGMA foreign_key_list columns: id, seq, table, from, to, ...
+        # PRAGMA foreign_key_list の列: id, seq, table, from, to, ...
         referenced_tables = {row[2] for row in fk_rows}
         assert "rooms" in referenced_tables, (
             f"[FAIL] directives has no FK to rooms (§確定 R1-B).\n"

--- a/backend/tests/infrastructure/persistence/sqlite/test_alembic_directive.py
+++ b/backend/tests/infrastructure/persistence/sqlite/test_alembic_directive.py
@@ -1,18 +1,19 @@
-"""Alembic 6th revision tests — directive aggregate (TC-IT-DRR-001〜006).
+"""Alembic 6 番目リビジョンテスト — directive aggregate (TC-IT-DRR-001〜006)。
 
-REQ-DRR-003 / §確定 R1-B / §確定 R1-C.
+REQ-DRR-003 / §確定 R1-B / §確定 R1-C。
 
-Real Alembic upgrade/downgrade against a real SQLite file, plus chain
-integrity check that makes sure the 0001→…→0006 chain stays linear.
+実際の SQLite ファイルに対する実際の Alembic upgrade/downgrade、
+および 0001→…→0006 チェーンが線形（head fork なし）であることを
+確認するチェーン完全性チェック。
 
-Also verifies:
-* ``directives`` table created with correct columns.
-* ``ix_directives_target_room_id_created_at`` composite index present.
-* ``target_room_id`` FK → ``rooms.id`` ON DELETE CASCADE exists.
-* §BUG-DRR-001: ``task_id → tasks.id`` FK does NOT exist at 0006 level.
+また以下も検証:
+* ``directives`` テーブルが正しいカラムで作成される。
+* ``ix_directives_target_room_id_created_at`` 複合インデックスが存在。
+* ``target_room_id`` FK → ``rooms.id`` ON DELETE CASCADE が存在。
+* §BUG-DRR-001: ``task_id → tasks.id`` FK は 0006 レベルで存在しない。
 
-Per ``docs/features/directive-repository/test-design.md`` TC-IT-DRR-001〜006.
-Issue #34 — M2 0006.
+``docs/features/directive-repository/test-design.md`` TC-IT-DRR-001〜006 に準拠。
+Issue #34 — M2 0006。
 """
 
 from __future__ import annotations

--- a/backend/tests/infrastructure/persistence/sqlite/test_alembic_directive.py
+++ b/backend/tests/infrastructure/persistence/sqlite/test_alembic_directive.py
@@ -81,7 +81,9 @@ class TestSixthRevisionApplied:
         self,
         empty_engine: AsyncEngine,
     ) -> None:
-        """``ix_directives_target_room_id_created_at`` コンポジットインデックスが存在 (§確定 R1-D)。"""
+        """``ix_directives_target_room_id_created_at`` コンポジット
+        インデックスが存在 (§確定 R1-D)。
+        """
         await run_upgrade_head(empty_engine)
         async with empty_engine.connect() as conn:
             result = await conn.execute(
@@ -339,9 +341,9 @@ class TestBugDrr001TaskIdFkClosure:
         referenced_tables = {row[2] for row in fk_rows}
         assert "tasks" in referenced_tables, (
             f"[FAIL] directives.task_id FK to 'tasks' が HEAD レベルで不足。\n"
-            f"BUG-DRR-001 closure は 0007_task_aggregate が "
-            f"op.batch_alter_table('directives') + create_foreign_key('fk_directives_task_id', "
-            f"'tasks', ['task_id'], ['id'], ondelete='RESTRICT') 経由で FK を追加することを必要とする。\n"
+            f"BUG-DRR-001 closure は 0007_task_aggregate が batch_alter_table"
+            f"('directives') 経由で fk_directives_task_id ('tasks' の 'task_id' on "
+            f"delete RESTRICT) を追加することを必要とする。\n"
             f"FK 参照が見つかりました: {referenced_tables}"
         )
 
@@ -355,7 +357,8 @@ class TestBugDrr001TaskIdFkClosure:
             result = await conn.execute(text("PRAGMA table_info('directives')"))
             columns = {row[1]: {"notnull": row[3], "dflt": row[4]} for row in result}
         assert "task_id" in columns, (
-            f"[FAIL] task_id カラムが directives から不足。\nカラムが見つかりました: {list(columns.keys())}"
+            f"[FAIL] task_id カラムが directives から不足。\n"
+            f"カラムが見つかりました: {list(columns.keys())}"
         )
         assert columns["task_id"]["notnull"] == 0, (
             "[FAIL] task_id は 0006 レベルで nullable である必要があります (§BUG-DRR-001)。"

--- a/backend/tests/infrastructure/persistence/sqlite/test_alembic_empire.py
+++ b/backend/tests/infrastructure/persistence/sqlite/test_alembic_empire.py
@@ -33,7 +33,7 @@ pytestmark = pytest.mark.asyncio
 
 
 # ---------------------------------------------------------------------------
-# Fixtures
+# フィクスチャ
 # ---------------------------------------------------------------------------
 @pytest_asyncio.fixture
 async def empty_engine(tmp_path: Path) -> AsyncIterator[AsyncEngine]:
@@ -110,7 +110,7 @@ class TestUpgradeDowngradeIdempotent:
         empty_engine: AsyncEngine,
     ) -> None:
         """TC-IT-EMR-015: upgrade head → downgrade base → upgrade head。"""
-        # Up.
+        # アップグレード。
         await run_upgrade_head(empty_engine)
         # Alembic コマンドで base にダウン (asyncio 内で同期)。
         from alembic import command  # ローカルインポートはグローバルサイドエフェクト回避

--- a/backend/tests/infrastructure/persistence/sqlite/test_alembic_empire.py
+++ b/backend/tests/infrastructure/persistence/sqlite/test_alembic_empire.py
@@ -1,13 +1,14 @@
-"""Alembic 2nd revision tests (TC-IT-EMR-008 / 015 / 016).
+"""Alembic 2nd revision テスト (TC-IT-EMR-008 / 015 / 016)。
 
-Per ``docs/features/empire-repository/test-design.md``. Real Alembic
-upgrade / downgrade against a real SQLite file, plus a chain integrity
-check that makes sure ``0001_init`` → ``0002_empire_aggregate`` stays
-linear (no head fork).
+``docs/features/empire-repository/test-design.md`` に従う。
+実際の SQLite ファイルに対する Alembic upgrade / downgrade、
+および chain integrity チェック:
+``0001_init`` → ``0002_empire_aggregate`` が線形 (head fork なし)
+であることを確認。
 
-The conftest from ``tests/infrastructure/`` patches Alembic's
-``fileConfig`` so log capture survives migration; same workaround the
-M2 persistence-foundation tests rely on.
+``tests/infrastructure/`` の conftest は Alembic の ``fileConfig``
+をパッチして、ログキャプチャが migration 中も生き残るようにする；
+M2 persistence-foundation テストが依存している同じ回避策。
 """
 
 from __future__ import annotations
@@ -36,7 +37,7 @@ pytestmark = pytest.mark.asyncio
 # ---------------------------------------------------------------------------
 @pytest_asyncio.fixture
 async def empty_engine(tmp_path: Path) -> AsyncIterator[AsyncEngine]:
-    """Bring up a fresh app engine without running any migrations."""
+    """マイグレーションを実行せずに新規 app エンジンを起動する。"""
     url = f"sqlite+aiosqlite:///{tmp_path / 'bakufu.db'}"
     engine = engine_mod.create_engine(url)
     try:
@@ -46,9 +47,9 @@ async def empty_engine(tmp_path: Path) -> AsyncIterator[AsyncEngine]:
 
 
 def _alembic_config() -> Config:
-    """Resolve the bakufu Alembic config for ScriptDirectory inspection."""
-    # Same path the migrations module uses internally; we duplicate the
-    # walk so this test does not import private helpers.
+    """ScriptDirectory inspection 用に bakufu Alembic config を解決する。"""
+    # migrations モジュールが内部で使用するのと同じパス；
+    # このテストが private helper をインポートしないように walk を複製。
     backend_root = Path(__file__).resolve().parents[4]
     cfg = Config(str(backend_root / "alembic.ini"))
     cfg.set_main_option("script_location", str(backend_root / "alembic"))
@@ -59,13 +60,13 @@ def _alembic_config() -> Config:
 # TC-IT-EMR-008: 2nd revision applies the 3 Empire tables + indexes
 # ---------------------------------------------------------------------------
 class TestSecondRevisionApplied:
-    """TC-IT-EMR-008: ``alembic upgrade head`` adds the Empire schema."""
+    """TC-IT-EMR-008: ``alembic upgrade head`` が Empire スキーマを追加する。"""
 
     async def test_three_empire_tables_present_after_upgrade(
         self,
         empty_engine: AsyncEngine,
     ) -> None:
-        """TC-IT-EMR-008: empires / empire_room_refs / empire_agent_refs exist."""
+        """TC-IT-EMR-008: empires / empire_room_refs / empire_agent_refs が存在する。"""
         await run_upgrade_head(empty_engine)
         async with empty_engine.connect() as conn:
             result = await conn.execute(text("SELECT name FROM sqlite_master WHERE type='table'"))
@@ -76,12 +77,13 @@ class TestSecondRevisionApplied:
         self,
         empty_engine: AsyncEngine,
     ) -> None:
-        """TC-IT-EMR-008: UNIQUE indexes on (empire_id, room_id) / (empire_id, agent_id).
+        """TC-IT-EMR-008: (empire_id, room_id) / (empire_id, agent_id) 上の UNIQUE インデックス。
 
-        SQLite emits an ``sqlite_autoindex_*`` for every UNIQUE
-        constraint declared at table creation. A ``CREATE INDEX`` named
-        index also lands here; we accept either shape because the
-        Alembic 0002 revision uses the inline UNIQUE constraint form.
+        SQLite はテーブル作成時に宣言された UNIQUE 制約ごと
+        に ``sqlite_autoindex_*`` を発行する。``CREATE INDEX``
+        という名前のインデックスもここに格納される；
+        Alembic 0002 revision がインライン UNIQUE 制約形式
+        を使用しているため、どちらの形態も受け入れる。
         """
         await run_upgrade_head(empty_engine)
         async with empty_engine.connect() as conn:
@@ -91,25 +93,27 @@ class TestSecondRevisionApplied:
             rows = list(result)
         room_indexes = [name for name, tbl in rows if tbl == "empire_room_refs"]
         agent_indexes = [name for name, tbl in rows if tbl == "empire_agent_refs"]
-        assert room_indexes, "empire_room_refs must declare at least one index"
-        assert agent_indexes, "empire_agent_refs must declare at least one index"
+        assert room_indexes, "empire_room_refs は少なくとも 1 つのインデックスを宣言する必要がある"
+        assert agent_indexes, (
+            "empire_agent_refs は少なくとも 1 つのインデックスを宣言する必要がある"
+        )
 
 
 # ---------------------------------------------------------------------------
 # TC-IT-EMR-015: upgrade / downgrade are idempotent
 # ---------------------------------------------------------------------------
 class TestUpgradeDowngradeIdempotent:
-    """TC-IT-EMR-015: Alembic up + down + up again leaves the schema in the head state."""
+    """TC-IT-EMR-015: Alembic up + down + up でスキーマが head 状態に残る。"""
 
     async def test_full_cycle_leaves_empire_tables_present(
         self,
         empty_engine: AsyncEngine,
     ) -> None:
-        """TC-IT-EMR-015: upgrade head → downgrade base → upgrade head again."""
+        """TC-IT-EMR-015: upgrade head → downgrade base → upgrade head。"""
         # Up.
         await run_upgrade_head(empty_engine)
-        # Down to base via Alembic command (synchronous within asyncio).
-        from alembic import command  # local import to avoid global side effects
+        # Alembic コマンドで base にダウン (asyncio 内で同期)。
+        from alembic import command  # ローカルインポートはグローバルサイドエフェクト回避
 
         cfg = _alembic_config()
         url = str(empty_engine.url)
@@ -120,13 +124,13 @@ class TestUpgradeDowngradeIdempotent:
 
         await asyncio.to_thread(_do_downgrade)
 
-        # Schema is empty now — assert the Empire tables are gone.
+        # スキーマは今空 — Empire テーブルがなくなったことをアサート。
         async with empty_engine.connect() as conn:
             result = await conn.execute(text("SELECT name FROM sqlite_master WHERE type='table'"))
             tables = {row[0] for row in result}
         assert tables.isdisjoint({"empires", "empire_room_refs", "empire_agent_refs"})
 
-        # Up again — back to head.
+        # もう一度 Up — head に戻る。
         await run_upgrade_head(empty_engine)
         async with empty_engine.connect() as conn:
             result = await conn.execute(text("SELECT name FROM sqlite_master WHERE type='table'"))
@@ -138,21 +142,21 @@ class TestUpgradeDowngradeIdempotent:
 # TC-IT-EMR-016: revision chain is linear (no head fork)
 # ---------------------------------------------------------------------------
 class TestRevisionChainLinear:
-    """TC-IT-EMR-016: ``0001_init`` → ``0002_empire_aggregate`` (single head)."""
+    """TC-IT-EMR-016: ``0001_init`` → ``0002_empire_aggregate`` (単一 head)。"""
 
     async def test_alembic_heads_returns_single_revision(self) -> None:
-        """TC-IT-EMR-016: ``ScriptDirectory.get_heads()`` returns exactly one revision."""
+        """TC-IT-EMR-016: ``ScriptDirectory.get_heads()`` が正確に 1 つの revision を返す。"""
         cfg = _alembic_config()
         script = ScriptDirectory.from_config(cfg)
         heads = script.get_heads()
         assert len(heads) == 1, (
-            f"Alembic head must be linear; got branched heads {heads}. "
-            f"Each Aggregate Repository PR appends a single revision; "
-            f"branching breaks ``alembic upgrade head`` across CI runners."
+            f"Alembic head は線形である必要があります； branched heads {heads} を得た。"
+            f"各 Aggregate Repository PR は単一 revision を追加します；"
+            f"branching は CI runners 全体で ``alembic upgrade head`` を破壊します。"
         )
 
     async def test_0002_revision_has_correct_down_revision(self) -> None:
-        """TC-IT-EMR-016: ``0002_empire_aggregate.down_revision == "0001_init"``."""
+        """TC-IT-EMR-016: ``0002_empire_aggregate.down_revision == "0001_init"``。"""
         cfg = _alembic_config()
         script = ScriptDirectory.from_config(cfg)
         rev = script.get_revision("0002_empire_aggregate")

--- a/backend/tests/infrastructure/persistence/sqlite/test_alembic_external_review_gate.py
+++ b/backend/tests/infrastructure/persistence/sqlite/test_alembic_external_review_gate.py
@@ -44,7 +44,7 @@ pytestmark = pytest.mark.asyncio
 
 
 # ---------------------------------------------------------------------------
-# Fixtures
+# フィクスチャ
 # ---------------------------------------------------------------------------
 @pytest_asyncio.fixture
 async def empty_engine(tmp_path: Path) -> AsyncIterator[AsyncEngine]:

--- a/backend/tests/infrastructure/persistence/sqlite/test_alembic_external_review_gate.py
+++ b/backend/tests/infrastructure/persistence/sqlite/test_alembic_external_review_gate.py
@@ -1,25 +1,25 @@
-"""Alembic 8th revision tests — ExternalReviewGate aggregate (TC-IT-ERGR-001〜008).
+"""Alembic 第 8 リビジョンテスト ── ExternalReviewGate アグリゲート (TC-IT-ERGR-001〜008)。
 
 RQ-ERGR-007 / §確定 R1-B / §確定 R1-K / §設計決定 ERGR-001.
 
-Real Alembic upgrade/downgrade against a real SQLite file plus chain
-integrity check that makes sure 0001→…→0008 chain stays linear.
+実 SQLite ファイルに対する Alembic upgrade/downgrade を実行し、
+0001→…→0008 のチェーンが線形であることのチェーン整合性も確認する。
 
-Also verifies:
-* 3 tables created: external_review_gates / external_review_gate_attachments /
+加えて以下を検証する:
+* 3 テーブル作成: external_review_gates / external_review_gate_attachments /
   external_review_audit_entries.
-* 3 indexes: ix_external_review_gates_task_id_created /
+* 3 インデックス: ix_external_review_gates_task_id_created /
   ix_external_review_gates_reviewer_decision /
   ix_external_review_gates_decision.
 * FK: external_review_gates.task_id → tasks.id ON DELETE CASCADE.
-* §設計決定 ERGR-001: reviewer_id / snapshot_committed_by have NO FK.
+* §設計決定 ERGR-001: reviewer_id / snapshot_committed_by は FK を持たない。
 * 0008.down_revision == "0007_task_aggregate".
-* upgrade → downgrade → upgrade is idempotent.
-* Task CASCADE: deleting task removes associated Gates.
+* upgrade → downgrade → upgrade が冪等。
+* Task CASCADE: task を削除すると関連する Gate も削除される。
 
-Per ``docs/features/external-review-gate-repository/test-design.md``
-TC-IT-ERGR-001〜008.
-Issue #36 — M2 0008.
+``docs/features/external-review-gate-repository/test-design.md``
+TC-IT-ERGR-001〜008 準拠。
+Issue #36 — M2 0008。
 """
 
 from __future__ import annotations
@@ -48,7 +48,7 @@ pytestmark = pytest.mark.asyncio
 # ---------------------------------------------------------------------------
 @pytest_asyncio.fixture
 async def empty_engine(tmp_path: Path) -> AsyncIterator[AsyncEngine]:
-    """Fresh app engine with no migrations applied."""
+    """マイグレーション未適用の新規 app engine。"""
     url = f"sqlite+aiosqlite:///{tmp_path / 'bakufu.db'}"
     engine = engine_mod.create_engine(url)
     try:
@@ -58,7 +58,7 @@ async def empty_engine(tmp_path: Path) -> AsyncIterator[AsyncEngine]:
 
 
 def _alembic_config() -> Config:
-    """Resolve bakufu Alembic config for ScriptDirectory inspection."""
+    """ScriptDirectory 検査用に bakufu の Alembic config を解決する。"""
     backend_root = Path(__file__).resolve().parents[4]
     cfg = Config(str(backend_root / "alembic.ini"))
     cfg.set_main_option("script_location", str(backend_root / "alembic"))
@@ -69,13 +69,13 @@ def _alembic_config() -> Config:
 # TC-IT-ERGR-001: 0008 creates 3 ExternalReviewGate tables (受入基準 6)
 # ---------------------------------------------------------------------------
 class TestEighthRevisionThreeTablesPresent:
-    """TC-IT-ERGR-001: alembic upgrade head adds the 3 ExternalReviewGate tables."""
+    """TC-IT-ERGR-001: alembic upgrade head が 3 つの ExternalReviewGate テーブルを追加する。"""
 
     async def test_three_erg_tables_present_after_upgrade(
         self,
         empty_engine: AsyncEngine,
     ) -> None:
-        """TC-IT-ERGR-001: 3 ERG tables exist after upgrade head."""
+        """TC-IT-ERGR-001: upgrade head 後に 3 つの ERG テーブルが存在する。"""
         await run_upgrade_head(empty_engine)
         async with empty_engine.connect() as conn:
             result = await conn.execute(text("SELECT name FROM sqlite_master WHERE type='table'"))
@@ -97,13 +97,13 @@ class TestEighthRevisionThreeTablesPresent:
 # TC-IT-ERGR-002: 3 INDEXes on external_review_gates (§確定 R1-K)
 # ---------------------------------------------------------------------------
 class TestExternalReviewGateIndexesPresent:
-    """TC-IT-ERGR-002: All 3 required INDEXes exist on external_review_gates."""
+    """TC-IT-ERGR-002: external_review_gates に必須の 3 つの INDEX がすべて存在する。"""
 
     async def test_three_indexes_present(
         self,
         empty_engine: AsyncEngine,
     ) -> None:
-        """TC-IT-ERGR-002: ix_task_id_created / ix_reviewer_decision / ix_decision exist."""
+        """TC-IT-ERGR-002: ix_task_id_created / ix_reviewer_decision / ix_decision が存在する。"""
         await run_upgrade_head(empty_engine)
         async with empty_engine.connect() as conn:
             result = await conn.execute(
@@ -130,13 +130,13 @@ class TestExternalReviewGateIndexesPresent:
 # TC-IT-ERGR-003: FK external_review_gates.task_id → tasks.id CASCADE
 # ---------------------------------------------------------------------------
 class TestExternalReviewGateForeignKey:
-    """TC-IT-ERGR-003: external_review_gates.task_id → tasks.id ON DELETE CASCADE."""
+    """TC-IT-ERGR-003: external_review_gates.task_id → tasks.id ON DELETE CASCADE。"""
 
     async def test_task_id_fk_to_tasks_cascade(
         self,
         empty_engine: AsyncEngine,
     ) -> None:
-        """TC-IT-ERGR-003: PRAGMA foreign_key_list confirms tasks CASCADE FK."""
+        """TC-IT-ERGR-003: PRAGMA foreign_key_list で tasks への CASCADE FK を確認する。"""
         await run_upgrade_head(empty_engine)
         async with empty_engine.connect() as conn:
             result = await conn.execute(text("PRAGMA foreign_key_list('external_review_gates')"))
@@ -159,10 +159,10 @@ class TestExternalReviewGateForeignKey:
 # TC-IT-ERGR-004: Alembic chain 0001→...→0008 is a single head
 # ---------------------------------------------------------------------------
 class TestAlembicChainSingleHead:
-    """TC-IT-ERGR-004: ScriptDirectory has exactly 1 head (no branch divergence)."""
+    """TC-IT-ERGR-004: ScriptDirectory の head が 1 つだけ（ブランチ分岐なし）。"""
 
     def test_alembic_chain_has_single_head(self) -> None:
-        """TC-IT-ERGR-004: len(heads) == 1 — chain is linear 0001→...→0008."""
+        """TC-IT-ERGR-004: len(heads) == 1 ── チェーンは 0001→...→0008 の線形。"""
         cfg = _alembic_config()
         script_dir = ScriptDirectory.from_config(cfg)
         heads = script_dir.get_heads()
@@ -177,20 +177,21 @@ class TestAlembicChainSingleHead:
 # TC-IT-ERGR-005: upgrade → downgrade → upgrade is idempotent (受入基準 6)
 # ---------------------------------------------------------------------------
 class TestUpgradeDowngradeIdempotent:
-    """TC-IT-ERGR-005: upgrade head → downgrade base → upgrade head restores 3 tables."""
+    """TC-IT-ERGR-005: upgrade head → downgrade base → upgrade head で 3 テーブルが復元される。"""
 
     async def test_upgrade_downgrade_upgrade_idempotent(
         self,
         empty_engine: AsyncEngine,
     ) -> None:
-        """TC-IT-ERGR-005: Double migration cycle — final state has 3 ERG tables."""
+        """TC-IT-ERGR-005: 2 回マイグレーションサイクルを回し、最終状態に 3 つの ERG テーブル。"""
         import asyncio
 
         from alembic import command as alembic_command
 
         await run_upgrade_head(empty_engine)
 
-        # Downgrade to base via alembic command (runs in a thread to avoid event-loop deadlock)
+        # alembic command 経由で base まで downgrade
+        # （event-loop デッドロック回避のためスレッド実行）
         cfg = _alembic_config()
         cfg.set_main_option("sqlalchemy.url", str(empty_engine.url))
 
@@ -199,7 +200,7 @@ class TestUpgradeDowngradeIdempotent:
 
         await asyncio.to_thread(_do_downgrade)
 
-        # Verify ERG tables are gone after downgrade
+        # downgrade 後に ERG テーブルが消えていることを確認
         async with empty_engine.connect() as conn:
             result = await conn.execute(text("SELECT name FROM sqlite_master WHERE type='table'"))
             tables_after_down = {row[0] for row in result}
@@ -208,7 +209,7 @@ class TestUpgradeDowngradeIdempotent:
             f"Tables: {tables_after_down}"
         )
 
-        # Re-upgrade
+        # 再 upgrade
         await run_upgrade_head(empty_engine)
 
         async with empty_engine.connect() as conn:
@@ -229,10 +230,10 @@ class TestUpgradeDowngradeIdempotent:
 # TC-IT-ERGR-006: 0008.down_revision == "0007_task_aggregate"
 # ---------------------------------------------------------------------------
 class TestDownRevisionChain:
-    """TC-IT-ERGR-006: 0008 down_revision points to 0007_task_aggregate."""
+    """TC-IT-ERGR-006: 0008 の down_revision が 0007_task_aggregate を指す。"""
 
     def test_0008_down_revision_is_0007(self) -> None:
-        """TC-IT-ERGR-006: Chain is 0007_task_aggregate → 0008_external_review_gate_aggregate."""
+        """TC-IT-ERGR-006: チェーンは 0007_task_aggregate → 0008_external_review_gate_aggregate。"""
         cfg = _alembic_config()
         script_dir = ScriptDirectory.from_config(cfg)
         rev = script_dir.get_revision("0008_external_review_gate_aggregate")
@@ -247,13 +248,13 @@ class TestDownRevisionChain:
 # TC-IT-ERGR-007: Task CASCADE FK deletes Gates (受入基準 7)
 # ---------------------------------------------------------------------------
 class TestTaskCascadeDeletesGate:
-    """TC-IT-ERGR-007: DELETE FROM tasks cascades to external_review_gates."""
+    """TC-IT-ERGR-007: DELETE FROM tasks が external_review_gates に CASCADE する。"""
 
     async def test_delete_task_cascades_to_external_review_gates(
         self,
         empty_engine: AsyncEngine,
     ) -> None:
-        """TC-IT-ERGR-007: Deleting a Task row removes its associated Gate rows."""
+        """TC-IT-ERGR-007: Task 行を削除すると関連 Gate 行が削除される。"""
         await run_upgrade_head(empty_engine)
 
         empire_id = uuid4().hex
@@ -330,7 +331,7 @@ class TestTaskCascadeDeletesGate:
                 },
             )
 
-        # Verify gate exists before delete
+        # 削除前に gate が存在することを確認
         async with empty_engine.connect() as conn:
             row = (
                 await conn.execute(
@@ -340,12 +341,12 @@ class TestTaskCascadeDeletesGate:
             ).first()
         assert row is not None and row[0] == 1, "[FAIL] Gate row not inserted."
 
-        # Delete task — CASCADE should remove gate
+        # task を削除 ── CASCADE で gate も削除されるはず
         async with empty_engine.begin() as conn:
             await conn.execute(text("PRAGMA foreign_keys = ON"))
             await conn.execute(text("DELETE FROM tasks WHERE id = :id"), {"id": task_id})
 
-        # Gate must be gone
+        # Gate が消えていなければならない
         async with empty_engine.connect() as conn:
             row = (
                 await conn.execute(
@@ -362,20 +363,22 @@ class TestTaskCascadeDeletesGate:
 # TC-IT-ERGR-008: §設計決定 ERGR-001 — reviewer_id / snapshot_committed_by have NO FK
 # ---------------------------------------------------------------------------
 class TestAggregrateBoundaryNoForeignKeys:
-    """TC-IT-ERGR-008: reviewer_id / snapshot_committed_by have no FK (§設計決定 ERGR-001)."""
+    """TC-IT-ERGR-008: reviewer_id / snapshot_committed_by は
+    FK を持たない (§設計決定 ERGR-001)。"""
 
     async def test_reviewer_id_has_no_fk(
         self,
         empty_engine: AsyncEngine,
     ) -> None:
-        """TC-IT-ERGR-008: PRAGMA foreign_key_list — no FK to owners/agents for reviewer_id."""
+        """TC-IT-ERGR-008: PRAGMA foreign_key_list ── reviewer_id
+        の owners/agents への FK が存在しない。"""
         await run_upgrade_head(empty_engine)
         async with empty_engine.connect() as conn:
             result = await conn.execute(text("PRAGMA foreign_key_list('external_review_gates')"))
             fk_list = [dict(row) for row in result.mappings()]
 
         referenced_tables = {fk.get("table") for fk in fk_list}
-        # The only FK must be tasks (CASCADE). Owner / Agent Aggregate tables must not appear.
+        # FK は tasks（CASCADE）のみであるべき。Owner / Agent Aggregate のテーブルは現れない。
         forbidden = {"owners", "agents", "users", "members"}
         leaked = referenced_tables & forbidden
         assert not leaked, (
@@ -388,7 +391,7 @@ class TestAggregrateBoundaryNoForeignKeys:
         self,
         empty_engine: AsyncEngine,
     ) -> None:
-        """TC-IT-ERGR-008: The only FK from external_review_gates is to tasks."""
+        """TC-IT-ERGR-008: external_review_gates から伸びる FK は tasks のみ。"""
         await run_upgrade_head(empty_engine)
         async with empty_engine.connect() as conn:
             result = await conn.execute(text("PRAGMA foreign_key_list('external_review_gates')"))

--- a/backend/tests/infrastructure/persistence/sqlite/test_alembic_init.py
+++ b/backend/tests/infrastructure/persistence/sqlite/test_alembic_init.py
@@ -1,10 +1,10 @@
-"""Alembic initial revision integration tests
-(TC-IT-PF-004 / 005 / 015 / 014).
+"""Alembic initial revision integration テスト
+(TC-IT-PF-004 / 005 / 015 / 014)。
 
-Confirmation C / Schneier 申し送り #4 — the SQLite triggers protecting
-``audit_log`` immutability are exercised against the **real**
-``DELETE`` / ``UPDATE`` paths so a future revision that forgets to
-re-apply them is caught at PR time.
+Confirmation C / Schneier 申し送り #4 — ``audit_log`` 不変性を保護する
+SQLite trigger は **実際の** ``DELETE`` / ``UPDATE`` パスに対して
+実行されます。将来の revision がこれらを再適用することを忘れた場合、
+PR 時にキャッチされるように。
 """
 
 from __future__ import annotations
@@ -22,24 +22,24 @@ pytestmark = pytest.mark.asyncio
 
 
 class TestSchemaCreatedByAlembic:
-    """TC-IT-PF-004: 3 tables + 2 triggers + index after upgrade head."""
+    """TC-IT-PF-004: upgrade head 後 3 テーブル + 2 トリガー + インデックス。"""
 
     async def test_three_tables_present(self, app_engine: AsyncEngine) -> None:
-        """TC-IT-PF-004: audit_log / bakufu_pid_registry / domain_event_outbox exist."""
+        """TC-IT-PF-004: audit_log / bakufu_pid_registry / domain_event_outbox が存在。"""
         async with app_engine.connect() as conn:
             result = await conn.execute(text("SELECT name FROM sqlite_master WHERE type='table'"))
             tables = {row[0] for row in result}
         assert {"audit_log", "bakufu_pid_registry", "domain_event_outbox"}.issubset(tables)
 
     async def test_two_triggers_present(self, app_engine: AsyncEngine) -> None:
-        """TC-IT-PF-004: audit_log_no_delete + audit_log_update_restricted exist."""
+        """TC-IT-PF-004: audit_log_no_delete + audit_log_update_restricted が存在。"""
         async with app_engine.connect() as conn:
             result = await conn.execute(text("SELECT name FROM sqlite_master WHERE type='trigger'"))
             triggers = {row[0] for row in result}
         assert {"audit_log_no_delete", "audit_log_update_restricted"}.issubset(triggers)
 
     async def test_outbox_polling_index_present(self, app_engine: AsyncEngine) -> None:
-        """TC-IT-PF-004: ix_outbox_status_next_attempt for polling SQL."""
+        """TC-IT-PF-004: polling SQL 用の ix_outbox_status_next_attempt。"""
         async with app_engine.connect() as conn:
             result = await conn.execute(text("SELECT name FROM sqlite_master WHERE type='index'"))
             indices = {row[0] for row in result}
@@ -47,16 +47,15 @@ class TestSchemaCreatedByAlembic:
 
 
 class TestAuditLogDeleteForbidden:
-    """TC-IT-PF-005: DELETE on audit_log raises (Schneier #4)."""
+    """TC-IT-PF-005: audit_log への DELETE が raise (Schneier #4)。"""
 
     async def test_delete_raw_sql_aborts(self, app_engine: AsyncEngine) -> None:
-        """TC-IT-PF-005: DELETE FROM audit_log triggers RAISE(ABORT)."""
+        """TC-IT-PF-005: DELETE FROM audit_log が RAISE(ABORT) をトリガー。"""
         from datetime import UTC, datetime
         from uuid import uuid4
 
-        # Insert a row directly (mask listener fires for ORM, raw INSERT
-        # below uses parameter binding — same path the dispatcher would
-        # use).
+        # 直接行を INSERT (ORM の mask listener 発火、下記の raw INSERT は
+        # parameter binding を使用 — dispatcher が使用するのと同じパス)。
         row_id = uuid4().hex
         async with app_engine.begin() as conn:
             await conn.execute(
@@ -73,20 +72,20 @@ class TestAuditLogDeleteForbidden:
                 },
             )
 
-        # The trigger turns DELETE into a runtime error.
+        # Trigger が DELETE をランタイムエラーに変える。
         with pytest.raises(sa_exc.SQLAlchemyError) as excinfo:
             async with app_engine.begin() as conn:
                 await conn.execute(text("DELETE FROM audit_log WHERE id=:id"), {"id": row_id})
-        # SQLAlchemy wraps SQLite errors in OperationalError. The error
-        # message must carry the trigger's RAISE message.
+        # SQLAlchemy が SQLite エラーを OperationalError でラップ。エラー
+        # メッセージは trigger の RAISE メッセージを含む必要がある。
         assert "audit_log is append-only" in str(excinfo.value)
 
 
 class TestAuditLogUpdateOnceLocked:
-    """TC-IT-PF-015: UPDATE on audit_log row with result NOT NULL is forbidden."""
+    """TC-IT-PF-015: result NOT NULL の audit_log 行への UPDATE は禁止。"""
 
     async def test_update_after_result_set_is_aborted(self, app_engine: AsyncEngine) -> None:
-        """TC-IT-PF-015: cannot mutate result once it has a value."""
+        """TC-IT-PF-015: result が値を持つと mutate できない。"""
         from datetime import UTC, datetime
         from uuid import uuid4
 
@@ -116,7 +115,7 @@ class TestAuditLogUpdateOnceLocked:
         assert "audit_log result is immutable once set" in str(excinfo.value)
 
     async def test_update_with_null_result_is_allowed(self, app_engine: AsyncEngine) -> None:
-        """TC-IT-PF-015 supplemental: NULL → value transition is the *one* allowed UPDATE."""
+        """TC-IT-PF-015 補足: NULL → value 遷移が唯一許可される UPDATE。"""
         from datetime import UTC, datetime
         from uuid import uuid4
 
@@ -135,7 +134,7 @@ class TestAuditLogUpdateOnceLocked:
                     "ts": datetime.now(UTC).isoformat(),
                 },
             )
-        # First UPDATE — populating NULL result — must succeed.
+        # 最初の UPDATE — NULL result を定義 — は成功する必要がある。
         async with app_engine.begin() as conn:
             await conn.execute(
                 text("UPDATE audit_log SET result='SUCCESS' WHERE id=:id"),

--- a/backend/tests/infrastructure/persistence/sqlite/test_alembic_room.py
+++ b/backend/tests/infrastructure/persistence/sqlite/test_alembic_room.py
@@ -44,7 +44,7 @@ pytestmark = pytest.mark.asyncio
 # ---------------------------------------------------------------------------
 @pytest_asyncio.fixture
 async def empty_engine(tmp_path: Path) -> AsyncIterator[AsyncEngine]:
-    """Bring up a fresh app engine without running any migrations."""
+    """マイグレーションを実行せずに新規 app エンジンを起動。"""
     url = f"sqlite+aiosqlite:///{tmp_path / 'bakufu.db'}"
     engine = engine_mod.create_engine(url)
     try:
@@ -54,7 +54,7 @@ async def empty_engine(tmp_path: Path) -> AsyncIterator[AsyncEngine]:
 
 
 def _alembic_config() -> Config:
-    """Resolve the bakufu Alembic config for ScriptDirectory inspection."""
+    """ScriptDirectory inspection 用に bakufu Alembic config を解決。"""
     backend_root = Path(__file__).resolve().parents[4]
     cfg = Config(str(backend_root / "alembic.ini"))
     cfg.set_main_option("script_location", str(backend_root / "alembic"))
@@ -65,30 +65,30 @@ def _alembic_config() -> Config:
 # TC-IT-RR-012: 5th revision creates rooms + room_members tables + index
 # ---------------------------------------------------------------------------
 class TestFifthRevisionApplied:
-    """TC-IT-RR-012: ``alembic upgrade head`` adds the Room schema."""
+    """TC-IT-RR-012: ``alembic upgrade head`` が Room スキーマを追加。"""
 
     async def test_two_room_tables_present_after_upgrade(
         self,
         empty_engine: AsyncEngine,
     ) -> None:
-        """rooms + room_members exist after upgrade head."""
+        """upgrade head 後に rooms + room_members が存在。"""
         await run_upgrade_head(empty_engine)
         async with empty_engine.connect() as conn:
             result = await conn.execute(text("SELECT name FROM sqlite_master WHERE type='table'"))
             tables = {row[0] for row in result}
         assert {"rooms", "room_members"}.issubset(tables), (
-            f"[FAIL] rooms or room_members missing from schema after upgrade head.\n"
-            f"Tables found: {tables}"
+            f"[FAIL] upgrade head 後にスキーマから rooms または room_members が不足。\n"
+            f"見つかったテーブル: {tables}"
         )
 
     async def test_rooms_empire_id_name_index_present(
         self,
         empty_engine: AsyncEngine,
     ) -> None:
-        """``ix_rooms_empire_id_name`` composite index is created (§確定 R1-F).
+        """``ix_rooms_empire_id_name`` コンポジットインデックスが作成される (§確定 R1-F)。
 
-        The index left-prefix optimises ``WHERE empire_id = ?`` and
-        ``WHERE empire_id = ? AND name = ?`` for ``find_by_name``.
+        インデックスの左プリフィックスが ``WHERE empire_id = ?`` と
+        ``WHERE empire_id = ? AND name = ?`` を ``find_by_name`` 向けに最適化。
         """
         await run_upgrade_head(empty_engine)
         async with empty_engine.connect() as conn:
@@ -97,35 +97,35 @@ class TestFifthRevisionApplied:
             )
             index_names = {row[0] for row in result}
         assert "ix_rooms_empire_id_name" in index_names, (
-            f"[FAIL] ix_rooms_empire_id_name index missing on rooms table.\n"
-            f"Indexes found: {index_names}\n"
-            f"Next: ensure ``op.create_index('ix_rooms_empire_id_name', ...)`` "
-            f"is present in 0005_room_aggregate.py upgrade()."
+            f"[FAIL] ix_rooms_empire_id_name インデックスが rooms テーブルから不足。\n"
+            f"見つかったインデックス: {index_names}\n"
+            f"次：0005_room_aggregate.py upgrade() に ``op.create_index('ix_rooms_empire_id_name', ...)`` "
+            f"が存在することを確認。"
         )
 
     async def test_empire_room_refs_fk_closure_applied(
         self,
         empty_engine: AsyncEngine,
     ) -> None:
-        """BUG-EMR-001 FK closure: ``empire_room_refs.room_id → rooms.id``.
+        """BUG-EMR-001 FK closure: ``empire_room_refs.room_id → rooms.id``。
 
-        ``0005_room_aggregate.py`` adds the FK via ``batch_alter_table``
-        (SQLite does not support ALTER TABLE ... ADD CONSTRAINT). After
-        upgrade head, ``PRAGMA foreign_key_list('empire_room_refs')``
-        must list a reference to the ``rooms`` table.
+        ``0005_room_aggregate.py`` が ``batch_alter_table`` 経由で FK を追加
+        (SQLite は ALTER TABLE ... ADD CONSTRAINT をサポートしない)。upgrade head 後、
+        ``PRAGMA foreign_key_list('empire_room_refs')`` は
+        ``rooms`` テーブルへの参照をリストアップする必要がある。
         """
         await run_upgrade_head(empty_engine)
         async with empty_engine.connect() as conn:
             result = await conn.execute(text("PRAGMA foreign_key_list('empire_room_refs')"))
             fk_rows = list(result)
-        # PRAGMA foreign_key_list returns rows with columns:
+        # PRAGMA foreign_key_list はカラムを持つ行を返す:
         #   id, seq, table, from, to, on_update, on_delete, match
-        referenced_tables = {row[2] for row in fk_rows}  # col index 2 = 'table'
+        referenced_tables = {row[2] for row in fk_rows}  # カラムインデックス 2 = 'table'
         assert "rooms" in referenced_tables, (
-            f"[FAIL] empire_room_refs has no FK to rooms (BUG-EMR-001 not closed).\n"
-            f"FK references found: {referenced_tables}\n"
-            f"Next: ensure op.batch_alter_table('empire_room_refs') in 0005_room_aggregate.py "
-            f"adds the FK to rooms.id."
+            f"[FAIL] empire_room_refs は rooms への FK を持たない (BUG-EMR-001 が閉じられていない)。\n"
+            f"FK 参照が見つかりました: {referenced_tables}\n"
+            f"次：0005_room_aggregate.py で op.batch_alter_table('empire_room_refs') が"
+            f"rooms.id への FK を追加することを確認。"
         )
 
 
@@ -133,15 +133,15 @@ class TestFifthRevisionApplied:
 # TC-IT-RR-012 補強: upgrade / downgrade are idempotent
 # ---------------------------------------------------------------------------
 class TestUpgradeDowngradeIdempotent:
-    """upgrade head → downgrade base → upgrade head again all green."""
+    """upgrade head → downgrade base → upgrade head 再び全て成功。"""
 
     async def test_full_cycle_leaves_room_tables_present(
         self,
         empty_engine: AsyncEngine,
     ) -> None:
-        """upgrade head → downgrade base → upgrade head again."""
+        """upgrade head → downgrade base → upgrade head 再び。"""
         await run_upgrade_head(empty_engine)
-        from alembic import command  # local import to avoid global side effects
+        from alembic import command  # グローバルサイドエフェクトを回避するためのローカルインポート
 
         cfg = _alembic_config()
         url = str(empty_engine.url)
@@ -156,7 +156,7 @@ class TestUpgradeDowngradeIdempotent:
             result = await conn.execute(text("SELECT name FROM sqlite_master WHERE type='table'"))
             tables = {row[0] for row in result}
         assert tables.isdisjoint({"rooms", "room_members"}), (
-            f"[FAIL] rooms/room_members still present after downgrade to base.\nTables: {tables}"
+            f"[FAIL] base への downgrade 後も rooms/room_members が存在。\nテーブル: {tables}"
         )
 
         await run_upgrade_head(empty_engine)
@@ -164,7 +164,7 @@ class TestUpgradeDowngradeIdempotent:
             result = await conn.execute(text("SELECT name FROM sqlite_master WHERE type='table'"))
             tables = {row[0] for row in result}
         assert {"rooms", "room_members"}.issubset(tables), (
-            f"[FAIL] rooms/room_members missing after re-upgrade.\nTables: {tables}"
+            f"[FAIL] re-upgrade 後に rooms/room_members が不足。\nテーブル: {tables}"
         )
 
 
@@ -172,44 +172,44 @@ class TestUpgradeDowngradeIdempotent:
 # TC-IT-RR-012: revision chain is linear (no head fork)
 # ---------------------------------------------------------------------------
 class TestRevisionChainLinear:
-    """0001 → 0002 → 0003 → 0004 → 0005 single-head chain."""
+    """0001 → 0002 → 0003 → 0004 → 0005 単一-head チェーン。"""
 
     async def test_alembic_heads_returns_single_revision(self) -> None:
-        """``ScriptDirectory.get_heads()`` returns exactly one revision."""
+        """``ScriptDirectory.get_heads()`` が正確に 1 つの revision を返す。"""
         cfg = _alembic_config()
         script = ScriptDirectory.from_config(cfg)
         heads = script.get_heads()
         assert len(heads) == 1, (
-            f"Alembic head must be linear; got branched heads {heads}.\n"
-            f"Each Aggregate Repository PR appends a single revision."
+            f"Alembic head は線形である必要があります；分岐した heads {heads} を得た。\n"
+            f"各アグリゲートリポジトリ PR は単一 revision を追加します。"
         )
 
     async def test_0005_revision_has_correct_down_revision(self) -> None:
-        """``0005_room_aggregate.down_revision == "0004_agent_aggregate"``."""
+        """``0005_room_aggregate.down_revision == "0004_agent_aggregate"``。"""
         cfg = _alembic_config()
         script = ScriptDirectory.from_config(cfg)
         rev = script.get_revision("0005_room_aggregate")
         assert rev is not None
         assert rev.down_revision == "0004_agent_aggregate", (
-            f"[FAIL] 0005_room_aggregate.down_revision is {rev.down_revision!r}; "
-            f"expected '0004_agent_aggregate'."
+            f"[FAIL] 0005_room_aggregate.down_revision は {rev.down_revision!r} ；"
+            f"'0004_agent_aggregate' を期待。"
         )
 
     async def test_chain_walks_from_0005_back_to_base(self) -> None:
-        """Walking ``down_revision`` reaches base in 5 hops (no branching)."""
+        """``down_revision`` を走査すると 5 ホップで base に到達 (分岐なし)。"""
         cfg = _alembic_config()
         script = ScriptDirectory.from_config(cfg)
         chain: list[str] = []
         current_id: str | None = "0005_room_aggregate"
-        for _ in range(10):  # generous bound for safety
+        for _ in range(10):  # 安全性のための余裕のある境界
             if current_id is None:
                 break
             rev = script.get_revision(current_id)
-            assert rev is not None, f"Revision {current_id!r} not found"
+            assert rev is not None, f"Revision {current_id!r} が見つかりません"
             chain.append(rev.revision)
             down = rev.down_revision
             if isinstance(down, tuple | list):
-                pytest.fail(f"Revision {rev.revision!r} has multiple down_revisions {down}")
+                pytest.fail(f"Revision {rev.revision!r} は複数の down_revisions {down} を持つ")
             current_id = down  # pyright: ignore[reportAssignmentType]
 
         assert chain == [
@@ -218,4 +218,4 @@ class TestRevisionChainLinear:
             "0003_workflow_aggregate",
             "0002_empire_aggregate",
             "0001_init",
-        ], f"Unexpected revision chain: {chain}"
+        ], f"予期しない revision chain: {chain}"

--- a/backend/tests/infrastructure/persistence/sqlite/test_alembic_room.py
+++ b/backend/tests/infrastructure/persistence/sqlite/test_alembic_room.py
@@ -97,10 +97,10 @@ class TestFifthRevisionApplied:
             )
             index_names = {row[0] for row in result}
         assert "ix_rooms_empire_id_name" in index_names, (
-            f"[FAIL] ix_rooms_empire_id_name インデックスが rooms テーブルから不足。\n"
+            f"[FAIL] ix_rooms_empire_id_name インデックスが不足。\n"
             f"見つかったインデックス: {index_names}\n"
-            f"次：0005_room_aggregate.py upgrade() に ``op.create_index('ix_rooms_empire_id_name', ...)`` "
-            f"が存在することを確認。"
+            f"次：0005_room_aggregate.py upgrade() に "
+            f"``op.create_index('ix_rooms_empire_id_name', ...)`` が存在を確認。"
         )
 
     async def test_empire_room_refs_fk_closure_applied(
@@ -120,12 +120,12 @@ class TestFifthRevisionApplied:
             fk_rows = list(result)
         # PRAGMA foreign_key_list はカラムを持つ行を返す:
         #   id, seq, table, from, to, on_update, on_delete, match
-        referenced_tables = {row[2] for row in fk_rows}  # カラムインデックス 2 = 'table'
+        referenced_tables = {row[2] for row in fk_rows}  # カラムインデックス 2
         assert "rooms" in referenced_tables, (
-            f"[FAIL] empire_room_refs は rooms への FK を持たない (BUG-EMR-001 が閉じられていない)。\n"
+            f"[FAIL] empire_room_refs は rooms への FK を持たない。\n"
             f"FK 参照が見つかりました: {referenced_tables}\n"
-            f"次：0005_room_aggregate.py で op.batch_alter_table('empire_room_refs') が"
-            f"rooms.id への FK を追加することを確認。"
+            f"次：0005_room_aggregate.py で batch_alter_table が "
+            f"rooms.id への FK を追加を確認。"
         )
 
 

--- a/backend/tests/infrastructure/persistence/sqlite/test_alembic_room.py
+++ b/backend/tests/infrastructure/persistence/sqlite/test_alembic_room.py
@@ -39,7 +39,7 @@ pytestmark = pytest.mark.asyncio
 
 
 # ---------------------------------------------------------------------------
-# Fixtures
+# フィクスチャ
 # ---------------------------------------------------------------------------
 @pytest_asyncio.fixture
 async def empty_engine(tmp_path: Path) -> AsyncIterator[AsyncEngine]:
@@ -118,7 +118,7 @@ class TestFifthRevisionApplied:
             result = await conn.execute(text("PRAGMA foreign_key_list('empire_room_refs')"))
             fk_rows = list(result)
         # PRAGMA foreign_key_list はカラムを持つ行を返す:
-        #   id, seq, table, from, to, on_update, on_delete, match
+        #   PRAGMA foreign_key_list の列: id, seq, table, from, to, on_update, on_delete, match
         referenced_tables = {row[2] for row in fk_rows}  # カラムインデックス 2
         assert "rooms" in referenced_tables, (
             f"[FAIL] empire_room_refs は rooms への FK を持たない。\n"

--- a/backend/tests/infrastructure/persistence/sqlite/test_alembic_room.py
+++ b/backend/tests/infrastructure/persistence/sqlite/test_alembic_room.py
@@ -1,21 +1,20 @@
-"""Alembic 5th revision tests (TC-IT-RR-012 — chain + DDL + idempotency).
+"""Alembic 5 番目リビジョンテスト (TC-IT-RR-012 — チェーン + DDL + べき等性)。
 
-Per ``docs/features/room-repository/test-design.md``. Real Alembic
-upgrade / downgrade against a real SQLite file, plus a chain
-integrity check that makes sure
+``docs/features/room-repository/test-design.md`` に従う。実際の SQLite ファイルに対する
+実際の Alembic upgrade / downgrade、および
 ``0001_init`` → ``0002_empire_aggregate`` → ``0003_workflow_aggregate``
-→ ``0004_agent_aggregate`` → ``0005_room_aggregate`` stays linear
-(no head fork).
+→ ``0004_agent_aggregate`` → ``0005_room_aggregate`` が
+線形（head fork なし）であることを確認するチェーン完全性チェック。
 
-Also verifies:
-* ``rooms`` + ``room_members`` tables created by the 5th revision.
-* ``ix_rooms_empire_id_name`` composite index present (§確定 R1-F).
-* BUG-EMR-001 FK closure: ``empire_room_refs.room_id`` now has a FK
-  constraint onto ``rooms.id`` (added via ``batch_alter_table``).
+また以下も検証:
+* 5 番目リビジョンで作成される ``rooms`` + ``room_members`` テーブル。
+* ``ix_rooms_empire_id_name`` 複合インデックスが存在 (§確定 R1-F)。
+* BUG-EMR-001 FK クロージャ: ``empire_room_refs.room_id`` は
+  ``rooms.id`` への FK 制約を持つようになった (``batch_alter_table`` 経由で追加)。
 
-The conftest from ``tests/infrastructure/`` patches Alembic's
-``fileConfig`` so log capture survives migration; same workaround the
-M2 persistence-foundation tests rely on.
+``tests/infrastructure/`` の conftest は Alembic の ``fileConfig`` をパッチして、
+ログキャプチャがマイグレーション中も生き残るようにする；
+M2 persistence-foundation テストが依存している同じ回避策。
 """
 
 from __future__ import annotations

--- a/backend/tests/infrastructure/persistence/sqlite/test_alembic_task.py
+++ b/backend/tests/infrastructure/persistence/sqlite/test_alembic_task.py
@@ -1,21 +1,21 @@
-"""Alembic 7th revision tests — task aggregate (TC-IT-TR-001〜009).
+"""Alembic 7 番目のリビジョンテスト ── task aggregate (TC-IT-TR-001〜009).
 
 REQ-TR-005 / §確定 R1-B / §確定 R1-C / §確定 R1-K / §設計決定 TR-001.
 
-Real Alembic upgrade/downgrade against a real SQLite file plus chain
-integrity check that makes sure 0001→…→0007 chain stays linear.
+実 SQLite ファイルに対する実 Alembic upgrade/downgrade に加えて、
+0001→…→0007 のチェーンが線形であることを検証する。
 
-Also verifies:
-* 4 tables created: tasks / task_assigned_agents / deliverables /
+加えて以下を検証:
+* 4 テーブル作成: tasks / task_assigned_agents / deliverables /
   deliverable_attachments (conversations / conversation_messages は §BUG-TR-002
-  凍結済みのため除外).
-* 2 indexes: ix_tasks_room_id / ix_tasks_status_updated_id (§確定 R1-K).
-* tasks FK constraints: room_id → rooms CASCADE, directive_id → directives CASCADE.
-* BUG-DRR-001 FK closure: directives.task_id → tasks.id present at HEAD (0007).
-* §設計決定 TR-001: task_assigned_agents.agent_id has NO FK to agents.
+  凍結済みのため除外)。
+* 2 インデックス: ix_tasks_room_id / ix_tasks_status_updated_id (§確定 R1-K)。
+* tasks の FK 制約: room_id → rooms CASCADE, directive_id → directives CASCADE。
+* BUG-DRR-001 FK 閉鎖: directives.task_id → tasks.id が HEAD (0007) で存在。
+* §設計決定 TR-001: task_assigned_agents.agent_id は agents への FK を持たない。
 
-Per ``docs/features/task-repository/test-design.md`` TC-IT-TR-001〜009.
-Issue #35 — M2 0007.
+``docs/features/task-repository/test-design.md`` TC-IT-TR-001〜009 準拠。
+Issue #35 ── M2 0007。
 """
 
 from __future__ import annotations
@@ -42,11 +42,11 @@ pytestmark = pytest.mark.asyncio
 
 
 # ---------------------------------------------------------------------------
-# Fixtures
+# フィクスチャ
 # ---------------------------------------------------------------------------
 @pytest_asyncio.fixture
 async def empty_engine(tmp_path: Path) -> AsyncIterator[AsyncEngine]:
-    """Fresh app engine with no migrations applied."""
+    """マイグレーション未適用の新規アプリエンジン。"""
     url = f"sqlite+aiosqlite:///{tmp_path / 'bakufu.db'}"
     engine = engine_mod.create_engine(url)
     try:
@@ -56,7 +56,7 @@ async def empty_engine(tmp_path: Path) -> AsyncIterator[AsyncEngine]:
 
 
 def _alembic_config() -> Config:
-    """Resolve bakufu Alembic config for ScriptDirectory inspection."""
+    """ScriptDirectory 検査用に bakufu の Alembic config を解決する。"""
     backend_root = Path(__file__).resolve().parents[4]
     cfg = Config(str(backend_root / "alembic.ini"))
     cfg.set_main_option("script_location", str(backend_root / "alembic"))
@@ -68,18 +68,18 @@ def _alembic_config() -> Config:
 # conversations / conversation_messages は §BUG-TR-002 凍結 (YAGNI)
 # ---------------------------------------------------------------------------
 class TestSeventhRevisionFourTablesPresent:
-    """TC-IT-TR-001: alembic upgrade head adds the 4 Task-aggregate tables.
+    """TC-IT-TR-001: alembic upgrade head が Task-aggregate の 4 テーブルを追加する。
 
-    conversations / conversation_messages are §BUG-TR-002 凍結:
-    Task domain model has no conversations attribute; these tables are
-    NOT created by 0007_task_aggregate (deferred to feature/conversation-repository).
+    conversations / conversation_messages は §BUG-TR-002 凍結:
+    Task ドメインモデルに conversations 属性は存在しない。これらのテーブルは
+    0007_task_aggregate では作成されない (feature/conversation-repository に延期)。
     """
 
     async def test_four_task_tables_present_after_upgrade(
         self,
         empty_engine: AsyncEngine,
     ) -> None:
-        """4 task tables exist after upgrade head (§BUG-TR-002: conversations excluded)."""
+        """upgrade head 後に 4 つの task テーブルが存在する (§BUG-TR-002: conversations 除外)。"""
         await run_upgrade_head(empty_engine)
         async with empty_engine.connect() as conn:
             result = await conn.execute(text("SELECT name FROM sqlite_master WHERE type='table'"))
@@ -96,7 +96,7 @@ class TestSeventhRevisionFourTablesPresent:
             f"Missing: {expected - tables}\n"
             f"Tables found: {tables}"
         )
-        # Verify §BUG-TR-002: conversations / conversation_messages must NOT exist yet.
+        # §BUG-TR-002 検証: conversations / conversation_messages はまだ存在してはならない。
         assert "conversations" not in tables, (
             "[FAIL] conversations table exists but §BUG-TR-002 requires it to be excluded."
         )
@@ -108,12 +108,11 @@ class TestSeventhRevisionFourTablesPresent:
         self,
         empty_engine: AsyncEngine,
     ) -> None:
-        """§BUG-TR-002 凍結: conversations / conversation_messages must NOT exist.
+        """§BUG-TR-002 凍結: conversations / conversation_messages は存在してはならない。
 
-        Task PR #35 intentionally omits these tables (YAGNI — no conversations
-        attribute on Task domain model). They are deferred to the
-        feature/conversation-repository PR. If they appear here, the YAGNI
-        decision was violated.
+        Task PR #35 は意図的にこれらのテーブルを省略する (YAGNI ── Task ドメイン
+        モデルに conversations 属性が無いため)。feature/conversation-repository PR
+        に延期される。ここで現れた場合、YAGNI 決定に違反している。
         """
         await run_upgrade_head(empty_engine)
         async with empty_engine.connect() as conn:
@@ -132,13 +131,13 @@ class TestSeventhRevisionFourTablesPresent:
 # TC-IT-TR-002: 2 indexes on tasks (§確定 R1-K)
 # ---------------------------------------------------------------------------
 class TestTaskIndexesPresent:
-    """TC-IT-TR-002: ix_tasks_room_id and ix_tasks_status_updated_id exist."""
+    """TC-IT-TR-002: ix_tasks_room_id と ix_tasks_status_updated_id が存在する。"""
 
     async def test_ix_tasks_room_id_present(
         self,
         empty_engine: AsyncEngine,
     ) -> None:
-        """ix_tasks_room_id single-column index exists on tasks."""
+        """tasks 上の ix_tasks_room_id 単一カラムインデックスが存在する。"""
         await run_upgrade_head(empty_engine)
         async with empty_engine.connect() as conn:
             result = await conn.execute(
@@ -155,7 +154,7 @@ class TestTaskIndexesPresent:
         self,
         empty_engine: AsyncEngine,
     ) -> None:
-        """ix_tasks_status_updated_id composite index (status, updated_at, id) exists."""
+        """ix_tasks_status_updated_id 複合インデックス (status, updated_at, id) が存在する。"""
         await run_upgrade_head(empty_engine)
         async with empty_engine.connect() as conn:
             result = await conn.execute(
@@ -174,13 +173,13 @@ class TestTaskIndexesPresent:
 # TC-IT-TR-003: tasks FK constraints (→rooms CASCADE, →directives CASCADE)
 # ---------------------------------------------------------------------------
 class TestTaskForeignKeys:
-    """TC-IT-TR-003: tasks.room_id → rooms CASCADE and tasks.directive_id → directives CASCADE."""
+    """TC-IT-TR-003: tasks.room_id → rooms CASCADE と tasks.directive_id → directives CASCADE。"""
 
     async def test_tasks_room_id_fk_to_rooms(
         self,
         empty_engine: AsyncEngine,
     ) -> None:
-        """PRAGMA foreign_key_list('tasks') shows FK → rooms."""
+        """PRAGMA foreign_key_list('tasks') が rooms への FK を示す。"""
         await run_upgrade_head(empty_engine)
         async with empty_engine.connect() as conn:
             result = await conn.execute(text("PRAGMA foreign_key_list('tasks')"))
@@ -194,7 +193,7 @@ class TestTaskForeignKeys:
         self,
         empty_engine: AsyncEngine,
     ) -> None:
-        """PRAGMA foreign_key_list('tasks') shows FK → directives."""
+        """PRAGMA foreign_key_list('tasks') が directives への FK を示す。"""
         await run_upgrade_head(empty_engine)
         async with empty_engine.connect() as conn:
             result = await conn.execute(text("PRAGMA foreign_key_list('tasks')"))
@@ -209,10 +208,10 @@ class TestTaskForeignKeys:
 # TC-IT-TR-004: Alembic chain 0001→…→0007 single head (分岐なし)
 # ---------------------------------------------------------------------------
 class TestRevisionChainLinear:
-    """TC-IT-TR-004: 0001→0002→…→0007 single-head chain."""
+    """TC-IT-TR-004: 0001→0002→…→0007 の単一 head チェーン。"""
 
     async def test_alembic_heads_returns_single_revision(self) -> None:
-        """ScriptDirectory.get_heads() returns exactly one revision."""
+        """ScriptDirectory.get_heads() がちょうど 1 つのリビジョンを返す。"""
         cfg = _alembic_config()
         script = ScriptDirectory.from_config(cfg)
         heads = script.get_heads()
@@ -222,7 +221,7 @@ class TestRevisionChainLinear:
         )
 
     async def test_chain_walks_from_0007_back_to_base(self) -> None:
-        """Walking down_revision from 0007 reaches base in 7 hops."""
+        """0007 から down_revision を辿ると 7 ホップで base に到達する。"""
         cfg = _alembic_config()
         script = ScriptDirectory.from_config(cfg)
         chain: list[str] = []
@@ -253,16 +252,16 @@ class TestRevisionChainLinear:
 # TC-IT-TR-005: upgrade/downgrade idempotent
 # ---------------------------------------------------------------------------
 class TestUpgradeDowngradeIdempotent:
-    """TC-IT-TR-005: upgrade head → downgrade base → upgrade head again."""
+    """TC-IT-TR-005: upgrade head → downgrade base → 再度 upgrade head。"""
 
     async def test_full_cycle_leaves_task_tables_present(
         self,
         empty_engine: AsyncEngine,
     ) -> None:
-        """upgrade head → downgrade base → upgrade head — task tables survive."""
+        """upgrade head → downgrade base → upgrade head ── task テーブルが残る。"""
         await run_upgrade_head(empty_engine)
 
-        from alembic import command  # local import to avoid global side effects
+        from alembic import command  # グローバル副作用回避のためローカル import
 
         cfg = _alembic_config()
         url = str(empty_engine.url)
@@ -293,7 +292,7 @@ class TestUpgradeDowngradeIdempotent:
         assert expected.issubset(tables), (
             f"[FAIL] task tables missing after re-upgrade.\nMissing: {expected - tables}"
         )
-        # §BUG-TR-002 凍結: conversations / conversation_messages must remain absent
+        # §BUG-TR-002 凍結: conversations / conversation_messages は不在のままでなければならない
         for absent_table in ("conversations", "conversation_messages"):
             assert absent_table not in tables, (
                 f"[FAIL] {absent_table!r} must NOT exist after re-upgrade.\n"
@@ -305,10 +304,10 @@ class TestUpgradeDowngradeIdempotent:
 # TC-IT-TR-006: 0007.down_revision == "0006_directive_aggregate"
 # ---------------------------------------------------------------------------
 class TestDownRevision:
-    """TC-IT-TR-006: 0007_task_aggregate chains onto 0006_directive_aggregate."""
+    """TC-IT-TR-006: 0007_task_aggregate は 0006_directive_aggregate に連結する。"""
 
     async def test_0007_revision_has_correct_down_revision(self) -> None:
-        """0007_task_aggregate.down_revision == '0006_directive_aggregate'."""
+        """0007_task_aggregate.down_revision == '0006_directive_aggregate' であること。"""
         cfg = _alembic_config()
         script = ScriptDirectory.from_config(cfg)
         rev = script.get_revision("0007_task_aggregate")
@@ -323,17 +322,17 @@ class TestDownRevision:
 # TC-IT-TR-007: Room CASCADE → tasks deleted (受入基準 §確定 R1-C)
 # ---------------------------------------------------------------------------
 class TestRoomCascadeDeletesTask:
-    """TC-IT-TR-007: Deleting a Room auto-deletes its Tasks (CASCADE)."""
+    """TC-IT-TR-007: Room を削除すると配下の Task が自動削除される (CASCADE)。"""
 
     async def test_room_deletion_cascades_to_tasks(
         self,
         empty_engine: AsyncEngine,
     ) -> None:
-        """DELETE FROM rooms → Task row automatically deleted (CASCADE).
+        """DELETE FROM rooms → Task 行が自動削除される (CASCADE)。
 
-        Inserts empire → workflow → room → directive → task via raw SQL to
-        avoid Repository layer dependencies. Then DELETEs the room and
-        verifies the task row disappears due to ON DELETE CASCADE.
+        Repository 層への依存を避けるため、empire → workflow → room → directive → task
+        を raw SQL で挿入する。次に room を DELETE し、ON DELETE CASCADE により
+        task 行が消えることを確認する。
         """
         await run_upgrade_head(empty_engine)
 
@@ -390,7 +389,7 @@ class TestRoomCascadeDeletesTask:
                 },
             )
 
-        # Verify task exists before delete
+        # 削除前に task が存在することを確認
         async with empty_engine.connect() as conn:
             await conn.execute(text("PRAGMA foreign_keys = ON"))
             result = await conn.execute(
@@ -399,7 +398,7 @@ class TestRoomCascadeDeletesTask:
             )
             assert result.first() is not None, "Task must exist before CASCADE test"
 
-        # Delete the room — CASCADE should remove the task
+        # Room を削除 ── CASCADE で task が削除されるはず
         async with empty_engine.begin() as conn:
             await conn.execute(text("PRAGMA foreign_keys = ON"))
             await conn.execute(
@@ -424,19 +423,19 @@ class TestRoomCascadeDeletesTask:
 # TC-IT-TR-008: BUG-DRR-001 closure — directives.task_id FK to tasks present
 # ---------------------------------------------------------------------------
 class TestBugDrr001FkClosureAtHead:
-    """TC-IT-TR-008: directives.task_id → tasks.id FK exists at HEAD (0007).
+    """TC-IT-TR-008: HEAD (0007) において directives.task_id → tasks.id FK が存在する。
 
-    BUG-DRR-001: at 0006 level, directives.task_id had no FK because
-    the tasks table did not exist yet. 0007_task_aggregate closes this
-    via op.batch_alter_table('directives', recreate='always') adding
-    fk_directives_task_id (directives.task_id → tasks.id ON DELETE RESTRICT).
+    BUG-DRR-001: 0006 段階では tasks テーブルが未だ存在せず directives.task_id
+    に FK が無い。0007_task_aggregate が op.batch_alter_table('directives',
+    recreate='always') で fk_directives_task_id (directives.task_id → tasks.id
+    ON DELETE RESTRICT) を追加することで閉じる。
     """
 
     async def test_directives_task_id_fk_present_at_head(
         self,
         empty_engine: AsyncEngine,
     ) -> None:
-        """PRAGMA foreign_key_list('directives') has reference to 'tasks' at HEAD."""
+        """HEAD で PRAGMA foreign_key_list('directives') が 'tasks' への参照を持つ。"""
         await run_upgrade_head(empty_engine)
         async with empty_engine.connect() as conn:
             result = await conn.execute(text("PRAGMA foreign_key_list('directives')"))
@@ -455,24 +454,26 @@ class TestBugDrr001FkClosureAtHead:
 # TC-IT-TR-009: §設計決定 TR-001 — task_assigned_agents.agent_id has NO FK to agents
 # ---------------------------------------------------------------------------
 class TestDesignDecisionTr001AgentFkAbsent:
-    """TC-IT-TR-009: §設計決定 TR-001 — task_assigned_agents.agent_id has no FK to agents.
+    """TC-IT-TR-009: §設計決定 TR-001 ──
+    task_assigned_agents.agent_id は agents への FK を持たない。
 
-    §設計決定 TR-001 rationale: room_members.agent_id は agents テーブルへの FK なし
-    の前例と同方針。archived agent の CASCADE 削除が task_assigned_agents を巻き
-    込む危険性を避けるため、FK は設計決定として意図的に省略した (BUG 扱いではない)。
+    §設計決定 TR-001 の根拠: room_members.agent_id が agents テーブルへの FK を
+    持たない前例と同方針。archived agent の CASCADE 削除が task_assigned_agents
+    を巻き込む危険性を避けるため、FK は設計決定として意図的に省略した
+    (BUG 扱いではない)。
 
-    This test physically confirms the absence at HEAD (0007).
+    本テストは HEAD (0007) で物理的にその不在を確認する。
     """
 
     async def test_task_assigned_agents_has_no_agent_fk(
         self,
         empty_engine: AsyncEngine,
     ) -> None:
-        """PRAGMA foreign_key_list('task_assigned_agents') has NO reference to 'agents'.
+        """PRAGMA foreign_key_list('task_assigned_agents') は 'agents' への参照を持たない。
 
-        §設計決定 TR-001: task_assigned_agents.agent_id intentionally has no FK
-        onto agents.id. Cascade-deleting an archived agent must not silently
-        wipe task assignment history (same rationale as room_members.agent_id).
+        §設計決定 TR-001: task_assigned_agents.agent_id は意図的に agents.id への
+        FK を持たない。archived agent の CASCADE 削除で task assignment 履歴を
+        黙って消してはならない (room_members.agent_id と同じ根拠)。
         """
         await run_upgrade_head(empty_engine)
         async with empty_engine.connect() as conn:
@@ -486,7 +487,7 @@ class TestDesignDecisionTr001AgentFkAbsent:
             f"If this FK was added intentionally, update §設計決定 TR-001 in the "
             f"detailed-design.md first."
         )
-        # Only tasks FK should be present (via task_id → tasks.id ON DELETE CASCADE)
+        # tasks への FK のみが存在するはず (task_id → tasks.id ON DELETE CASCADE 経由)
         assert "tasks" in referenced_tables, (
             f"[FAIL] task_assigned_agents.task_id FK to tasks missing.\n"
             f"FK references found: {referenced_tables}"

--- a/backend/tests/infrastructure/persistence/sqlite/test_alembic_workflow.py
+++ b/backend/tests/infrastructure/persistence/sqlite/test_alembic_workflow.py
@@ -1,14 +1,14 @@
-"""Alembic 3rd revision tests (TC-IT-WFR-020 / 021 / 022).
+"""Alembic 3rd revision テスト (TC-IT-WFR-020 / 021 / 022)。
 
-Per ``docs/features/workflow-repository/test-design.md``. Real Alembic
-upgrade / downgrade against a real SQLite file, plus a chain integrity
-check that makes sure
+``docs/features/workflow-repository/test-design.md`` に従う。
+実際の SQLite ファイルに対する Alembic upgrade / downgrade、
+および chain integrity チェック:
 ``0001_init`` → ``0002_empire_aggregate`` → ``0003_workflow_aggregate``
-stays linear (no head fork).
+が線形（head fork なし）であることを確認。
 
-The conftest from ``tests/infrastructure/`` patches Alembic's
-``fileConfig`` so log capture survives migration; same workaround the
-M2 persistence-foundation tests rely on.
+``tests/infrastructure/`` の conftest は Alembic の ``fileConfig``
+をパッチして、ログキャプチャが migration 中も生き残るようにする；
+M2 persistence-foundation テストが依存している同じ回避策。
 """
 
 from __future__ import annotations
@@ -37,7 +37,7 @@ pytestmark = pytest.mark.asyncio
 # ---------------------------------------------------------------------------
 @pytest_asyncio.fixture
 async def empty_engine(tmp_path: Path) -> AsyncIterator[AsyncEngine]:
-    """Bring up a fresh app engine without running any migrations."""
+    """マイグレーションを実行せずに新規 app エンジンを起動する。"""
     url = f"sqlite+aiosqlite:///{tmp_path / 'bakufu.db'}"
     engine = engine_mod.create_engine(url)
     try:
@@ -47,9 +47,9 @@ async def empty_engine(tmp_path: Path) -> AsyncIterator[AsyncEngine]:
 
 
 def _alembic_config() -> Config:
-    """Resolve the bakufu Alembic config for ScriptDirectory inspection."""
-    # Same path the migrations module uses internally; we duplicate the
-    # walk so this test does not import private helpers.
+    """ScriptDirectory inspection 用に bakufu Alembic config を解決する。"""
+    # migrations モジュールが内部で使用するのと同じパス；
+    # このテストが private helper をインポートしないように walk を複製。
     backend_root = Path(__file__).resolve().parents[4]
     cfg = Config(str(backend_root / "alembic.ini"))
     cfg.set_main_option("script_location", str(backend_root / "alembic"))
@@ -60,13 +60,13 @@ def _alembic_config() -> Config:
 # TC-IT-WFR-020: 3rd revision applies the 3 Workflow tables + UNIQUE indexes
 # ---------------------------------------------------------------------------
 class TestThirdRevisionApplied:
-    """TC-IT-WFR-020: ``alembic upgrade head`` adds the Workflow schema."""
+    """TC-IT-WFR-020: ``alembic upgrade head`` が Workflow スキーマを追加する。"""
 
     async def test_three_workflow_tables_present_after_upgrade(
         self,
         empty_engine: AsyncEngine,
     ) -> None:
-        """TC-IT-WFR-020: workflows / workflow_stages / workflow_transitions exist."""
+        """TC-IT-WFR-020: workflows / workflow_stages / workflow_transitions が存在する。"""
         await run_upgrade_head(empty_engine)
         async with empty_engine.connect() as conn:
             result = await conn.execute(text("SELECT name FROM sqlite_master WHERE type='table'"))
@@ -77,16 +77,17 @@ class TestThirdRevisionApplied:
         self,
         empty_engine: AsyncEngine,
     ) -> None:
-        """TC-IT-WFR-020: UNIQUE indexes for the two side tables.
+        """TC-IT-WFR-020: 2 つのサイドテーブルの UNIQUE インデックス。
 
-        ``workflow_stages``: UNIQUE ``(workflow_id, stage_id)``.
-        ``workflow_transitions``: UNIQUE ``(workflow_id, transition_id)``.
+        ``workflow_stages``: UNIQUE ``(workflow_id, stage_id)``。
+        ``workflow_transitions``: UNIQUE ``(workflow_id, transition_id)``。
 
-        SQLite emits an ``sqlite_autoindex_*`` for every UNIQUE
-        constraint declared at table creation. A ``CREATE INDEX``
-        named index also lands here; we accept either shape because
-        the Alembic 0003 revision uses the inline UNIQUE constraint
-        form (``uq_workflow_stages_pair`` / ``uq_workflow_transitions_pair``).
+        SQLite はテーブル作成時に宣言された UNIQUE 制約ごと
+        に ``sqlite_autoindex_*`` を発行する。``CREATE INDEX``
+        という名前のインデックスもここに格納される；
+        Alembic 0003 revision がインライン UNIQUE 制約形式
+        (``uq_workflow_stages_pair`` / ``uq_workflow_transitions_pair``)
+        を使用しているため、どちらの形態も受け入れる。
         """
         await run_upgrade_head(empty_engine)
         async with empty_engine.connect() as conn:
@@ -96,25 +97,27 @@ class TestThirdRevisionApplied:
             rows = list(result)
         stage_indexes = [name for name, tbl in rows if tbl == "workflow_stages"]
         transition_indexes = [name for name, tbl in rows if tbl == "workflow_transitions"]
-        assert stage_indexes, "workflow_stages must declare at least one index"
-        assert transition_indexes, "workflow_transitions must declare at least one index"
+        assert stage_indexes, "workflow_stages は少なくとも 1 つのインデックスを宣言する必要がある"
+        assert transition_indexes, (
+            "workflow_transitions は少なくとも 1 つのインデックスを宣言する必要がある"
+        )
 
 
 # ---------------------------------------------------------------------------
 # TC-IT-WFR-021: upgrade / downgrade are idempotent
 # ---------------------------------------------------------------------------
 class TestUpgradeDowngradeIdempotent:
-    """TC-IT-WFR-021: Alembic up + down + up again leaves the schema in the head state."""
+    """TC-IT-WFR-021: Alembic up + down + up でスキーマが head 状態に残る。"""
 
     async def test_full_cycle_leaves_workflow_tables_present(
         self,
         empty_engine: AsyncEngine,
     ) -> None:
-        """TC-IT-WFR-021: upgrade head → downgrade base → upgrade head again."""
+        """TC-IT-WFR-021: upgrade head → downgrade base → upgrade head。"""
         # Up.
         await run_upgrade_head(empty_engine)
-        # Down to base via Alembic command (synchronous within asyncio).
-        from alembic import command  # local import to avoid global side effects
+        # Alembic コマンドで base にダウン (asyncio 内で同期)。
+        from alembic import command  # ローカルインポートはグローバルサイドエフェクト回避
 
         cfg = _alembic_config()
         url = str(empty_engine.url)
@@ -125,13 +128,13 @@ class TestUpgradeDowngradeIdempotent:
 
         await asyncio.to_thread(_do_downgrade)
 
-        # Schema is empty now — assert the Workflow tables are gone.
+        # スキーマは今空 — Workflow テーブルがなくなったことをアサート。
         async with empty_engine.connect() as conn:
             result = await conn.execute(text("SELECT name FROM sqlite_master WHERE type='table'"))
             tables = {row[0] for row in result}
         assert tables.isdisjoint({"workflows", "workflow_stages", "workflow_transitions"})
 
-        # Up again — back to head.
+        # もう一度 Up — head に戻る。
         await run_upgrade_head(empty_engine)
         async with empty_engine.connect() as conn:
             result = await conn.execute(text("SELECT name FROM sqlite_master WHERE type='table'"))
@@ -143,24 +146,24 @@ class TestUpgradeDowngradeIdempotent:
 # TC-IT-WFR-022: revision chain is linear (no head fork)
 # ---------------------------------------------------------------------------
 class TestRevisionChainLinear:
-    """TC-IT-WFR-022: revision chain is linear (single head).
+    """TC-IT-WFR-022: revision chain は線形 (単一 head)。
 
-    ``0001_init`` → ``0002_empire_aggregate`` → ``0003_workflow_aggregate``.
+    ``0001_init`` → ``0002_empire_aggregate`` → ``0003_workflow_aggregate``。
     """
 
     async def test_alembic_heads_returns_single_revision(self) -> None:
-        """TC-IT-WFR-022: ``ScriptDirectory.get_heads()`` returns exactly one revision."""
+        """TC-IT-WFR-022: ``ScriptDirectory.get_heads()`` が正確に 1 つの revision を返す。"""
         cfg = _alembic_config()
         script = ScriptDirectory.from_config(cfg)
         heads = script.get_heads()
         assert len(heads) == 1, (
-            f"Alembic head must be linear; got branched heads {heads}. "
-            f"Each Aggregate Repository PR appends a single revision; "
-            f"branching breaks ``alembic upgrade head`` across CI runners."
+            f"Alembic head は線形である必要があります； branched heads {heads} を得た。"
+            f"各 Aggregate Repository PR は単一 revision を追加します；"
+            f"branching は CI runners 全体で ``alembic upgrade head`` を破壊します。"
         )
 
     async def test_0003_revision_has_correct_down_revision(self) -> None:
-        """TC-IT-WFR-022: ``0003_workflow_aggregate.down_revision == "0002_empire_aggregate"``."""
+        """TC-IT-WFR-022: ``0003_workflow_aggregate.down_revision == "0002_empire_aggregate"``。"""
         cfg = _alembic_config()
         script = ScriptDirectory.from_config(cfg)
         rev = script.get_revision("0003_workflow_aggregate")
@@ -168,27 +171,27 @@ class TestRevisionChainLinear:
         assert rev.down_revision == "0002_empire_aggregate"
 
     async def test_chain_walks_from_0003_back_to_base(self) -> None:
-        """TC-IT-WFR-022 補強: walking ``down_revision`` reaches base in 3 hops.
+        """TC-IT-WFR-022 補強: ``down_revision`` 走査が 3 ホップで base に到達。
 
-        Catches a future PR that accidentally registers ``0003`` with
-        a ``down_revision = None`` (which would create a branch off
-        base) — the heads() check would still pass with branching, so
-        we walk the chain explicitly.
+        ``down_revision = None`` で誤って ``0003`` を登録する future PR を
+        キャッチする (これは base から branch を作成することになる) —
+        heads() チェックは branch でもまだパスするため、
+        chain を明示的に走査する。
         """
         cfg = _alembic_config()
         script = ScriptDirectory.from_config(cfg)
         chain: list[str] = []
         current_id: str | None = "0003_workflow_aggregate"
-        for _ in range(10):  # generous bound to avoid infinite loop on bad data
+        for _ in range(10):  # 悪いデータで無限ループを避けるための余裕のある境界
             if current_id is None:
                 break
             rev = script.get_revision(current_id)
-            assert rev is not None, f"Revision {current_id!r} not found"
+            assert rev is not None, f"Revision {current_id!r} が見つかりません"
             chain.append(rev.revision)
             down = rev.down_revision
             if isinstance(down, tuple | list):
-                pytest.fail(f"Revision {rev.revision!r} has multiple down_revisions {down}")
-            # ``down`` is now narrowed to ``str | None`` by the guard above.
+                pytest.fail(f"Revision {rev.revision!r} は複数の down_revisions {down} を持つ")
+            # 上記のガード後、``down`` は ``str | None`` に絞られた。
             current_id = down  # pyright: ignore[reportAssignmentType]
 
         # 0003 → 0002 → 0001 → base (None)
@@ -196,4 +199,4 @@ class TestRevisionChainLinear:
             "0003_workflow_aggregate",
             "0002_empire_aggregate",
             "0001_init",
-        ], f"Unexpected revision chain: {chain}"
+        ], f"予期しない revision chain: {chain}"

--- a/backend/tests/infrastructure/persistence/sqlite/test_alembic_workflow.py
+++ b/backend/tests/infrastructure/persistence/sqlite/test_alembic_workflow.py
@@ -33,7 +33,7 @@ pytestmark = pytest.mark.asyncio
 
 
 # ---------------------------------------------------------------------------
-# Fixtures
+# フィクスチャ
 # ---------------------------------------------------------------------------
 @pytest_asyncio.fixture
 async def empty_engine(tmp_path: Path) -> AsyncIterator[AsyncEngine]:
@@ -114,7 +114,7 @@ class TestUpgradeDowngradeIdempotent:
         empty_engine: AsyncEngine,
     ) -> None:
         """TC-IT-WFR-021: upgrade head → downgrade base → upgrade head。"""
-        # Up.
+        # アップグレード。
         await run_upgrade_head(empty_engine)
         # Alembic コマンドで base にダウン (asyncio 内で同期)。
         from alembic import command  # ローカルインポートはグローバルサイドエフェクト回避
@@ -194,7 +194,7 @@ class TestRevisionChainLinear:
             # 上記のガード後、``down`` は ``str | None`` に絞られた。
             current_id = down  # pyright: ignore[reportAssignmentType]
 
-        # 0003 → 0002 → 0001 → base (None)
+        # ダウングレード経路: 0003 → 0002 → 0001 → base（None）
         assert chain == [
             "0003_workflow_aggregate",
             "0002_empire_aggregate",

--- a/backend/tests/infrastructure/persistence/sqlite/test_db_file_mode.py
+++ b/backend/tests/infrastructure/persistence/sqlite/test_db_file_mode.py
@@ -1,19 +1,18 @@
-"""DB file mode forensic audit integration tests
-(TC-IT-PF-002-A / 002-B / 002-C, REQ-PF-002-A, Schneier 致命1).
+"""DB ファイルモード フォレンジック監査の結合テスト
+(TC-IT-PF-002-A / 002-B / 002-C, REQ-PF-002-A, Schneier 致命1)。
 
-Bootstrap stage 0 sets ``umask 0o077`` so newly-created SQLite files
-inherit ``0o600``. These tests pin the *forensic* contract: when a
-prior bakufu run left ``bakufu.db`` / ``bakufu.db-wal`` /
-``bakufu.db-shm`` at ``0o644``, the
-:func:`db_file_mode.verify_and_repair` audit must:
+Bootstrap stage 0 が ``umask 0o077`` を設定し、新規作成 SQLite ファイルは
+``0o600`` を継承する。本テスト群は *フォレンジック* 契約を固定する:
+直前の bakufu 実行が ``bakufu.db`` / ``bakufu.db-wal`` / ``bakufu.db-shm``
+を ``0o644`` で残した場合、:func:`db_file_mode.verify_and_repair` 監査は:
 
-* **Detect** the anomaly (status=``"repaired"``).
-* **WARN-log** with the original mode for post-incident analysis.
-* **Repair** the file to ``0o600`` so the next process is safe.
-* **Continue** — no Fail Fast — so operators do not lose the forensic
-  trail by seeing a startup abort.
+* 異常を **検出** する（status=``"repaired"``）。
+* 事後分析のため元のモードを **WARN ログ** に記録する。
+* 次プロセスが安全になるよう ``0o600`` に **修復** する。
+* **継続** する ── Fail Fast せず、オペレータが起動アボートで
+  フォレンジック痕跡を失わないようにする。
 
-Linux/macOS only; Windows returns ``"windows_skip"`` for every file.
+Linux/macOS のみ。Windows は全ファイルに対し ``"windows_skip"`` を返す。
 """
 
 from __future__ import annotations
@@ -31,7 +30,7 @@ from bakufu.infrastructure.persistence.sqlite.db_file_mode import (
     verify_and_repair,
 )
 
-# Skip the whole module on Windows — POSIX mode bits do not apply.
+# POSIX モードビットが適用できないため、Windows ではモジュール全体をスキップ。
 pytestmark = pytest.mark.skipif(
     platform.system() == "Windows",
     reason="POSIX file mode bits unavailable on Windows",
@@ -39,30 +38,30 @@ pytestmark = pytest.mark.skipif(
 
 
 def _write_with_mode(path: Path, mode: int) -> None:
-    """Create a placeholder file at ``path`` and chmod to ``mode``."""
+    """``path`` にプレースホルダファイルを作成し、``mode`` に chmod する。"""
     path.write_bytes(b"sqlite-test-stub")
     path.chmod(mode)
 
 
 class TestNewFilesAlready0o600:
-    """TC-IT-PF-002-A: file already at 0o600 → status ``"ok"``, no WARN."""
+    """TC-IT-PF-002-A: 既に 0o600 のファイル → status ``"ok"``、WARN なし。"""
 
     def test_new_db_at_0o600_is_marked_ok(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """TC-IT-PF-002-A: bakufu.db created at 0o600 yields status='ok'."""
+        """TC-IT-PF-002-A: 0o600 で作成された bakufu.db は status='ok' を得る。"""
         _write_with_mode(tmp_path / "bakufu.db", SECURE_FILE_MODE)
 
         with caplog.at_level(logging.WARNING):
             results = verify_and_repair(tmp_path)
 
         assert results["bakufu.db"] == "ok"
-        # No WARN should fire for a clean file.
+        # クリーンなファイルでは WARN を発火させてはならない。
         warn_msgs = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
         assert all("DB file mode anomaly" not in m for m in warn_msgs)
 
     def test_post_audit_mode_unchanged(self, tmp_path: Path) -> None:
-        """TC-IT-PF-002-A: a clean file's mode is not altered."""
+        """TC-IT-PF-002-A: クリーンファイルのモードは変更されない。"""
         target = tmp_path / "bakufu.db"
         _write_with_mode(target, SECURE_FILE_MODE)
         verify_and_repair(tmp_path)
@@ -70,12 +69,12 @@ class TestNewFilesAlready0o600:
 
 
 class TestExistingFileAt0o644Repairs:
-    """TC-IT-PF-002-B: 0o644 file → WARN + chmod to 0o600 + status ``"repaired"``."""
+    """TC-IT-PF-002-B: 0o644 ファイル → WARN + 0o600 へ chmod + status ``"repaired"``。"""
 
     def test_anomaly_detected_and_repaired(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """TC-IT-PF-002-B: a 0o644 bakufu.db is repaired to 0o600."""
+        """TC-IT-PF-002-B: 0o644 の bakufu.db が 0o600 に修復される。"""
         target = tmp_path / "bakufu.db"
         _write_with_mode(target, 0o644)
 
@@ -88,17 +87,16 @@ class TestExistingFileAt0o644Repairs:
     def test_warn_log_carries_original_mode(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """TC-IT-PF-002-B: forensic WARN must record the *original* mode."""
+        """TC-IT-PF-002-B: フォレンジック WARN は *元の* モードを記録しなければならない。"""
         _write_with_mode(tmp_path / "bakufu.db", 0o644)
 
         with caplog.at_level(logging.WARNING):
             verify_and_repair(tmp_path)
 
         warn_msgs = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
-        # The forensic message must (a) name the file, (b) include the
-        # original mode in octal so post-incident investigators can
-        # correlate against process audit logs, and (c) note the
-        # umask-0o077 enforcement gap.
+        # フォレンジックメッセージは (a) ファイル名を記載し、(b) プロセス監査ログと
+        # 突き合わせるため元のモードを 8 進数で含み、(c) umask-0o077 の
+        # 強制ギャップを記述しなければならない。
         assert any("DB file mode anomaly" in m for m in warn_msgs)
         assert any("0o644" in m for m in warn_msgs)
         assert any("umask" in m for m in warn_msgs)
@@ -106,10 +104,9 @@ class TestExistingFileAt0o644Repairs:
     def test_repair_does_not_block_startup(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """TC-IT-PF-002-B: forensic policy says continue, never Fail Fast."""
+        """TC-IT-PF-002-B: フォレンジックポリシーは「継続せよ、Fail Fast するな」。"""
         _write_with_mode(tmp_path / "bakufu.db", 0o644)
-        # The function returns a status dict (no raise) — that itself is
-        # the proof that startup is not blocked.
+        # 関数が（raise せず）status dict を返すことが、起動がブロックされない証拠そのもの。
         with caplog.at_level(logging.WARNING):
             results = verify_and_repair(tmp_path)
         assert isinstance(results, dict)
@@ -117,12 +114,12 @@ class TestExistingFileAt0o644Repairs:
 
 
 class TestWalAndShmFilesAuditedToo:
-    """TC-IT-PF-002-C: bakufu.db-wal and bakufu.db-shm follow the same audit."""
+    """TC-IT-PF-002-C: bakufu.db-wal と bakufu.db-shm も同じ監査に従う。"""
 
     def test_wal_at_0o644_is_repaired(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """TC-IT-PF-002-C: bakufu.db-wal repair path."""
+        """TC-IT-PF-002-C: bakufu.db-wal の修復経路。"""
         wal = tmp_path / "bakufu.db-wal"
         _write_with_mode(wal, 0o644)
 
@@ -135,7 +132,7 @@ class TestWalAndShmFilesAuditedToo:
     def test_shm_at_0o644_is_repaired(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """TC-IT-PF-002-C: bakufu.db-shm repair path."""
+        """TC-IT-PF-002-C: bakufu.db-shm の修復経路。"""
         shm = tmp_path / "bakufu.db-shm"
         _write_with_mode(shm, 0o644)
 
@@ -146,8 +143,8 @@ class TestWalAndShmFilesAuditedToo:
         assert stat.S_IMODE(shm.stat().st_mode) == SECURE_FILE_MODE
 
     def test_absent_wal_and_shm_are_marked_absent(self, tmp_path: Path) -> None:
-        """TC-IT-PF-002-C: WAL/SHM may be absent right after upgrade — status='absent'."""
-        # Only the main DB exists; WAL/SHM materialise on first write.
+        """TC-IT-PF-002-C: upgrade 直後は WAL/SHM が無い場合がある ── status='absent'。"""
+        # メイン DB のみ存在。WAL/SHM は最初の書き込みでマテリアライズされる。
         _write_with_mode(tmp_path / "bakufu.db", SECURE_FILE_MODE)
 
         results = verify_and_repair(tmp_path)
@@ -158,7 +155,7 @@ class TestWalAndShmFilesAuditedToo:
     def test_three_files_audited_independently(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """TC-IT-PF-002-C: each of the three files gets its own status entry."""
+        """TC-IT-PF-002-C: 3 ファイルそれぞれが独自の status エントリを得る。"""
         for name in DB_FILE_NAMES:
             _write_with_mode(tmp_path / name, 0o644)
 
@@ -172,7 +169,7 @@ class TestWalAndShmFilesAuditedToo:
 
 
 class TestRepairFailureDoesNotRaise:
-    """REQ-PF-002-A continuity: chmod failure is logged ERROR, never raises."""
+    """REQ-PF-002-A 継続性: chmod 失敗は ERROR ログで記録され、決して raise しない。"""
 
     def test_chmod_failure_is_swallowed(
         self,
@@ -180,7 +177,7 @@ class TestRepairFailureDoesNotRaise:
         caplog: pytest.LogCaptureFixture,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """REQ-PF-002-A: chmod raising OSError → status='repair_failed', no raise."""
+        """REQ-PF-002-A: chmod が OSError を投げる → status='repair_failed'、raise なし。"""
         target = tmp_path / "bakufu.db"
         _write_with_mode(target, 0o644)
 
@@ -197,20 +194,19 @@ class TestRepairFailureDoesNotRaise:
             results = verify_and_repair(tmp_path)
 
         assert results["bakufu.db"] == "repair_failed"
-        # The audit must surface the failure with an ERROR-level entry so
-        # ops dashboards can alert.
+        # ops ダッシュボードがアラートできるよう、監査は失敗を ERROR レベルで表面化する。
         error_msgs = [r.getMessage() for r in caplog.records if r.levelname == "ERROR"]
         assert any("DB file mode repair failed" in m for m in error_msgs)
 
 
 class TestDbFileModeBootstrapIntegration:
-    """Bootstrap stage 3 wires the audit; the mode dict appears in the INFO log."""
+    """Bootstrap stage 3 が監査を配線する。モード辞書が INFO ログに現れる。"""
 
     @pytest.mark.asyncio
     async def test_bootstrap_logs_mode_audit_results(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """REQ-PF-002-A: Bootstrap.run() emits 'DB file mode audit:' INFO line."""
+        """REQ-PF-002-A: Bootstrap.run() が 'DB file mode audit:' INFO 行を出力する。"""
         from bakufu.infrastructure.bootstrap import Bootstrap
         from bakufu.infrastructure.persistence.sqlite.migrations import run_upgrade_head
 
@@ -223,6 +219,6 @@ class TestDbFileModeBootstrapIntegration:
         assert any("DB file mode audit:" in m for m in info_msgs)
 
 
-# Re-export the module so coverage attributes the tests to the right
-# source file when reports are aggregated.
+# レポート集約時にカバレッジが正しいソースファイルにテストを紐付けるよう、
+# モジュールを再エクスポートする。
 _ = db_file_mode

--- a/backend/tests/infrastructure/persistence/sqlite/test_engine_pragma.py
+++ b/backend/tests/infrastructure/persistence/sqlite/test_engine_pragma.py
@@ -1,11 +1,11 @@
-"""Engine PRAGMA + dual connection integration tests
-(TC-IT-PF-003 / 013 / 003-A / 003-B / 003-C / 003-D).
+"""Engine PRAGMA + 二重接続統合テスト
+(TC-IT-PF-003 / 013 / 003-A / 003-B / 003-C / 003-D)。
 
-Confirmation D-1〜D-4 / Schneier 重大 2 物理保証. The application engine
-sets eight PRAGMAs including ``defensive=ON`` / ``writable_schema=OFF``
-/ ``trusted_schema=OFF`` so a runtime ``DROP TRIGGER`` cannot remove
-the audit_log defenses. The migration engine relaxes those guards but
-is explicitly disposed before stage 4 starts.
+Confirmation D-1〜D-4 / Schneier 重大 2 物理保証。アプリケーションエンジンは
+8 つの PRAGMA を設定（``defensive=ON`` / ``writable_schema=OFF``
+/ ``trusted_schema=OFF`` 含む）ため、実行時 ``DROP TRIGGER`` は
+audit_log 防御を削除できない。マイグレーションエンジンはそれらのガードを
+緩和するが、ステージ 4 開始前に明示的に破棄される。
 """
 
 from __future__ import annotations
@@ -26,7 +26,7 @@ pytestmark = pytest.mark.asyncio
 
 @pytest_asyncio.fixture
 async def fresh_app_engine(tmp_path: Path) -> AsyncIterator[AsyncEngine]:
-    """Bring up a fresh app engine per test (no Alembic, no shared state)."""
+    """テストごとに新規 app エンジンを起動 (Alembic なし、共有状態なし)。"""
     url = f"sqlite+aiosqlite:///{tmp_path / 'bakufu.db'}"
     engine = engine_mod.create_engine(url)
     try:
@@ -36,38 +36,38 @@ async def fresh_app_engine(tmp_path: Path) -> AsyncIterator[AsyncEngine]:
 
 
 class TestApplicationPragmas:
-    """TC-IT-PF-003 / 013 / 003-A: application engine sets 8 PRAGMAs."""
+    """TC-IT-PF-003 / 013 / 003-A: アプリケーションエンジンが 8 つの PRAGMA を設定。"""
 
     async def test_journal_mode_is_wal(self, fresh_app_engine: AsyncEngine) -> None:
-        """TC-IT-PF-003: journal_mode = WAL after first connect."""
+        """TC-IT-PF-003: journal_mode = WAL (初回接続後)。"""
         async with fresh_app_engine.connect() as conn:
             result = await conn.execute(text("PRAGMA journal_mode"))
             value = result.scalar()
         assert value == "wal"
 
     async def test_foreign_keys_on(self, fresh_app_engine: AsyncEngine) -> None:
-        """TC-IT-PF-003: foreign_keys ON per-connection."""
+        """TC-IT-PF-003: foreign_keys = ON (接続ごと)。"""
         async with fresh_app_engine.connect() as conn:
             result = await conn.execute(text("PRAGMA foreign_keys"))
             value = result.scalar()
         assert value == 1
 
     async def test_busy_timeout_5000(self, fresh_app_engine: AsyncEngine) -> None:
-        """TC-IT-PF-003: busy_timeout = 5000 ms."""
+        """TC-IT-PF-003: busy_timeout = 5000 ms。"""
         async with fresh_app_engine.connect() as conn:
             result = await conn.execute(text("PRAGMA busy_timeout"))
             value = result.scalar()
         assert value == 5000
 
     async def test_synchronous_normal(self, fresh_app_engine: AsyncEngine) -> None:
-        """TC-IT-PF-003: synchronous = NORMAL (1)."""
+        """TC-IT-PF-003: synchronous = NORMAL (1)。"""
         async with fresh_app_engine.connect() as conn:
             result = await conn.execute(text("PRAGMA synchronous"))
             value = result.scalar()
         assert value == 1
 
     async def test_temp_store_memory(self, fresh_app_engine: AsyncEngine) -> None:
-        """TC-IT-PF-003: temp_store = MEMORY (2)."""
+        """TC-IT-PF-003: temp_store = MEMORY (2)。"""
         async with fresh_app_engine.connect() as conn:
             result = await conn.execute(text("PRAGMA temp_store"))
             value = result.scalar()
@@ -75,49 +75,48 @@ class TestApplicationPragmas:
 
 
 class TestDefensivePragmasOptional:
-    """TC-IT-PF-003-A: defensive guards are best-effort (D-4 fallback).
+    """TC-IT-PF-003-A: defensive ガードは best-effort (D-4 フォールバック)。
 
-    SQLite ``PRAGMA defensive`` requires SQLITE_DBCONFIG_DEFENSIVE which
-    is built-in only when the SQLite library is compiled with the
-    ``SQLITE_ENABLE_DESERIALIZE`` option. On older builds the engine logs
-    a WARN and continues — Confirmation D-4 frames this as the
-    documented fallback.
+    SQLite ``PRAGMA defensive`` は SQLITE_DBCONFIG_DEFENSIVE を必要とするが、
+    SQLite ライブラリが ``SQLITE_ENABLE_DESERIALIZE`` オプションでコンパイルされた場合
+    のみ組み込まれる。古いビルドでは、エンジンは WARN をログして続行 —
+    Confirmation D-4 はこれを文書化されたフォールバックとして位置付ける。
     """
 
     async def test_defensive_pragma_does_not_break_engine(
         self, fresh_app_engine: AsyncEngine
     ) -> None:
-        """TC-IT-PF-003-A: engine connects successfully even on older SQLite.
+        """TC-IT-PF-003-A: エンジンが古い SQLite でも正常に接続。
 
-        ``PRAGMA defensive`` is set-only on SQLite (no SELECT form), so
-        we can only confirm the engine connects. The Confirmation D-4
-        fallback path either applies the PRAGMA silently (modern SQLite)
-        or logs a WARN and continues (older builds). Either way the
-        application engine must be usable for normal queries.
+        ``PRAGMA defensive`` は SQLite で設定のみ (SELECT 形式なし) なので、
+        エンジンが接続することのみを確認できる。Confirmation D-4 フォールバック
+        パスは PRAGMA を静かに適用するか (現代 SQLite) または WARN をログして
+        続行 (古いビルド)。いずれにしろアプリケーションエンジンは通常クエリに
+        使用可能である必要がある。
         """
         async with fresh_app_engine.connect() as conn:
-            # Engine must be usable for normal queries; if PRAGMA
-            # application failed catastrophically the connect would
-            # have raised at engine.connect() time.
+            # エンジンは通常クエリに使用可能でなければならない；
+            # PRAGMA 適用が致命的に失敗した場合、接続は
+            # engine.connect() 時点で raise していただろう。
             result = await conn.execute(text("SELECT 1"))
             value = result.scalar()
         assert value == 1
 
 
 class TestDropTriggerDefense:
-    """TC-IT-PF-003-B: with defensive=ON, ``DROP TRIGGER`` cannot remove the audit_log guard.
+    """TC-IT-PF-003-B: defensive=ON で、``DROP TRIGGER`` は audit_log ガードを削除できない。
 
-    On builds where defensive=ON is supported, a DROP TRIGGER from the
-    application engine raises. On older builds (D-4 fallback) the OS
-    file-permission layer becomes the trust boundary — we still confirm
-    the trigger *survives* the lifetime of the app engine so a future
-    repository PR cannot accidentally rely on dropping it.
+    defensive=ON がサポートされているビルドでは、
+    アプリケーションエンジンからの DROP TRIGGER は raise。古いビルド (D-4 フォールバック)
+    では、OS ファイルパーミッション層が信頼境界になる — 我々はまだ
+    トリガーがアプリケーションエンジンの生存期間中に *生き残る* ことを確認する
+    ため、将来のリポジトリ PR はそれを削除することに誤って依存できない。
     """
 
     async def test_audit_log_no_delete_trigger_survives(
         self, fresh_app_engine: AsyncEngine
     ) -> None:
-        """TC-IT-PF-003-B: trigger remains after Alembic upgrade."""
+        """TC-IT-PF-003-B: トリガーが Alembic upgrade 後に残存。"""
         await run_upgrade_head(fresh_app_engine)
         async with fresh_app_engine.connect() as conn:
             result = await conn.execute(
@@ -131,24 +130,24 @@ class TestDropTriggerDefense:
 
 
 class TestDualConnectionLifecycle:
-    """TC-IT-PF-003-D: migration engine is disposed after Alembic runs."""
+    """TC-IT-PF-003-D: マイグレーションエンジンが Alembic 実行後に破棄される。"""
 
     async def test_migration_runner_disposes_its_own_engine(
         self, fresh_app_engine: AsyncEngine
     ) -> None:
-        """TC-IT-PF-003-D: ``run_upgrade_head`` returns after dispose; app engine still alive.
+        """TC-IT-PF-003-D: ``run_upgrade_head`` が破棄後に戻る ; app エンジンはまだ生きている。
 
-        The exact head id advances every Aggregate Repository PR
+        正確な head id は各アグリゲートリポジトリ PR ごとに進行
         (PR #19 → ``0001_init`` → PR #25 → ``0002_empire_aggregate`` →
-        future PRs append further revisions). The test only cares that
-        ``run_upgrade_head`` reports a non-empty revision id and that
-        the M2 cross-cutting tables are present after the upgrade.
+        将来の PR はさらなる revision を追加)。テストは ``run_upgrade_head`` が
+        空でない revision id をレポートし、upgrade 後に M2 cross-cutting
+        テーブルが存在することのみを気にする。
         """
         head = await run_upgrade_head(fresh_app_engine)
         assert head, (
-            "run_upgrade_head should return the latest Alembic revision id, not an empty string"
+            "run_upgrade_head は最新 Alembic revision id をレポートすべき、空文字列ではなく"
         )
-        # Application engine remains usable.
+        # アプリケーションエンジンが使用可能なままである。
         async with fresh_app_engine.connect() as conn:
             result = await conn.execute(text("SELECT name FROM sqlite_master WHERE type='table'"))
             tables = {row[0] for row in result}

--- a/backend/tests/infrastructure/persistence/sqlite/test_engine_pragma.py
+++ b/backend/tests/infrastructure/persistence/sqlite/test_engine_pragma.py
@@ -20,7 +20,7 @@ from bakufu.infrastructure.persistence.sqlite.migrations import run_upgrade_head
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine
 
-# Each test in this module exercises async code.
+# このモジュールの各テストは async コードを実行。
 pytestmark = pytest.mark.asyncio
 
 
@@ -95,9 +95,8 @@ class TestDefensivePragmasOptional:
         使用可能である必要がある。
         """
         async with fresh_app_engine.connect() as conn:
-            # エンジンは通常クエリに使用可能でなければならない；
-            # PRAGMA 適用が致命的に失敗した場合、接続は
-            # engine.connect() 時点で raise していただろう。
+            # エンジンは通常クエリに使用可能でなければならない；PRAGMA 適用が
+            # 致命的に失敗した場合、接続は engine.connect() 時点で raise していただろう。
             result = await conn.execute(text("SELECT 1"))
             value = result.scalar()
         assert value == 1

--- a/backend/tests/infrastructure/persistence/sqlite/test_pid_gc.py
+++ b/backend/tests/infrastructure/persistence/sqlite/test_pid_gc.py
@@ -27,16 +27,16 @@ from tests.factories.psutil_process import (
 
 
 class TestClassifyRow:
-    """TC-UT-PF-010: classifier returns the correct verdict per psutil shape."""
+    """TC-UT-PF-010: 分類器は psutil 形状に従って正しい判定を返す。"""
 
     def test_no_such_process_returns_absent(self) -> None:
-        """TC-UT-PF-010 (absent): NoSuchProcess at psutil.Process() → 'absent'."""
+        """TC-UT-PF-010 (absent): psutil.Process() での NoSuchProcess → 'absent'。"""
         with patch("psutil.Process", side_effect=psutil.NoSuchProcess(123)):
             verdict = _classify_row(pid=123, recorded_started_at=datetime.now(UTC))
         assert verdict == "absent"
 
     def test_create_time_match_returns_orphan_kill(self) -> None:
-        """TC-UT-PF-010 (orphan_kill): create_time matches → kill verdict."""
+        """TC-UT-PF-010 (orphan_kill): create_time が一致 → kill 判定。"""
         recorded = datetime.now(UTC)
         proc = make_orphan_process(pid=456, create_time_seconds=recorded.timestamp())
         with patch("psutil.Process", return_value=proc):
@@ -44,7 +44,7 @@ class TestClassifyRow:
         assert verdict == "orphan_kill"
 
     def test_create_time_mismatch_returns_protected(self) -> None:
-        """TC-UT-PF-010 (protected): mismatching create_time → 'protected'."""
+        """TC-UT-PF-010 (protected): create_time が不一致 → 'protected'。"""
         recorded = datetime.now(UTC)
         proc = make_protected_process(pid=789, recorded_started_at=recorded)
         with patch("psutil.Process", return_value=proc):
@@ -53,47 +53,47 @@ class TestClassifyRow:
 
 
 class TestProtectedNeverKilled:
-    """TC-UT-PF-026: protected verdict skips _kill_descendants."""
+    """TC-UT-PF-026: protected 判定が _kill_descendants をスキップ。"""
 
     def test_protected_pid_send_signal_not_called(self) -> None:
-        """TC-UT-PF-026: PID-reused processes are never signaled."""
+        """TC-UT-PF-026: PID 再利用プロセスはシグナルを受信しない。"""
         recorded = datetime.now(UTC)
         proc = make_protected_process(pid=555, recorded_started_at=recorded)
         with patch("psutil.Process", return_value=proc):
             verdict = _classify_row(pid=555, recorded_started_at=recorded)
         assert verdict == "protected"
-        # _classify_row never calls send_signal — it only inspects.
+        # _classify_row は send_signal を呼び出さない — 検査のみ。
         assert proc.send_signal.call_count == 0
 
 
 class TestAccessDeniedRetry:
-    """TC-UT-PF-027: AccessDenied bubbles up so the row is left for next sweep."""
+    """TC-UT-PF-027: AccessDenied がバブルアップして行を次のスイープに残す。"""
 
     def test_access_denied_propagates(self) -> None:
-        """TC-UT-PF-027: psutil.AccessDenied → caller WARN-logs + skip."""
+        """TC-UT-PF-027: psutil.AccessDenied → 呼び出し側 WARN-ログ + スキップ。"""
         proc = make_access_denied_process(pid=777)
         with patch("psutil.Process", return_value=proc), pytest.raises(psutil.AccessDenied):
             _classify_row(pid=777, recorded_started_at=datetime.now(UTC))
 
 
 class TestKillDescendantsOrder:
-    """TC-UT-PF-028: SIGTERM → grace → SIGKILL with recursive=True."""
+    """TC-UT-PF-028: SIGTERM → grace → SIGKILL with recursive=True。"""
 
     def test_recursive_children_signal_dispatch(self) -> None:
-        """TC-UT-PF-028: send_signal called on parent + every child returned."""
+        """TC-UT-PF-028: 親と返された全ての子に send_signal を呼び出し。"""
         child1 = make_child_process(pid=2001)
         child2 = make_child_process(pid=2002)
         parent = make_orphan_process(pid=999, children=[child1, child2])
         with patch("psutil.Process", return_value=parent):
             _kill_descendants(pid=999)
-        # Each target receives at least one SIGTERM (is_running=False so
-        # the grace loop terminates without escalating to SIGKILL).
+        # 各ターゲットは少なくとも 1 つの SIGTERM を受信 (is_running=False なので
+        # grace ループは SIGKILL にエスカレートせずに終了)。
         assert parent.send_signal.call_count >= 1
         assert child1.send_signal.call_count >= 1
         assert child2.send_signal.call_count >= 1
 
     def test_recursive_keyword_passed_to_children(self) -> None:
-        """TC-UT-PF-028 補強: ``children(recursive=True)`` is honored."""
+        """TC-UT-PF-028 補強: ``children(recursive=True)`` が尊重される。"""
         parent = make_orphan_process(pid=1000)
         with patch("psutil.Process", return_value=parent):
             _kill_descendants(pid=1000)

--- a/backend/tests/infrastructure/security/test_masking.py
+++ b/backend/tests/infrastructure/security/test_masking.py
@@ -1,9 +1,9 @@
-"""MaskingGateway unit tests (TC-UT-PF-006 / 016 / 017 / 018 / 019 / 041 / 042).
+"""MaskingGateway 単体テスト（TC-UT-PF-006 / 016 / 017 / 018 / 019 / 041 / 042）。
 
-Covers REQ-PF-005 (single masking gateway) + Confirmation A's nine regex
-patterns + Confirmation F's Fail-Secure contract. The gateway must
-**never raise** — internal failures fall back to ``<REDACTED:*>``
-sentinels rather than letting raw bytes escape.
+REQ-PF-005（masking ゲートウェイの単一化）+ Confirmation A の 9 種の正規表現
++ Confirmation F の Fail-Secure 契約をカバーする。ゲートウェイは
+**決して例外を投げてはならない** — 内部失敗時は生バイトを漏らす代わりに
+``<REDACTED:*>`` センチネルへフォールバックする。
 """
 
 from __future__ import annotations
@@ -16,10 +16,10 @@ from bakufu.infrastructure.security import masking
 def _initialize_masking(  # pyright: ignore[reportUnusedFunction]
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Re-init masking with a known HOME so home-path tests are deterministic."""
+    """ホームパステストを決定的にするため、HOME を既知値に固定して masking を再初期化する。"""
     monkeypatch.setenv("HOME", "/home/myuser")
-    # Strip any provider env vars from the host so tests assert against a
-    # clean Layer-1 list.
+    # ホスト由来の provider 環境変数をすべて剥がし、テストはクリーンな
+    # Layer-1 リストに対してのみアサートする。
     for env_key in (
         "ANTHROPIC_API_KEY",
         "OPENAI_API_KEY",
@@ -34,7 +34,7 @@ def _initialize_masking(  # pyright: ignore[reportUnusedFunction]
 
 
 class TestNineRegexPatterns:
-    """TC-UT-PF-006 / 042: each of the nine secret formats is redacted."""
+    """TC-UT-PF-006 / 042: 9 種類のシークレットフォーマットそれぞれが redact される。"""
 
     @pytest.mark.parametrize(
         ("payload", "expected_redaction"),
@@ -60,23 +60,23 @@ class TestNineRegexPatterns:
         ],
     )
     def test_each_regex_pattern_redacts(self, payload: str, expected_redaction: str) -> None:
-        """TC-UT-PF-042: parametrized over all nine regex families."""
+        """TC-UT-PF-042: 9 種すべての regex ファミリに対するパラメタライズ。"""
         masked = masking.mask(payload)
         assert expected_redaction in masked
 
 
 class TestApplicationOrder:
-    """TC-UT-PF-016: Anthropic regex applies before OpenAI regex."""
+    """TC-UT-PF-016: Anthropic regex は OpenAI regex より先に適用される。"""
 
     def test_anthropic_key_does_not_become_openai_redaction(self) -> None:
-        """TC-UT-PF-016: 'sk-ant-...' is redacted as ANTHROPIC, never OPENAI."""
+        """TC-UT-PF-016: 'sk-ant-...' は ANTHROPIC として redact され、OPENAI にはならない。"""
         ant_key = "sk-ant-api03-" + "A" * 60
         masked = masking.mask(f"key={ant_key}")
         assert "<REDACTED:ANTHROPIC_KEY>" in masked
         assert "<REDACTED:OPENAI_KEY>" not in masked
 
     def test_openai_key_does_not_match_anthropic(self) -> None:
-        """TC-UT-PF-016: plain 'sk-...' redacts as OPENAI, not ANTHROPIC."""
+        """TC-UT-PF-016: 素の 'sk-...' は OPENAI として redact される（ANTHROPIC ではない）。"""
         oai_key = "sk-" + "B" * 40
         masked = masking.mask(f"key={oai_key}")
         assert "<REDACTED:OPENAI_KEY>" in masked
@@ -84,19 +84,19 @@ class TestApplicationOrder:
 
 
 class TestEnvLengthFloor:
-    """TC-UT-PF-017: env values shorter than 8 chars are not patternized."""
+    """TC-UT-PF-017: 8 文字未満の env 値はパターン化されない。"""
 
     def test_short_env_value_skipped(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """TC-UT-PF-017: 5-char ANTHROPIC_API_KEY is ignored."""
+        """TC-UT-PF-017: 5 文字の ANTHROPIC_API_KEY は無視される。"""
         monkeypatch.setenv("ANTHROPIC_API_KEY", "short")
         masking.init()
-        # 'short' must not be redacted — only the 9 regex / home pass should fire.
+        # 'short' は redact されてはならない。9 種の regex / home パスのみが発火する。
         masked = masking.mask("plain text containing short value")
         assert "short" in masked
         assert "<REDACTED:ENV:ANTHROPIC_API_KEY>" not in masked
 
     def test_eight_char_env_value_is_patternized(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """TC-UT-PF-017: 8-char value lands in the env layer."""
+        """TC-UT-PF-017: 8 文字の値は env レイヤに到達する。"""
         monkeypatch.setenv("ANTHROPIC_API_KEY", "12345678")
         masking.init()
         masked = masking.mask("contains 12345678 secret")
@@ -105,39 +105,39 @@ class TestEnvLengthFloor:
 
 
 class TestFailSecureFallback:
-    """TC-UT-PF-018 / 006-A / 006-B: confirmation F sentinels for failure paths."""
+    """TC-UT-PF-018 / 006-A / 006-B: Confirmation F の失敗パス向けセンチネル。"""
 
     def test_non_str_input_is_coerced_or_redacted(self) -> None:
-        """TC-UT-PF-018: bytes payload is coerced via str() before masking."""
+        """TC-UT-PF-018: bytes ペイロードは masking 前に str() で変換される。"""
         masked = masking.mask(b"raw bytes data")
         assert isinstance(masked, str)
 
     def test_oversized_value_returns_overflow_sentinel(self) -> None:
-        """TC-UT-PF-006-B: an individual value above MAX_BYTES_FOR_RECURSION → MASK_OVERFLOW.
+        """TC-UT-PF-006-B: MAX_BYTES_FOR_RECURSION を超える個別値は MASK_OVERFLOW へ。
 
-        The overflow guard runs per recursion frame: the dict overhead
-        is tiny, so the dict itself stays a dict, but the giant string
-        value inside gets replaced with the overflow sentinel. Either
-        path is Fail-Secure — raw bytes never escape.
+        オーバーフローガードは再帰フレームごとに走る。dict のオーバーヘッドは
+        小さいので dict 自体は dict のまま残るが、中の巨大文字列値はオー
+        バーフローセンチネルに置換される。どちらの経路も Fail-Secure であり、
+        生バイトは漏れない。
         """
         huge = "x" * (masking.MAX_BYTES_FOR_RECURSION + 1)
         wrapped = {"k": huge}
         result = masking.mask_in(wrapped)
-        # Either the dict or its value gets replaced; both flavors
-        # satisfy the Fail-Secure contract (raw bytes do not leak).
+        # dict またはその値が置換される。どちらの形でも Fail-Secure 契約を
+        # 満たす（生バイトは漏れない）。
         if isinstance(result, dict):
             assert result["k"] == masking.REDACT_MASK_OVERFLOW
         else:
             assert result == masking.REDACT_MASK_OVERFLOW
 
     def test_oversized_string_directly_returns_overflow_sentinel(self) -> None:
-        """TC-UT-PF-006-B (direct): a giant top-level string also Fail-Secures."""
+        """TC-UT-PF-006-B（直接版）: 巨大なトップレベル文字列も Fail-Secure に倒れる。"""
         huge = "x" * (masking.MAX_BYTES_FOR_RECURSION + 1)
         result = masking.mask_in(huge)
         assert result == masking.REDACT_MASK_OVERFLOW
 
     def test_recursive_structure_walks_all_levels(self) -> None:
-        """TC-UT-PF-019: dict / list nesting recurses and masks every str."""
+        """TC-UT-PF-019: dict / list のネストを再帰的に走査し、全 str を mask する。"""
         payload = {
             "key": "sk-ant-api03-" + "A" * 50,
             "nested": {"pat": "ghp_" + "X" * 36, "list": ["plain"]},
@@ -150,32 +150,31 @@ class TestFailSecureFallback:
 
 
 class TestHomePathLayer:
-    """TC-UT-PF-041: $HOME absolute path → '<HOME>'."""
+    """TC-UT-PF-041: $HOME 配下の絶対パス → '<HOME>'。"""
 
     def test_home_path_substitution(self) -> None:
-        """TC-UT-PF-041: 'error at /home/myuser/...' gets replaced."""
+        """TC-UT-PF-041: 'error at /home/myuser/...' が置換される。"""
         masked = masking.mask("error at /home/myuser/.local/share/bakufu/db.sqlite")
         assert "/home/myuser" not in masked
         assert "<HOME>" in masked
 
 
 class TestFailSecureListenerErrorSentinel:
-    """TC-UT-PF-006-C: Listener-error sentinel exists and is publicly importable.
+    """TC-UT-PF-006-C: Listener エラーセンチネルが存在し、公開 import 可能であること。
 
-    The actual listener-failure path is exercised in the integration
-    tests because it requires a live SQLAlchemy listener that we can
-    force into the catch arm. Here we just freeze the sentinel value
-    contract for masking-listener consumers.
+    実際の listener 失敗パスは統合テスト側でカバーする。catch アームへ
+    強制的に倒すには本物の SQLAlchemy listener が必要なため。ここでは
+    masking-listener 利用者のためにセンチネル値の契約を凍結するに留める。
     """
 
     def test_listener_error_sentinel_value(self) -> None:
-        """TC-UT-PF-006-C: REDACT_LISTENER_ERROR is the documented sentinel."""
+        """TC-UT-PF-006-C: REDACT_LISTENER_ERROR は文書化されたセンチネル値である。"""
         assert masking.REDACT_LISTENER_ERROR == "<REDACTED:LISTENER_ERROR>"
 
     def test_mask_error_sentinel_value(self) -> None:
-        """TC-UT-PF-006-A: REDACT_MASK_ERROR matches the design wording."""
+        """TC-UT-PF-006-A: REDACT_MASK_ERROR は設計文言と一致する。"""
         assert masking.REDACT_MASK_ERROR == "<REDACTED:MASK_ERROR>"
 
     def test_mask_overflow_sentinel_value(self) -> None:
-        """TC-UT-PF-006-B: REDACT_MASK_OVERFLOW matches the design wording."""
+        """TC-UT-PF-006-B: REDACT_MASK_OVERFLOW は設計文言と一致する。"""
         assert masking.REDACT_MASK_OVERFLOW == "<REDACTED:MASK_OVERFLOW>"

--- a/backend/tests/infrastructure/storage/test_attachment_root.py
+++ b/backend/tests/infrastructure/storage/test_attachment_root.py
@@ -1,9 +1,9 @@
-"""Attachment FS root integration tests
-(TC-IT-PF-011 / 029, TC-UT-PF-030).
+"""Attachment FS root 統合テスト
+(TC-IT-PF-011 / 029, TC-UT-PF-030)。
 
-Confirmation E + REQ-PF-009: ``ensure_root`` creates the directory at
-``0o700`` on POSIX. ``start_orphan_gc_scheduler`` returns an
-asyncio.Task we can cancel cleanly.
+Confirmation E + REQ-PF-009: ``ensure_root`` が POSIX 上で
+``0o700`` でディレクトリを作成。``start_orphan_gc_scheduler`` は
+きれいにキャンセルできる asyncio.Task を返す。
 """
 
 from __future__ import annotations
@@ -18,23 +18,23 @@ from bakufu.infrastructure.storage import attachment_root
 
 
 class TestEnsureRootCreatesDirectory:
-    """TC-IT-PF-011: directory created at 0o700 on POSIX."""
+    """TC-IT-PF-011: POSIX 上で 0o700 でディレクトリを作成。"""
 
     def test_creates_attachments_subdir(self, tmp_path: Path) -> None:
-        """TC-IT-PF-011: <DATA_DIR>/attachments exists after call."""
+        """TC-IT-PF-011: 呼び出し後に <DATA_DIR>/attachments が存在。"""
         result = attachment_root.ensure_root(tmp_path)
         assert result == tmp_path / "attachments"
         assert result.is_dir()
 
-    @pytest.mark.skipif(platform.system() == "Windows", reason="POSIX-only mode bits")
+    @pytest.mark.skipif(platform.system() == "Windows", reason="POSIX 限定モードビット")
     def test_directory_mode_is_0o700(self, tmp_path: Path) -> None:
-        """TC-IT-PF-011: chmod 0o700 enforced (POSIX only)."""
+        """TC-IT-PF-011: chmod 0o700 を強制 (POSIX のみ)。"""
         result = attachment_root.ensure_root(tmp_path)
         mode = result.stat().st_mode & 0o777
         assert mode == 0o700
 
     def test_idempotent_when_directory_exists(self, tmp_path: Path) -> None:
-        """TC-IT-PF-011: re-running on an existing dir is a no-op."""
+        """TC-IT-PF-011: 既存ディレクトリで再実行は no-op。"""
         first = attachment_root.ensure_root(tmp_path)
         second = attachment_root.ensure_root(tmp_path)
         assert first == second
@@ -42,12 +42,12 @@ class TestEnsureRootCreatesDirectory:
 
 
 class TestEnsureRootRejectsUnwritableParent:
-    """TC-IT-PF-029: parent dir read-only → BakufuConfigError(MSG-PF-003)."""
+    """TC-IT-PF-029: 親ディレクトリ読み取り専用 → BakufuConfigError(MSG-PF-003)。"""
 
-    @pytest.mark.skipif(platform.system() == "Windows", reason="POSIX-only mode bits")
+    @pytest.mark.skipif(platform.system() == "Windows", reason="POSIX 限定モードビット")
     def test_unwritable_parent_raises(self, tmp_path: Path) -> None:
-        """TC-IT-PF-029: parent at 0o500 → mkdir fails → MSG-PF-003."""
-        # Make tmp_path read-only (read + execute, no write).
+        """TC-IT-PF-029: 親が 0o500 → mkdir 失敗 → MSG-PF-003。"""
+        # tmp_path を読み取り専用に (読み取り + 実行、書き込みなし)。
         tmp_path.chmod(0o500)
         try:
             with pytest.raises(BakufuConfigError) as excinfo:
@@ -55,39 +55,39 @@ class TestEnsureRootRejectsUnwritableParent:
             assert excinfo.value.msg_id == "MSG-PF-003"
             assert "Attachment FS root initialization failed" in excinfo.value.message
         finally:
-            # Restore so the tmp cleanup works.
+            # tmp cleanup が動作するよう復元。
             tmp_path.chmod(0o700)
 
 
 class TestWindowsBranch:
-    """TC-UT-PF-030: ``os.chmod`` skipped on Windows."""
+    """TC-UT-PF-030: Windows で ``os.chmod`` をスキップ。"""
 
     def test_windows_skips_chmod(
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """TC-UT-PF-030: platform=Windows → ensure_root succeeds without chmod."""
+        """TC-UT-PF-030: platform=Windows → ensure_root が chmod なしで成功。"""
         monkeypatch.setattr("platform.system", lambda: "Windows")
-        # On real Windows there'd be no chmod call, but on a POSIX runner
-        # the test verifies the platform branch chooses to skip — the
-        # function must still succeed and the directory must exist.
+        # 実際の Windows には chmod 呼び出しはないが、POSIX runner では
+        # テストがプラットフォームブランチがスキップを選択することを検証 —
+        # 関数はまだ成功し、ディレクトリが存在する必要がある。
         result = attachment_root.ensure_root(tmp_path)
         assert result.is_dir()
 
 
 class TestOrphanScheduler:
-    """Confirmation J supplemental: scheduler task is cancellable."""
+    """Confirmation J 補足: スケジューラタスクはキャンセル可能。"""
 
     @pytest.mark.asyncio
     async def test_scheduler_task_cancels_cleanly(self) -> None:
-        """Scheduler returns an asyncio.Task we can cancel without leaking."""
+        """スケジューラがリークなしでキャンセルできる asyncio.Task を返す。"""
         import contextlib
 
         task = attachment_root.start_orphan_gc_scheduler()
         try:
             assert isinstance(task, asyncio.Task)
-            await asyncio.sleep(0)  # let the scheduler enter its loop
+            await asyncio.sleep(0)  # スケジューラがループに入るのを待つ
         finally:
             task.cancel()
             with contextlib.suppress(asyncio.CancelledError):

--- a/backend/tests/infrastructure/test_bootstrap_cleanup.py
+++ b/backend/tests/infrastructure/test_bootstrap_cleanup.py
@@ -1,12 +1,13 @@
-"""Bootstrap cleanup LIFO contract tests
-(TC-IT-PF-012-A / 012-B / 012-C, Confirmation J).
+"""ブートストラップ cleanup LIFO 契約テスト
+(TC-IT-PF-012-A / 012-B / 012-C, Confirmation J)。
 
-Schneier 中等 4 物理保証 — when a stage fails the ``finally`` block
-must cancel asyncio tasks in **reverse start order** so the
-attachments scheduler stops *before* the dispatcher (whose
-``stop_event`` it might depend on), and ``engine.dispose()`` runs no
-matter which stage exploded. Engine ``dispose()`` flushes the
-connection pool / WAL — without it tmp_path teardown can race.
+Schneier 中等 4 物理保証 — あるステージが失敗したとき、``finally`` ブロック
+は asyncio タスクを **逆開始順** でキャンセルしなければならない。
+これにより attachments スケジューラが dispatcher より先に停止し
+(dispatcher は ``stop_event`` に依存しているかもしれない)、
+``engine.dispose()`` はどのステージが失敗しても実行される。
+エンジンの ``dispose()`` は接続プール/WAL をフラッシュする —
+これがないと tmp_path teardown がレース条件に陥る。
 """
 
 from __future__ import annotations
@@ -32,13 +33,13 @@ def _bakufu_data_dir(  # pyright: ignore[reportUnusedFunction]
 
 
 class TestStage8FailureCancelsTasks:
-    """TC-IT-PF-012-A / 012-B: a stage 8 failure cancels stage 6 + 7 tasks."""
+    """TC-IT-PF-012-A / 012-B: ステージ 8 失敗時にステージ 6 + 7 タスクがキャンセルされる。"""
 
     async def test_listener_failure_cancels_dispatcher_and_scheduler(
         self,
         _bakufu_data_dir: Path,
     ) -> None:
-        """TC-IT-PF-012-B: dispatcher_task + attachments_task end up cancelled."""
+        """TC-IT-PF-012-B: dispatcher_task + attachments_task がキャンセルされる。"""
 
         async def _failing_listener() -> None:
             msg = "intentional listener bind failure"
@@ -51,9 +52,9 @@ class TestStage8FailureCancelsTasks:
         with pytest.raises(BakufuConfigError):
             await boot.run()
 
-        # Both background tasks should be in a terminal state — either
-        # cancelled or done. ``finally`` ran LIFO cleanup and called
-        # cancel + gather on each.
+        # 両方のバックグラウンドタスクは終了状態にあるべき — キャンセルされているか、
+        # 完了しているか。``finally`` が LIFO cleanup を実行して、
+        # 各タスクに対して cancel + gather を呼び出した。
         for attr in ("_dispatcher_task", "_attachments_task"):
             task = getattr(boot, attr)
             assert task is not None
@@ -61,22 +62,22 @@ class TestStage8FailureCancelsTasks:
 
 
 class TestEngineDisposeRunsOnFailure:
-    """TC-IT-PF-012-C: engine.dispose() runs even when a later stage explodes."""
+    """TC-IT-PF-012-C: 後のステージが失敗しても engine.dispose() が実行される。"""
 
     async def test_engine_disposed_after_stage_failure(
         self,
         _bakufu_data_dir: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """TC-IT-PF-012-C: engine.dispose() is invoked by cleanup."""
+        """TC-IT-PF-012-C: engine.dispose() は cleanup により呼び出される。"""
 
         async def _failing_listener() -> None:
             msg = "intentional listener bind failure"
             raise RuntimeError(msg)
 
-        # Spy on AsyncEngine.dispose so we can assert the cleanup path
-        # invoked it without depending on the (recreatable) post-dispose
-        # connection-pool behavior of SQLAlchemy 2.x.
+        # AsyncEngine.dispose をスパイして、cleanup パスがこれを呼び出したことを
+        # アサートできるようにする。SQLAlchemy 2.x の (再現可能な)
+        # post-dispose 接続プール動作に依存しない。
         from sqlalchemy.ext.asyncio import AsyncEngine as _AsyncEngine
 
         dispose_calls: list[None] = []
@@ -95,34 +96,34 @@ class TestEngineDisposeRunsOnFailure:
         with pytest.raises(BakufuConfigError):
             await boot.run()
 
-        # Cleanup must have called dispose() at least once on the
-        # application engine. Migration engine also disposes, so >=1.
+        # Cleanup は アプリケーションエンジンに対して dispose() を
+        # 少なくとも 1 回呼び出していなければならない。
+        # Migration エンジンも dispose するので >=1。
         assert len(dispose_calls) >= 1
 
 
 class TestCleanupRunsOnHappyPath:
-    """Confirmation J supplemental: cleanup also fires when run() completes normally.
+    """Confirmation J 補足: cleanup は run() が正常に完了したときも発火する。
 
-    Even on success the dispatcher / scheduler should be cancellable so
-    the test process can shut down cleanly.
+    成功時でも dispatcher / scheduler はキャンセル可能であるべき
+    なので、テストプロセスはきれいにシャットダウンできる。
     """
 
     async def test_cleanup_finalizes_tasks_after_normal_run(
         self,
         _bakufu_data_dir: Path,
     ) -> None:
-        """Cleanup leaves no dangling asyncio tasks after Bootstrap.run()."""
+        """Cleanup は Bootstrap.run() 後にぶら下がる asyncio タスクを残さない。"""
         boot = Bootstrap(migration_runner=run_upgrade_head)
         await boot.run()
-        # Without an explicit listener, run() completes successfully but
-        # cleanup still runs. After return the tasks should be done.
+        # 明示的なリスナーがないと、run() は正常に完了するが
+        # cleanup はまだ実行される。戻った後、タスクは完了しているべき。
         for attr in ("_dispatcher_task", "_attachments_task"):
             task = getattr(boot, attr)
             assert task is not None
             assert task.done()
 
-        # No dangling running tasks in the loop (besides the one running
-        # the test itself).
+        # ループ内にぶら下がるタスク（テスト自体を実行しているもの以外）がない。
         loop = asyncio.get_running_loop()
         running = [
             t for t in asyncio.all_tasks(loop) if not t.done() and t is not asyncio.current_task()

--- a/backend/tests/infrastructure/test_bootstrap_sequence.py
+++ b/backend/tests/infrastructure/test_bootstrap_sequence.py
@@ -1,10 +1,10 @@
-"""Bootstrap end-to-end sequence integration tests
-(TC-IT-PF-012 / 031 / 032 / 036 / 037).
+"""Bootstrap end-to-end sequence 統合テスト
+(TC-IT-PF-012 / 031 / 032 / 036 / 037)。
 
-Confirmation G + Schneier 中等 4 物理保証 — full eight-stage cold start
-runs against real SQLite + real Alembic + real masking gateway. The
-listener (stage 8) is left as ``None`` so we don't drag in the FastAPI
-HTTP surface that lives in a future PR.
+Confirmation G + Schneier 中等 4 物理保証 — 8 ステージ冷起動が
+実際の SQLite + 実際の Alembic + 実際のマスキングゲートウェイに対して
+実行される。リスナー (ステージ 8) は ``None`` のままにする（別 PR で予定されている
+FastAPI HTTP surface を引き込まないため）。
 """
 
 from __future__ import annotations
@@ -26,36 +26,36 @@ def _bakufu_data_dir(  # pyright: ignore[reportUnusedFunction]
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> Path:
-    """Point BAKUFU_DATA_DIR at a fresh tmp_path subdirectory."""
+    """BAKUFU_DATA_DIR を新規の tmp_path サブディレクトリに指す。"""
     monkeypatch.setenv("BAKUFU_DATA_DIR", str(tmp_path))
     return tmp_path
 
 
 class TestBootstrapHappyPath:
-    """TC-IT-PF-012 / 036: Bootstrap.run() walks 0→8 with real Alembic."""
+    """TC-IT-PF-012 / 036: Bootstrap.run() が 0→8 を実際の Alembic で実行。"""
 
     async def test_full_run_creates_db_with_schema(
         self,
         _bakufu_data_dir: Path,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """TC-IT-PF-012 / 036: end-to-end Bootstrap.run() succeeds."""
+        """TC-IT-PF-012 / 036: end-to-end Bootstrap.run() が成功。"""
         boot = Bootstrap(migration_runner=run_upgrade_head)
         with caplog.at_level(logging.INFO):
             await boot.run()
         try:
-            # Stage logs trace the documented 0→8 ordering.
+            # ステージログが文書化された 0→8 順序をトレースする。
             info_messages = [r.getMessage() for r in caplog.records if r.levelname == "INFO"]
             for stage in range(1, 8):
                 assert any(f"Bootstrap stage {stage}/8" in m for m in info_messages), (
-                    f"missing stage {stage} INFO log"
+                    f"ステージ {stage} の INFO ログが不足"
                 )
 
-            # The DB file + schema exist after Bootstrap returns.
+            # Bootstrap が戻った後、DB ファイル + スキーマが存在する。
             db_path = _bakufu_data_dir / "bakufu.db"
             assert db_path.exists()
 
-            # And the attachments directory was prepared in stage 5.
+            # ステージ 5 で attachments ディレクトリが準備された。
             attachments_dir = _bakufu_data_dir / "attachments"
             assert attachments_dir.is_dir()
         finally:
@@ -64,13 +64,13 @@ class TestBootstrapHappyPath:
 
 
 class TestStageFailFast:
-    """TC-IT-PF-031: a stage 1 failure stops the cascade."""
+    """TC-IT-PF-031: ステージ 1 の失敗がカスケードを停止。"""
 
     async def test_relative_data_dir_fails_at_stage_1(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """TC-IT-PF-031: BAKUFU_DATA_DIR=./relative aborts at stage 1."""
+        """TC-IT-PF-031: BAKUFU_DATA_DIR=./relative がステージ 1 で中止。"""
         monkeypatch.setenv("BAKUFU_DATA_DIR", "./relative-path")
         boot = Bootstrap(migration_runner=run_upgrade_head)
         with pytest.raises(BakufuConfigError) as excinfo:
@@ -81,10 +81,10 @@ class TestStageFailFast:
         self,
         _bakufu_data_dir: Path,
     ) -> None:
-        """TC-IT-PF-031: stage 3 raises ``BakufuMigrationError`` when Alembic fails."""
+        """TC-IT-PF-031: ステージ 3 が Alembic 失敗時に ``BakufuMigrationError`` を raise。"""
 
         async def _exploding_migration(_engine: object) -> str:
-            msg = "intentional migration explosion"
+            msg = "意図的なマイグレーション爆発"
             raise RuntimeError(msg)
 
         boot = Bootstrap(migration_runner=_exploding_migration)
@@ -95,7 +95,7 @@ class TestStageFailFast:
 
 
 class TestStage4NonFatal:
-    """TC-IT-PF-032: stage 4 (pid_gc) failure does not abort startup."""
+    """TC-IT-PF-032: ステージ 4 (pid_gc) 失敗が起動を中止しない。"""
 
     async def test_pid_gc_failure_is_logged_and_bootstrap_continues(
         self,
@@ -103,10 +103,10 @@ class TestStage4NonFatal:
         monkeypatch: pytest.MonkeyPatch,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """TC-IT-PF-032: pid_gc raise → WARN, but stages 5-8 still run."""
+        """TC-IT-PF-032: pid_gc raise → WARN だが、ステージ 5-8 はまだ実行。"""
 
         async def _explode(_factory: object) -> dict[str, int]:
-            msg = "pid_gc collapsed"
+            msg = "pid_gc 崩壊"
             raise RuntimeError(msg)
 
         from bakufu.infrastructure.persistence.sqlite import pid_gc
@@ -127,14 +127,14 @@ class TestStage4NonFatal:
 
 
 class TestEmptyHandlerRegistryWarn:
-    """TC-IT-PF-008-A: stage 6 logs WARN when handler_registry is empty."""
+    """TC-IT-PF-008-A: ステージ 6 は handler_registry が空のとき WARN をログ。"""
 
     async def test_empty_registry_warn_at_startup(
         self,
         _bakufu_data_dir: Path,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """TC-IT-PF-008-A: 'No event handlers registered' WARN appears."""
+        """TC-IT-PF-008-A: 'No event handlers registered' WARN が出現。"""
         boot = Bootstrap(migration_runner=run_upgrade_head)
         with caplog.at_level(logging.WARNING):
             await boot.run()
@@ -147,18 +147,18 @@ class TestEmptyHandlerRegistryWarn:
 
 
 class TestUmaskAtStage0:
-    """TC-IT-PF-001-A / TC-UT-PF-001-A: stage 0 sets umask 0o077 (POSIX)."""
+    """TC-IT-PF-001-A / TC-UT-PF-001-A: ステージ 0 が umask 0o077 を設定 (POSIX)。"""
 
     async def test_umask_applied_at_stage_0(
         self,
         _bakufu_data_dir: Path,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """TC-UT-PF-001-A: stage 0 INFO log mentions ``umask set to 0o077``."""
+        """TC-UT-PF-001-A: ステージ 0 INFO ログが ``umask set to 0o077`` に言及。"""
         import platform
 
         if platform.system() == "Windows":
-            pytest.skip("os.umask is a no-op on Windows")
+            pytest.skip("os.umask は Windows では no-op")
         boot = Bootstrap(migration_runner=run_upgrade_head)
         with caplog.at_level(logging.INFO):
             await boot.run()
@@ -173,18 +173,18 @@ class TestUmaskAtStage0:
         self,
         _bakufu_data_dir: Path,
     ) -> None:
-        """TC-IT-PF-001-A: DB file written under umask 0o077 has 0o600 mode."""
+        """TC-IT-PF-001-A: umask 0o077 の下で書き込まれた DB ファイルは 0o600 モード。"""
         import platform
 
         if platform.system() == "Windows":
-            pytest.skip("POSIX-only file mode bits")
+            pytest.skip("POSIX 限定ファイルモードビット")
         boot = Bootstrap(migration_runner=run_upgrade_head)
         await boot.run()
         try:
             db_path = _bakufu_data_dir / "bakufu.db"
             mode = db_path.stat().st_mode & 0o777
-            # 0o600 is the strict goal; 0o644 here would mean umask was not
-            # applied. Allow exact 0o600 only.
+            # 0o600 が厳密な目標； ここで 0o644 は umask が
+            # 適用されていないことを意味する。0o600 のみを許可。
             assert mode == 0o600
         finally:
             if boot.app_engine is not None:
@@ -192,13 +192,13 @@ class TestUmaskAtStage0:
 
 
 class TestFullDbContractAfterBootstrap:
-    """TC-IT-PF-036: the post-Bootstrap DB matches the documented contract."""
+    """TC-IT-PF-036: Bootstrap 後の DB が文書化されたコントラクトと一致。"""
 
     async def test_three_tables_and_two_triggers_present(
         self,
         _bakufu_data_dir: Path,
     ) -> None:
-        """TC-IT-PF-036: tables + triggers + index visible via raw SQL."""
+        """TC-IT-PF-036: テーブル + トリガー + インデックスが生 SQL で可視。"""
         boot = Bootstrap(migration_runner=run_upgrade_head)
         await boot.run()
 

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -1,20 +1,22 @@
-"""Shared fixtures for http-api-foundation integration tests.
+"""http-api-foundation 結合テスト共通フィクスチャ。
 
-Per ``docs/features/http-api-foundation/http-api/test-design.md`` §外部 I/O 依存マップ.
+``docs/features/http-api-foundation/http-api/test-design.md`` §外部 I/O 依存マップ
+に従う。
 
-Uses real SQLite under pytest ``tmp_path`` — no mocked DB.
-FastAPI lifespan is bypassed for most tests: ``app.state.session_factory`` is
-injected directly so the production lifespan (file-system DB path resolution)
-is not required.  TC-IT-HAF-007 tests the actual lifespan separately.
+pytest の ``tmp_path`` 配下に実 SQLite を用いる ── DB のモックは行わない。
+ほとんどのテストでは FastAPI の lifespan を意図的にバイパスする:
+``app.state.session_factory`` を直接注入することで本番 lifespan
+(ファイルシステム上の DB パス解決) を不要にする。TC-IT-HAF-007 では
+実 lifespan を別途検証する。
 
-Design note — route handlers at module level
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``from __future__ import annotations`` (PEP 563) turns ALL annotations into
-strings.  FastAPI resolves those strings via ``typing.get_type_hints(fn, ...)``,
-which looks up names in ``fn.__globals__`` (the module-level namespace).
-Therefore any route handler that uses ``SessionDep`` or local Pydantic models
-**must** be defined at module level in THIS file so that both symbols are
-present in ``conftest.__dict__`` when FastAPI does its introspection.
+設計メモ ── ルートハンドラはモジュール直下に置く必要がある
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``from __future__ import annotations`` (PEP 563) により**全ての型注釈**が
+文字列化される。FastAPI はこれを ``typing.get_type_hints(fn, ...)`` 経由で
+解決し、名前は ``fn.__globals__`` (モジュールレベル名前空間) を引く。
+そのため ``SessionDep`` やローカル Pydantic モデルを利用するルートハンドラ
+は、**必ず**本ファイルのモジュール直下で定義する必要がある ── そうしない
+と FastAPI が型解決を行う際に ``conftest.__dict__`` に必要な記号が揃わない。
 """
 
 from __future__ import annotations
@@ -24,7 +26,7 @@ from pathlib import Path
 
 import pytest_asyncio
 
-# ── Module-level symbols needed for FastAPI annotation resolution ──────────────
+# ── FastAPI の型注釈解決に必要なモジュールレベル記号 ──────────────────────────
 from bakufu.interfaces.http.dependencies import SessionDep
 from fastapi import APIRouter
 from httpx import ASGITransport, AsyncClient
@@ -32,33 +34,33 @@ from pydantic import BaseModel
 
 
 class _Item(BaseModel):
-    """Request body model for the test validation endpoint."""
+    """テスト用バリデーションエンドポイントのリクエストボディモデル。"""
 
     name: str
 
 
-# ── Module-level route handler functions ──────────────────────────────────────
-# All handlers MUST live at module level so that FastAPI's ``get_type_hints``
-# call can resolve annotations from ``conftest.__dict__``.
+# ── モジュールレベルのルートハンドラ関数群 ────────────────────────────────────
+# 全ハンドラは FastAPI の ``get_type_hints`` 呼び出しが ``conftest.__dict__``
+# から型注釈を解決できるよう、モジュール直下で定義しなければならない。
 
 
 async def _validation_endpoint(item: _Item) -> dict[str, str]:
-    """POST /test/validation-required — requires JSON body; absence → 422."""
+    """POST /test/validation-required ── JSON ボディが必須。欠落時は 422。"""
     return {"name": item.name}
 
 
 async def _exception_endpoint() -> None:
-    """GET /test/raise-exception — raises RuntimeError to test 500 handler."""
+    """GET /test/raise-exception ── 500 ハンドラ検証用に RuntimeError を送出する。"""
     raise RuntimeError("test internal error")
 
 
 async def _session_di_endpoint(session: SessionDep) -> dict[str, str]:
-    """GET /test/session-type — uses SessionDep to verify DI yields AsyncSession."""
+    """GET /test/session-type ── SessionDep が AsyncSession を yield することを確認する。"""
     return {"session_type": type(session).__name__}
 
 
 def _build_test_router() -> APIRouter:
-    """Construct the test-only router with module-level handlers pre-wired."""
+    """モジュール直下のハンドラを事前配線したテスト専用ルータを構築する。"""
     router = APIRouter()
     router.add_api_route(
         "/test/validation-required",
@@ -80,11 +82,11 @@ def _build_test_router() -> APIRouter:
 
 @pytest_asyncio.fixture
 async def empire_app_client(tmp_path: Path) -> AsyncIterator[AsyncClient]:
-    """httpx.AsyncClient wired to the FastAPI app with empire routes + real SQLite tempdb.
+    """empire ルート + 実 SQLite tempdb を配線した FastAPI app に繋ぐ httpx.AsyncClient。
 
-    Unlike ``app_client``, no test-only routes are added (empire router is
-    already registered via ``create_app()``).  ORM tables are created via
-    ``create_all_tables`` so CRUD operations hit a real SQLite DB.
+    ``app_client`` と異なりテスト専用ルートは追加しない (empire ルータは
+    ``create_app()`` 経由で既に登録されている)。ORM テーブルは
+    ``create_all_tables`` で作成され、CRUD 操作は実 SQLite DB に到達する。
     """
     from bakufu.interfaces.http.app import create_app
 
@@ -106,13 +108,13 @@ async def empire_app_client(tmp_path: Path) -> AsyncIterator[AsyncClient]:
 
 @pytest_asyncio.fixture
 async def app_client(tmp_path: Path) -> AsyncIterator[AsyncClient]:
-    """httpx.AsyncClient wired to the FastAPI app with test routes and real SQLite tempdb.
+    """テスト用ルート + 実 SQLite tempdb を配線した FastAPI app に繋ぐ httpx.AsyncClient。
 
-    Lifespan is intentionally bypassed: ``app.state.session_factory`` is set
-    directly from a temp-db engine.  ``raise_app_exceptions=False`` is required
-    so TC-IT-HAF-004 can assert the 500 JSON body — Starlette 1.0 ``ServerErrorMiddleware``
-    always re-raises the exception after sending the response, which httpx would
-    otherwise surface as a test-level ``RuntimeError``.
+    lifespan は意図的にバイパスし、``app.state.session_factory`` を temp-db
+    エンジンから直接設定する。``raise_app_exceptions=False`` を指定しなけ
+    れば TC-IT-HAF-004 が 500 JSON ボディをアサートできない ── Starlette 1.0
+    の ``ServerErrorMiddleware`` はレスポンス送信後に必ず例外を再送出する
+    ため、httpx 側ではテストレベルの ``RuntimeError`` として浮上してしまう。
     """
     from bakufu.interfaces.http.app import create_app
 
@@ -120,7 +122,7 @@ async def app_client(tmp_path: Path) -> AsyncIterator[AsyncClient]:
 
     app = create_app()
 
-    # ── Bypass production lifespan ──────────────────────────────────────────
+    # ── 本番 lifespan をバイパス ────────────────────────────────────────────
     engine = make_test_engine(tmp_path / "test.db")
     session_factory = make_test_session_factory(engine)
     app.state.engine = engine

--- a/backend/tests/integration/test_empire_http_api.py
+++ b/backend/tests/integration/test_empire_http_api.py
@@ -30,14 +30,14 @@ from httpx import AsyncClient
 pytestmark = pytest.mark.asyncio
 
 # ---------------------------------------------------------------------------
-# Helpers
+# ヘルパ
 # ---------------------------------------------------------------------------
 
 _EMPIRE_NAME = "山田の幕府"
 
 
 async def _create_empire(client: AsyncClient, name: str = _EMPIRE_NAME) -> dict[str, object]:
-    """POST /api/empires and return parsed JSON body (assert 201 internally)."""
+    """POST /api/empires してパース済み JSON ボディを返す（内部で 201 を assert）。"""
     resp = await client.post("/api/empires", json={"name": name})
     assert resp.status_code == 201, f"Empire creation failed: {resp.text}"
     return resp.json()  # type: ignore[return-value]
@@ -47,7 +47,7 @@ async def _create_empire(client: AsyncClient, name: str = _EMPIRE_NAME) -> dict[
 # TC-IT-EM-HTTP-001: POST /api/empires → 201 EmpireResponse
 # ---------------------------------------------------------------------------
 class TestCreateEmpire:
-    """TC-IT-EM-HTTP-001: POST /api/empires creates new Empire (REQ-EM-HTTP-001)."""
+    """TC-IT-EM-HTTP-001: POST /api/empires が新しい Empire を作成する (REQ-EM-HTTP-001)。"""
 
     async def test_create_returns_201(self, empire_app_client: AsyncClient) -> None:
         resp = await empire_app_client.post("/api/empires", json={"name": _EMPIRE_NAME})
@@ -82,7 +82,7 @@ class TestCreateEmpire:
 # TC-IT-EM-HTTP-002: POST 重複 → 409 conflict (MSG-EM-HTTP-001, R1-5)
 # ---------------------------------------------------------------------------
 class TestCreateEmpireConflict:
-    """TC-IT-EM-HTTP-002: second POST → 409 conflict (EmpireAlreadyExistsError, R1-5)."""
+    """TC-IT-EM-HTTP-002: 2 回目の POST → 409 conflict (EmpireAlreadyExistsError, R1-5)。"""
 
     async def test_duplicate_returns_409(self, empire_app_client: AsyncClient) -> None:
         await _create_empire(empire_app_client)
@@ -128,7 +128,7 @@ class TestCreateEmpireConflict:
 # TC-IT-EM-HTTP-003: GET /api/empires → 200 EmpireListResponse
 # ---------------------------------------------------------------------------
 class TestListEmpires:
-    """TC-IT-EM-HTTP-003: GET /api/empires (REQ-EM-HTTP-002)."""
+    """TC-IT-EM-HTTP-003: GET /api/empires (REQ-EM-HTTP-002)。"""
 
     async def test_list_empty_returns_200(self, empire_app_client: AsyncClient) -> None:
         resp = await empire_app_client.get("/api/empires")
@@ -160,7 +160,7 @@ class TestListEmpires:
 # TC-IT-EM-HTTP-004: GET /api/empires/{id} → 200 EmpireResponse
 # ---------------------------------------------------------------------------
 class TestGetEmpire:
-    """TC-IT-EM-HTTP-004: GET /api/empires/{id} (REQ-EM-HTTP-003)."""
+    """TC-IT-EM-HTTP-004: GET /api/empires/{id} (REQ-EM-HTTP-003)。"""
 
     async def test_get_returns_200(self, empire_app_client: AsyncClient) -> None:
         body = await _create_empire(empire_app_client)
@@ -187,7 +187,7 @@ class TestGetEmpire:
 # TC-IT-EM-HTTP-005: GET 不在 → 404 not_found (MSG-EM-HTTP-002)
 # ---------------------------------------------------------------------------
 class TestGetEmpireNotFound:
-    """TC-IT-EM-HTTP-005: GET /api/empires/{unknown-id} → 404 (EmpireNotFoundError)."""
+    """TC-IT-EM-HTTP-005: GET /api/empires/{unknown-id} → 404 (EmpireNotFoundError)。"""
 
     async def test_not_found_returns_404(self, empire_app_client: AsyncClient) -> None:
         resp = await empire_app_client.get(f"/api/empires/{uuid.uuid4()}")
@@ -207,7 +207,7 @@ class TestGetEmpireNotFound:
 # TC-IT-EM-HTTP-006: PATCH /api/empires/{id} → 200 更新済み (REQ-EM-HTTP-004)
 # ---------------------------------------------------------------------------
 class TestUpdateEmpire:
-    """TC-IT-EM-HTTP-006: PATCH /api/empires/{id} updates empire name (REQ-EM-HTTP-004)."""
+    """TC-IT-EM-HTTP-006: PATCH /api/empires/{id} が empire 名を更新する (REQ-EM-HTTP-004)。"""
 
     async def test_patch_returns_200(self, empire_app_client: AsyncClient) -> None:
         body = await _create_empire(empire_app_client)
@@ -244,7 +244,8 @@ class TestUpdateEmpire:
 # TC-IT-EM-HTTP-007: PATCH アーカイブ済み → 409 conflict (MSG-EM-HTTP-003, R1-8)
 # ---------------------------------------------------------------------------
 class TestUpdateArchivedEmpire:
-    """TC-IT-EM-HTTP-007: PATCH on archived Empire → 409 conflict (EmpireArchivedError, R1-8)."""
+    """TC-IT-EM-HTTP-007: アーカイブ済み Empire への PATCH →
+    409 conflict (EmpireArchivedError, R1-8)。"""
 
     async def test_patch_archived_returns_409(self, empire_app_client: AsyncClient) -> None:
         body = await _create_empire(empire_app_client)
@@ -278,7 +279,7 @@ class TestUpdateArchivedEmpire:
 # TC-IT-EM-HTTP-008: DELETE /api/empires/{id} → 204 + archived=true
 # ---------------------------------------------------------------------------
 class TestDeleteEmpire:
-    """TC-IT-EM-HTTP-008: DELETE /api/empires/{id} → 204 + GET shows archived=true (REQ-EM-HTTP-005)."""  # noqa: E501
+    """TC-IT-EM-HTTP-008: DELETE /api/empires/{id} → 204 + GET で archived=true (REQ-EM-HTTP-005)。"""  # noqa: E501
 
     async def test_delete_returns_204(self, empire_app_client: AsyncClient) -> None:
         body = await _create_empire(empire_app_client)
@@ -311,7 +312,7 @@ class TestDeleteEmpire:
 # TC-IT-EM-HTTP-009: DELETE 不在 → 404 not_found (MSG-EM-HTTP-002)
 # ---------------------------------------------------------------------------
 class TestDeleteEmpireNotFound:
-    """TC-IT-EM-HTTP-009: DELETE /api/empires/{unknown-id} → 404 (EmpireNotFoundError)."""
+    """TC-IT-EM-HTTP-009: DELETE /api/empires/{unknown-id} → 404 (EmpireNotFoundError)。"""
 
     async def test_delete_not_found_returns_404(self, empire_app_client: AsyncClient) -> None:
         resp = await empire_app_client.delete(f"/api/empires/{uuid.uuid4()}")

--- a/backend/tests/integration/test_http_api_foundation_http_api.py
+++ b/backend/tests/integration/test_http_api_foundation_http_api.py
@@ -1,16 +1,17 @@
-"""http-api-foundation / http-api 結合テスト (TC-IT-HAF-001, 002, 003, 004, 006, 007, 008).
+"""http-api-foundation / http-api 結合テスト (TC-IT-HAF-001, 002, 003, 004, 006, 007, 008)。
 
-Per ``docs/features/http-api-foundation/http-api/test-design.md`` §結合テストケース.
+``docs/features/http-api-foundation/http-api/test-design.md`` §結合テストケース 準拠。
 
-Covers:
+カバー範囲:
   TC-IT-HAF-001  GET /health → 200 {"status": "ok"} (REQ-HAF-002, feature-spec.md §9 #1)
   TC-IT-HAF-002  GET /nonexistent → 404 not_found (REQ-HAF-003, MSG-HAF-001, §9 #2)
-  TC-IT-HAF-003  POST no body → 422 validation_error (REQ-HAF-003, MSG-HAF-002, §9 #3)
-  TC-IT-HAF-004  GET raises RuntimeError → 500 no stack trace (REQ-HAF-003, MSG-HAF-003, §9 #4, T3)
-  TC-IT-HAF-006  get_session() yields AsyncSession (REQ-HAF-004, §9 #6)
-  TC-IT-HAF-007  lifespan: startup sets session_factory; shutdown disposes engine
+  TC-IT-HAF-003  body 無しの POST → 422 validation_error (REQ-HAF-003, MSG-HAF-002, §9 #3)
+  TC-IT-HAF-004  GET で RuntimeError → 500 スタックトレース無し
+                 (REQ-HAF-003, MSG-HAF-003, §9 #4, T3)
+  TC-IT-HAF-006  get_session() が AsyncSession を yield する (REQ-HAF-004, §9 #6)
+  TC-IT-HAF-007  lifespan: startup で session_factory を設定し、shutdown で engine を dispose
                  (REQ-HAF-001/007, §9 #7)
-  TC-IT-HAF-008  POST + evil Origin → 403 CSRF failed (MSG-HAF-004, T2, §9 #8)
+  TC-IT-HAF-008  POST + 不正 Origin → 403 CSRF failed (MSG-HAF-004, T2, §9 #8)
 
 Issue: #55
 """
@@ -31,7 +32,7 @@ pytestmark = pytest.mark.asyncio
 # TC-IT-HAF-001: GET /health → 200 {"status": "ok"}
 # ---------------------------------------------------------------------------
 class TestHealthEndpoint:
-    """TC-IT-HAF-001: GET /health responds HTTP 200 with {"status": "ok"}."""
+    """TC-IT-HAF-001: GET /health が HTTP 200 と {"status": "ok"} を返す。"""
 
     async def test_health_returns_200(self, app_client: AsyncClient) -> None:
         response = await app_client.get("/health")
@@ -46,7 +47,7 @@ class TestHealthEndpoint:
 # TC-IT-HAF-002: GET /nonexistent → 404 not_found (MSG-HAF-001)
 # ---------------------------------------------------------------------------
 class TestNotFoundHandler:
-    """TC-IT-HAF-002: undefined route → 404 ErrorResponse with code=not_found."""
+    """TC-IT-HAF-002: 未定義ルート → code=not_found の 404 ErrorResponse。"""
 
     async def test_not_found_returns_404(self, app_client: AsyncClient) -> None:
         response = await app_client.get("/nonexistent")
@@ -61,7 +62,7 @@ class TestNotFoundHandler:
         assert response.json()["error"]["message"] == "Resource not found."
 
     async def test_not_found_response_has_error_key(self, app_client: AsyncClient) -> None:
-        """Response body must follow {"error": {...}} envelope (REQ-HAF-003)."""
+        """レスポンスボディは {"error": {...}} エンベロープ形式に従わねばならない (REQ-HAF-003)。"""
         response = await app_client.get("/nonexistent")
         body = response.json()
         assert "error" in body
@@ -73,7 +74,7 @@ class TestNotFoundHandler:
 # TC-IT-HAF-003: POST no body → 422 validation_error (MSG-HAF-002)
 # ---------------------------------------------------------------------------
 class TestValidationErrorHandler:
-    """TC-IT-HAF-003: POST with missing required body → 422 with code=validation_error."""
+    """TC-IT-HAF-003: 必須 body 欠落の POST → code=validation_error の 422。"""
 
     async def test_missing_body_returns_422(self, app_client: AsyncClient) -> None:
         response = await app_client.post("/test/validation-required")
@@ -94,7 +95,7 @@ class TestValidationErrorHandler:
 # TC-IT-HAF-004: RuntimeError → 500, no stack trace (MSG-HAF-003, T3)
 # ---------------------------------------------------------------------------
 class TestInternalErrorHandler:
-    """TC-IT-HAF-004: unhandled RuntimeError → 500 without stack trace (T3)."""
+    """TC-IT-HAF-004: 未処理 RuntimeError → スタックトレース無しの 500 (T3)。"""
 
     async def test_exception_returns_500(self, app_client: AsyncClient) -> None:
         response = await app_client.get("/test/raise-exception")
@@ -109,20 +110,20 @@ class TestInternalErrorHandler:
         assert response.json()["error"]["message"] == "An internal server error occurred."
 
     async def test_no_traceback_in_body(self, app_client: AsyncClient) -> None:
-        """T3: スタックトレース非露出 — body must not contain traceback."""
+        """T3: スタックトレース非露出 ── body に traceback が含まれてはならない。"""
         response = await app_client.get("/test/raise-exception")
         body = response.text
         assert "Traceback" not in body
 
     async def test_no_runtime_error_in_body(self, app_client: AsyncClient) -> None:
-        """T3: internal exception class name must not leak into response body."""
+        """T3: 内部例外のクラス名がレスポンスボディに漏れてはならない。"""
         response = await app_client.get("/test/raise-exception")
         assert "RuntimeError" not in response.text
 
     async def test_no_test_error_message_in_body(self, app_client: AsyncClient) -> None:
-        """T3: internal error message must not leak into response body."""
+        """T3: 内部エラーメッセージがレスポンスボディに漏れてはならない。"""
         response = await app_client.get("/test/raise-exception")
-        # "test internal error" is the RuntimeError message; must not appear
+        # "test internal error" は RuntimeError のメッセージ。出現してはならない。
         assert "test internal error" not in response.text
 
 
@@ -130,10 +131,10 @@ class TestInternalErrorHandler:
 # TC-IT-HAF-006: get_session() yields AsyncSession (REQ-HAF-004)
 # ---------------------------------------------------------------------------
 class TestGetSessionDI:
-    """TC-IT-HAF-006: get_session() DI dependency yields a real AsyncSession."""
+    """TC-IT-HAF-006: get_session() DI 依存が実際の AsyncSession を yield する。"""
 
     async def test_session_type_is_async_session(self, app_client: AsyncClient) -> None:
-        """Session DI yields AsyncSession (not None / wrong type)."""
+        """Session DI が AsyncSession を yield する（None や誤った型ではない）。"""
         response = await app_client.get("/test/session-type")
         assert response.status_code == 200
         assert response.json()["session_type"] == "AsyncSession"
@@ -143,12 +144,12 @@ class TestGetSessionDI:
 # TC-IT-HAF-007: lifespan startup sets session_factory; shutdown disposes engine
 # ---------------------------------------------------------------------------
 class TestLifespan:
-    """TC-IT-HAF-007: full lifespan cycle — startup + health + shutdown."""
+    """TC-IT-HAF-007: lifespan の完全サイクル ── startup + health + shutdown。"""
 
     async def test_lifespan_startup_sets_session_factory(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """After lifespan startup event, app.state.session_factory is not None."""
+        """lifespan の startup イベント後、app.state.session_factory が None でない。"""
         monkeypatch.setenv("BAKUFU_DATA_DIR", str(tmp_path))
         from bakufu.infrastructure.config import data_dir
 
@@ -185,7 +186,7 @@ class TestLifespan:
     async def test_lifespan_startup_emits_startup_complete(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Lifespan startup sends lifespan.startup.complete ASGI event."""
+        """Lifespan startup が lifespan.startup.complete ASGI イベントを送る。"""
         monkeypatch.setenv("BAKUFU_DATA_DIR", str(tmp_path))
         from bakufu.infrastructure.config import data_dir
 
@@ -222,7 +223,7 @@ class TestLifespan:
     async def test_lifespan_health_responds_after_startup(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """After lifespan startup, GET /health returns HTTP 200 {"status": "ok"}."""
+        """lifespan startup 後、GET /health が HTTP 200 と {"status": "ok"} を返す。"""
         monkeypatch.setenv("BAKUFU_DATA_DIR", str(tmp_path))
         from bakufu.infrastructure.config import data_dir
 
@@ -262,10 +263,10 @@ class TestLifespan:
     async def test_lifespan_engine_dispose_called_on_shutdown(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """After lifespan shutdown, engine.dispose() has been called exactly once.
+        """lifespan shutdown 後、engine.dispose() がちょうど 1 回呼ばれている。
 
-        Patches AsyncEngine.dispose at the class level (instance attribute is
-        read-only in SQLAlchemy) to track calls.
+        SQLAlchemy ではインスタンス属性が read-only なため、AsyncEngine.dispose を
+        クラスレベルでパッチして呼び出しを追跡する。
         """
         monkeypatch.setenv("BAKUFU_DATA_DIR", str(tmp_path))
         from bakufu.infrastructure.config import data_dir
@@ -304,12 +305,12 @@ class TestLifespan:
 
             await queue.put({"type": "lifespan.startup"})
             await asyncio.sleep(0.2)
-            assert len(dispose_calls) == 0  # not yet disposed
+            assert len(dispose_calls) == 0  # まだ dispose されていない
 
             await queue.put({"type": "lifespan.shutdown"})
             await task
 
-        assert len(dispose_calls) == 1  # disposed exactly once on shutdown
+        assert len(dispose_calls) == 1  # shutdown でちょうど 1 回 dispose される
         data_dir.reset()
 
 
@@ -317,10 +318,11 @@ class TestLifespan:
 # TC-IT-HAF-008: POST + evil Origin → 403 CSRF check failed (MSG-HAF-004, T2)
 # ---------------------------------------------------------------------------
 class TestCsrfOriginMiddleware:
-    """TC-IT-HAF-008: CSRF Origin check — evil Origin → 403; no Origin → pass (MVP rule)."""
+    """TC-IT-HAF-008: CSRF Origin チェック ── 不正 Origin → 403、
+    Origin なし → 許可 (MVP ルール)。"""
 
     async def test_evil_origin_returns_403(self, app_client: AsyncClient) -> None:
-        """POST with Origin: http://evil.example.com → 403."""
+        """Origin: http://evil.example.com の POST → 403。"""
         response = await app_client.post(
             "/test/validation-required",
             headers={"Origin": "http://evil.example.com"},
@@ -345,7 +347,7 @@ class TestCsrfOriginMiddleware:
         assert response.json()["error"]["message"] == "CSRF check failed: Origin not allowed."
 
     async def test_no_origin_header_passes(self, app_client: AsyncClient) -> None:
-        """MVP rule: POST without Origin header passes (AI agent / SDK support)."""
+        """MVP ルール: Origin ヘッダなしの POST は通過する（AI agent / SDK サポート）。"""
         response = await app_client.post(
             "/test/validation-required",
             json={"name": "test"},
@@ -353,7 +355,7 @@ class TestCsrfOriginMiddleware:
         assert response.status_code == 200
 
     async def test_allowed_origin_passes(self, app_client: AsyncClient) -> None:
-        """POST with allowed Origin (default: http://localhost:5173) passes."""
+        """許可された Origin（デフォルト: http://localhost:5173）の POST は通過する。"""
         response = await app_client.post(
             "/test/validation-required",
             headers={"Origin": "http://localhost:5173"},
@@ -362,7 +364,7 @@ class TestCsrfOriginMiddleware:
         assert response.status_code == 200
 
     async def test_safe_method_get_ignores_origin(self, app_client: AsyncClient) -> None:
-        """GET is a safe method: even evil Origin is not CSRF-checked."""
+        """GET は安全メソッド: 不正 Origin でも CSRF チェック対象外。"""
         response = await app_client.get(
             "/health",
             headers={"Origin": "http://evil.example.com"},
@@ -374,34 +376,36 @@ class TestCsrfOriginMiddleware:
 # TC-IT-HAF-009: http_exception_handler status_code 分岐 (ヘルスバーグ指摘 #1)
 # ---------------------------------------------------------------------------
 class TestHttpExceptionHandlerBranching:
-    """TC-IT-HAF-009: http_exception_handler routes status codes to distinct error codes.
+    """TC-IT-HAF-009: http_exception_handler が status code を別個の error code に振り分ける。
 
-    Ensures that non-404 HTTP exceptions do not get squashed to "not_found",
-    and that 404 still returns the exact MSG-HAF-001 message.
+    404 以外の HTTP 例外が "not_found" に潰されないこと、および 404 が引き続き
+    MSG-HAF-001 と完全一致するメッセージを返すことを保証する。
     """
 
     async def test_404_returns_not_found_code(self, app_client: AsyncClient) -> None:
-        """GET /nonexistent → code "not_found" (re-verified after branching refactor)."""
+        """GET /nonexistent → code "not_found"（分岐リファクタ後に再検証）。"""
         response = await app_client.get("/nonexistent")
         assert response.json()["error"]["code"] == "not_found"
 
     async def test_404_returns_msg_haf_001_message(self, app_client: AsyncClient) -> None:
-        """GET /nonexistent → message equals MSG-HAF-001 "Resource not found.", not "Not Found"."""
+        """GET /nonexistent → message が MSG-HAF-001
+        "Resource not found." と一致（"Not Found" ではなく）。"""
         response = await app_client.get("/nonexistent")
         assert response.json()["error"]["message"] == "Resource not found."
 
     async def test_405_returns_method_not_allowed_code(self, app_client: AsyncClient) -> None:
-        """POST /health (GET-only route, no Origin) → 405 with code "method_not_allowed"."""
+        """POST /health（GET 専用ルート、Origin なし）→ code "method_not_allowed" の 405。"""
         response = await app_client.post("/health")
         assert response.status_code == 405
 
     async def test_405_error_code_is_method_not_allowed(self, app_client: AsyncClient) -> None:
-        """POST /health → error code "method_not_allowed" (not "not_found")."""
+        """POST /health → error code "method_not_allowed"（"not_found" ではない）。"""
         response = await app_client.post("/health")
         assert response.json()["error"]["code"] == "method_not_allowed"
 
     async def test_405_has_error_envelope(self, app_client: AsyncClient) -> None:
-        """POST /health → response uses {"error": {"code": ..., "message": ...}} envelope."""
+        """POST /health → レスポンスが
+        {"error": {"code": ..., "message": ...}} エンベロープを用いる。"""
         response = await app_client.post("/health")
         body = response.json()
         assert "error" in body

--- a/backend/tests/test_smoke.py
+++ b/backend/tests/test_smoke.py
@@ -1,4 +1,4 @@
-"""Smoke test to keep CI green until M1 domain skeleton lands."""
+"""M1 ドメインスケルトン投入までの間 CI を緑に保つためのスモークテスト。"""
 
 from bakufu import __version__
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ select = [
     "RUF", # ruff-specific
 ]
 ignore = [
+    "RUF001",  # Japanese full-width parentheses in string literals are intentional
     "RUF002",  # Japanese full-width parentheses in docstrings are intentional
     "RUF003",  # Japanese full-width parentheses in comments are intentional
 ]


### PR DESCRIPTION
## 概要

- Issue #102 対応。backend 全体（src + tests）に残存していた英文コメント・docstring を日本語化。
- 設計ドキュメントが日本語で統一されているため、コードコメント類も統一。
- 全テスト 1319 件合格、lint・型・audit すべてグリーン。

## 変更内容

| 区分 | ファイル数（概算） | 主な変更 |
|------|------------------|----------|
| `backend/src` | 122 | 行コメント・docstring を日本語化（識別子/契約文字列は維持） |
| `backend/tests` | 170 | 同上 |
| `backend/alembic` | 7 | revision の docstring・コメント日本語化 |
| `pyproject.toml` | 1 | `RUF001`（文字列リテラル中の全角カッコ）を ignore に追加（既存の `RUF002`/`003` と同方針） |

## 翻訳ルール

**翻訳対象**:
- 行コメント（`# ...`）の説明文
- docstring（`"""..."""`）全て

**英語のまま維持**:
- ツール向けディレクティブ（`# noqa:`, `# type:`, `# fmt:` 等）
- API 契約文字列（例外メッセージ・ログメッセージ・SQLAlchemy `comment=` 等、テストが文字列等価で検査）
- 識別子・テストID（`MSG-XX-NNN`, `TC-XX`, `UC-XX`, クラス名・関数名・テーブル名）
- 正規表現ドキュメントコメント（`# Discord Bot Token ── [...]` 等）
- セクション見出しの識別子（`# Persona`, `# CompletionPolicy` 等のクラス名ラベル）

## テスト計画

- [x] `just lint`: All checks passed!
- [x] `just fmt-check`: 302 files already formatted
- [x] `just typecheck` (pyright): 0 errors, 0 warnings, 0 informations
- [x] `just test-backend`: 1319 passed, 2 warnings（既存の async marker warning）
- [x] `just audit`: No known vulnerabilities
- [x] `just audit-secrets`: no leaks found
- [x] `just audit-pin-sync`: OK
- [x] `just audit-masking-columns`: OK

## 注意

- 並列エージェントによる翻訳作業の都合で、コミット数は多め。
- `RUF001` を ignore に追加した点については、既存の `RUF002`/`003` と同方針で「Japanese full-width parentheses are intentional」というコメントを付与。

Closes #102