### PR TITLE
fix(workflow): test_required_deliverables の pyright エラー解消

### DIFF
--- a/backend/tests/domain/workflow/test_required_deliverables.py
+++ b/backend/tests/domain/workflow/test_required_deliverables.py
@@ -8,7 +8,7 @@
 from __future__ import annotations
 
 from typing import cast
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 from bakufu.domain.exceptions import StageInvariantViolation
@@ -19,11 +19,10 @@ from bakufu.domain.workflow import Workflow
 from tests.factories.workflow import build_v_model_payload, make_stage
 
 
-def _make_ref(template_id: object | None = None) -> DeliverableTemplateRef:
+def _make_ref(template_id: UUID | None = None) -> DeliverableTemplateRef:
     """妥当な DeliverableTemplateRef を 1 件組み立てるヘルパ。"""
-    tid = template_id if template_id is not None else uuid4()
     return DeliverableTemplateRef(
-        template_id=tid,
+        template_id=template_id if template_id is not None else uuid4(),
         minimum_version=SemVer(major=1, minor=0, patch=0),
     )
 


### PR DESCRIPTION
## 概要

`backend/tests/domain/workflow/test_required_deliverables.py:26` の pyright エラーを解消する。

```
error: Argument of type \"object | UUID\" cannot be assigned to parameter \"template_id\" of type \"DeliverableTemplateId\"
  Type \"object | UUID\" is not assignable to type \"DeliverableTemplateId\"
    \"object\" is not assignable to \"UUID\" (reportArgumentType)
```

## 原因

`_make_ref` ヘルパの `template_id` 引数型が `object | None` だったため、`DeliverableTemplateRef.template_id`（型: `DeliverableTemplateId = UUID`）への代入で型不整合となっていた。

## 修正

`_make_ref` の引数型を `UUID | None` に変更。中間変数 `tid` も削除して直接渡す形に整理。
呼び出し側は全て `uuid4()` を渡しているため挙動への影響なし。

## 動作確認

- [x] `just typecheck` (pyright + tsc) 通過
- [x] `just lint` 通過
- [x] `pytest tests/domain/workflow/test_required_deliverables.py` 9 passed

Github-Issue: #117