### PR TITLE
feat(workflow): Stage.deliverable_template を required_deliverables に置換 (Issue #117)

### DIFF
--- a/backend/alembic/versions/0011_stage_required_deliverables.py
+++ b/backend/alembic/versions/0011_stage_required_deliverables.py
@@ -1,0 +1,62 @@
+"""workflow_stages: deliverable_template 廃止 → required_deliverables_json 追加（Issue #117）。
+
+Issue #117 で ``Stage.deliverable_template: str`` が廃止され、
+``Stage.required_deliverables: tuple[DeliverableRequirement, ...]`` に移行する。
+
+永続化スキーマの対応変更:
+
+* ``workflow_stages.deliverable_template`` (TEXT NOT NULL DEFAULT '') を削除
+* ``workflow_stages.required_deliverables_json`` (TEXT NOT NULL DEFAULT '[]') を追加
+
+§確定 L（``docs/features/workflow/repository/detailed-design.md``）に従い、
+SQLite 3.35.0+ で利用可能な ``DROP COLUMN`` を使用する。
+``pyproject.toml`` の ``requires-python = ">=3.12"`` により Python 3.12 同梱
+SQLite は 3.42.0 以上が保証されるため、追加要件なし。
+
+MVP 時点で本番データなし → ``DEFAULT '[]'`` のみで充足（データ変換不要）。
+
+Revision ID: 0011_stage_required_deliverables
+Revises: 0010_workflow_archived
+Create Date: 2026-04-30
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0011_stage_required_deliverables"
+down_revision: str | None = "0010_workflow_archived"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # §確定 L: DROP → ADD の順序で単一トランザクション相当の変更を行う。
+    op.drop_column("workflow_stages", "deliverable_template")
+    op.add_column(
+        "workflow_stages",
+        sa.Column(
+            "required_deliverables_json",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("'[]'"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    # required_deliverables_json を削除し deliverable_template を復元する。
+    # 既存データ復元は不要（空文字 default で充足）。
+    op.drop_column("workflow_stages", "required_deliverables_json")
+    op.add_column(
+        "workflow_stages",
+        sa.Column(
+            "deliverable_template",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("''"),
+        ),
+    )

--- a/backend/src/bakufu/application/presets/workflow_presets.py
+++ b/backend/src/bakufu/application/presets/workflow_presets.py
@@ -50,7 +50,7 @@ _VMODEL_STAGES: list[dict[str, Any]] = [
         "required_role": ["LEADER"],
         "completion_policy": {"kind": "manual", "description": ""},
         "notify_channels": [],
-        "deliverable_template": "",
+        "required_deliverables": [],
     },
     {
         "id": "00000001-0000-4000-8000-000000000002",
@@ -59,7 +59,7 @@ _VMODEL_STAGES: list[dict[str, Any]] = [
         "required_role": ["REVIEWER"],
         "completion_policy": {"kind": "manual", "description": ""},
         "notify_channels": [],
-        "deliverable_template": "",
+        "required_deliverables": [],
     },
     {
         "id": "00000001-0000-4000-8000-000000000003",
@@ -68,7 +68,7 @@ _VMODEL_STAGES: list[dict[str, Any]] = [
         "required_role": ["DEVELOPER"],
         "completion_policy": {"kind": "manual", "description": ""},
         "notify_channels": [],
-        "deliverable_template": "",
+        "required_deliverables": [],
     },
     {
         "id": "00000001-0000-4000-8000-000000000004",
@@ -77,7 +77,7 @@ _VMODEL_STAGES: list[dict[str, Any]] = [
         "required_role": ["REVIEWER"],
         "completion_policy": {"kind": "manual", "description": ""},
         "notify_channels": [],
-        "deliverable_template": "",
+        "required_deliverables": [],
     },
     {
         "id": "00000001-0000-4000-8000-000000000005",
@@ -86,7 +86,7 @@ _VMODEL_STAGES: list[dict[str, Any]] = [
         "required_role": ["DEVELOPER"],
         "completion_policy": {"kind": "manual", "description": ""},
         "notify_channels": [],
-        "deliverable_template": "",
+        "required_deliverables": [],
     },
     {
         "id": "00000001-0000-4000-8000-000000000006",
@@ -95,7 +95,7 @@ _VMODEL_STAGES: list[dict[str, Any]] = [
         "required_role": ["REVIEWER"],
         "completion_policy": {"kind": "manual", "description": ""},
         "notify_channels": [],
-        "deliverable_template": "",
+        "required_deliverables": [],
     },
     {
         "id": "00000001-0000-4000-8000-000000000007",
@@ -104,7 +104,7 @@ _VMODEL_STAGES: list[dict[str, Any]] = [
         "required_role": ["DEVELOPER"],
         "completion_policy": {"kind": "manual", "description": ""},
         "notify_channels": [],
-        "deliverable_template": "",
+        "required_deliverables": [],
     },
     {
         "id": "00000001-0000-4000-8000-000000000008",
@@ -113,7 +113,7 @@ _VMODEL_STAGES: list[dict[str, Any]] = [
         "required_role": ["TESTER"],
         "completion_policy": {"kind": "manual", "description": ""},
         "notify_channels": [],
-        "deliverable_template": "",
+        "required_deliverables": [],
     },
     {
         "id": "00000001-0000-4000-8000-000000000009",
@@ -122,7 +122,7 @@ _VMODEL_STAGES: list[dict[str, Any]] = [
         "required_role": ["REVIEWER"],
         "completion_policy": {"kind": "manual", "description": ""},
         "notify_channels": [],
-        "deliverable_template": "",
+        "required_deliverables": [],
     },
     {
         "id": "00000001-0000-4000-8000-000000000010",
@@ -131,7 +131,7 @@ _VMODEL_STAGES: list[dict[str, Any]] = [
         "required_role": ["TESTER"],
         "completion_policy": {"kind": "manual", "description": ""},
         "notify_channels": [],
-        "deliverable_template": "",
+        "required_deliverables": [],
     },
     {
         "id": "00000001-0000-4000-8000-000000000011",
@@ -140,7 +140,7 @@ _VMODEL_STAGES: list[dict[str, Any]] = [
         "required_role": ["TESTER"],
         "completion_policy": {"kind": "manual", "description": ""},
         "notify_channels": [],
-        "deliverable_template": "",
+        "required_deliverables": [],
     },
     {
         "id": "00000001-0000-4000-8000-000000000012",
@@ -149,7 +149,7 @@ _VMODEL_STAGES: list[dict[str, Any]] = [
         "required_role": ["REVIEWER"],
         "completion_policy": {"kind": "manual", "description": ""},
         "notify_channels": [],
-        "deliverable_template": "",
+        "required_deliverables": [],
     },
     {
         "id": "00000001-0000-4000-8000-000000000013",
@@ -158,7 +158,7 @@ _VMODEL_STAGES: list[dict[str, Any]] = [
         "required_role": ["LEADER"],
         "completion_policy": {"kind": "manual", "description": ""},
         "notify_channels": [],
-        "deliverable_template": "",
+        "required_deliverables": [],
     },
 ]
 
@@ -289,7 +289,7 @@ _AGILE_STAGES: list[dict[str, Any]] = [
         "required_role": ["LEADER"],
         "completion_policy": {"kind": "manual", "description": ""},
         "notify_channels": [],
-        "deliverable_template": "",
+        "required_deliverables": [],
     },
     {
         "id": "00000002-0000-4000-8000-000000000002",
@@ -298,7 +298,7 @@ _AGILE_STAGES: list[dict[str, Any]] = [
         "required_role": ["DEVELOPER"],
         "completion_policy": {"kind": "manual", "description": ""},
         "notify_channels": [],
-        "deliverable_template": "",
+        "required_deliverables": [],
     },
     {
         "id": "00000002-0000-4000-8000-000000000003",
@@ -307,7 +307,7 @@ _AGILE_STAGES: list[dict[str, Any]] = [
         "required_role": ["DEVELOPER"],
         "completion_policy": {"kind": "manual", "description": ""},
         "notify_channels": [],
-        "deliverable_template": "",
+        "required_deliverables": [],
     },
     {
         "id": "00000002-0000-4000-8000-000000000004",
@@ -316,7 +316,7 @@ _AGILE_STAGES: list[dict[str, Any]] = [
         "required_role": ["REVIEWER"],
         "completion_policy": {"kind": "manual", "description": ""},
         "notify_channels": [],
-        "deliverable_template": "",
+        "required_deliverables": [],
     },
     {
         "id": "00000002-0000-4000-8000-000000000005",
@@ -325,7 +325,7 @@ _AGILE_STAGES: list[dict[str, Any]] = [
         "required_role": ["TESTER"],
         "completion_policy": {"kind": "manual", "description": ""},
         "notify_channels": [],
-        "deliverable_template": "",
+        "required_deliverables": [],
     },
     {
         "id": "00000002-0000-4000-8000-000000000006",
@@ -334,7 +334,7 @@ _AGILE_STAGES: list[dict[str, Any]] = [
         "required_role": ["LEADER"],
         "completion_policy": {"kind": "manual", "description": ""},
         "notify_channels": [],
-        "deliverable_template": "",
+        "required_deliverables": [],
     },
 ]
 

--- a/backend/src/bakufu/domain/exceptions.py
+++ b/backend/src/bakufu/domain/exceptions.py
@@ -98,10 +98,11 @@ type WorkflowViolationKind = Literal[
 
 
 type StageViolationKind = Literal[
+    "duplicate_required_deliverable",
     "empty_required_role",
     "missing_notify",
 ]
-""":class:`StageInvariantViolation` の判別子（Workflow 詳細設計）。"""
+""":class:`StageInvariantViolation` の判別子（Workflow 詳細設計 / Issue #117）。"""
 
 
 # DDD: "Violation" は不変条件違反を表現するもので、プログラミングのバグではない。

--- a/backend/src/bakufu/domain/value_objects/__init__.py
+++ b/backend/src/bakufu/domain/value_objects/__init__.py
@@ -68,6 +68,7 @@ from bakufu.domain.value_objects.references import (
 )
 from bakufu.domain.value_objects.template_vos import (
     AcceptanceCriterion,
+    DeliverableRequirement,
     DeliverableTemplateRef,
     SemVer,
 )
@@ -87,6 +88,7 @@ __all__ = [
     "CompletionPolicy",
     "CompletionPolicyKind",
     "Deliverable",
+    "DeliverableRequirement",
     "DeliverableTemplateId",
     "DeliverableTemplateRef",
     "DirectiveId",

--- a/backend/src/bakufu/domain/value_objects/template_vos.py
+++ b/backend/src/bakufu/domain/value_objects/template_vos.py
@@ -5,6 +5,7 @@
 - :class:`SemVer` — セマンティック バージョン（major.minor.patch）
 - :class:`DeliverableTemplateRef` — テンプレートへの参照（id + 最低バージョン）
 - :class:`AcceptanceCriterion` — 受け入れ基準の 1 項目
+- :class:`DeliverableRequirement` — Stage が要求する成果物テンプレート参照（ref + optional フラグ）
 """
 
 from __future__ import annotations
@@ -82,8 +83,25 @@ class AcceptanceCriterion(BaseModel):
     required: bool = True
 
 
+class DeliverableRequirement(BaseModel):
+    """Stage が要求する成果物テンプレート参照（Issue #117）。
+
+    ``template_ref`` は参照先成果物テンプレート、``optional`` は
+    ``False``（デフォルト）のとき必須成果物、``True`` のとき任意成果物を意味する。
+
+    重複チェックは呼び出し元（``Stage._check_self_invariants``）に委譲する。
+    本 VO は単純な immutable container として機能する。
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", arbitrary_types_allowed=False)
+
+    template_ref: DeliverableTemplateRef
+    optional: bool = False
+
+
 __all__ = [
     "AcceptanceCriterion",
+    "DeliverableRequirement",
     "DeliverableTemplateRef",
     "SemVer",
 ]

--- a/backend/src/bakufu/domain/workflow/entities.py
+++ b/backend/src/bakufu/domain/workflow/entities.py
@@ -29,6 +29,8 @@ from pydantic import (
 from bakufu.domain.exceptions import StageInvariantViolation
 from bakufu.domain.value_objects import (
     CompletionPolicy,
+    DeliverableRequirement,
+    DeliverableTemplateId,
     NotifyChannel,
     Role,
     StageId,
@@ -60,7 +62,7 @@ class Stage(BaseModel):
     name: str = Field(min_length=1, max_length=80)
     kind: StageKind
     required_role: frozenset[Role]
-    deliverable_template: str = Field(default="", max_length=10_000)
+    required_deliverables: tuple[DeliverableRequirement, ...] = ()
     completion_policy: CompletionPolicy
     notify_channels: list[NotifyChannel] = []
 
@@ -88,6 +90,20 @@ class Stage(BaseModel):
                 ),
                 detail={"stage_id": str(self.id)},
             )
+        # REQ-WF-007-③ required_deliverables 内の template_id 重複不可（MSG-WF-013 / Issue #117）。
+        seen_template_ids: set[DeliverableTemplateId] = set()
+        for dr in self.required_deliverables:
+            tid: DeliverableTemplateId = dr.template_ref.template_id
+            if tid in seen_template_ids:
+                raise StageInvariantViolation(
+                    kind="duplicate_required_deliverable",
+                    message=(
+                        f"[FAIL] Stage {self.id} required_deliverables "
+                        f"has duplicate template_id: {tid}"
+                    ),
+                    detail={"stage_id": str(self.id), "template_id": str(tid)},
+                )
+            seen_template_ids.add(tid)
         return self
 
 

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/repositories/workflow_repository.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/repositories/workflow_repository.py
@@ -55,6 +55,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from bakufu.domain.value_objects import (
     CompletionPolicy,
+    DeliverableRequirement,
     NotifyChannel,
     Role,
     StageKind,
@@ -193,7 +194,11 @@ class SqliteWorkflowRepository:
                 # §確定 G: ソート済み CSV。``sorted(..., key=str)`` により Python の
                 # frozenset がどんな順序で反復しようとバイト等価性のコントラクトを保つ。
                 "roles_csv": ",".join(sorted(role.value for role in stage.required_role)),
-                "deliverable_template": stage.deliverable_template,
+                # §確定 C（Issue #117）: DeliverableRequirement を model_dump(mode='json') で
+                # list[dict] に変換。JSONEncoded TypeDecorator が json.dumps で永続化する。
+                "required_deliverables_json": [
+                    dr.model_dump(mode="json") for dr in stage.required_deliverables
+                ],
                 # §確定 I: 通常の JSONEncoded。``model_dump(mode='json')`` は
                 # ``{'kind': ..., 'description': ...}`` を返す。
                 "completion_policy_json": stage.completion_policy.model_dump(mode="json"),
@@ -255,6 +260,15 @@ class SqliteWorkflowRepository:
         # が ``ValueError`` を送出し、Aggregate の StageInvariantViolation 経路が
         # ダウンストリームで引き継ぐ（Fail-Fast）。
         roles = frozenset(Role(token) for token in row.roles_csv.split(","))
+        # §確定 C（Issue #117）: json.loads → list[dict] →
+        # DeliverableRequirement.model_validate 経由で復元（生 dict 直渡し禁止）。
+        deliverable_payloads = cast(
+            "list[dict[str, Any]]",
+            row.required_deliverables_json or [],
+        )
+        required_deliverables = tuple(
+            DeliverableRequirement.model_validate(d) for d in deliverable_payloads
+        )
         completion_policy = CompletionPolicy.model_validate(row.completion_policy_json)
         # §確定 H §不可逆性: NotifyChannel.model_validate は、保存時に ``target``
         # フィールドが伏字化されているため例外を送出することがある。例外が
@@ -269,7 +283,7 @@ class SqliteWorkflowRepository:
             name=row.name,
             kind=StageKind(row.kind),
             required_role=roles,
-            deliverable_template=row.deliverable_template,
+            required_deliverables=required_deliverables,
             completion_policy=completion_policy,
             notify_channels=notify_channels,
         )

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/tables/workflow_stages.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/tables/workflow_stages.py
@@ -25,8 +25,10 @@
   Schneier 申し送り #6 の 6 カテゴリ スキャンに照らしてもシークレット保持値を
   持たないため、``MaskedJSONEncoded`` だと **過剰マスキング**（詳細設計 §確定 I
   で禁止）になる。
-* 残りのカラムは UUID / enum / CEO 著作の Markdown テンプレートを保持し、6 つの
-  マスキング カテゴリには該当しない。
+* ``required_deliverables_json`` は通常の :class:`JSONEncoded` カラム（Issue #117）。
+  ``DeliverableRequirement`` は ``template_ref``（UUID + SemVer）と ``optional``（bool）
+  のみを保持し、シークレット値を含まないため ``MaskedJSONEncoded`` だと過剰マスキング。
+* 残りのカラムは UUID / enum を保持し、6 つのマスキング カテゴリには該当しない。
 
 CI 3 層防御は本テーブル上の ``MaskedJSONEncoded`` カラム数を厳密に 1 個に固定する
 （``notify_channels_json`` への positive コントラクト、その他全カラムは no-mask）。
@@ -37,7 +39,7 @@ from __future__ import annotations
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import ForeignKey, String, Text, UniqueConstraint
+from sqlalchemy import ForeignKey, String, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
 from bakufu.infrastructure.persistence.sqlite.base import (
@@ -63,11 +65,10 @@ class WorkflowStageRow(Base):
     name: Mapped[str] = mapped_column(String(80), nullable=False)
     kind: Mapped[str] = mapped_column(String(32), nullable=False)
     roles_csv: Mapped[str] = mapped_column(String(255), nullable=False)
-    deliverable_template: Mapped[str] = mapped_column(
-        Text,
-        nullable=False,
-        default="",
-    )
+    # §確定 C（Issue #117）: json.loads → list[dict] →
+    # DeliverableRequirement.model_validate 経由で復元。
+    # DEFAULT '[]' は 0011_stage_required_deliverables.py の server_default で強制。
+    required_deliverables_json: Mapped[Any] = mapped_column(JSONEncoded, nullable=False)
     completion_policy_json: Mapped[Any] = mapped_column(JSONEncoded, nullable=False)
     # デフォルト ``[]`` は 0003_workflow_aggregate.py の ``server_default`` で SQL
     # レベルにおいて強制される。Repository が常に明示的なリストを渡すため、

--- a/backend/src/bakufu/interfaces/http/schemas/workflow.py
+++ b/backend/src/bakufu/interfaces/http/schemas/workflow.py
@@ -50,7 +50,7 @@ class StageCreate(BaseModel):
     required_role: list[str] = Field(min_length=1)
     completion_policy: dict[str, Any] | None = None
     notify_channels: list[str] = []
-    deliverable_template: str = ""
+    required_deliverables: list[dict[str, Any]] = []
 
     @field_validator("kind", mode="before")
     @classmethod
@@ -174,7 +174,7 @@ class StageResponse(BaseModel):
     required_role: list[str]
     completion_policy: dict[str, Any] | None
     notify_channels: list[str]
-    deliverable_template: str
+    required_deliverables: list[dict[str, Any]]
 
     @model_validator(mode="before")
     @classmethod
@@ -191,7 +191,11 @@ class StageResponse(BaseModel):
                 data.completion_policy.model_dump(mode="json") if data.completion_policy else None
             ),
             "notify_channels": [c.model_dump(mode="json")["target"] for c in data.notify_channels],
-            "deliverable_template": data.deliverable_template,
+            # Issue #117: required_deliverables は DeliverableRequirement の list。
+            # duck typing で model_dump を呼ぶ（domain import なし — Q-3）。
+            "required_deliverables": [
+                dr.model_dump(mode="json") for dr in data.required_deliverables
+            ],
         }
         return result
 

--- a/backend/tests/architecture/test_masking_columns.py
+++ b/backend/tests/architecture/test_masking_columns.py
@@ -264,7 +264,7 @@ class TestPartialMaskContract:
 
     Workflow Repository (PR #31) で 'partial mask' パターンを導入。
     ``workflow_stages.notify_channels_json`` のみが masking 対象で、
-    他カラムは masking しない ── ``deliverable_template`` /
+    他カラムは masking しない ── ``required_deliverables_json`` /
     ``completion_policy_json`` 等への過剰 masking を防ぐため。
     別カラムを追加で masking する PR は、まず §逆引き表 を更新せよ。
     さもないと本アサーションが発火する。

--- a/backend/tests/domain/workflow/test_dag_invariants.py
+++ b/backend/tests/domain/workflow/test_dag_invariants.py
@@ -172,7 +172,7 @@ class TestExternalReviewNotify:
             name=good.name,
             kind=StageKind.EXTERNAL_REVIEW,
             required_role=good.required_role,
-            deliverable_template=good.deliverable_template,
+            required_deliverables=good.required_deliverables,
             completion_policy=good.completion_policy,
             notify_channels=[],
         )
@@ -211,7 +211,7 @@ class TestRequiredRoleNonEmpty:
             name=good.name,
             kind=StageKind.WORK,
             required_role=frozenset(),
-            deliverable_template=good.deliverable_template,
+            required_deliverables=good.required_deliverables,
             completion_policy=good.completion_policy,
             notify_channels=[],
         )

