### PR TITLE
docs(deliverable-template): Issue #119 repository sub-feature 設計書

### DIFF
--- a/docs/features/deliverable-template/repository/basic-design.md
+++ b/docs/features/deliverable-template/repository/basic-design.md
@@ -1,0 +1,390 @@
+# 基本設計書
+
+> feature: `deliverable-template` / sub-feature: `repository`
+> 親業務仕様: [`../feature-spec.md`](../feature-spec.md)
+> 関連: [`../../empire/repository/`](../../empire/repository/) **テンプレート真実源** / [`../../workflow/repository/`](../../workflow/repository/) **partial-mask テンプレート参照** / [`../domain/`](../domain/)（domain 設計済み PR #127）
+
+## 記述ルール（必ず守ること）
+
+基本設計に**疑似コード・サンプル実装（python/ts/sh/yaml 等の言語コードブロック）を書かない**。
+ソースコードと二重管理になりメンテナンスコストしか生まない。
+必要なのは構造契約（クラス・モジュール・データの関係）であり、実装の細部は [detailed-design.md](detailed-design.md) で凍結する。
+
+## §モジュール契約（機能要件）
+
+本 sub-feature が満たすべき機能要件を凍結する。親 [`../feature-spec.md`](../feature-spec.md) §5 UC-DT-005 および §9 受入基準 AC#14〜15 をここで実装レベルに展開する。
+
+### REQ-DTR-001: DeliverableTemplateRepository Protocol 定義
+
+| 項目 | 内容 |
+|-----|-----|
+| 入力 | なし（Protocol 定義） |
+| 処理 | `find_by_id(id: DeliverableTemplateId) → DeliverableTemplate \| None` / `find_all() → list[DeliverableTemplate]` / `save(template: DeliverableTemplate) → None` の 3 メソッドを `async def` で宣言 |
+| 出力 | Protocol クラス（`application/ports/deliverable_template_repository.py`） |
+| エラー時 | 定義エラーは import 時に静的検査（pyright strict）で検出 |
+
+### REQ-DTR-002: SqliteDeliverableTemplateRepository 実装
+
+| 項目 | 内容 |
+|-----|-----|
+| 入力 | `AsyncSession`（コンストラクタ）、`DeliverableTemplateId` または `DeliverableTemplate` インスタンス（各メソッド） |
+| 処理 | Protocol 3 メソッドを SQLite + SQLAlchemy 2.x AsyncSession で実装。`save()` は `deliverable_templates` 1 テーブルへの UPSERT（§確定 B）。`find_by_id()` / `find_all()` は SELECT + `_from_row` で Aggregate 再構築。`schema` カラムは type 判別でシリアライズ（§確定 D） |
+| 出力 | `DeliverableTemplate \| None`（find_by_id）/ `list[DeliverableTemplate]`（find_all）/ None（save） |
+| エラー時 | `sqlalchemy.IntegrityError` / `sqlalchemy.OperationalError` / `pydantic.ValidationError` を上位伝播（握り潰し禁止） |
+
+### REQ-DTR-003: RoleProfileRepository Protocol 定義
+
+| 項目 | 内容 |
+|-----|-----|
+| 入力 | なし（Protocol 定義） |
+| 処理 | `find_by_empire_and_role(empire_id: EmpireId, role: Role) → RoleProfile \| None` / `find_all_by_empire(empire_id: EmpireId) → list[RoleProfile]` / `save(role_profile: RoleProfile) → None` の 3 メソッドを `async def` で宣言 |
+| 出力 | Protocol クラス（`application/ports/role_profile_repository.py`） |
+| エラー時 | 定義エラーは import 時に静的検査（pyright strict）で検出 |
+
+### REQ-DTR-004: SqliteRoleProfileRepository 実装
+
+| 項目 | 内容 |
+|-----|-----|
+| 入力 | `AsyncSession`（コンストラクタ）、`EmpireId` / `Role` / `RoleProfile` インスタンス（各メソッド） |
+| 処理 | Protocol 3 メソッドを SQLite + SQLAlchemy 2.x AsyncSession で実装。`save()` は `role_profiles` 1 テーブルへの UPSERT（§確定 B）。`find_by_empire_and_role()` / `find_all_by_empire()` は WHERE 句 + `_from_row` で Aggregate 再構築。`deliverable_template_refs_json` は JSONEncoded（§確定 G） |
+| 出力 | `RoleProfile \| None`（find_by_empire_and_role）/ `list[RoleProfile]`（find_all_by_empire）/ None（save） |
+| エラー時 | `UNIQUE(empire_id, role)` 違反時は `IntegrityError` を上位伝播（application 層が 409 にマッピング） |
+
+### REQ-DTR-005: Alembic 0012 マイグレーション
+
+| 項目 | 内容 |
+|-----|-----|
+| 入力 | Alembic upgrade head コマンド |
+| 処理 | `0012_deliverable_template_aggregate.py` revision で `deliverable_templates` / `role_profiles` の 2 テーブル + UNIQUE 制約を追加。`down_revision="0011_stage_required_deliverables"` で chain 一直線 |
+| 出力 | 2 テーブル追加済みの SQLite DB |
+| エラー時 | `downgrade` は逆順で 2 テーブル削除（`role_profiles` → `deliverable_templates` の順） |
+
+### REQ-DTR-006: CI 三層防衛拡張
+
+| 項目 | 内容 |
+|-----|-----|
+| 入力 | `scripts/ci/check_masking_columns.sh`（Layer 1）/ `backend/tests/architecture/test_masking_columns.py`（Layer 2） |
+| 処理 | Layer 1: `deliverable_templates` / `role_profiles` 両テーブルに `MaskedJSONEncoded` / `MaskedText` が存在しないことを明示 assert（masking 対象なし登録）。Layer 2: arch test parametrize に 2 テーブルを追加（empire-repository §確定 E テンプレート準拠） |
+| 出力 | CI pass / fail |
+| エラー時 | 将来 PR が誤って Masked* を追加した場合、Layer 2 が検出して CI ブロック |
+
+**masking 対象なし根拠**: 親 [`../feature-spec.md §13`](../feature-spec.md) が両 Aggregate の全カラムを機密レベル「低」と判定し、「masking 対象の追加が必要と判断された場合は別 Issue で対応する」と明示している。domain/basic-design.md §ER 図注記の "MaskedText（将来 repository sub-feature で配線）" は業務判断前の暫定メモであり、本 PR で feature-spec §13 の業務判定に従い `MaskedText` は不使用とする。
+
+### REQ-DTR-007: storage.md 逆引き表更新
+
+| 項目 | 内容 |
+|-----|-----|
+| 入力 | `docs/design/domain-model/storage.md` |
+| 処理 | §逆引き表に `deliverable_templates`（masking 対象なし）/ `role_profiles`（masking 対象なし）の 2 行を追加 |
+| 出力 | 更新済み `storage.md` |
+| エラー時 | 該当なし |
+
+## モジュール構成
+
+| 機能 ID | モジュール | ディレクトリ | 責務 |
+|--------|----------|------------|------|
+| REQ-DTR-001 | `DeliverableTemplateRepository` Protocol | `backend/src/bakufu/application/ports/deliverable_template_repository.py` | Repository ポート定義（empire-repo §確定 A テンプレート準拠） |
+| REQ-DTR-002 | `SqliteDeliverableTemplateRepository` | `backend/src/bakufu/infrastructure/persistence/sqlite/repositories/deliverable_template_repository.py` | SQLite 実装、§確定 B + §確定 D〜F |
+| REQ-DTR-003 | `RoleProfileRepository` Protocol | `backend/src/bakufu/application/ports/role_profile_repository.py` | Repository ポート定義（同上） |
+| REQ-DTR-004 | `SqliteRoleProfileRepository` | `backend/src/bakufu/infrastructure/persistence/sqlite/repositories/role_profile_repository.py` | SQLite 実装、§確定 B + §確定 G〜H |
+| REQ-DTR-005 | Alembic 0012 revision | `backend/alembic/versions/0012_deliverable_template_aggregate.py` | 2 テーブル追加、`down_revision="0011_stage_required_deliverables"` |
+| REQ-DTR-006 | CI 三層防衛拡張（Layer 1） | `scripts/ci/check_masking_columns.sh`（既存更新） | 2 テーブルを masking 対象なしで明示登録 |
+| REQ-DTR-006 | CI 三層防衛拡張（Layer 2） | `backend/tests/architecture/test_masking_columns.py`（既存更新） | parametrize に 2 テーブル追加 |
+| REQ-DTR-007 | storage.md 逆引き表更新 | `docs/design/domain-model/storage.md`（既存更新） | 2 行追加（masking 対象なし） |
+| 共通 | tables/deliverable_templates.py | `backend/src/bakufu/infrastructure/persistence/sqlite/tables/deliverable_templates.py` | 新規 |
+| 共通 | tables/role_profiles.py | `backend/src/bakufu/infrastructure/persistence/sqlite/tables/role_profiles.py` | 新規 |
+
+```
+ディレクトリ構造（本 feature で追加・変更されるファイル）:
+
+.
+├── backend/
+│   ├── alembic/
+│   │   └── versions/
+│   │       └── 0012_deliverable_template_aggregate.py     # 新規: 2 テーブル追加
+│   ├── src/
+│   │   └── bakufu/
+│   │       ├── application/
+│   │       │   └── ports/
+│   │       │       ├── deliverable_template_repository.py # 新規: Protocol
+│   │       │       └── role_profile_repository.py         # 新規: Protocol
+│   │       └── infrastructure/
+│   │           └── persistence/
+│   │               └── sqlite/
+│   │                   ├── repositories/
+│   │                   │   ├── deliverable_template_repository.py  # 新規: Sqlite実装
+│   │                   │   └── role_profile_repository.py          # 新規: Sqlite実装
+│   │                   └── tables/
+│   │                       ├── deliverable_templates.py   # 新規
+│   │                       └── role_profiles.py           # 新規
+│   └── tests/
+│       ├── architecture/
+│       │   └── test_masking_columns.py                    # 既存更新: 2 テーブル追加
+│       └── infrastructure/
+│           └── persistence/
+│               └── sqlite/
+│                   └── repositories/
+│                       ├── test_deliverable_template_repository/  # 新規ディレクトリ
+│                       │   ├── __init__.py
+│                       │   └── test_crud.py               # ヤン・ルカン担当（test-design.md）
+│                       └── test_role_profile_repository/  # 新規ディレクトリ
+│                           ├── __init__.py
+│                           └── test_crud.py               # ヤン・ルカン担当（test-design.md）
+├── scripts/
+│   └── ci/
+│       └── check_masking_columns.sh                       # 既存更新: 2 テーブル追加（対象なし）
+└── docs/
+    ├── design/
+    │   └── domain-model/
+    │       └── storage.md                                  # 既存更新: 2 行追加
+    └── features/
+        └── deliverable-template/
+            └── repository/                                 # 本 feature 設計書群
+```
+
+## クラス設計（概要）
+
+```mermaid
+classDiagram
+    class DeliverableTemplateRepository {
+        <<Protocol>>
+        +async find_by_id(id: DeliverableTemplateId) DeliverableTemplate | None
+        +async find_all() list~DeliverableTemplate~
+        +async save(template: DeliverableTemplate) None
+    }
+    class SqliteDeliverableTemplateRepository {
+        +session: AsyncSession
+        +async find_by_id(id: DeliverableTemplateId) DeliverableTemplate | None
+        +async find_all() list~DeliverableTemplate~
+        +async save(template: DeliverableTemplate) None
+        -_to_row(template: DeliverableTemplate) dict
+        -_from_row(row: dict) DeliverableTemplate
+    }
+    class RoleProfileRepository {
+        <<Protocol>>
+        +async find_by_empire_and_role(empire_id: EmpireId, role: Role) RoleProfile | None
+        +async find_all_by_empire(empire_id: EmpireId) list~RoleProfile~
+        +async save(role_profile: RoleProfile) None
+    }
+    class SqliteRoleProfileRepository {
+        +session: AsyncSession
+        +async find_by_empire_and_role(empire_id: EmpireId, role: Role) RoleProfile | None
+        +async find_all_by_empire(empire_id: EmpireId) list~RoleProfile~
+        +async save(role_profile: RoleProfile) None
+        -_to_row(role_profile: RoleProfile) dict
+        -_from_row(row: dict) RoleProfile
+    }
+    class DeliverableTemplate {
+        <<Aggregate Root>>
+        +id: DeliverableTemplateId
+        +name: str
+        +description: str
+        +type: TemplateType
+        +schema: dict | str
+        +version: SemVer
+        +acceptance_criteria: tuple~AcceptanceCriterion~
+        +composition: tuple~DeliverableTemplateRef~
+    }
+    class RoleProfile {
+        <<Aggregate Root>>
+        +id: RoleProfileId
+        +empire_id: EmpireId
+        +role: Role
+        +deliverable_template_refs: tuple~DeliverableTemplateRef~
+    }
+
+    SqliteDeliverableTemplateRepository ..|> DeliverableTemplateRepository : implements
+    SqliteDeliverableTemplateRepository --> DeliverableTemplate : returns
+    DeliverableTemplateRepository ..> DeliverableTemplate : returns
+    SqliteRoleProfileRepository ..|> RoleProfileRepository : implements
+    SqliteRoleProfileRepository --> RoleProfile : returns
+    RoleProfileRepository ..> RoleProfile : returns
+```
+
+**凝集のポイント**:
+
+- 両 Protocol は `application` 層に配置。domain は永続化を知らない
+- 両 `Sqlite*Repository` は `infrastructure` 層。Protocol を**型レベルで満たす**（`@runtime_checkable` なし、duck typing）
+- domain ↔ row 変換は private method `_to_row()` / `_from_row()` で Repository に閉じる
+- `save()` は 1 テーブルへの UPSERT（子テーブルなし）。子コレクション（acceptance_criteria / composition / deliverable_template_refs）は JSONEncoded カラムにシリアライズ
+- `DeliverableTemplate.schema` は `type` カラム（TemplateType）を判別キーとして Text でシリアライズ・デシリアライズ（§確定 D）
+- SemVer は `"major.minor.patch"` 形式の TEXT で永続化（§確定 E）
+- 呼び出し側 service が `async with session.begin():` で UoW 境界を管理。Repository は session を受け取るのみ
+
+## データモデル
+
+2 テーブル。詳細は [`detailed-design.md §データ構造（永続化キー）`](detailed-design.md)。
+
+| テーブル | 主要属性 |
+|---|---|
+| `deliverable_templates` | `id` PK / `name` / `description` / `type` / `version` TEXT "1.2.3" / `schema` Text（§確定 D）/ `acceptance_criteria_json` JSONEncoded / `composition_json` JSONEncoded |
+| `role_profiles` | `id` PK / `empire_id` FK→empires / `role` / `deliverable_template_refs_json` JSONEncoded / UNIQUE(empire_id, role) |
+
+**masking 対象カラム**: なし（feature-spec §13 の業務判断に従い CI 三層防衛で物理保証、REQ-DTR-006）
+
+## 依存関係
+
+| 区分 | 依存 | 備考 |
+|---|---|---|
+| ランタイム | Python 3.12+ | 既存 |
+| Python 依存 | SQLAlchemy 2.x / Alembic | 既存 |
+| ドメイン | `DeliverableTemplate` / `DeliverableTemplateId` / `RoleProfile` / `RoleProfileId` / `EmpireId` / `Role` / `SemVer` / `DeliverableTemplateRef` / `AcceptanceCriterion` | PR #127 実装済み |
+| インフラ | `Base` / `UUIDStr` / `JSONEncoded` / `AsyncSession` | 既存 |
+| 外部サービス | 該当なし | infrastructure 層のため外部通信なし |
+
+## 処理フロー
+
+### ユースケース 1: DeliverableTemplate の保存（save 経路）
+
+1. application 層 `DeliverableTemplateService.create(...)` が `DeliverableTemplate` Aggregate を構築
+2. service が `async with session.begin():` で UoW 境界を開く
+3. service が `DeliverableTemplateRepository.save(template)` を呼ぶ
+4. `SqliteDeliverableTemplateRepository.save(template)` が以下を実行:
+   - `_to_row(template)` で `deliverable_templates_row: dict` に変換（schema シリアライズ §確定 D、SemVer TEXT §確定 E、JSON カラム §確定 F）
+   - `INSERT INTO deliverable_templates (...) ON CONFLICT (id) DO UPDATE SET ...`（UPSERT）
+5. `session.begin()` ブロック退出で commit、例外なら rollback
+
+### ユースケース 2: DeliverableTemplate の取得（find_by_id 経路）
+
+1. application 層が `DeliverableTemplateRepository.find_by_id(template_id)` を呼ぶ
+2. `SqliteDeliverableTemplateRepository.find_by_id(template_id)` が以下を実行:
+   - `SELECT * FROM deliverable_templates WHERE id = :id` で行を取得（不在なら None を返す）
+   - `_from_row(row)` で `DeliverableTemplate` を構築（schema デシリアライズ §確定 D、SemVer 復元 §確定 E、JSON カラム復元 §確定 F）
+3. valid な `DeliverableTemplate` を返却
+
+### ユースケース 3: RoleProfile の保存・取得（save / find 経路）
+
+1. application 層が `RoleProfileRepository.save(role_profile)` を呼ぶ
+2. `SqliteRoleProfileRepository.save(role_profile)` が `_to_row(role_profile)` → UPSERT（§確定 B）
+3. `find_by_empire_and_role(empire_id, role)`:
+   - `SELECT * FROM role_profiles WHERE empire_id = :empire_id AND role = :role` → `_from_row` で復元
+4. `find_all_by_empire(empire_id)`:
+   - `SELECT * FROM role_profiles WHERE empire_id = :empire_id ORDER BY role` → `_from_row` で復元
+
+## シーケンス図
+
+```mermaid
+sequenceDiagram
+    participant Svc as DeliverableTemplateService（別 PR）
+    participant DTRepo as SqliteDeliverableTemplateRepository
+    participant Sess as AsyncSession
+    participant DB as SQLite
+
+    Svc->>Sess: async with session.begin():
+    Svc->>DTRepo: save(template)
+    DTRepo->>DTRepo: _to_row(template)
+    DTRepo->>Sess: INSERT INTO deliverable_templates ... ON CONFLICT DO UPDATE
+    Sess->>DB: SQL
+    DB-->>Sess: ok
+    DTRepo-->>Svc: ok（例外なし）
+    Svc->>Sess: session.begin() 退出 → commit
+    Sess->>DB: COMMIT
+    DB-->>Sess: ok
+
+    Note over Svc,DB: find_by_id 経路
+    Svc->>DTRepo: find_by_id(template_id)
+    DTRepo->>Sess: SELECT * FROM deliverable_templates WHERE id = :id
+    Sess->>DB: SQL
+    DB-->>Sess: row or None
+    DTRepo->>DTRepo: _from_row(row)
+    DTRepo-->>Svc: DeliverableTemplate | None
+```
+
+## アーキテクチャへの影響
+
+- `docs/design/domain-model/storage.md` への変更: §逆引き表に `deliverable_templates` / `role_profiles` の 2 行追加（masking 対象なし、REQ-DTR-007）
+- `docs/design/domain-model/aggregates.md` への変更: なし（domain PR #127 で既に追加済み）
+- `docs/design/tech-stack.md` への変更: なし
+- 既存 feature への波及:
+  - `feature/persistence-foundation` の上に乗る、追加要件なし
+  - `feature/deliverable-template/domain`（PR #127 マージ済み）の domain 層 Aggregate を import するのみ、domain 設計書は変更しない
+  - `feature/empire/repository` の `empires` テーブルへの FK（`role_profiles.empire_id → empires.id`）が新たに追加される
+
+## 外部連携
+
+該当なし — 理由: infrastructure 層（SQLite Repository）に閉じる。外部システムへの通信は発生しない。
+
+| 連携先 | 目的 | プロトコル | 認証 | タイムアウト / リトライ |
+|-------|------|----------|-----|--------------------|
+| 該当なし | — | — | — | — |
+
+## UX 設計
+
+該当なし — 理由: UI を持たない infrastructure 層。
+
+| シナリオ | 期待される挙動 |
+|---------|------------|
+| 該当なし | — |
+
+**アクセシビリティ方針**: 該当なし（UI なし）。
+
+## セキュリティ設計
+
+### 脅威モデル
+
+詳細な信頼境界は [`docs/design/threat-model.md`](../../../design/threat-model.md)。本 feature 範囲では以下の 2 件。
+
+| 想定攻撃者 | 攻撃経路 | 保護資産 | 対策 |
+|-----------|---------|---------|------|
+| **T1: Masked* 誤追加（後続 PR の事故）** | 後続 PR の実装者が `schema` / `acceptance_criteria_json` を `MaskedText` / `MaskedJSONEncoded` と誤判断して追加 | masking 整合性（BUG-PF-001: 過剰マスキング防止） | CI 三層防衛 Layer 1（grep guard）+ Layer 2（arch test）で 2 テーブルを「masking 対象なし」として明示登録（REQ-DTR-006）。feature-spec §13 の業務判断を設計書で凍結 |
+| **T2: UNIQUE(empire_id, role) 制約違反による同一 Role の RoleProfile 重複** | 競合 Tx で同一 Role の `save()` が並走 → DB 制約違反 | RoleProfile 1:1 制約（feature-spec 業務ルール R1-D） | SQLite の UNIQUE 制約が最終防衛線。`IntegrityError` を application 層に伝播し 409 Conflict にマッピング（service 層が `find_by_empire_and_role` 事前チェック + Tx 内で 2 重防衛） |
+
+### OWASP Top 10 対応
+
+| # | カテゴリ | 対応状況 |
+|---|---------|---------|
+| A01 | Broken Access Control | 該当なし（infrastructure 層、認可は別 feature） |
+| A02 | Cryptographic Failures | **適用**: 両 Aggregate の全カラムは feature-spec §13 が「機密レベル低」と判断。masking 不要（REQ-DTR-006 CI 三層防衛で物理保証）。将来 secret 混入リスクが高まった場合は別 Issue で `MaskedText` / `MaskedJSONEncoded` を追加する |
+| A03 | Injection | **適用**: SQLAlchemy ORM + Core バインドパラメータで SQL injection 防御。raw SQL 文字列は使わない |
+| A04 | Insecure Design | **適用**: Repository ポート分離（依存方向 domain ← application ← infrastructure）+ UPSERT 原子性 |
+| A05 | Security Misconfiguration | M2 永続化基盤の PRAGMA 強制（defensive=ON 等）の上に乗る、追加要件なし |
+| A06 | Vulnerable Components | SQLAlchemy 2.x / Alembic / aiosqlite（pip-audit で監視） |
+| A07 | Auth Failures | 該当なし |
+| A08 | Data Integrity Failures | **適用**: `role_profiles` の UNIQUE(empire_id, role) 制約で RoleProfile 1:1 業務ルール R1-D を DB レベルで物理保証。Tx 原子性（WAL）で半端更新を防止 |
+| A09 | Logging Failures | **適用**: `_from_row` 内の `pydantic.ValidationError` は DB 破損として上位伝播。acceptance_criteria.description 等の自然言語フィールドは feature-spec §13 の業務判断に従い audit_log に raw で記録（secret 混入リスク低）。将来リスク再評価が必要な場合は別 Issue |
+| A10 | SSRF | 該当なし |
+
+## ER 図
+
+```mermaid
+erDiagram
+    EMPIRES {
+        UUIDStr id PK
+    }
+    DELIVERABLE_TEMPLATES {
+        UUIDStr id PK
+        String name "1〜80 文字"
+        Text description "0〜500 文字"
+        String type "TemplateType enum (MARKDOWN/JSON_SCHEMA/OPENAPI/CODE_SKELETON/PROMPT)"
+        Text version "SemVer TEXT: 'major.minor.patch'"
+        Text schema "DeliverableTemplate.schema: JSON dump (JSON_SCHEMA/OPENAPI) または plain text (その他)"
+        JSONEncoded acceptance_criteria_json "list[AcceptanceCriterion] NOT NULL DEFAULT '[]'"
+        JSONEncoded composition_json "list[DeliverableTemplateRef] NOT NULL DEFAULT '[]'"
+    }
+    ROLE_PROFILES {
+        UUIDStr id PK
+        UUIDStr empire_id FK
+        String role "Role StrEnum"
+        JSONEncoded deliverable_template_refs_json "list[DeliverableTemplateRef] NOT NULL DEFAULT '[]'"
+    }
+
+    EMPIRES ||--o{ ROLE_PROFILES : "has 0..N profiles (CASCADE)"
+```
+
+UNIQUE 制約:
+
+- `role_profiles(empire_id, role)`: 同一 Empire 内で同 Role 値の RoleProfile の重複を禁止（業務ルール R1-D）
+
+**masking 対象カラム**: なし（feature-spec §13 の業務判断、CI 三層防衛で物理保証）
+
+## エラーハンドリング方針
+
+| 例外種別 | 処理方針 | ユーザーへの通知 |
+|---------|---------|----------------|
+| `sqlalchemy.IntegrityError`（UNIQUE 違反: `role_profiles(empire_id, role)`） | application 層に伝播、409 Conflict にマッピング | application 層 / HTTP API の MSG（別 feature） |
+| `sqlalchemy.IntegrityError`（FK 違反: `role_profiles.empire_id → empires.id`） | application 層に伝播、404 / 422 にマッピング | 同上 |
+| `sqlalchemy.OperationalError`（接続切断、ロック timeout） | application 層に伝播、503 にマッピング | 同上 |
+| `pydantic.ValidationError`（`_from_row` 内 Aggregate 構築時） | Repository 内で catch せず application 層に伝播、データ破損として扱う | application 層 / HTTP API の MSG |
+| その他 | 握り潰さない、application 層へ伝播 | 汎用エラーメッセージ |
+
+**Repository 内で明示的な commit / rollback はしない**: 呼び出し側 service が `async with session.begin():` で UoW 境界を管理。これにより 1 Tx 内で複数 Repository を呼ぶシナリオに対応。