--- a/backend/tests/domain/workflow/test_mutators.py
+++ b/backend/tests/domain/workflow/test_mutators.py
@@ -60,7 +60,7 @@ class TestAddStageCapacity:
                     "name": "S",
                     "kind": StageKind.WORK.value,
                     "required_role": [Role.DEVELOPER.value],
-                    "deliverable_template": "",
+                    "required_deliverables": [],
                     "completion_policy": {"kind": "manual", "description": ""},
                     "notify_channels": [],
                 }
@@ -155,7 +155,7 @@ class TestAddTransitionCapacity:
                 "name": "S",
                 "kind": StageKind.WORK.value,
                 "required_role": [Role.DEVELOPER.value],
-                "deliverable_template": "",
+                "required_deliverables": [],
                 "completion_policy": {"kind": "manual", "description": ""},
                 "notify_channels": [],
             }

--- a/backend/tests/domain/workflow/test_required_deliverables.py
+++ b/backend/tests/domain/workflow/test_required_deliverables.py
@@ -1,0 +1,171 @@
+"""required_deliverables VO 契約 + Stage 不変条件 (Issue #117).
+
+対象:
+- TC-UT-VO-WF-005〜007: DeliverableRequirement VO (構築 / frozen 不変性)
+- TC-UT-WF-061〜064: Stage.required_deliverables (空 / 1 件 / 重複 / from_dict)
+"""
+
+from __future__ import annotations
+
+from typing import cast
+from uuid import uuid4
+
+import pytest
+from bakufu.domain.exceptions import StageInvariantViolation
+from bakufu.domain.value_objects import DeliverableRequirement
+from bakufu.domain.value_objects.template_vos import DeliverableTemplateRef, SemVer
+from bakufu.domain.workflow import Workflow
+
+from tests.factories.workflow import build_v_model_payload, make_stage
+
+
+def _make_ref(template_id: object | None = None) -> DeliverableTemplateRef:
+    """妥当な DeliverableTemplateRef を 1 件組み立てるヘルパ。"""
+    tid = template_id if template_id is not None else uuid4()
+    return DeliverableTemplateRef(
+        template_id=tid,
+        minimum_version=SemVer(major=1, minor=0, patch=0),
+    )
+
+
+def _make_req(*, optional: bool = False) -> DeliverableRequirement:
+    """妥当な DeliverableRequirement を 1 件組み立てるヘルパ。"""
+    return DeliverableRequirement(template_ref=_make_ref(), optional=optional)
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-VO-WF-005 / 006 / 007: DeliverableRequirement VO
+# ---------------------------------------------------------------------------
+class TestDeliverableRequirementVO:
+    """DeliverableRequirement VO 構築 + frozen 不変性 (TC-UT-VO-WF-005〜007)."""
+
+    def test_construction_optional_false(self) -> None:
+        """TC-UT-VO-WF-005: optional=False(デフォルト)で構築成功し、フィールドが保持される。"""
+        req = _make_req(optional=False)
+        assert req.optional is False
+        assert isinstance(req.template_ref, DeliverableTemplateRef)
+
+    def test_construction_optional_true(self) -> None:
+        """TC-UT-VO-WF-006: optional=True で構築成功し、フィールドが保持される。"""
+        req = _make_req(optional=True)
+        assert req.optional is True
+
+    def test_frozen_assignment_raises(self) -> None:
+        """TC-UT-VO-WF-007: frozen=True — 直接代入は TypeError を送出する。"""
+        req = _make_req()
+        with pytest.raises((TypeError, Exception)):
+            req.optional = True  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-WF-061 / 062: Stage.required_deliverables 正常系
+# ---------------------------------------------------------------------------
+class TestStageRequiredDeliverablesHappyPath:
+    """Stage.required_deliverables の正常系 (TC-UT-WF-061 / 062)."""
+
+    def test_empty_tuple_constructs(self) -> None:
+        """TC-UT-WF-061: required_deliverables=() で Stage 構築成功 (R1-17: 空は合法)。"""
+        stage = make_stage(required_deliverables=())
+        assert stage.required_deliverables == ()
+
+    def test_single_item_constructs(self) -> None:
+        """TC-UT-WF-062: required_deliverables 1 件で構築成功、len == 1。"""
+        req = _make_req()
+        stage = make_stage(required_deliverables=(req,))
+        assert len(stage.required_deliverables) == 1
+        assert stage.required_deliverables[0] == req
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-WF-063: 重複 template_id で StageInvariantViolation
+# ---------------------------------------------------------------------------
+class TestStageRequiredDeliverablesDuplicate:
+    """Stage.required_deliverables 内 template_id 重複 → 不変条件違反 (TC-UT-WF-063)."""
+
+    def test_duplicate_template_id_raises_stage_invariant_violation(self) -> None:
+        """TC-UT-WF-063: 同一 template_id を持つ DeliverableRequirement 2 件は
+        StageInvariantViolation(kind='duplicate_required_deliverable') を raise する。
+        Workflow 構築前に Stage レベルで検出される (R1-17)。
+        """
+        shared_id = uuid4()
+        ref_a = DeliverableTemplateRef(
+            template_id=shared_id,
+            minimum_version=SemVer(major=1, minor=0, patch=0),
+        )
+        ref_b = DeliverableTemplateRef(
+            template_id=shared_id,
+            minimum_version=SemVer(major=2, minor=0, patch=0),
+        )
+        req_a = DeliverableRequirement(template_ref=ref_a, optional=False)
+        req_b = DeliverableRequirement(template_ref=ref_b, optional=True)
+
+        with pytest.raises(StageInvariantViolation) as excinfo:
+            make_stage(required_deliverables=(req_a, req_b))
+
+        err = excinfo.value
+        assert err.kind == "duplicate_required_deliverable"
+
+    def test_msg_wf_013_exact_wording(self) -> None:
+        """TC-UT-WF-063: MSG-WF-013 の文言が完全一致。
+        ``[FAIL] Stage {stage_id} required_deliverables has duplicate template_id: {template_id}``
+        """
+        shared_id = uuid4()
+        ref = _make_ref(template_id=shared_id)
+        req = DeliverableRequirement(template_ref=ref, optional=False)
+
+        with pytest.raises(StageInvariantViolation) as excinfo:
+            make_stage(required_deliverables=(req, req))
+
+        err = excinfo.value
+        stage_id_str = str(err.detail["stage_id"])
+        template_id_str = str(err.detail["template_id"])
+        expected_message = (
+            f"[FAIL] Stage {stage_id_str} required_deliverables "
+            f"has duplicate template_id: {template_id_str}"
+        )
+        assert err.message == expected_message
+
+    def test_detail_keys_are_whitelisted(self) -> None:
+        """TC-UT-WF-063: detail は {"stage_id": str, "template_id": str} のキーのみ (A09)。"""
+        shared_id = uuid4()
+        ref = _make_ref(template_id=shared_id)
+        req = DeliverableRequirement(template_ref=ref, optional=False)
+
+        with pytest.raises(StageInvariantViolation) as excinfo:
+            make_stage(required_deliverables=(req, req))
+
+        detail = excinfo.value.detail
+        assert set(detail.keys()) == {"stage_id", "template_id"}, (
+            f"detail keys must be exactly {{stage_id, template_id}}, got {set(detail.keys())}"
+        )
+        assert isinstance(detail["stage_id"], str)
+        assert isinstance(detail["template_id"], str)
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-WF-064: from_dict で required_deliverables ペイロード
+# ---------------------------------------------------------------------------
+class TestFromDictWithRequiredDeliverables:
+    """from_dict が required_deliverables 含む Stage ペイロードを受理する (TC-UT-WF-064)."""
+
+    def test_from_dict_with_required_deliverables_payload(self) -> None:
+        """TC-UT-WF-064: required_deliverables を含む Stage ペイロードで Workflow 構築成功。
+        stages[n].required_deliverables に 1 件の DeliverableRequirement が含まれる (R1-17)。
+        """
+        payload = build_v_model_payload()
+        stages = cast("list[dict[str, object]]", payload["stages"])
+        template_id = uuid4()
+        stages[0]["required_deliverables"] = [
+            {
+                "template_ref": {
+                    "template_id": str(template_id),
+                    "minimum_version": {"major": 1, "minor": 0, "patch": 0},
+                },
+                "optional": False,
+            }
+        ]
+        workflow = Workflow.from_dict(payload)
+        stage = workflow.stages[0]
+        assert len(stage.required_deliverables) == 1
+        assert stage.required_deliverables[0].template_ref.template_id == template_id
+        assert stage.required_deliverables[0].optional is False