--- a/docs/features/deliverable-template/repository/detailed-design.md
+++ b/docs/features/deliverable-template/repository/detailed-design.md
@@ -1,0 +1,402 @@
+# 詳細設計書
+
+> feature: `deliverable-template` / sub-feature: `repository`
+> 関連: [basic-design.md](basic-design.md) / [`docs/features/persistence-foundation/detailed-design.md`](../../persistence-foundation/detailed-design.md) / [`docs/features/empire/repository/detailed-design.md`](../../empire/repository/detailed-design.md) テンプレート真実源
+
+## 記述ルール（必ず守ること）
+
+詳細設計に**疑似コード・サンプル実装（python/ts/sh/yaml 等の言語コードブロック）を書かない**。
+ソースコードと二重管理になりメンテナンスコストしか生まない。
+必要なのは「構造契約（属性名・型・制約）」と「確定文言（メッセージ文字列）」と「実装の意図」。
+
+## クラス設計（詳細）
+
+```mermaid
+classDiagram
+    class DeliverableTemplateRepository {
+        <<Protocol>>
+        +async find_by_id(id: DeliverableTemplateId) DeliverableTemplate | None
+        +async find_all() list~DeliverableTemplate~
+        +async save(template: DeliverableTemplate) None
+    }
+    class SqliteDeliverableTemplateRepository {
+        +session: AsyncSession
+        +async find_by_id(id: DeliverableTemplateId) DeliverableTemplate | None
+        +async find_all() list~DeliverableTemplate~
+        +async save(template: DeliverableTemplate) None
+        -_to_row(template: DeliverableTemplate) dict
+        -_from_row(row: dict) DeliverableTemplate
+    }
+    class RoleProfileRepository {
+        <<Protocol>>
+        +async find_by_empire_and_role(empire_id: EmpireId, role: Role) RoleProfile | None
+        +async find_all_by_empire(empire_id: EmpireId) list~RoleProfile~
+        +async save(role_profile: RoleProfile) None
+    }
+    class SqliteRoleProfileRepository {
+        +session: AsyncSession
+        +async find_by_empire_and_role(empire_id: EmpireId, role: Role) RoleProfile | None
+        +async find_all_by_empire(empire_id: EmpireId) list~RoleProfile~
+        +async save(role_profile: RoleProfile) None
+        -_to_row(role_profile: RoleProfile) dict
+        -_from_row(row: dict) RoleProfile
+    }
+```
+
+### Protocol: DeliverableTemplateRepository（`application/ports/deliverable_template_repository.py`）
+
+| メソッド | 引数 | 戻り値 | 制約 |
+|----|----|----|----|
+| `find_by_id(id: DeliverableTemplateId)` | DeliverableTemplateId | `DeliverableTemplate \| None` | 不在時 None。SQLAlchemy 例外は上位伝播 |
+| `find_all()` | なし | `list[DeliverableTemplate]` | `ORDER BY name ASC` で決定論的順序保証（§確定 I）。0 件の場合は空リスト |
+| `save(template: DeliverableTemplate)` | DeliverableTemplate | None | `deliverable_templates` テーブルへの UPSERT（§確定 B）。子テーブルなし |
+
+`@runtime_checkable` は付与しない（empire-repository §確定 A テンプレート、duck typing）。
+
+### Protocol: RoleProfileRepository（`application/ports/role_profile_repository.py`）
+
+| メソッド | 引数 | 戻り値 | 制約 |
+|----|----|----|----|
+| `find_by_empire_and_role(empire_id: EmpireId, role: Role)` | EmpireId, Role | `RoleProfile \| None` | 不在時 None。UNIQUE 制約により最大 1 件 |
+| `find_all_by_empire(empire_id: EmpireId)` | EmpireId | `list[RoleProfile]` | `ORDER BY role ASC` で決定論的順序保証（§確定 I）。0 件の場合は空リスト |
+| `save(role_profile: RoleProfile)` | RoleProfile | None | `role_profiles` テーブルへの UPSERT（§確定 B）。`role_profile.empire_id` を UPSERT WHERE 条件に含める |
+
+`@runtime_checkable` は付与しない（同上）。
+
+### Class: SqliteDeliverableTemplateRepository（`infrastructure/persistence/sqlite/repositories/deliverable_template_repository.py`）
+
+| 属性 | 型 | 制約 |
+|----|----|----|
+| `session` | `AsyncSession` | コンストラクタで注入、Tx 境界は外側 service が管理 |
+
+| 関数 | 引数 | 戻り値 | 制約 |
+|----|----|----|----|
+| `__init__(session: AsyncSession)` | session | None | session を保持するだけ、Tx は開かない |
+| `find_by_id(id)` | DeliverableTemplateId | `DeliverableTemplate \| None` | `SELECT * FROM deliverable_templates WHERE id = :id` → 不在なら None → `_from_row` で構築 |
+| `find_all()` | なし | `list[DeliverableTemplate]` | `SELECT * FROM deliverable_templates ORDER BY name ASC` → `[_from_row(row) for row in rows]`（§確定 I） |
+| `save(template)` | DeliverableTemplate | None | `_to_row(template)` → `INSERT ... ON CONFLICT (id) DO UPDATE SET ...`（§確定 B） |
+| `_to_row(template)` | DeliverableTemplate | `dict[str, Any]` | schema シリアライズ（§確定 D）+ SemVer TEXT（§確定 E）+ JSON カラム（§確定 F）の変換を担う |
+| `_from_row(row)` | `dict[str, Any]` | `DeliverableTemplate` | schema デシリアライズ（§確定 D）+ SemVer 復元（§確定 E）+ JSON カラム復元（§確定 F）。生 dict 直渡しは禁止（§確定 F 理由参照） |
+
+### Class: SqliteRoleProfileRepository（`infrastructure/persistence/sqlite/repositories/role_profile_repository.py`）
+
+| 属性 | 型 | 制約 |
+|----|----|----|
+| `session` | `AsyncSession` | コンストラクタで注入、Tx 境界は外側 service が管理 |
+
+| 関数 | 引数 | 戻り値 | 制約 |
+|----|----|----|----|
+| `__init__(session: AsyncSession)` | session | None | session を保持するだけ、Tx は開かない |
+| `find_by_empire_and_role(empire_id, role)` | EmpireId, Role | `RoleProfile \| None` | `SELECT * FROM role_profiles WHERE empire_id = :empire_id AND role = :role` → 不在なら None → `_from_row` で構築 |
+| `find_all_by_empire(empire_id)` | EmpireId | `list[RoleProfile]` | `SELECT * FROM role_profiles WHERE empire_id = :empire_id ORDER BY role ASC` → `[_from_row(row) for row in rows]`（§確定 I） |
+| `save(role_profile)` | RoleProfile | None | `_to_row(role_profile)` → `INSERT ... ON CONFLICT (id) DO UPDATE SET ...`（§確定 B）。`UNIQUE(empire_id, role)` 違反は `IntegrityError` として上位伝播（§確定 H） |
+| `_to_row(role_profile)` | RoleProfile | `dict[str, Any]` | `deliverable_template_refs_json` JSONEncoded 変換を担う（§確定 G） |
+| `_from_row(row)` | `dict[str, Any]` | `RoleProfile` | `deliverable_template_refs_json` 復元を担う（§確定 G）。生 dict 直渡しは禁止 |
+
+### Tables（infrastructure/persistence/sqlite/tables/）
+
+| テーブル | モジュール | 主要カラム |
+|----|----|----|
+| `deliverable_templates` | `tables/deliverable_templates.py`（新規） | `id: UUIDStr PK` / `name: String(80) NOT NULL` / `description: Text NOT NULL` / `type: String(32) NOT NULL` / `version: String(20) NOT NULL` / `schema: Text NOT NULL` / `acceptance_criteria_json: JSONEncoded NOT NULL` / `composition_json: JSONEncoded NOT NULL` |
+| `role_profiles` | `tables/role_profiles.py`（新規） | `id: UUIDStr PK` / `empire_id: UUIDStr FK CASCADE` / `role: String(32) NOT NULL` / `deliverable_template_refs_json: JSONEncoded NOT NULL` / UNIQUE(empire_id, role) |
+
+すべて `bakufu.infrastructure.persistence.sqlite.base.Base` を継承。
+
+## 確定事項（先送り撤廃）
+
+### 確定 A: Repository ポート配置 — empire-repository §確定 A 踏襲
+
+`application/ports/{aggregate}_repository.py` の命名規則に従う。
+
+| Aggregate | Protocol ファイル | 担当 PR |
+|---|---|---|
+| DeliverableTemplate | `application/ports/deliverable_template_repository.py` | **本 PR** |
+| RoleProfile | `application/ports/role_profile_repository.py` | **本 PR** |
+
+Protocol 定義の規約は empire-repository §確定 A（async def / @runtime_checkable なし / domain 型のみ）に完全準拠する。
+
+### 確定 B: `save()` 戦略 — UPSERT（子テーブルなし）
+
+`DeliverableTemplate` / `RoleProfile` は acceptance_criteria / composition / deliverable_template_refs をそれぞれ JSON カラムにシリアライズするため、**子テーブルは存在しない**。empire-repository の delete-then-insert（子テーブルを全件削除→再挿入）パターンとは異なり、1 テーブルへの UPSERT のみで完結する。
+
+##### `SqliteDeliverableTemplateRepository.save()` 手順（凍結）
+
+| 順 | 操作 | SQL（概要） |
+|---|---|---|
+| 1 | deliverable_templates UPSERT | `INSERT INTO deliverable_templates (id, name, description, type, version, schema, acceptance_criteria_json, composition_json) VALUES (...) ON CONFLICT (id) DO UPDATE SET name=EXCLUDED.name, description=EXCLUDED.description, type=EXCLUDED.type, version=EXCLUDED.version, schema=EXCLUDED.schema, acceptance_criteria_json=EXCLUDED.acceptance_criteria_json, composition_json=EXCLUDED.composition_json` |
+
+##### `SqliteRoleProfileRepository.save()` 手順（凍結）
+
+| 順 | 操作 | SQL（概要） |
+|---|---|---|
+| 1 | role_profiles UPSERT | `INSERT INTO role_profiles (id, empire_id, role, deliverable_template_refs_json) VALUES (...) ON CONFLICT (id) DO UPDATE SET empire_id=EXCLUDED.empire_id, role=EXCLUDED.role, deliverable_template_refs_json=EXCLUDED.deliverable_template_refs_json` |
+
+**注**: `ON CONFLICT (id)` を使用する理由: `id` は不変の Aggregate 識別子。application 層が既存 RoleProfile を `find_by_empire_and_role` で取得して `role` を変更した場合（同一 `id`、別 `role`）も UPSERT で自然に処理される。一方、同一 `(empire_id, role)` で別 `id` の insert を試みると `UNIQUE(empire_id, role)` 違反として `IntegrityError` が発生し、application 層の 1:1 制約チェックをすり抜けた並走バグを検出できる（§確定 H）。
+
+##### Tx 境界の責務分離
+
+`save()` は **明示的な commit / rollback をしない**（empire-repository §確定 B テンプレート）。呼び出し側 service が `async with session.begin():` で UoW 境界を管理する。
+
+### 確定 C: domain ↔ row 変換 — Repository クラス内 private method
+
+`_to_row()` / `_from_row()` を各 Repository クラスの private method として配置する（empire-repository §確定 C テンプレート）。
+
+- `_to_row(aggregate)` は `dict[str, Any]` を返す（SQLAlchemy Core `insert().values(row)` に渡す形式）
+- `_from_row(row)` は `dict[str, Any]` を受け取り Aggregate を返す（SQLAlchemy `Row` オブジェクトは `.mapping` 経由で dict に変換して渡す）
+- Aggregate の不変条件は `model_validate` 経由で再走る（Repository は再 validate しない契約だが、構築は valid な状態で行われる）
+
+### 確定 D: schema カラムシリアライズ契約（type 判別）
+
+`DeliverableTemplate.schema` は `dict[str, object] | str` の Union 型。DB カラム名は `schema`（Text NOT NULL）。
+
+##### `_to_row` での schema シリアライズ
+
+| template.type | template.schema の Python 型 | DB 格納値（Text） |
+|---|---|---|
+| `TemplateType.JSON_SCHEMA` | `dict[str, object]` | `json.dumps(template.schema)` |
+| `TemplateType.OPENAPI` | `dict[str, object]` | `json.dumps(template.schema)` |
+| `TemplateType.MARKDOWN` | `str` | そのまま格納（plain text） |
+| `TemplateType.CODE_SKELETON` | `str` | そのまま格納（plain text） |
+| `TemplateType.PROMPT` | `str` | そのまま格納（plain text） |
+
+##### `_from_row` での schema デシリアライズ
+
+| row['type'] | row['schema'] の格納値 | _from_row での変換 |
+|---|---|---|
+| `'JSON_SCHEMA'` / `'OPENAPI'` | JSON 文字列（`json.dumps` した dict） | `json.loads(row['schema'])` → `dict` |
+| `'MARKDOWN'` / `'CODE_SKELETON'` / `'PROMPT'` | plain text 文字列 | そのまま `str` として使用 |
+
+**設計根拠**: `type` カラムが判別キーとして機能するため、NULL 可能な 2 カラム設計（`schema_dict` / `schema_text`）より単純。`json.dumps` 済みの文字列が plain text と混在するが、`type` による一意の分岐で曖昧性なし。
+
+### 確定 E: SemVer 永続化契約（TEXT "major.minor.patch"）
+
+`DeliverableTemplate.version` は `SemVer` VO（`major: int`, `minor: int`, `patch: int`）。DB カラム `version` は `String(20) NOT NULL`（TEXT 型）。
+
+| 操作 | 変換 | 根拠 |
+|---|---|---|
+| `_to_row` | `str(template.version)` → `"1.2.3"` 形式 | `SemVer.__str__` が `f"{major}.{minor}.{patch}"` を返す（domain 実装済み） |
+| `_from_row` | `SemVer.from_str(row['version'])` → `SemVer` | `SemVer.from_str` が `"1.2.3"` を解析する class method（domain 実装済み）。解析失敗は DB 破損として `ValueError` を上位伝播 |
+
+3 カラム分割（`version_major` / `version_minor` / `version_patch`）は採用しない。TEXT 1 カラムの方が可読性が高く、`SemVer.from_str` が既に提供されているため冗長な変換ロジック不要。
+
+### 確定 F: acceptance_criteria_json / composition_json シリアライズ契約
+
+`DeliverableTemplate.acceptance_criteria: tuple[AcceptanceCriterion, ...]` および `DeliverableTemplate.composition: tuple[DeliverableTemplateRef, ...]` は JSONEncoded カラムに格納する。
+
+##### `_to_row` シリアライズ（acceptance_criteria_json）
+
+| 変換操作 | 結果 |
+|---|---|
+| `[c.model_dump(mode='json') for c in template.acceptance_criteria]` | `list[dict]` — JSONEncoded が `json.dumps` して Text に格納 |
+
+各 `AcceptanceCriterion` の `id` フィールド（UUID 型）は `model_dump(mode='json')` により文字列にシリアライズされる。
+
+##### `_from_row` 復元（acceptance_criteria_json）
+
+| 操作 | 理由 |
+|---|---|
+| `json.loads(row['acceptance_criteria_json'])` → `list[dict]` → `[AcceptanceCriterion.model_validate(d) for d in ...]` → `tuple(...)` | **生 dict 直渡し禁止**: `model_validate` を経由することで AcceptanceCriterion の UUID 型変換（`str` → `UUID`）が保証される。生 dict を `DeliverableTemplate.model_validate({'acceptance_criteria': [...raw dicts...], ...})` に渡すと Pydantic が `str` → `UUID` 変換を試みるが、Aggregate 全体の model_validate のネスト変換に依存するより VO 単位で明示的に変換する方が障害局所化が明確（workflow §確定 H 同パターン） |
+
+##### `_to_row` シリアライズ（composition_json）
+
+| 変換操作 | 結果 |
+|---|---|
+| `[r.model_dump(mode='json') for r in template.composition]` | `list[dict]` — `[{"template_id": "...", "minimum_version": {"major": 1, "minor": 0, "patch": 0}}, ...]` 形式 |
+
+##### `_from_row` 復元（composition_json）
+
+| 操作 | 形式 |
+|---|---|
+| `json.loads(row['composition_json'])` → `list[dict]` → `[DeliverableTemplateRef.model_validate(d) for d in ...]` → `tuple(...)` | `tuple[DeliverableTemplateRef, ...]` |
+
+**`DeliverableTemplate` 全体の `_from_row` 変換フロー**:
+
+| DB カラム | Python 型変換 | Aggregate フィールド |
+|---|---|---|
+| `id` (TEXT) | `DeliverableTemplateId(UUID(row['id']))` | `id: DeliverableTemplateId` |
+| `name` (TEXT) | そのまま `str` | `name: str` |
+| `description` (TEXT) | そのまま `str` | `description: str` |
+| `type` (TEXT) | `TemplateType(row['type'])` | `type: TemplateType` |
+| `version` (TEXT "1.2.3") | `SemVer.from_str(row['version'])` | `version: SemVer` |
+| `schema` (TEXT) | `json.loads(...)` or そのまま（§確定 D） | `schema: dict \| str` |
+| `acceptance_criteria_json` (JSONEncoded) | `tuple(AcceptanceCriterion.model_validate(d) for d in ...)` | `acceptance_criteria: tuple[AcceptanceCriterion, ...]` |
+| `composition_json` (JSONEncoded) | `tuple(DeliverableTemplateRef.model_validate(d) for d in ...)` | `composition: tuple[DeliverableTemplateRef, ...]` |
+
+最終的に `DeliverableTemplate.model_validate({...})` に渡して Aggregate を構築する。
+
+### 確定 G: deliverable_template_refs_json シリアライズ契約（RoleProfile）
+
+`RoleProfile.deliverable_template_refs: tuple[DeliverableTemplateRef, ...]` は `deliverable_template_refs_json: JSONEncoded` カラムに格納する（§確定 F の composition_json と同パターン）。
+
+##### `_to_row` シリアライズ
+
+| 変換操作 | 結果 |
+|---|---|
+| `[r.model_dump(mode='json') for r in role_profile.deliverable_template_refs]` | `[{"template_id": "...", "minimum_version": {"major": 1, "minor": 0, "patch": 0}}, ...]` |
+
+##### `_from_row` 復元
+
+| 操作 | 形式 |
+|---|---|
+| `json.loads(row['deliverable_template_refs_json'])` → `list[dict]` → `[DeliverableTemplateRef.model_validate(d) for d in ...]` → `tuple(...)` | `tuple[DeliverableTemplateRef, ...]` |
+
+**`RoleProfile` 全体の `_from_row` 変換フロー**:
+
+| DB カラム | Python 型変換 | Aggregate フィールド |
+|---|---|---|
+| `id` (TEXT) | `RoleProfileId(UUID(row['id']))` | `id: RoleProfileId` |
+| `empire_id` (TEXT) | `EmpireId(UUID(row['empire_id']))` | `empire_id: EmpireId` |
+| `role` (TEXT) | `Role(row['role'])` | `role: Role` |
+| `deliverable_template_refs_json` (JSONEncoded) | `tuple(DeliverableTemplateRef.model_validate(d) for d in ...)` | `deliverable_template_refs: tuple[DeliverableTemplateRef, ...]` |
+
+最終的に `RoleProfile.model_validate({...})` に渡して Aggregate を構築する。
+
+### 確定 H: UNIQUE(empire_id, role) DB 制約と IntegrityError 伝播
+
+`role_profiles` テーブルの `UNIQUE(empire_id, role)` 制約は業務ルール R1-D（同一 Role に 1 件のみ）の DB レベルの最終防衛線。
+
+| 状況 | 動作 |
+|---|---|
+| 同一 Empire 内で同 Role の新規 `save()` | `INSERT ... ON CONFLICT (id)` で `id` が異なる場合 `UNIQUE(empire_id, role)` 違反 → `sqlalchemy.IntegrityError` を application 層に伝播 |
+| 既存 RoleProfile の `save()`（同 id） | `ON CONFLICT (id) DO UPDATE SET ...` で `empire_id` / `role` も上書き。`UNIQUE(empire_id, role)` は id 不変の前提では違反しない |
+| 競合 Tx（並走 insert） | SQLite のファイルロック + WAL で直列化。後発 Tx が `IntegrityError` → application 層が 409 Conflict にマッピング |
+
+**application 層の 2 重防衛**: service が `find_by_empire_and_role(empire_id, role)` で事前チェック → 存在時は業務エラー → 不在確認後に `save()` → 競合 Tx をすり抜けた場合は DB 制約が最終防衛。
+
+### 確定 I: ORDER BY での決定論的順序保証（empire-repository §BUG-EMR-001 踏襲）
+
+SQLite は `ORDER BY` を明示しない場合、行スキャン順（INSERT 順 / PAGE 順）が返り値の順序になる保証がない。
+
+| メソッド | ORDER BY | 根拠 |
+|---|---|---|
+| `SqliteDeliverableTemplateRepository.find_all()` | `ORDER BY name ASC` | テンプレート一覧は名前順が自然。決定論的順序でテスト比較を可能にする |
+| `SqliteRoleProfileRepository.find_all_by_empire(empire_id)` | `ORDER BY role ASC` | Role は StrEnum 値（大文字）。アルファベット昇順が自然かつ決定論的 |
+
+`find_by_id` / `find_by_empire_and_role` は単一行の取得のため ORDER BY 不要。
+
+### 確定 J: CI 三層防衛の DeliverableTemplate / RoleProfile 拡張
+
+empire-repository §確定 E テンプレートに従う。
+
+##### Layer 1: grep guard（`scripts/ci/check_masking_columns.sh`）
+
+| 登録内容 | 期待結果 |
+|---|---|
+| `deliverable_templates` テーブル宣言ファイルに `MaskedJSONEncoded` / `MaskedText` が登場しないこと | grep ゼロヒット → pass |
+| `role_profiles` テーブル宣言ファイルに同上 | 同上 |
+
+##### Layer 2: arch test（`backend/tests/architecture/test_masking_columns.py`）
+
+| 入力 | 期待 assertion |
+|---|---|
+| `Base.metadata.tables['deliverable_templates']` | 全カラムの `column.type.__class__` が `MaskedJSONEncoded` でも `MaskedText` でもない（= `String` / `UUIDStr` / `Text` / `JSONEncoded` のみ） |
+| `Base.metadata.tables['role_profiles']` | 同上（= `String` / `UUIDStr` / `JSONEncoded` のみ） |
+
+##### Layer 3: storage.md 逆引き表更新（REQ-DTR-007）
+
+`docs/design/domain-model/storage.md` §逆引き表に「masking 対象なし」行 2 件を追加。
+
+### 確定 K: Alembic 0012 revision 方針
+
+| 項目 | 内容 |
+|---|---|
+| revision id | `"0012_deliverable_template_aggregate"` |
+| down_revision | `"0011_stage_required_deliverables"` |
+| upgrade 操作 | `op.create_table('deliverable_templates', ...)` → `op.create_table('role_profiles', ...)` の順 |
+| downgrade 操作 | `op.drop_table('role_profiles')` → `op.drop_table('deliverable_templates')` の逆順（FK を持つ `role_profiles` を先に削除） |
+| MVP 時データ | 本番データなし。DEFAULT '[]' のみで充足（データ変換不要） |
+
+**SQLite DROP COLUMN 保証**: `requires-python = ">=3.12"` により Python 3.12 同梱 SQLite は 3.42.0 以上が保証（3.35.0+ が DROP COLUMN サポートの最低要件、大幅に上回るため追加要件なし）。本 revision では DROP COLUMN は不使用（新規テーブル追加のみ）のため非該当。
+
+## データ構造（永続化キー）
+
+### `deliverable_templates` テーブル
+
+| カラム | 型 | 制約 | 意図 |
+|----|----|----|----|
+| `id` | `UUIDStr` | PK, NOT NULL | DeliverableTemplateId |
+| `name` | `String(80)` | NOT NULL | テンプレート名（1〜80 文字、domain 不変条件で保証） |
+| `description` | `Text` | NOT NULL | テンプレート説明（0〜500 文字） |
+| `type` | `String(32)` | NOT NULL | TemplateType enum 値（"MARKDOWN" / "JSON_SCHEMA" / "OPENAPI" / "CODE_SKELETON" / "PROMPT"）|
+| `version` | `String(20)` | NOT NULL | SemVer TEXT 形式（"major.minor.patch"、例: "1.2.3"）|
+| `schema` | `Text` | NOT NULL | DeliverableTemplate.schema フィールド: JSON_SCHEMA / OPENAPI 時は `json.dumps(dict)`、その他は plain text（§確定 D） |
+| `acceptance_criteria_json` | `JSONEncoded` | NOT NULL DEFAULT '[]' | `list[AcceptanceCriterion]` の JSON シリアライズ（§確定 F） |
+| `composition_json` | `JSONEncoded` | NOT NULL DEFAULT '[]' | `list[DeliverableTemplateRef]` の JSON シリアライズ（§確定 F） |
+
+masking 対象カラム: **なし**（feature-spec §13 業務判断、CI 三層防衛で物理保証）
+
+### `role_profiles` テーブル
+
+| カラム | 型 | 制約 | 意図 |
+|----|----|----|----|
+| `id` | `UUIDStr` | PK, NOT NULL | RoleProfileId |
+| `empire_id` | `UUIDStr` | FK → `empires.id` ON DELETE CASCADE, NOT NULL | 所属 Empire（empire-scope の一意性基盤） |
+| `role` | `String(32)` | NOT NULL | Role StrEnum 値（文字列、例: "ENGINEER" / "REVIEWER"） |
+| `deliverable_template_refs_json` | `JSONEncoded` | NOT NULL DEFAULT '[]' | `list[DeliverableTemplateRef]` の JSON シリアライズ（§確定 G） |
+| UNIQUE | `(empire_id, role)` | — | 業務ルール R1-D: 同一 Empire 内で同 Role の RoleProfile は 1 件のみ（§確定 H） |
+
+masking 対象カラム: **なし**（同上）
+
+### Alembic 0012 revision キー構造（`0012_deliverable_template_aggregate.py`）
+
+revision id: `"0012_deliverable_template_aggregate"`（固定）
+down_revision: `"0011_stage_required_deliverables"`
+
+| 操作 | 対象 |
+|----|----|
+| `op.create_table('deliverable_templates', ...)` | 8 カラム |
+| `op.create_table('role_profiles', ...)` | 4 カラム + UNIQUE(empire_id, role) + FK → empires.id ON DELETE CASCADE |
+
+`downgrade()` は `op.drop_table` で逆順実行（FK を持つ `role_profiles` から先に削除）。
+
+## Known Issues
+
+該当なし（Issue #119 スコープ開始時点で既知の問題なし）。
+
+## 設計判断の補足
+
+### なぜ子テーブルを使わず JSONEncoded カラムに集約するか
+
+empire-repository では `empire_room_refs` / `empire_agent_refs` の子テーブルを delete-then-insert で管理したが、本 Repository では acceptance_criteria / composition / deliverable_template_refs を JSONEncoded カラムに格納する。
+
+| 観点 | 子テーブル方式 | JSONEncoded 方式（採用） |
+|---|---|---|
+| 正規化 | ◎ 正規化、個別 AcceptanceCriterion の集計クエリが容易 | △ 非正規化、JSON カラムの中身は SQL 集計不可 |
+| 実装複雑性 | ✗ delete-then-insert + 3〜5 テーブル | ◎ 1 テーブル UPSERT のみ |
+| MVP ユースケース | AcceptanceCriterion 単位の集計クエリなし（application 層が全件ロード後に処理） | ◎ ユースケースに過不足なし |
+| 将来拡張性 | ◎ 個別 ID での UPDATE / SELECT が容易 | △ JSON 展開が必要（YAGNI 原則で将来 Issue） |
+
+**MVP 判断**: UC-DT-005（永続化）の要件は「再起動を跨いで Aggregate が復元できること」のみ。AcceptanceCriterion 単位の SQL クエリは Issue #107 スコープ外。YAGNI 原則により子テーブルは作成しない。将来 AI 評価（Issue #123）や集計が必要になった段階で別 Alembic revision で子テーブルを追加できる。
+
+### なぜ schema カラム名を `schema` にするか（`body` ではなく）
+
+domain ER 図（`domain/basic-design.md §ER 図`）および domain Aggregate のフィールド名（`DeliverableTemplate.schema`）との一貫性を優先する。SQLite は `schema` を列名として予約していない。SQLAlchemy `mapped_column` の属性名として `schema` を使用しても `Base` クラスとの衝突はない。一方、`body` は REST API の "request body" と混同されやすい。
+
+### なぜ `save(role_profile: RoleProfile)` に empire_id を別引数で渡さないか
+
+`RoleProfile` Aggregate は `empire_id: EmpireId` を属性として保持する（`role_profile.py` 実装済み、PR #127 確認済み）。`save(role_profile, empire_id)` のように empire_id を引数で渡す設計は:
+- 属性の二重管理（`role_profile.empire_id` と引数 `empire_id` が食い違うバグの可能性）
+- Protocol の引数が domain 層の Aggregate 型のみ（empire-repository §確定 A 規約）から逸脱
+
+`save(role_profile: RoleProfile)` とし、`_to_row` 内で `role_profile.empire_id` を参照するのが正しい設計。
+
+## ユーザー向けメッセージの確定文言
+
+該当なし — 理由: Repository は内部 API、ユーザー向けメッセージは application 層 / HTTP API 層が定義する。Repository は SQLAlchemy 例外（IntegrityError 等）を上位伝播するのみ。
+
+## API エンドポイント詳細
+
+該当なし — 理由: 本 feature は infrastructure 層のみ。HTTP API は `feature/deliverable-template/http-api`（Issue #122）で凍結する。
+
+## 出典・参考
+
+- [SQLAlchemy 2.0 — async / AsyncEngine / AsyncSession](https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html)
+- [SQLAlchemy 2.0 — INSERT with ON CONFLICT](https://docs.sqlalchemy.org/en/20/dialects/sqlite.html#insert-on-conflict)
+- [Alembic Tutorial](https://alembic.sqlalchemy.org/en/latest/tutorial.html)
+- [Python typing.Protocol](https://docs.python.org/3/library/typing.html#typing.Protocol)
+- [`docs/features/empire/repository/detailed-design.md`](../../empire/repository/detailed-design.md) — §確定 A〜F テンプレート真実源
+- [`docs/features/workflow/repository/detailed-design.md`](../../workflow/repository/detailed-design.md) — §確定 H JSONEncoded / MaskedJSONEncoded パターン参照
+- [`docs/features/deliverable-template/feature-spec.md`](../feature-spec.md) — §13 機密レベル業務判断の真実源
+- [`docs/features/deliverable-template/domain/basic-design.md`](../domain/basic-design.md) — Aggregate 属性・VO 構造の真実源
+- [`docs/features/persistence-foundation/`](../../persistence-foundation/) — M2 永続化基盤（JSONEncoded / MaskedJSONEncoded TypeDecorator）
+- [`docs/design/domain-model/storage.md`](../../../design/domain-model/storage.md) — 逆引き表（本 PR で 2 行追加）

--- a/docs/features/deliverable-template/repository/test-design.md
+++ b/docs/features/deliverable-template/repository/test-design.md
@@ -1,0 +1,353 @@
+# テスト設計書
+
+> feature: `deliverable-template` / sub-feature: `repository`
+> 親業務仕様: [`../feature-spec.md`](../feature-spec.md)
+> 対象範囲: REQ-DTR-001〜007 / §9 受入基準 AC#14, #15 + 内部品質基準（§確定 A〜K）/
+> Repository ポート + UPSERT 1 テーブル + domain↔row 変換（§D/E/F/G）+ schema type 判別 +
+> SemVer TEXT + ORDER BY 規約 + UNIQUE 制約 + CI 三層防衛 no-mask
+
+本 sub-feature は M2 Repository **4 番目の Aggregate Repository PR** であり、
+empire-repository（PR #25）が凍結したテンプレート（§確定 A〜F）を**完全継承**する。
+本 feature 固有の追加凍結条項は §確定 D（schema type 判別）/ §確定 E（SemVer TEXT）/
+§確定 F（acceptance_criteria_json / composition_json JSONEncoded + A08）/
+§確定 G（deliverable_template_refs_json JSONEncoded + A08）/ §確定 H（UNIQUE(empire_id, role)
+IntegrityError 伝播）/ §確定 I（ORDER BY 規約）/ §確定 J（CI 三層防衛 no-mask 拡張）/
+§確定 K（Alembic 0012 revision）の 8 件。
+
+戦略ガイド §結合テスト方針「DB は実接続」「外部 API のみモック」に従い、本 sub-feature のテストは:
+
+- **integration test 主導**: Alembic 0012 revision 適用 → AsyncSession で
+  `find_by_id` / `find_all` / `save` / `find_by_empire_and_role` / `find_all_by_empire`
+  の各メソッド契約検証（`tmp_path` で実 SQLite ファイル）。
+  persistence-foundation conftest の `app_engine` / `session_factory` fixture を再利用。
+- **CI 三層防衛 no-mask 拡張**: Layer 1（grep guard）+ Layer 2（arch test）+
+  Layer 3（storage.md）の 3 層が「`deliverable_templates` / `role_profiles` の全カラムが
+  masking 対象外」を物理保証（§確定 J / REQ-DTR-006）
+- **schema type 判別の物理確認**: §確定 D が規定する type カラム判別ロジックを
+  JSON_SCHEMA / OPENAPI（json.dumps）と MARKDOWN 等（plain text）の両経路で IT 物理確認
+- **A08 防御（Unsafe Deserialization）の物理確認**: `_from_row` が
+  `AcceptanceCriterion.model_validate` / `DeliverableTemplateRef.model_validate` を
+  必ず経由することを DB 直 INSERT → find 経路で物理確認（§確定 F/G）
+- **UNIQUE(empire_id, role) 制約違反の物理確認**: 同一 `(empire_id, role)` 別 id の
+  二重 save が `IntegrityError` を raise することを実 SQLite で確認（§確定 H）
+- **assumed mock 禁止規約**: `mock.return_value` インライン辞書は禁止、
+  DeliverableTemplate / RoleProfile は既存 `tests/factories/deliverable_template.py`
+  （domain sub-feature 由来）から取得
+
+masking 配線（MaskedJSONEncoded / MaskedText）は **本 sub-feature には存在しない**。
+feature-spec §13 の業務判断に従い全カラムが機密レベル「低」のため、masking 実装・テストは
+不要（CI 三層防衛 Layer 1〜3 で「masking 対象なし」を物理保証、§確定 J）。
+
+E2E は親 [`../system-test-design.md`](../system-test-design.md) が担当。
+本テスト設計書は IT / UT のみ扱う。
+
+## テストマトリクス
+
+| 要件ID | 実装アーティファクト | テストケースID | テストレベル | 種別 | 受入基準 |
+|--------|-------------------|--------------|-----------|----|---------|
+| REQ-DTR-001 | `DeliverableTemplateRepository(Protocol)` 定義 | TC-IT-DTR-001 | 結合 | 正常系 | 内部品質基準 |
+| REQ-DTR-001 | `SqliteDeliverableTemplateRepository` の Protocol 充足 | TC-IT-DTR-002 | 結合 | 正常系 | 内部品質基準 |
+| REQ-DTR-002 | `find_by_id(existing_id)` で DeliverableTemplate 取得 | TC-IT-DTR-003 | 結合 | 正常系 | AC#14 |
+| REQ-DTR-002 | `find_by_id(unknown_id)` で None | TC-IT-DTR-004 | 結合 | 異常系 | 内部品質基準 |
+| REQ-DTR-002（§確定 I, ORDER BY name） | `find_all()` が `ORDER BY name ASC` で決定論的順序を返す | TC-IT-DTR-005 | 結合 | 正常系 | 内部品質基準 |
+| REQ-DTR-002（§確定 I, ORDER BY name） | 0 件の場合 `find_all()` が空リストを返す | TC-IT-DTR-006 | 結合 | 正常系 | 内部品質基準 |
+| REQ-DTR-002（§確定 B, UPSERT 新規） | `save(template)` 新規挿入で `deliverable_templates` に行が入る | TC-IT-DTR-007 | 結合 | 正常系 | AC#14 |
+| REQ-DTR-002（§確定 B, UPSERT 更新） | `save(template)` 既存上書きで全カラムが最新値に置換される | TC-IT-DTR-008 | 結合 | 正常系 | 内部品質基準 |
+| REQ-DTR-002（§確定 B, Tx 境界） | service 側 `async with session.begin()` で commit / rollback 両経路、Repository は明示的 commit/rollback しない | TC-IT-DTR-009 | 結合 | 正常系/異常系 | （責務境界） |
+| REQ-DTR-002（§確定 D, schema JSON_SCHEMA） | `type=JSON_SCHEMA` の `schema(dict)` が `json.dumps` で Text 格納 → `json.loads` で dict 復元 | TC-IT-DTR-010 | 結合 | 正常系 | 内部品質基準 |
+| REQ-DTR-002（§確定 D, schema OPENAPI） | `type=OPENAPI` の `schema(dict)` が `json.dumps` で Text 格納 → `json.loads` で dict 復元 | TC-IT-DTR-011 | 結合 | 正常系 | 内部品質基準 |
+| REQ-DTR-002（§確定 D, schema MARKDOWN） | `type=MARKDOWN` の `schema(str)` が plain text 格納 → そのまま str 復元 | TC-IT-DTR-012 | 結合 | 正常系 | 内部品質基準 |
+| REQ-DTR-002（§確定 D, schema CODE_SKELETON） | `type=CODE_SKELETON` の `schema(str)` が plain text 格納 → そのまま str 復元 | TC-IT-DTR-013 | 結合 | 正常系 | 内部品質基準 |
+| REQ-DTR-002（§確定 D, schema PROMPT） | `type=PROMPT` の `schema(str)` が plain text 格納 → そのまま str 復元 | TC-IT-DTR-014 | 結合 | 正常系 | 内部品質基準 |
+| REQ-DTR-002（§確定 E, SemVer TEXT） | SemVer が `"major.minor.patch"` TEXT で格納 → `SemVer.from_str` で復元 | TC-IT-DTR-015 | 結合 | 正常系 | 内部品質基準 |
+| REQ-DTR-002（§確定 F, A08, acceptance_criteria） | `acceptance_criteria_json` 復元が `AcceptanceCriterion.model_validate` 経由（A08 防御） | TC-IT-DTR-016 | 結合 | 正常系 | 内部品質基準 |
+| REQ-DTR-002（§確定 F, A08, composition） | `composition_json` 復元が `DeliverableTemplateRef.model_validate` 経由（A08 防御） | TC-IT-DTR-017 | 結合 | 正常系 | 内部品質基準 |
+| REQ-DTR-002（§確定 F, A08, 不正 JSON） | `_from_row` で `acceptance_criteria_json` が不正データの場合 `ValidationError` / `ValueError` 上位伝播（A08 Fail-Fast） | TC-IT-DTR-018 | 結合 | 異常系 | 内部品質基準 |
+| REQ-DTR-002（§確定 C, ラウンドトリップ） | `save(template) → find_by_id(template.id)` で全フィールド構造的等価 | TC-IT-DTR-019 | 結合 | 正常系 | AC#14 |
+| REQ-DTR-003 | `RoleProfileRepository(Protocol)` 定義 | TC-IT-RPR-001 | 結合 | 正常系 | 内部品質基準 |
+| REQ-DTR-003 | `SqliteRoleProfileRepository` の Protocol 充足 | TC-IT-RPR-002 | 結合 | 正常系 | 内部品質基準 |
+| REQ-DTR-004 | `find_by_empire_and_role(empire_id, role)` 既存 RoleProfile 取得 | TC-IT-RPR-003 | 結合 | 正常系 | AC#15 |
+| REQ-DTR-004 | `find_by_empire_and_role(empire_id, role)` 不在 → None | TC-IT-RPR-004 | 結合 | 異常系 | 内部品質基準 |
+| REQ-DTR-004（§確定 I, ORDER BY role） | `find_all_by_empire(empire_id)` が `ORDER BY role ASC` で決定論的順序を返す | TC-IT-RPR-005 | 結合 | 正常系 | 内部品質基準 |
+| REQ-DTR-004（§確定 I） | `find_all_by_empire(empire_id)` は別 empire の行を返さない | TC-IT-RPR-006 | 結合 | 正常系 | 内部品質基準 |
+| REQ-DTR-004（§確定 B, UPSERT 新規） | `save(role_profile)` 新規挿入で `role_profiles` に行が入る | TC-IT-RPR-007 | 結合 | 正常系 | AC#15 |
+| REQ-DTR-004（§確定 B, UPSERT 更新） | `save(role_profile)` 既存上書きで全カラムが最新値に置換される（同 id 上書き） | TC-IT-RPR-008 | 結合 | 正常系 | 内部品質基準 |
+| REQ-DTR-004（§確定 B, Tx 境界） | service 側 `async with session.begin()` で commit / rollback 両経路、Repository は明示的 commit/rollback しない | TC-IT-RPR-009 | 結合 | 正常系/異常系 | （責務境界） |
+| REQ-DTR-004（§確定 G, A08, deliverable_template_refs） | `deliverable_template_refs_json` 復元が `DeliverableTemplateRef.model_validate` 経由（A08 防御） | TC-IT-RPR-010 | 結合 | 正常系 | 内部品質基準 |
+| REQ-DTR-004（§確定 G, A08, 不正 JSON） | `_from_row` で `deliverable_template_refs_json` が不正データの場合 `ValidationError` / `ValueError` 上位伝播（A08 Fail-Fast） | TC-IT-RPR-011 | 結合 | 異常系 | 内部品質基準 |
+| REQ-DTR-004（§確定 H, UNIQUE 違反） | 同一 `(empire_id, role)` 別 id の `save()` が `IntegrityError` を raise（DB 最終防衛線） | TC-IT-RPR-012 | 結合 | 異常系 | 内部品質基準 |
+| REQ-DTR-004（§確定 H, UNIQUE 同 id UPSERT） | 同一 id の `save()` 再呼び出しが `IntegrityError` を raise しない（正常 UPSERT） | TC-IT-RPR-013 | 結合 | 正常系 | 内部品質基準 |
+| REQ-DTR-004（FK CASCADE） | `empires` の CASCADE DELETE で `role_profiles` 行が連鎖削除される | TC-IT-RPR-014 | 結合 | 正常系 | （データモデル） |
+| REQ-DTR-004（§確定 C, ラウンドトリップ） | `save(role_profile) → find_by_empire_and_role(empire_id, role)` で全フィールド構造的等価 | TC-IT-RPR-015 | 結合 | 正常系 | AC#15 |
+| REQ-DTR-005（Alembic 0012 upgrade） | `upgrade head` で `deliverable_templates` / `role_profiles` 2 テーブル追加 | TC-IT-MIGR-012-001 | 結合 | 正常系 | 内部品質基準 |
+| REQ-DTR-005（Alembic 0012 UNIQUE 制約） | upgrade 後 `role_profiles` に `UNIQUE(empire_id, role)` 制約が存在する | TC-IT-MIGR-012-002 | 結合 | 正常系 | 内部品質基準 |
+| REQ-DTR-005（Alembic 0012 downgrade） | `downgrade` で `role_profiles` → `deliverable_templates` の逆順削除 | TC-IT-MIGR-012-003 | 結合 | 正常系 | 内部品質基準 |
+| REQ-DTR-005（Alembic 0012 round-trip） | upgrade → downgrade → upgrade が冪等 | TC-IT-MIGR-012-004 | 結合 | 正常系 | 内部品質基準 |
+| REQ-DTR-005（revision chain 一直線） | 0012 が単一 head / `down_revision == "0011_stage_required_deliverables"` | TC-IT-MIGR-012-005 | 結合 | 正常系 | 内部品質基準 |
+| REQ-DTR-006（Layer 1 grep） | `scripts/ci/check_masking_columns.sh` で両テーブルが Masked* 不在を pass | TC-CI-DTR-001 | CI script | 正常系 | 内部品質基準 |
+| REQ-DTR-006（Layer 2 arch） | `tests/architecture/test_masking_columns.py` で両テーブルの全カラムが Masked* 不在を assert | TC-IT-DTR-020 | 結合 | 正常系 | 内部品質基準 |
+| REQ-DTR-007（Layer 3 storage.md） | §逆引き表に `deliverable_templates` / `role_profiles` の 2 行（masking 対象なし）が存在 | TC-DOC-DTR-001 | doc 検証 | 正常系 | （Layer 3） |
+
+**マトリクス充足の証拠**:
+
+- REQ-DTR-001〜007 すべてに最低 1 件のテストケース
+- **§9 受入基準 AC#14（DeliverableTemplate 永続化・再起動跨ぎ保持）**: TC-IT-DTR-003 / 007 / 019 で IT カバー。E2E（再起動跨ぎ）は親 system-test-design.md
+- **§9 受入基準 AC#15（RoleProfile 永続化・再起動跨ぎ保持）**: TC-IT-RPR-003 / 007 / 015 で IT カバー。E2E は親 system-test-design.md
+- **§確定 D（schema type 判別）**: TC-IT-DTR-010〜014 で JSON_SCHEMA / OPENAPI / MARKDOWN / CODE_SKELETON / PROMPT の 5 type すべてを物理確認
+- **§確定 E（SemVer TEXT）**: TC-IT-DTR-015 でラウンドトリップ
+- **§確定 F（JSONEncoded A08）**: TC-IT-DTR-016〜018 で正常系 model_validate 経由 + 不正 JSON Fail-Fast を物理確認
+- **§確定 G（deliverable_template_refs_json A08）**: TC-IT-RPR-010〜011 で同上
+- **§確定 H（UNIQUE 制約 IntegrityError 伝播）**: TC-IT-RPR-012 で IntegrityError、TC-IT-RPR-013 で正常 UPSERT を物理確認
+- **§確定 I（ORDER BY 規約）**: TC-IT-DTR-005（name ASC）+ TC-IT-RPR-005（role ASC）で決定論的順序を物理確認
+- **§確定 B（Tx 境界 UPSERT）**: TC-IT-DTR-009 + TC-IT-RPR-009 で commit / rollback 両経路、Repository が明示的 commit/rollback しないことを assert
+- **§確定 K（Alembic 0012）**: TC-IT-MIGR-012-001〜005 で upgrade / downgrade / round-trip / chain 一直線を物理確認
+- **CI 三層防衛 no-mask（§確定 J）**: Layer 1（TC-CI-DTR-001）+ Layer 2（TC-IT-DTR-020）+ Layer 3（TC-DOC-DTR-001）3 層すべてに証拠ケース
+- 孤児要件ゼロ
+
+## 外部 I/O 依存マップ
+
+本 sub-feature は infrastructure 層の Repository 実装。empire-repository / workflow-repository と同方針で本物の SQLite + 本物の Alembic + 本物の SQLAlchemy AsyncSession を使う。
+
+| 外部 I/O | 用途 | raw fixture | factory | characterization 状態 |
+|--------|-----|------------|---------|---------------------|
+| **SQLite (sqlite+aiosqlite)** | engine / session / 2 テーブル / Alembic migration | 不要（実 DB を `tmp_path` 配下で起動、テストごとに使い捨て） | 不要 | **済（本物使用、persistence-foundation conftest.py の `app_engine` / `session_factory` fixture を再利用）** |
+| **ファイルシステム** | `bakufu.db` / WAL/SHM ファイル | 不要（`pytest.tmp_path`） | 不要 | **済（本物使用）** |
+| **Alembic** | 0012 revision の `upgrade head` / `downgrade` | 不要（本物の `alembic upgrade` を実 SQLite に対し実行） | 不要 | **済（本物使用、persistence-foundation の `run_upgrade_head` を再利用）** |
+| **SQLAlchemy 2.x AsyncSession** | UoW 境界 / Repository メソッド経由の SQL 発行 | 不要 | 不要 | **済（本物使用）** |
+
+**factory（合成データ）の扱い**:
+
+| factory | 出力 | `_meta.synthetic` 付与 |
+|--------|-----|------------------|
+| `make_deliverable_template`（既存、domain sub-feature 由来） | `DeliverableTemplate`（デフォルト: MARKDOWN 型、空 schema / acceptance_criteria / composition） | `True` |
+| `make_role_profile`（既存） | `RoleProfile`（デフォルト: DEVELOPER ロール、空 deliverable_template_refs） | `True` |
+| `make_acceptance_criterion`（既存） | `AcceptanceCriterion`（id=uuid4(), description="満たすべき条件", required=True） | `True` |
+| `make_deliverable_template_ref`（既存） | `DeliverableTemplateRef`（template_id=uuid4(), minimum_version=SemVer(1,0,0)） | `True` |
+| `make_semver`（既存） | `SemVer`（デフォルト: 1.0.0） | `True` |
+| `make_empire`（既存、empire factory 由来） | `Empire`（role_profiles の FK 先 empire 行を `empires` テーブルに INSERT するために使用） | `True` |
+
+`tests/factories/deliverable_template.py` は domain sub-feature（PR #127）で確立済み。本 PR では factory 追加なし。
+
+**raw fixture / characterization は不要**: SQLite + SQLAlchemy + Alembic はすべて標準ライブラリ仕様 / 既存 conftest セット内動作で固定、外部観測（実 DB ファイル）が真実源として常時使える。masking gateway は不使用のため、masking 初期化 fixture も不要。
+
+## 結合テストケース
+
+「Repository 契約 + 実 SQLite + 実 Alembic」を contract testing する層。M2 永続化基盤の `app_engine` / `session_factory` fixture を再利用。
+
+### Protocol 定義 + 充足（内部品質基準、§確定 A）
+
+| テストID | 対象モジュール連携 | 使用 fixture | 前提条件 | 操作 | 期待結果 |
+|---------|------------------|------------|---------|------|---------|
+| TC-IT-DTR-001 | `DeliverableTemplateRepository(Protocol)` 定義 | — | `application/ports/deliverable_template_repository.py` がインポート可能 | `from bakufu.application.ports.deliverable_template_repository import DeliverableTemplateRepository` | Protocol が `find_by_id` / `find_all` / `save` の 3 メソッドを宣言、すべて `async def`。`@runtime_checkable` なし |
+| TC-IT-DTR-002 | `SqliteDeliverableTemplateRepository` の Protocol 充足 | `session_factory` | engine + Alembic 適用済み | `repo: DeliverableTemplateRepository = SqliteDeliverableTemplateRepository(session)` で型代入が pyright で通る | pyright strict pass。duck typing で `hasattr(repo, 'find_by_id') and hasattr(repo, 'find_all') and hasattr(repo, 'save')` 全 True |
+| TC-IT-RPR-001 | `RoleProfileRepository(Protocol)` 定義 | — | `application/ports/role_profile_repository.py` がインポート可能 | `from bakufu.application.ports.role_profile_repository import RoleProfileRepository` | Protocol が `find_by_empire_and_role` / `find_all_by_empire` / `save` の 3 メソッドを宣言、すべて `async def`。`@runtime_checkable` なし |
+| TC-IT-RPR-002 | `SqliteRoleProfileRepository` の Protocol 充足 | `session_factory` | engine + Alembic 適用済み | `repo: RoleProfileRepository = SqliteRoleProfileRepository(session)` で型代入が pyright で通る | pyright strict pass。duck typing で `hasattr(repo, 'find_by_empire_and_role') and hasattr(repo, 'find_all_by_empire') and hasattr(repo, 'save')` 全 True |
+
+### DeliverableTemplate 基本 CRUD（AC#14 / 内部品質基準）
+
+| テストID | 対象モジュール連携 | 使用 fixture | 前提条件 | 操作 | 期待結果 |
+|---------|------------------|------------|---------|------|---------|
+| TC-IT-DTR-003 | `find_by_id(existing_id)` | `session_factory` + `make_deliverable_template` | `save(template)` で 1 件保存済み | 別 session で `find_by_id(template.id)` | 保存した DeliverableTemplate と同一 id を持つ Aggregate を返す |
+| TC-IT-DTR-004 | `find_by_id(unknown_id)` | `session_factory` | DB 空 | `find_by_id(uuid4())` を呼ぶ | `None` を返す。例外を raise しない |
+| TC-IT-DTR-005 | `find_all()` ORDER BY name ASC | `session_factory` + `make_deliverable_template` | 異なる name（"Z-template" / "A-template" / "M-template"）で 3 件 save 済み | `find_all()` を呼ぶ | name アルファベット昇順 `["A-template", "M-template", "Z-template"]` の順序で返す（§確定 I） |
+| TC-IT-DTR-006 | `find_all()` 0 件 | `session_factory` | DB 空 | `find_all()` を呼ぶ | 空リスト `[]` を返す。例外を raise しない |
+| TC-IT-DTR-007 | `save(template)` 新規 UPSERT | `session_factory` + `make_deliverable_template` | DB 空 | `save(template)` 後、別 session で raw SQL `SELECT * FROM deliverable_templates WHERE id=?` | 1 行が存在し、`name` / `type` / `version` / `schema` が Aggregate VO 値と一致 |
+| TC-IT-DTR-008 | `save(template)` 既存上書き UPSERT | `session_factory` + `make_deliverable_template` | 1 度 save 済みの template | name を変更した同 id の template を再 `save(updated_template)` | `find_by_id(template.id)` で取得した Aggregate が更新後 name を返す。古い値は残らない（1 テーブル UPSERT §確定 B） |
+| TC-IT-DTR-009 | Tx 境界の責務分離（§確定 B） | `session_factory` + `make_deliverable_template` | — | (1) **正常系**: `async with session.begin(): await repo.save(template)` → ブロック退出で commit、(2) **異常系**: 同ブロック内で `raise RuntimeError` → rollback | commit 経路で template が永続化、rollback 経路で原子的に消える。Repository は `await session.commit()` / `session.rollback()` を呼ばない（§確定 B） |
+
+### §確定 D（schema type 判別、内部品質基準）
+
+`type=JSON_SCHEMA` / `OPENAPI` は `json.dumps(dict)` で格納、
+`MARKDOWN` / `CODE_SKELETON` / `PROMPT` は plain text のまま格納。
+`_from_row` は `row['type']` を判別キーとして `json.loads` or 素通しを切り替える。
+
+| テストID | 対象モジュール連携 | 使用 fixture | 前提条件 | 操作 | 期待結果 |
+|---------|------------------|------------|---------|------|---------|
+| TC-IT-DTR-010 | schema JSON_SCHEMA → json.dumps → json.loads ラウンドトリップ | `session_factory` + `make_deliverable_template` | — | `type=JSON_SCHEMA`, `schema={"$schema": "http://json-schema.org/draft-07/schema#", "type": "object"}` の template を save → find_by_id | 復元 `template.schema` が元の `dict` と等価。DB カラム `schema` は JSON 文字列（raw SQL で `{"$schema"` 等の文字列が観測できる）。`type(restored.schema) is dict` |
+| TC-IT-DTR-011 | schema OPENAPI → json.dumps → json.loads ラウンドトリップ | `session_factory` + `make_deliverable_template` | — | `type=OPENAPI`, `schema={"openapi": "3.0.0", "info": {"title": "test"}}` の template を save → find_by_id | 復元 `template.schema` が元の `dict` と等価。`type(restored.schema) is dict` |
+| TC-IT-DTR-012 | schema MARKDOWN → plain text ラウンドトリップ | `session_factory` + `make_deliverable_template` | — | `type=MARKDOWN`, `schema="# 設計書\n## 概要\n..."` の template を save → find_by_id | 復元 `template.schema` が元の `str` と等価（改行含む）。`type(restored.schema) is str` |
+| TC-IT-DTR-013 | schema CODE_SKELETON → plain text ラウンドトリップ | `session_factory` + `make_deliverable_template` | — | `type=CODE_SKELETON`, `schema="def main(): pass"` の template を save → find_by_id | 復元 `template.schema` が元の `str` と等価。`type(restored.schema) is str` |
+| TC-IT-DTR-014 | schema PROMPT → plain text ラウンドトリップ | `session_factory` + `make_deliverable_template` | — | `type=PROMPT`, `schema="あなたは...としてふるまいます"` の template を save → find_by_id | 復元 `template.schema` が元の `str` と等価。`type(restored.schema) is str` |
+
+### §確定 E（SemVer TEXT ラウンドトリップ、内部品質基準）
+
+| テストID | 対象モジュール連携 | 使用 fixture | 前提条件 | 操作 | 期待結果 |
+|---------|------------------|------------|---------|------|---------|
+| TC-IT-DTR-015 | SemVer TEXT "major.minor.patch" ラウンドトリップ | `session_factory` + `make_deliverable_template` + `make_semver` | — | `version=SemVer(major=3, minor=14, patch=159)` の template を save → find_by_id、かつ raw SQL で `version` カラム文字列を取得 | (1) raw SQL `version` カラムが文字列 `"3.14.159"` そのものを格納、(2) `find_by_id` 復元後の `template.version == SemVer(3, 14, 159)` |
+
+### §確定 F（acceptance_criteria_json / composition_json A08 防御、内部品質基準）
+
+| テストID | 対象モジュール連携 | 使用 fixture | 前提条件 | 操作 | 期待結果 |
+|---------|------------------|------------|---------|------|---------|
+| TC-IT-DTR-016 | `acceptance_criteria_json` A08 防御（model_validate 経由の物理確認） | `session_factory` | — | DB に valid な `acceptance_criteria_json` を直接 INSERT（UUID 文字列含む JSON）し、`find_by_id` で水和 | 復元 `template.acceptance_criteria[0]` が `AcceptanceCriterion` インスタンス。`type(restored.acceptance_criteria[0].id) is UUID`（str ではなく UUID 型）。model_validate が UUID 変換を保証したことの証拠 |
+| TC-IT-DTR-017 | `composition_json` A08 防御（model_validate 経由の物理確認） | `session_factory` | — | DB に valid な `composition_json` を直接 INSERT（`template_id` UUID 文字列 + `minimum_version` dict を含む JSON）し、`find_by_id` で水和 | 復元 `template.composition[0]` が `DeliverableTemplateRef` インスタンス。`type(restored.composition[0].template_id) is UUID`（UUID 型）。`restored.composition[0].minimum_version == SemVer(major, minor, patch)` |
+| TC-IT-DTR-018 | `_from_row` 不正 `acceptance_criteria_json` → ValidationError（A08 Fail-Fast） | `session_factory` | — | `acceptance_criteria_json` に `template_id` が UUID 形式でない壊れた JSON（`[{"id": "not-a-uuid", "description": "x", "required": true}]`）を直接 INSERT し、`find_by_id` を呼ぶ | `pydantic.ValidationError` または `ValueError` が raise される。Repository が Exception を握り潰さない（A08 Fail-Fast = DB 破損を起動時に検出） |
+
+### §確定 C（DeliverableTemplate domain↔row ラウンドトリップ、内部品質基準）
+
+| テストID | 対象モジュール連携 | 使用 fixture | 前提条件 | 操作 | 期待結果 |
+|---------|------------------|------------|---------|------|---------|
+| TC-IT-DTR-019 | `save → find_by_id` 全フィールド構造的等価 | `session_factory` + `make_deliverable_template` + `make_acceptance_criterion` + `make_deliverable_template_ref` | — | `acceptance_criteria` 2 件 + `composition` 1 件 + SemVer(2,3,4) + `type=MARKDOWN` + `schema="test schema"` の template を save → find_by_id | `restored.id == template.id`、`restored.name == template.name`、`restored.version == SemVer(2,3,4)`、`restored.acceptance_criteria == template.acceptance_criteria`（tuple 順・等値）、`restored.composition == template.composition` |
+
+### RoleProfile 基本 CRUD（AC#15 / 内部品質基準）
+
+**前提**: `role_profiles.empire_id` は `empires.id` への FK。テスト前に `make_empire()` を使い empire 行を `empires` テーブルに直接 INSERT すること（または empire repository を使い save すること）。
+
+| テストID | 対象モジュール連携 | 使用 fixture | 前提条件 | 操作 | 期待結果 |
+|---------|------------------|------------|---------|------|---------|
+| TC-IT-RPR-003 | `find_by_empire_and_role(empire_id, role)` 既存取得 | `session_factory` + `make_role_profile` | empire 行 + `save(role_profile)` で 1 件保存済み | 別 session で `find_by_empire_and_role(role_profile.empire_id, role_profile.role)` | 保存した RoleProfile と同一 id を持つ Aggregate を返す |
+| TC-IT-RPR-004 | `find_by_empire_and_role` 不在 → None | `session_factory` | DB 空 | `find_by_empire_and_role(uuid4(), Role.DEVELOPER)` | `None` を返す。例外を raise しない |
+| TC-IT-RPR-005 | `find_all_by_empire(empire_id)` ORDER BY role ASC | `session_factory` + `make_role_profile` | 同一 empire に `Role.TESTER` / `Role.DEVELOPER` / `Role.REVIEWER` の 3 件 save 済み | `find_all_by_empire(empire_id)` | role アルファベット昇順（"DEVELOPER", "REVIEWER", "TESTER" の順）で返す（§確定 I） |
+| TC-IT-RPR-006 | `find_all_by_empire` 別 empire を除外 | `session_factory` + `make_role_profile` | empire A の DEVELOPER 1 件 + empire B の DEVELOPER 1 件 save 済み | `find_all_by_empire(empire_a_id)` | empire A の 1 件のみ返す。empire B の行は含まれない |
+| TC-IT-RPR-007 | `save(role_profile)` 新規 UPSERT | `session_factory` + `make_role_profile` | empire 行あり、DB 空 | `save(role_profile)` 後、raw SQL `SELECT * FROM role_profiles WHERE id=?` | 1 行が存在し、`empire_id` / `role` / `deliverable_template_refs_json` が Aggregate VO 値と一致 |
+| TC-IT-RPR-008 | `save(role_profile)` 既存上書き UPSERT（同 id） | `session_factory` + `make_role_profile` | 1 度 save 済みの role_profile | `deliverable_template_refs` を更新した同 id の role_profile を再 `save(updated_role_profile)` | `find_by_empire_and_role` で取得した Aggregate が更新後 refs を返す。古い refs は残らない |
+| TC-IT-RPR-009 | Tx 境界の責務分離（§確定 B） | `session_factory` + `make_role_profile` | empire 行あり | (1) **正常系**: `async with session.begin(): await repo.save(role_profile)` → commit、(2) **異常系**: 同ブロック内で `raise RuntimeError` → rollback | commit 経路で role_profile が永続化、rollback 経路で消える。Repository は `await session.commit()` / `session.rollback()` を呼ばない |
+
+### §確定 G（deliverable_template_refs_json A08 防御、内部品質基準）
+
+| テストID | 対象モジュール連携 | 使用 fixture | 前提条件 | 操作 | 期待結果 |
+|---------|------------------|------------|---------|------|---------|
+| TC-IT-RPR-010 | `deliverable_template_refs_json` A08 防御（model_validate 経由の物理確認） | `session_factory` | empire 行あり | DB に valid な `deliverable_template_refs_json`（`[{"template_id": "<uuid>", "minimum_version": {"major": 2, "minor": 1, "patch": 0}}]`）を直接 INSERT し、`find_by_empire_and_role` で水和 | 復元 `role_profile.deliverable_template_refs[0]` が `DeliverableTemplateRef` インスタンス。`type(restored.deliverable_template_refs[0].template_id) is UUID`。`minimum_version == SemVer(2, 1, 0)` |
+| TC-IT-RPR-011 | `_from_row` 不正 `deliverable_template_refs_json` → ValidationError（A08 Fail-Fast） | `session_factory` | empire 行あり | `deliverable_template_refs_json` に UUID 形式でない壊れた JSON を直接 INSERT し、`find_by_empire_and_role` を呼ぶ | `pydantic.ValidationError` または `ValueError` が raise される |
+
+### §確定 H（UNIQUE(empire_id, role) 制約違反、内部品質基準）
+
+| テストID | 対象モジュール連携 | 使用 fixture | 前提条件 | 操作 | 期待結果 |
+|---------|------------------|------------|---------|------|---------|
+| TC-IT-RPR-012 | 同一 `(empire_id, role)` 別 id → `IntegrityError` | `session_factory` + `make_role_profile` | empire 行あり + (empire_id=A, role=DEVELOPER) 1 件 save 済み | **別 id** で同じ `(empire_id=A, role=DEVELOPER)` の `RoleProfile` を `save()` | `sqlalchemy.IntegrityError`（または `UniqueViolation`）が raise される。DB の UNIQUE(empire_id, role) 制約が最終防衛線として機能（§確定 H） |
+| TC-IT-RPR-013 | 同 id UPSERT は IntegrityError しない | `session_factory` + `make_role_profile` | empire 行あり + 1 件 save 済み | 同一 id、同一 `(empire_id, role)` の `save()` を再呼び出し | 例外を raise せず正常に完了する。`ON CONFLICT (id) DO UPDATE` が動作（§確定 B 設計根拠） |
+| TC-IT-RPR-014 | FK CASCADE DELETE（`empires` DELETE → `role_profiles` 連鎖削除） | `session_factory` + `make_role_profile` | empire 行あり + role_profile save 済み | raw SQL で `DELETE FROM empires WHERE id=:empire_id` を実行 | `role_profiles` の対応行が CASCADE で削除される（FK ON DELETE CASCADE 物理確認） |
+
+### §確定 C（RoleProfile domain↔row ラウンドトリップ、AC#15）
+
+| テストID | 対象モジュール連携 | 使用 fixture | 前提条件 | 操作 | 期待結果 |
+|---------|------------------|------------|---------|------|---------|
+| TC-IT-RPR-015 | `save → find_by_empire_and_role` 全フィールド構造的等価 | `session_factory` + `make_role_profile` + `make_deliverable_template_ref` | empire 行あり | `deliverable_template_refs` 2 件の RoleProfile（REVIEWER ロール）を save → `find_by_empire_and_role(empire_id, Role.REVIEWER)` | `restored.id == role_profile.id`、`restored.empire_id == role_profile.empire_id`、`restored.role == Role.REVIEWER`、`restored.deliverable_template_refs == role_profile.deliverable_template_refs`（tuple 順・等値） |
+
+### Alembic 0012 revision（内部品質基準、§確定 K）
+
+| テストID | 対象モジュール連携 | 使用 fixture | 前提条件 | 操作 | 期待結果 |
+|---------|------------------|------------|---------|------|---------|
+| TC-IT-MIGR-012-001 | upgrade で 2 テーブル追加 | `tmp_path` 配下の bakufu.db | スキーマ未適用の新規 engine | `alembic upgrade head` を実行 | `SELECT name FROM sqlite_master WHERE type='table'` で `deliverable_templates` / `role_profiles` の 2 テーブルが存在する |
+| TC-IT-MIGR-012-002 | upgrade 後 `role_profiles` UNIQUE 制約が存在する | `tmp_path` | upgrade 済み | `PRAGMA index_list(role_profiles)` を実行 | UNIQUE インデックス（名前または sqlite_autoindex_*）が `role_profiles` テーブルに存在する（§確定 H 物理確認） |
+| TC-IT-MIGR-012-003 | downgrade で 2 テーブル削除（FK 安全順序） | `tmp_path` | upgrade 済み | `alembic downgrade` を `"0011_stage_required_deliverables"` まで実行 | (a) `role_profiles` が削除されている、(b) `deliverable_templates` が削除されている。`workflow_stages` / `workflow_transitions` など他テーブルは残る |
+| TC-IT-MIGR-012-004 | upgrade → downgrade → upgrade の冪等性 | `tmp_path` | スキーマ未適用 | (1) upgrade head → 2 テーブル確認、(2) downgrade to 0011 → 2 テーブル削除確認、(3) 再 upgrade head | (3) 後に `deliverable_templates` / `role_profiles` が再度存在する。UNIQUE 制約も再作成される |
+| TC-IT-MIGR-012-005 | revision chain 一直線（単一 head + 0012.down_revision） | Alembic config | versions/ に 0012 ファイルあり | `ScriptDirectory.get_heads()` + `script.get_revision("0012_deliverable_template_aggregate")` | (a) heads は 1 件のみ（head 分岐なし）、(b) `rev.down_revision == "0011_stage_required_deliverables"` |
+
+### CI 三層防衛 no-mask（§確定 J / REQ-DTR-006）
+
+| テストID | 対象モジュール連携 | 使用 fixture | 前提条件 | 操作 | 期待結果 |
+|---------|------------------|------------|---------|------|---------|
+| TC-CI-DTR-001 | Layer 1: `scripts/ci/check_masking_columns.sh` の deliverable-template 拡張 | repo root | スクリプトが `deliverable_templates` / `role_profiles` 両テーブルを「masking 対象なし」として明示登録 | `bash scripts/ci/check_masking_columns.sh` を実行 | exit 0。両テーブルファイルに `MaskedJSONEncoded` / `MaskedText` が存在しないことを grep guard が確認し pass |
+| TC-IT-DTR-020 | Layer 2: `tests/architecture/test_masking_columns.py` の no-mask parametrize | `Base.metadata` | arch test に両テーブルの parametrize を追加済み | test が parametrize で `deliverable_templates` / `role_profiles` の全カラムを順に検査 | 全カラムの `column.type.__class__` が `MaskedJSONEncoded` でも `MaskedText` でもない（`String` / `UUIDStr` / `Text` / `JSONEncoded` のみ）。後続 PR が誤って Masked* を追加した瞬間 CI がブロック |
+| TC-DOC-DTR-001 | Layer 3: `docs/design/domain-model/storage.md` §逆引き表に 2 行追加 | repo root | `storage.md` 編集済み | `storage.md` 内で `deliverable_templates` / `role_profiles` の 2 行が存在することを確認 | 両テーブル名が「masking 対象なし」を明示した行として §逆引き表に記載されている（empire-repository / workflow-repository の no-mask テンプレートと同形式） |
+
+## ユニットテストケース
+
+`tests/factories/deliverable_template.py` の factory 経由で domain 層 Aggregate を生成する。Repository クラス内 private method (`_to_row` / `_from_row`) は実 DB アクセスを伴うため integration として扱い、純 unit としての追加ケースは設けない（§確定 D/E/F/G の format 検証が DB 経由でこそ価値があるため integration に集約。empire-repository の TC-UT-EMR-001〜003 パターン同様の判断）。
+
+## カバレッジ基準
+
+- REQ-DTR-001 〜 007 の各要件が**最低 1 件**のテストケースで検証されている（マトリクス参照）
+- **§確定 D（schema type 判別 5 経路）**: TC-IT-DTR-010〜014 で JSON_SCHEMA / OPENAPI / MARKDOWN / CODE_SKELETON / PROMPT の 5 type すべてを物理確認
+- **§確定 E（SemVer TEXT）**: TC-IT-DTR-015 でラウンドトリップ + raw SQL カラム値物理確認
+- **§確定 F（acceptance_criteria_json / composition_json A08 防御）**: TC-IT-DTR-016〜018 で model_validate 経由 + 不正 JSON Fail-Fast の 2 経路を物理確認
+- **§確定 G（deliverable_template_refs_json A08 防御）**: TC-IT-RPR-010〜011 で同上
+- **§確定 H（UNIQUE 制約 IntegrityError 伝播）**: TC-IT-RPR-012 で IntegrityError、TC-IT-RPR-013 で正常 UPSERT の両経路を物理確認
+- **§確定 I（ORDER BY 規約）**: TC-IT-DTR-005（name ASC）+ TC-IT-RPR-005（role ASC）で決定論的順序を実 DB で物理確認
+- **§確定 B（Tx 境界 UPSERT）**: TC-IT-DTR-009 + TC-IT-RPR-009 で commit / rollback 両経路、Repository が明示的 commit/rollback しないことを assert
+- **§確定 C（domain↔row ラウンドトリップ）**: TC-IT-DTR-019 + TC-IT-RPR-015 で実 DB 経由の全フィールド構造的等価
+- **§確定 K（Alembic 0012 migration）**: TC-IT-MIGR-012-001〜005 で upgrade / downgrade / round-trip / chain 一直線を物理確認
+- **CI 三層防衛 no-mask（§確定 J）**: Layer 1（TC-CI-DTR-001）+ Layer 2（TC-IT-DTR-020）+ Layer 3（TC-DOC-DTR-001）3 層すべてに証拠ケース
+- **AC#14（DeliverableTemplate 永続化）**: TC-IT-DTR-003 / 007 / 019 で IT カバー
+- **AC#15（RoleProfile 永続化）**: TC-IT-RPR-003 / 007 / 015 で IT カバー
+- §確定 A〜K すべてに証拠ケース
+- C0 目標: `application/ports/deliverable_template_repository.py` /
+  `application/ports/role_profile_repository.py` /
+  `infrastructure/persistence/sqlite/repositories/deliverable_template_repository.py` /
+  `infrastructure/persistence/sqlite/repositories/role_profile_repository.py` で **90% 以上**
+
+## 人間が動作確認できるタイミング
+
+- CI 統合後: `gh pr checks` で 7 ジョブ緑
+- ローカル:
+  ```
+  bash scripts/setup.sh
+  cd backend && uv run pytest \
+    tests/infrastructure/persistence/sqlite/repositories/test_deliverable_template_repository \
+    tests/infrastructure/persistence/sqlite/repositories/test_role_profile_repository \
+    tests/infrastructure/persistence/sqlite/test_alembic_deliverable_template.py \
+    tests/architecture/test_masking_columns.py \
+    tests/docs/test_storage_md_back_index.py \
+    -v
+  ```
+- Backend 実起動: `cd backend && uv run python -m bakufu`（`BAKUFU_DATA_DIR=/tmp/bakufu-test`）
+  - 起動時 Alembic auto-migrate で 0012 が適用されることをログで目視
+  - `sqlite3 <DATA_DIR>/bakufu.db ".tables"` で `deliverable_templates` / `role_profiles` が見える
+  - `sqlite3 <DATA_DIR>/bakufu.db "PRAGMA index_list(role_profiles)"` で UNIQUE インデックスが見える
+- カバレッジ確認:
+  ```
+  cd backend && uv run pytest \
+    --cov=bakufu.application.ports.deliverable_template_repository \
+    --cov=bakufu.application.ports.role_profile_repository \
+    --cov=bakufu.infrastructure.persistence.sqlite.repositories.deliverable_template_repository \
+    --cov=bakufu.infrastructure.persistence.sqlite.repositories.role_profile_repository \
+    --cov-report=term-missing
+  ```
+  → 90% 以上
+
+## テストディレクトリ構造
+
+```
+backend/
+  tests/
+    factories/
+      deliverable_template.py             # 既存（domain sub-feature PR #127）追加なし
+    architecture/
+      test_masking_columns.py             # 既存 + deliverable-template no-mask parametrize
+                                          # TC-IT-DTR-020
+    infrastructure/
+      persistence/
+        sqlite/
+          repositories/
+            test_deliverable_template_repository/
+              __init__.py
+              test_crud.py                # TC-IT-DTR-001〜019（Protocol/CRUD/type判別/SemVer/A08）
+            test_role_profile_repository/
+              __init__.py
+              test_crud.py                # TC-IT-RPR-001〜015（Protocol/CRUD/UNIQUE/A08）
+          test_alembic_deliverable_template.py  # TC-IT-MIGR-012-001〜005（0012 migration 検証）
+    docs/
+      test_storage_md_back_index.py       # 既存 + deliverable-template 行検証（TC-DOC-DTR-001）
+```
+
+**配置の根拠**:
+
+- empire-repository / workflow-repository の `test_*_repository/` ディレクトリ分割パターンを継承
+- masking 専用ファイル（`test_masking.py`）は不要（本 feature は masking 対象なし）。各 Repository の IT を `test_crud.py` 1 ファイルに集約（500 行 Norman ルールの範囲内）
+- `test_alembic_deliverable_template.py` は empire の `test_alembic_empire.py` + workflow の `test_alembic_stage_required_deliverables.py` 同パターン
+- `tests/architecture/test_masking_columns.py` + `tests/docs/test_storage_md_back_index.py` は既存ファイルを EDIT で拡張（no-mask テンプレートとして deliverable-template を追加）
+
+## 未決課題・要起票 characterization task
+
+| # | タスク | 起票先 | 備考 |
+|---|-------|--------|------|
+| （N/A） | 該当なし — SQLite + Alembic + SQLAlchemy は標準ライブラリ仕様で固定 | — | masking gateway は不使用のため characterization task なし |
+
+## レビュー観点（テスト設計レビュー時）
+
+- [ ] REQ-DTR-001〜007 すべてに 1 件以上のテストケースがあり、AC#14 / AC#15 が IT カバーされている
+- [ ] **§確定 D（schema type 判別）** が TC-IT-DTR-010〜014 で 5 type 全経路を物理確認している
+- [ ] **§確定 E（SemVer TEXT）** が TC-IT-DTR-015 で raw SQL カラム値 `"3.14.159"` を物理確認している
+- [ ] **§確定 F（acceptance_criteria_json A08 防御）** が TC-IT-DTR-016〜018 で model_validate 経由 + 不正 JSON Fail-Fast の 2 経路を物理確認している
+- [ ] **§確定 G（deliverable_template_refs_json A08 防御）** が TC-IT-RPR-010〜011 で同上物理確認している
+- [ ] **§確定 H（UNIQUE 制約 IntegrityError）** が TC-IT-RPR-012 で実 SQLite に対し IntegrityError を物理確認している
+- [ ] **§確定 I（ORDER BY 規約）** が TC-IT-DTR-005（name ASC）+ TC-IT-RPR-005（role ASC）で物理確認している
+- [ ] **§確定 B（Tx 境界）** が TC-IT-DTR-009 + TC-IT-RPR-009 で commit / rollback 両経路を確認し、Repository が明示的 commit/rollback しないことを assert している
+- [ ] **§確定 C（domain↔row ラウンドトリップ）** が TC-IT-DTR-019 + TC-IT-RPR-015 で全フィールド構造的等価を確認している
+- [ ] **§確定 K（Alembic 0012）** が TC-IT-MIGR-012-001〜005 で upgrade / downgrade / round-trip / chain 一直線を物理確認している
+- [ ] **CI 三層防衛 no-mask（§確定 J）** が Layer 1（TC-CI-DTR-001）+ Layer 2（TC-IT-DTR-020）+ Layer 3（TC-DOC-DTR-001）の 3 層すべてに証拠ケースを持っている
+- [ ] empire-repository / persistence-foundation の `app_engine` / `session_factory` fixture を再利用し、新 fixture を追加していない
+- [ ] FK 先 empire 行を事前 INSERT する前提条件が `test_role_profile_repository/` の全テストケースで明記されている
+- [ ] masking 配線テスト（`test_masking.py`）が**存在しない**ことが正しい（本 sub-feature は masking 対象なし。誤って追加した場合は CI 三層防衛 Layer 2 が検出する）
+- [ ] §確定 A〜K すべてに証拠ケースが含まれる


### PR DESCRIPTION
## Summary

- `docs/features/deliverable-template/repository/basic-design.md` 新規作成
- `docs/features/deliverable-template/repository/detailed-design.md` 新規作成

Issue #119（DeliverableTemplate / RoleProfile SQLite Repository）の設計書 2 ファイルを凍結。

### 凍結内容

**basic-design.md**
- REQ-DTR-001〜007: 7 件の機能要件（Protocol 定義 × 2 / SQLite 実装 × 2 / Alembic 0012 / CI 三層防衛 / storage.md 更新）
- 2 テーブル（`deliverable_templates` / `role_profiles`）のデータモデル・ER 図
- masking 対象なしの根拠（feature-spec §13 業務判断を明示）

**detailed-design.md**
- §確定 A: Repository ポート配置（empire-repository §確定 A テンプレート準拠）
- §確定 B: save() 戦略（1 テーブル UPSERT、子テーブルなし、JSON カラム集約）
- §確定 C: _to_row / _from_row private method 契約
- §確定 D: schema カラムシリアライズ（type 判別: JSON_SCHEMA/OPENAPI → json.dumps、その他 → plain text）
- §確定 E: SemVer 永続化（TEXT "major.minor.patch" / SemVer.from_str で復元）
- §確定 F: acceptance_criteria_json / composition_json（model_dump(mode='json') + model_validate 復元）
- §確定 G: deliverable_template_refs_json（RoleProfile、同パターン）
- §確定 H: UNIQUE(empire_id, role) DB 制約と IntegrityError 伝播
- §確定 I: ORDER BY 決定論的順序保証（find_all → name ASC / find_all_by_empire → role ASC）
- §確定 J: CI 三層防衛（masking 対象なし登録）
- §確定 K: Alembic 0012 revision（down_revision="0011_stage_required_deliverables"）

### 設計判断のハイライト

1. **子テーブルなし JSONEncoded 集約**: acceptance_criteria / composition / deliverable_template_refs を JSON カラムで管理。MVP の UC-DT-005（永続化・復元）のみを要件とし、YAGNI 原則で子テーブルを作成しない
2. **schema カラム type 判別**: `TemplateType.JSON_SCHEMA` / `OPENAPI` 時は `json.dumps`、その他 plain text。2 カラム分割なし、`type` が判別キー
3. **RoleProfile.save(role_profile)**: `empire_id` は `RoleProfile.empire_id` 属性から取得（引数分離なし、domain 実装確認済み）
4. **masking 対象なし**: domain/basic-design.md の "MaskedText（将来配線）" は暫定メモ。feature-spec §13 の業務判断（低リスク）を最終権威とする

## Test plan

- [ ] basic-design.md の §モジュール契約 REQ-DTR-001〜007 が feature-spec UC-DT-005 / AC#14〜15 と対応していることを確認
- [ ] detailed-design.md §確定 D（schema シリアライズ）の type 分岐が TemplateType 全 5 値に対して網羅されていることを確認
- [ ] detailed-design.md §確定 F（_from_row 変換フロー表）の全カラムが `deliverable_templates` テーブル定義と一致することを確認
- [ @ヤン・ルカン test-design.md の作成（本 PR マージ後に同ブランチで追加、または別 PR）

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)