--- a/backend/tests/factories/workflow.py
+++ b/backend/tests/factories/workflow.py
@@ -31,6 +31,7 @@ from weakref import WeakValueDictionary
 
 from bakufu.domain.value_objects import (
     CompletionPolicy,
+    DeliverableRequirement,
     NotifyChannel,
     Role,
     StageId,
@@ -98,7 +99,7 @@ def make_stage(
     name: str = "ステージ",
     kind: StageKind = StageKind.WORK,
     required_role: frozenset[Role] | None = None,
-    deliverable_template: str = "",
+    required_deliverables: tuple[DeliverableRequirement, ...] = (),
     completion_policy: CompletionPolicy | None = None,
     notify_channels: Sequence[NotifyChannel] | None = None,
 ) -> Stage:
@@ -107,6 +108,7 @@ def make_stage(
     デフォルトは ``kind=WORK`` + ``required_role={DEVELOPER}``。これで
     Stage の自己バリデータ (REQ-WF-007) が追加調整なしに通過する。
     EXTERNAL_REVIEW を使う呼び出し側は ``notify_channels`` を渡すこと。
+    ``required_deliverables`` は Issue #117 で追加された成果物要件タプル。
     """
     if required_role is None:
         required_role = frozenset({Role.DEVELOPER})
@@ -120,7 +122,7 @@ def make_stage(
         name=name,
         kind=kind,
         required_role=required_role,
-        deliverable_template=deliverable_template,
+        required_deliverables=required_deliverables,
         completion_policy=completion_policy,
         notify_channels=list(notify_channels),
     )
@@ -229,7 +231,7 @@ def build_v_model_payload() -> dict[str, object]:
             "name": stage_name,
             "kind": stage_kind.value,
             "required_role": [role.value for role in role_set],
-            "deliverable_template": "",
+            "required_deliverables": [],
             "completion_policy": {
                 "kind": "approved_by_reviewer",
                 "description": f"{stage_name} 完了判定",

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_workflow_repository/test_constraints_arch.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_workflow_repository/test_constraints_arch.py
@@ -111,7 +111,7 @@ class TestUniqueConstraintViolation:
                 text(
                     "INSERT INTO workflow_stages "
                     "(workflow_id, stage_id, name, kind, roles_csv, "
-                    "deliverable_template, completion_policy_json, "
+                    "required_deliverables_json, completion_policy_json, "
                     "notify_channels_json) "
                     "VALUES (:workflow_id, :stage_id, :name, :kind, :roles_csv, "
                     ":deliverable, :policy, :channels)"
@@ -122,7 +122,7 @@ class TestUniqueConstraintViolation:
                     "name": "first",
                     "kind": "WORK",
                     "roles_csv": "DEVELOPER",
-                    "deliverable": "",
+                    "deliverable": "[]",
                     "policy": '{"kind": "approved_by_reviewer", "description": ""}',
                     "channels": "[]",
                 },
@@ -134,7 +134,7 @@ class TestUniqueConstraintViolation:
                     text(
                         "INSERT INTO workflow_stages "
                         "(workflow_id, stage_id, name, kind, roles_csv, "
-                        "deliverable_template, completion_policy_json, "
+                        "required_deliverables_json, completion_policy_json, "
                         "notify_channels_json) "
                         "VALUES (:workflow_id, :stage_id, :name, :kind, :roles_csv, "
                         ":deliverable, :policy, :channels)"
@@ -145,7 +145,7 @@ class TestUniqueConstraintViolation:
                         "name": "duplicate",
                         "kind": "WORK",
                         "roles_csv": "DEVELOPER",
-                        "deliverable": "",
+                        "deliverable": "[]",
                         "policy": '{"kind": "approved_by_reviewer", "description": ""}',
                         "channels": "[]",
                     },

--- a/backend/tests/infrastructure/persistence/sqlite/repositories/test_workflow_repository/test_required_deliverables_roundtrip.py
+++ b/backend/tests/infrastructure/persistence/sqlite/repositories/test_workflow_repository/test_required_deliverables_roundtrip.py
@@ -1,0 +1,307 @@
+"""Workflow Repository: required_deliverables のラウンドトリップ + A08 防御確認 (Issue #117).
+
+TC-IT-WFR-025 / 026 / 027:
+- TC-IT-WFR-025: required_deliverables を含む Stage が save → find_by_id でラウンドトリップ
+- TC-IT-WFR-026: _stage_from_row が DeliverableRequirement.model_validate 経由で復元 (A08)
+  — json.loads → list[dict] → model_validate の経路を物理確認
+- TC-IT-WFR-027: required_deliverables=() の Stage が空 tuple でラウンドトリップ
+
+§確定 C (docs/features/workflow/repository/detailed-design.md):
+  _from_row: json.loads → list[dict] → [DeliverableRequirement.model_validate(d) for d in ...]
+  生 dict を Stage コンストラクタに直接渡すことは禁止。
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+import pytest
+from bakufu.domain.value_objects import DeliverableRequirement
+from bakufu.domain.value_objects.template_vos import DeliverableTemplateRef, SemVer
+from bakufu.infrastructure.persistence.sqlite.repositories.workflow_repository import (
+    SqliteWorkflowRepository,
+)
+from sqlalchemy import text
+
+from tests.factories.workflow import make_stage, make_workflow
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+pytestmark = pytest.mark.asyncio
+
+
+def _make_req(
+    *,
+    optional: bool = False,
+    major: int = 1,
+    minor: int = 0,
+    patch: int = 0,
+) -> DeliverableRequirement:
+    """テスト用 DeliverableRequirement ヘルパ。"""
+    return DeliverableRequirement(
+        template_ref=DeliverableTemplateRef(
+            template_id=uuid4(),
+            minimum_version=SemVer(major=major, minor=minor, patch=patch),
+        ),
+        optional=optional,
+    )
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-WFR-025: required_deliverables ラウンドトリップ
+# ---------------------------------------------------------------------------
+class TestRequiredDeliverablesRoundTrip:
+    """TC-IT-WFR-025: required_deliverables の save → find_by_id ラウンドトリップ。"""
+
+    async def test_empty_required_deliverables_round_trips(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """TC-IT-WFR-025a / TC-IT-WFR-027: required_deliverables=() が空 tuple でラウンドトリップ。
+
+        R1-17: 空リストは合法。
+        """
+        stage = make_stage(required_deliverables=())
+        workflow = make_workflow(stages=[stage], entry_stage_id=stage.id)
+
+        async with session_factory() as session, session.begin():
+            await SqliteWorkflowRepository(session).save(workflow)
+
+        async with session_factory() as session:
+            restored = await SqliteWorkflowRepository(session).find_by_id(workflow.id)
+
+        assert restored is not None
+        assert len(restored.stages) == 1
+        assert restored.stages[0].required_deliverables == ()
+
+    async def test_single_required_deliverable_round_trips(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """TC-IT-WFR-025b: required_deliverables 1 件が同値でラウンドトリップ。"""
+        req = _make_req(optional=False, major=2, minor=3, patch=1)
+        stage = make_stage(required_deliverables=(req,))
+        workflow = make_workflow(stages=[stage], entry_stage_id=stage.id)
+
+        async with session_factory() as session, session.begin():
+            await SqliteWorkflowRepository(session).save(workflow)
+
+        async with session_factory() as session:
+            restored = await SqliteWorkflowRepository(session).find_by_id(workflow.id)
+
+        assert restored is not None
+        assert len(restored.stages) == 1
+        r = restored.stages[0].required_deliverables
+        assert len(r) == 1
+        assert r[0].template_ref.template_id == req.template_ref.template_id
+        assert r[0].template_ref.minimum_version.major == 2
+        assert r[0].template_ref.minimum_version.minor == 3
+        assert r[0].template_ref.minimum_version.patch == 1
+        assert r[0].optional is False
+
+    async def test_multiple_required_deliverables_round_trip(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """TC-IT-WFR-025c: required_deliverables 複数件が件数・同値でラウンドトリップ。"""
+        req_a = _make_req(optional=False)
+        req_b = _make_req(optional=True, major=1, minor=2, patch=0)
+        stage = make_stage(required_deliverables=(req_a, req_b))
+        workflow = make_workflow(stages=[stage], entry_stage_id=stage.id)
+
+        async with session_factory() as session, session.begin():
+            await SqliteWorkflowRepository(session).save(workflow)
+
+        async with session_factory() as session:
+            restored = await SqliteWorkflowRepository(session).find_by_id(workflow.id)
+
+        assert restored is not None
+        r = restored.stages[0].required_deliverables
+        assert len(r) == 2
+        # template_id の一致確認（順序はステージ保存順）
+        template_ids = {dr.template_ref.template_id for dr in r}
+        expected_ids = {req_a.template_ref.template_id, req_b.template_ref.template_id}
+        assert template_ids == expected_ids
+        # optional 値の一致確認（idで引き当て）
+        restored_by_id = {dr.template_ref.template_id: dr for dr in r}
+        assert restored_by_id[req_a.template_ref.template_id].optional is False
+        assert restored_by_id[req_b.template_ref.template_id].optional is True
+
+    async def test_required_deliverables_type_is_tuple(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """TC-IT-WFR-025d: 復元後の required_deliverables は tuple[DeliverableRequirement, ...]。"""
+        req = _make_req()
+        stage = make_stage(required_deliverables=(req,))
+        workflow = make_workflow(stages=[stage], entry_stage_id=stage.id)
+
+        async with session_factory() as session, session.begin():
+            await SqliteWorkflowRepository(session).save(workflow)
+
+        async with session_factory() as session:
+            restored = await SqliteWorkflowRepository(session).find_by_id(workflow.id)
+
+        assert restored is not None
+        rd = restored.stages[0].required_deliverables
+        assert isinstance(rd, tuple), f"expected tuple, got {type(rd)}"
+        assert all(isinstance(d, DeliverableRequirement) for d in rd)
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-WFR-026: _stage_from_row の A08 防御（model_validate 経由を物理確認）
+# ---------------------------------------------------------------------------
+class TestStageFromRowA08Defense:
+    """TC-IT-WFR-026: _stage_from_row は DeliverableRequirement.model_validate を経由する (A08)。
+
+    §確定 C: json.loads → list[dict] → [DeliverableRequirement.model_validate(d) for d in ...]
+    生 dict を Stage コンストラクタに直接渡すことは禁止。
+
+    テスト戦略: DB に valid な required_deliverables_json を直接 INSERT し、
+    _stage_from_row を介して復元された Stage が DeliverableRequirement インスタンス
+    であることを確認する。型・フィールド値の完全一致で model_validate が通った証拠とする。
+    """
+
+    async def test_stage_from_row_deserializes_via_model_validate(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """TC-IT-WFR-026: DB 生 JSON から復元した Stage.required_deliverables が
+        DeliverableRequirement インスタンスで、フィールド値が正しい。
+        """
+        template_id = uuid4()
+        payload = json.dumps(
+            [
+                {
+                    "template_ref": {
+                        "template_id": str(template_id),
+                        "minimum_version": {"major": 3, "minor": 1, "patch": 4},
+                    },
+                    "optional": True,
+                }
+            ]
+        )
+
+        # DB に直接 INSERT して find_by_id で water してみる
+        wf_id = uuid4().hex
+        stage_id = uuid4().hex
+
+        async with session_factory() as session, session.begin():
+            await session.execute(
+                text(
+                    "INSERT INTO workflows (id, name, entry_stage_id) VALUES (:id, :name, :entry)"
+                ),
+                {"id": wf_id, "name": "a08-test-wf", "entry": stage_id},
+            )
+            await session.execute(
+                text(
+                    "INSERT INTO workflow_stages "
+                    "(workflow_id, stage_id, name, kind, roles_csv, "
+                    "required_deliverables_json, completion_policy_json, "
+                    "notify_channels_json) "
+                    "VALUES (:wf_id, :s_id, :name, :kind, :roles, "
+                    ":deliverable, :policy, :channels)"
+                ),
+                {
+                    "wf_id": wf_id,
+                    "s_id": stage_id,
+                    "name": "a08-test-stage",
+                    "kind": "WORK",
+                    "roles": "DEVELOPER",
+                    "deliverable": payload,
+                    "policy": '{"kind": "approved_by_reviewer", "description": ""}',
+                    "channels": "[]",
+                },
+            )
+
+        from uuid import UUID
+
+        async with session_factory() as session:
+            restored = await SqliteWorkflowRepository(session).find_by_id(UUID(wf_id))
+
+        assert restored is not None
+        assert len(restored.stages) == 1
+        rd = restored.stages[0].required_deliverables
+        assert len(rd) == 1
+
+        # model_validate を経由した証拠: DeliverableRequirement インスタンス
+        assert isinstance(rd[0], DeliverableRequirement), (
+            "[FAIL] required_deliverables の要素が DeliverableRequirement でない。\n"
+            "Next: _stage_from_row が model_validate を経由していることを確認せよ (§確定 C A08)。"
+        )
+        # template_id の型と値
+        assert rd[0].template_ref.template_id == template_id, (
+            f"[FAIL] template_id mismatch: {rd[0].template_ref.template_id} != {template_id}"
+        )
+        # SemVer フィールド
+        assert rd[0].template_ref.minimum_version.major == 3
+        assert rd[0].template_ref.minimum_version.minor == 1
+        assert rd[0].template_ref.minimum_version.patch == 4
+        # optional フィールド
+        assert rd[0].optional is True, (
+            "[FAIL] optional=True が復元されていない。model_validate 経路の確認が必要。"
+        )
+
+    async def test_stage_from_row_invalid_json_raises(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """TC-IT-WFR-026b: required_deliverables_json が不正な場合 ValidationError を送出。
+
+        A08 Fail-Fast: model_validate が型バリデーションを強制する。raw dict 直渡しでは
+        検出されないデータ破損を起動時に検出できる。
+        """
+        import pydantic
+
+        # template_id が UUID 形式でない壊れたペイロード
+        bad_payload = json.dumps(
+            [
+                {
+                    "template_ref": {
+                        "template_id": "not-a-uuid",
+                        "minimum_version": {"major": 1, "minor": 0, "patch": 0},
+                    },
+                    "optional": False,
+                }
+            ]
+        )
+
+        wf_id = uuid4().hex
+        stage_id = uuid4().hex
+
+        async with session_factory() as session, session.begin():
+            await session.execute(
+                text(
+                    "INSERT INTO workflows (id, name, entry_stage_id) VALUES (:id, :name, :entry)"
+                ),
+                {"id": wf_id, "name": "a08-fail-wf", "entry": stage_id},
+            )
+            await session.execute(
+                text(
+                    "INSERT INTO workflow_stages "
+                    "(workflow_id, stage_id, name, kind, roles_csv, "
+                    "required_deliverables_json, completion_policy_json, "
+                    "notify_channels_json) "
+                    "VALUES (:wf_id, :s_id, :name, :kind, :roles, "
+                    ":deliverable, :policy, :channels)"
+                ),
+                {
+                    "wf_id": wf_id,
+                    "s_id": stage_id,
+                    "name": "a08-fail-stage",
+                    "kind": "WORK",
+                    "roles": "DEVELOPER",
+                    "deliverable": bad_payload,
+                    "policy": '{"kind": "approved_by_reviewer", "description": ""}',
+                    "channels": "[]",
+                },
+            )
+
+        from uuid import UUID
+
+        with pytest.raises((pydantic.ValidationError, ValueError)):
+            async with session_factory() as session:
+                await SqliteWorkflowRepository(session).find_by_id(UUID(wf_id))

--- a/backend/tests/infrastructure/persistence/sqlite/test_alembic_stage_required_deliverables.py
+++ b/backend/tests/infrastructure/persistence/sqlite/test_alembic_stage_required_deliverables.py
@@ -1,0 +1,288 @@
+"""Alembic migration 0011 テスト: Stage.required_deliverables (Issue #117).
+
+TC-IT-MIGR-011-001〜004:
+- upgrade: required_deliverables_json 追加 / deliverable_template 削除
+- downgrade: required_deliverables_json 削除 / deliverable_template 復元
+- upgrade/downgrade/upgrade のラウンドトリップ
+- revision chain が線形 (0011 が head = 最新単一 head)
+
+§確定 L (docs/features/workflow/repository/detailed-design.md):
+  SQLite 3.35.0+ が DROP COLUMN を提供する。pyproject.toml requires-python = ">=3.12"
+  → Python 3.12 同梱 SQLite は 3.42.0 以上が保証されるため追加要件なし。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+from bakufu.infrastructure.persistence.sqlite import engine as engine_mod
+from bakufu.infrastructure.persistence.sqlite.migrations import run_upgrade_head
+from sqlalchemy import text
+
+pytestmark = pytest.mark.asyncio
+
+_REVISION_ID = "0011_stage_required_deliverables"
+_DOWN_REVISION = "0010_workflow_archived"
+
+
+# ---------------------------------------------------------------------------
+# フィクスチャ
+# ---------------------------------------------------------------------------
+@pytest_asyncio.fixture
+async def empty_engine(tmp_path: Path) -> AsyncIterator[engine_mod.AsyncEngine]:  # type: ignore[name-defined]
+    """スキーマ未適用の新規 SQLite エンジン。"""
+    from sqlalchemy.ext.asyncio import AsyncEngine
+
+    url = f"sqlite+aiosqlite:///{tmp_path / 'bakufu_0011.db'}"
+    engine: AsyncEngine = engine_mod.create_engine(url)
+    try:
+        yield engine
+    finally:
+        await engine.dispose()
+
+
+def _alembic_config() -> Config:
+    """bakufu の Alembic 設定オブジェクトを返す。"""
+    backend_root = Path(__file__).resolve().parents[4]
+    cfg = Config(str(backend_root / "alembic.ini"))
+    cfg.set_main_option("script_location", str(backend_root / "alembic"))
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-MIGR-011-001: upgrade で required_deliverables_json 追加 / deliverable_template 削除
+# ---------------------------------------------------------------------------
+class TestMigration0011Upgrade:
+    """TC-IT-MIGR-011-001: alembic upgrade head 後のスキーマ確認。"""
+
+    async def test_required_deliverables_json_column_exists_after_upgrade(
+        self,
+        empty_engine: engine_mod.AsyncEngine,
+    ) -> None:
+        """TC-IT-MIGR-011-001a: upgrade head → required_deliverables_json が存在する。
+
+        workflow_stages テーブルに列が追加されていることを PRAGMA table_info で確認。
+        §確定 L: 0011 upgrade = DROP deliverable_template + ADD required_deliverables_json。
+        """
+        from sqlalchemy.ext.asyncio import AsyncEngine
+
+        engine: AsyncEngine = empty_engine  # type: ignore[assignment]
+        await run_upgrade_head(engine)
+        async with engine.connect() as conn:
+            result = await conn.execute(text("PRAGMA table_info(workflow_stages)"))
+            columns = {row[1] for row in result}  # row[1] = column name
+        assert "required_deliverables_json" in columns, (
+            "[FAIL] required_deliverables_json が workflow_stages に存在しない。\n"
+            "Next: 0011_stage_required_deliverables.upgrade() を確認せよ。"
+        )
+
+    async def test_deliverable_template_column_absent_after_upgrade(
+        self,
+        empty_engine: engine_mod.AsyncEngine,
+    ) -> None:
+        """TC-IT-MIGR-011-001b: upgrade head → 旧 deliverable_template 列が削除されている。"""
+        from sqlalchemy.ext.asyncio import AsyncEngine
+
+        engine: AsyncEngine = empty_engine  # type: ignore[assignment]
+        await run_upgrade_head(engine)
+        async with engine.connect() as conn:
+            result = await conn.execute(text("PRAGMA table_info(workflow_stages)"))
+            columns = {row[1] for row in result}
+        assert "deliverable_template" not in columns, (
+            "[FAIL] deliverable_template 列が upgrade 後も残存している。\n"
+            "Next: 0011_stage_required_deliverables.upgrade() で op.drop_column を確認せよ。"
+        )
+
+    async def test_required_deliverables_json_default_is_empty_array(
+        self,
+        empty_engine: engine_mod.AsyncEngine,
+    ) -> None:
+        """TC-IT-MIGR-011-001c: required_deliverables_json の server_default が '[]' である。
+
+        §確定 L: DEFAULT '[]' — MVP 時点で本番データなし、変換不要。
+        """
+        from sqlalchemy.ext.asyncio import AsyncEngine
+
+        engine: AsyncEngine = empty_engine  # type: ignore[assignment]
+        await run_upgrade_head(engine)
+        # 最小行を挿入して DEFAULT 値を確認する
+        from uuid import uuid4
+
+        wf_id = uuid4().hex
+        stage_id = uuid4().hex
+        async with engine.connect() as conn:
+            await conn.execute(
+                text(
+                    "INSERT INTO workflows (id, name, entry_stage_id) VALUES (:id, :name, :entry)"
+                ),
+                {"id": wf_id, "name": "test-wf", "entry": stage_id},
+            )
+            await conn.execute(
+                text(
+                    "INSERT INTO workflow_stages "
+                    "(workflow_id, stage_id, name, kind, roles_csv, "
+                    "completion_policy_json, notify_channels_json) "
+                    "VALUES (:wf_id, :s_id, :name, :kind, :roles, :policy, :channels)"
+                ),
+                {
+                    "wf_id": wf_id,
+                    "s_id": stage_id,
+                    "name": "test-stage",
+                    "kind": "WORK",
+                    "roles": "DEVELOPER",
+                    "policy": '{"kind": "approved_by_reviewer", "description": ""}',
+                    "channels": "[]",
+                },
+            )
+            result = await conn.execute(
+                text(
+                    "SELECT required_deliverables_json FROM workflow_stages WHERE stage_id = :sid"
+                ),
+                {"sid": stage_id},
+            )
+            row = result.fetchone()
+            await conn.commit()
+        assert row is not None
+        assert row[0] == "[]", (
+            f"[FAIL] required_deliverables_json の DEFAULT が '[]' でなく {row[0]!r}。\n"
+            "Next: 0011 migration の server_default=sa.text(\"'[]'\") を確認せよ。"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-MIGR-011-002: downgrade で deliverable_template 復元 / required_deliverables_json 削除
+# ---------------------------------------------------------------------------
+class TestMigration0011Downgrade:
+    """TC-IT-MIGR-011-002: downgrade 後のスキーマ確認。"""
+
+    async def test_downgrade_removes_required_deliverables_json(
+        self,
+        empty_engine: engine_mod.AsyncEngine,
+    ) -> None:
+        """TC-IT-MIGR-011-002a: downgrade → required_deliverables_json が削除される。"""
+        from alembic import command
+        from sqlalchemy.ext.asyncio import AsyncEngine
+
+        engine: AsyncEngine = empty_engine  # type: ignore[assignment]
+        await run_upgrade_head(engine)
+
+        cfg = _alembic_config()
+        cfg.set_main_option("sqlalchemy.url", str(engine.url))
+
+        def _downgrade() -> None:
+            command.downgrade(cfg, _DOWN_REVISION)
+
+        await asyncio.to_thread(_downgrade)
+
+        async with engine.connect() as conn:
+            result = await conn.execute(text("PRAGMA table_info(workflow_stages)"))
+            columns = {row[1] for row in result}
+        assert "required_deliverables_json" not in columns, (
+            "[FAIL] downgrade 後も required_deliverables_json が残存している。\n"
+            "Next: 0011_stage_required_deliverables.downgrade() で op.drop_column を確認せよ。"
+        )
+
+    async def test_downgrade_restores_deliverable_template(
+        self,
+        empty_engine: engine_mod.AsyncEngine,
+    ) -> None:
+        """TC-IT-MIGR-011-002b: downgrade → deliverable_template 列が復元される。"""
+        from alembic import command
+        from sqlalchemy.ext.asyncio import AsyncEngine
+
+        engine: AsyncEngine = empty_engine  # type: ignore[assignment]
+        await run_upgrade_head(engine)
+
+        cfg = _alembic_config()
+        cfg.set_main_option("sqlalchemy.url", str(engine.url))
+
+        def _downgrade() -> None:
+            command.downgrade(cfg, _DOWN_REVISION)
+
+        await asyncio.to_thread(_downgrade)
+
+        async with engine.connect() as conn:
+            result = await conn.execute(text("PRAGMA table_info(workflow_stages)"))
+            columns = {row[1] for row in result}
+        assert "deliverable_template" in columns, (
+            "[FAIL] downgrade 後に deliverable_template 列が存在しない。\n"
+            "Next: 0011_stage_required_deliverables.downgrade() で op.add_column を確認せよ。"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-MIGR-011-003: upgrade / downgrade / upgrade ラウンドトリップ
+# ---------------------------------------------------------------------------
+class TestMigration0011RoundTrip:
+    """TC-IT-MIGR-011-003: upgrade head → downgrade → upgrade head が冪等。"""
+
+    async def test_round_trip_leaves_schema_at_head(
+        self,
+        empty_engine: engine_mod.AsyncEngine,
+    ) -> None:
+        """TC-IT-MIGR-011-003: up → down to 0010 → up が workflow_stages を正規状態に戻す。"""
+        from alembic import command
+        from sqlalchemy.ext.asyncio import AsyncEngine
+
+        engine: AsyncEngine = empty_engine  # type: ignore[assignment]
+        # 1st upgrade
+        await run_upgrade_head(engine)
+        async with engine.connect() as conn:
+            result = await conn.execute(text("PRAGMA table_info(workflow_stages)"))
+            cols_after_up = {row[1] for row in result}
+        assert "required_deliverables_json" in cols_after_up
+        assert "deliverable_template" not in cols_after_up
+
+        # downgrade
+        cfg = _alembic_config()
+        cfg.set_main_option("sqlalchemy.url", str(engine.url))
+
+        def _downgrade() -> None:
+            command.downgrade(cfg, _DOWN_REVISION)
+
+        await asyncio.to_thread(_downgrade)
+
+        # 2nd upgrade
+        await run_upgrade_head(engine)
+        async with engine.connect() as conn:
+            result = await conn.execute(text("PRAGMA table_info(workflow_stages)"))
+            cols_after_reup = {row[1] for row in result}
+        assert "required_deliverables_json" in cols_after_reup, (
+            "[FAIL] 2nd upgrade 後に required_deliverables_json がない。"
+        )
+        assert "deliverable_template" not in cols_after_reup, (
+            "[FAIL] 2nd upgrade 後に旧 deliverable_template 列が残存している。"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-MIGR-011-004: revision chain 線形性
+# ---------------------------------------------------------------------------
+class TestMigration0011RevisionChain:
+    """TC-IT-MIGR-011-004: 0011 が単一 head かつ down_revision チェーンが正しい。"""
+
+    async def test_alembic_has_single_head(self) -> None:
+        """TC-IT-MIGR-011-004a: ScriptDirectory.get_heads() は 1 件だけ返す。"""
+        cfg = _alembic_config()
+        script = ScriptDirectory.from_config(cfg)
+        heads = script.get_heads()
+        assert len(heads) == 1, (
+            f"[FAIL] Alembic head が複数存在: {heads}。"
+            "各 Repository PR は単一 revision を追加する。"
+        )
+
+    async def test_0011_has_correct_down_revision(self) -> None:
+        """TC-IT-MIGR-011-004b: 0011 の down_revision == '0010_workflow_archived'。"""
+        cfg = _alembic_config()
+        script = ScriptDirectory.from_config(cfg)
+        rev = script.get_revision(_REVISION_ID)
+        assert rev is not None, f"Revision {_REVISION_ID!r} が見つからない"
+        assert rev.down_revision == _DOWN_REVISION, (
+            f"[FAIL] 0011.down_revision = {rev.down_revision!r}, 期待値 = {_DOWN_REVISION!r}"
+        )

--- a/backend/tests/integration/test_workflow_http_api/helpers.py
+++ b/backend/tests/integration/test_workflow_http_api/helpers.py
@@ -71,7 +71,7 @@ def _minimal_stage_payload(stage_id: UUID | None = None) -> dict[str, object]:
         "required_role": ["DEVELOPER"],
         "completion_policy": None,
         "notify_channels": [],
-        "deliverable_template": "",
+        "required_deliverables": [],
     }
 
 
@@ -87,7 +87,7 @@ def _external_review_stage_payload(
         "required_role": ["REVIEWER"],
         "completion_policy": None,
         "notify_channels": [notify_url],
-        "deliverable_template": "",
+        "required_deliverables": [],
     }
 
 

--- a/backend/tests/integration/test_workflow_http_api/test_security.py
+++ b/backend/tests/integration/test_workflow_http_api/test_security.py
@@ -34,7 +34,7 @@ class TestCsrfProtection:
                         "kind": "WORK",
                         "required_role": ["DEVELOPER"],
                         "notify_channels": [],
-                        "deliverable_template": "",
+                        "required_deliverables": [],
                     }
                 ],
                 "transitions": [],

--- a/backend/tests/integration/test_workflow_http_api/test_validation.py
+++ b/backend/tests/integration/test_workflow_http_api/test_validation.py
@@ -57,7 +57,7 @@ class TestUuidPathInjection:
                         "kind": "WORK",
                         "required_role": ["DEVELOPER"],
                         "notify_channels": [],
-                        "deliverable_template": "",
+                        "required_deliverables": [],
                     }
                 ],
                 "transitions": [],


### PR DESCRIPTION
## Summary

- `Stage.deliverable_template: str` フィールドを廃止し、`Stage.required_deliverables: tuple[DeliverableRequirement, ...]` を追加（Issue #117 / REQ-WF-007-④ / R1-17）
- `DeliverableRequirement` VO（`template_ref: DeliverableTemplateRef`, `optional: bool = False`）を `template_vos.py` に追加
- `StageViolationKind` に `"duplicate_required_deliverable"` を追加し、Stage 自身の不変条件チェック（MSG-WF-013）を実装
- Alembic migration `0011_stage_required_deliverables.py`: `deliverable_template` DROP → `required_deliverables_json TEXT NOT NULL DEFAULT '[]'` ADD（§確定L）
- `WorkflowStageRow` / `SqliteWorkflowRepository` / HTTP スキーマ / プリセット / ファクトリ / テスト群を全面更新

## 変更ファイル

**ドメイン層**
- `domain/value_objects/template_vos.py` — `DeliverableRequirement` VO 追加
- `domain/value_objects/__init__.py` — `DeliverableRequirement` エクスポート追加
- `domain/exceptions.py` — `StageViolationKind` に `duplicate_required_deliverable` 追加
- `domain/workflow/entities.py` — `deliverable_template` 削除、`required_deliverables` 追加、重複チェック実装

**インフラ層**
- `infrastructure/persistence/sqlite/tables/workflow_stages.py` — `deliverable_template` → `required_deliverables_json: JSONEncoded`
- `infrastructure/persistence/sqlite/repositories/workflow_repository.py` — `_to_row` / `_stage_from_row` 更新（§確定C 安全なデシリアライゼーション）
- `alembic/versions/0011_stage_required_deliverables.py` — migration 追加

**インターフェース層**
- `interfaces/http/schemas/workflow.py` — `StageCreate` / `StageResponse` フィールド更新

**アプリケーション層**
- `application/presets/workflow_presets.py` — 全13プリセットを `required_deliverables: []` に更新

**テスト**
- `tests/domain/workflow/test_required_deliverables.py` — TC-UT-VO-WF-005〜007 / TC-UT-WF-061〜064 新規追加
- その他既存テスト（factories、integration、architecture等）の `deliverable_template` → `required_deliverables` 一斉更新

## テスト担当への確認観点

- TC-UT-WF-063（MSG-WF-013）の文言・detail キーホワイトリスト完全一致を確認
- migration 0011 の upgrade/downgrade ラウンドトリップ（SQLite DROP COLUMN Python 3.12 依存）
- `_stage_from_row` の `DeliverableRequirement.model_validate` による安全デシリアライズ（§確定C / A08 Unsafe Deserialization 防御）
- `StageResponse._from_domain` の duck typing による `required_deliverables` シリアライズ（domain import なし — Q-3）

Closes #117