### PR TITLE
feat(#158): M4 Domain Event / EventBus 実装（REQ-WSB-001〜007）

### DIFF
--- a/backend/src/bakufu/application/ports/event_bus.py
+++ b/backend/src/bakufu/application/ports/event_bus.py
@@ -1,0 +1,40 @@
+"""EventBusPort — Domain Event 配信ポート（REQ-WSB-006）。
+
+``Protocol`` クラスとして定義することで ``InMemoryEventBus`` が明示的な継承を
+必要とせず構造的に適合できる（structural subtyping）。将来の Redis EventBus 等も
+同様に Protocol 適合として扱える。
+
+実装方針は ``docs/features/websocket-broadcast/domain/detailed-design.md``
+§確定（EventBusPort）に従う。
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Protocol
+
+from bakufu.domain.events import DomainEvent
+
+#: EventBus ハンドラ型エイリアス。非同期 callable を受け取る。
+type HandlerType = Callable[[DomainEvent], Awaitable[None]]
+
+
+class EventBusPort(Protocol):
+    """Domain Event 配信インターフェース（Port パターン）。
+
+    application 層が持つ EventBus への唯一の参照点。
+    infrastructure 実装（``InMemoryEventBus``）は明示的な継承なしに本 Protocol に
+    適合する（``@runtime_checkable`` は付与しない — Python 3.12 の
+    duck typing で十分）。
+    """
+
+    def subscribe(self, handler: HandlerType) -> None:
+        """購読者ハンドラを登録する。"""
+        ...
+
+    async def publish(self, event: DomainEvent) -> None:
+        """全購読者ハンドラに ``event`` を配信する。"""
+        ...
+
+
+__all__ = ["EventBusPort", "HandlerType"]

--- a/backend/src/bakufu/application/services/external_review_gate_service.py
+++ b/backend/src/bakufu/application/services/external_review_gate_service.py
@@ -13,9 +13,12 @@ from bakufu.application.exceptions.gate_exceptions import (
 from bakufu.application.ports.deliverable_template_repository import (
     DeliverableTemplateRepository,
 )
+from bakufu.application.ports.event_bus import EventBusPort
 from bakufu.application.ports.external_review_gate_repository import (
     ExternalReviewGateRepository,
 )
+from bakufu.application.security import masking
+from bakufu.domain.events import ExternalReviewGateStateChangedEvent
 from bakufu.domain.exceptions import ExternalReviewGateInvariantViolation
 from bakufu.domain.external_review_gate.gate import ExternalReviewGate
 from bakufu.domain.value_objects import (
@@ -47,9 +50,11 @@ class ExternalReviewGateService:
         self,
         repo: ExternalReviewGateRepository,
         template_repo: DeliverableTemplateRepository,
+        event_bus: EventBusPort,
     ) -> None:
         self._repo = repo
         self._template_repo = template_repo
+        self._event_bus = event_bus
 
     async def create(
         self,
@@ -131,6 +136,9 @@ class ExternalReviewGateService:
         ExternalReviewGateInvariantViolation(kind='decision_already_decided')
         → GateAlreadyDecidedError (409) に変換する。save() は呼び出し元 router が
         async with session.begin() 内で行う（§確定E）。
+
+        domain 操作成功後に ``ExternalReviewGateStateChangedEvent`` を publish する。
+        ``reviewer_comment`` は ``masking.mask()`` 適用済みの値を渡す（§確定 F）。
         """
         if gate.reviewer_id != reviewer_id:
             raise GateAuthorizationError(
@@ -139,7 +147,7 @@ class ExternalReviewGateService:
                 expected_reviewer_id=gate.reviewer_id,
             )
         try:
-            return gate.approve(by_owner_id=reviewer_id, comment=comment, decided_at=decided_at)
+            updated = gate.approve(by_owner_id=reviewer_id, comment=comment, decided_at=decided_at)
         except ExternalReviewGateInvariantViolation as exc:
             if exc.kind == "decision_already_decided":
                 raise GateAlreadyDecidedError(
@@ -147,6 +155,17 @@ class ExternalReviewGateService:
                     current_decision=gate.decision,
                 ) from exc
             raise
+        # domain 操作成功後に publish（§確定 F: reviewer_comment は masking.mask() 適用）
+        await self._event_bus.publish(
+            ExternalReviewGateStateChangedEvent(
+                aggregate_id=str(gate.id),
+                task_id=str(gate.task_id),
+                old_status=str(gate.decision),
+                new_status=str(updated.decision),
+                reviewer_comment=masking.mask(comment),
+            )
+        )
+        return updated
 
     async def reject(
         self,
@@ -158,6 +177,9 @@ class ExternalReviewGateService:
         """Gate を差し戻す。
 
         approve と同構造。domain の gate.reject() に委譲する。
+
+        domain 操作成功後に ``ExternalReviewGateStateChangedEvent`` を publish する。
+        ``reviewer_comment`` は ``masking.mask()`` 適用済みの値を渡す（§確定 F）。
         """
         if gate.reviewer_id != reviewer_id:
             raise GateAuthorizationError(
@@ -166,7 +188,7 @@ class ExternalReviewGateService:
                 expected_reviewer_id=gate.reviewer_id,
             )
         try:
-            return gate.reject(
+            updated = gate.reject(
                 by_owner_id=reviewer_id, comment=feedback_text, decided_at=decided_at
             )
         except ExternalReviewGateInvariantViolation as exc:
@@ -176,6 +198,17 @@ class ExternalReviewGateService:
                     current_decision=gate.decision,
                 ) from exc
             raise
+        # domain 操作成功後に publish（§確定 F: reviewer_comment は masking.mask() 適用）
+        await self._event_bus.publish(
+            ExternalReviewGateStateChangedEvent(
+                aggregate_id=str(gate.id),
+                task_id=str(gate.task_id),
+                old_status=str(gate.decision),
+                new_status=str(updated.decision),
+                reviewer_comment=masking.mask(feedback_text),
+            )
+        )
+        return updated
 
     async def cancel(
         self,

--- a/backend/src/bakufu/application/services/task_service.py
+++ b/backend/src/bakufu/application/services/task_service.py
@@ -19,8 +19,10 @@ from bakufu.application.exceptions.task_exceptions import (
     TaskStateConflictError,
 )
 from bakufu.application.ports.agent_repository import AgentRepository
+from bakufu.application.ports.event_bus import EventBusPort
 from bakufu.application.ports.room_repository import RoomRepository
 from bakufu.application.ports.task_repository import TaskRepository
+from bakufu.domain.events import TaskStateChangedEvent
 from bakufu.domain.exceptions import TaskInvariantViolation
 from bakufu.domain.task.task import Task
 from bakufu.domain.value_objects import (
@@ -42,11 +44,13 @@ class TaskService:
         room_repo: RoomRepository,
         agent_repo: AgentRepository,
         session: AsyncSession,
+        event_bus: EventBusPort,
     ) -> None:
         self._task_repo = task_repo
         self._room_repo = room_repo
         self._agent_repo = agent_repo
         self._session = session
+        self._event_bus = event_bus
 
     async def find_by_id(self, task_id: TaskId) -> Task:
         """Task を返す。存在しない場合は ``TaskNotFoundError``。"""
@@ -83,6 +87,16 @@ class TaskService:
                 self._raise_conflict_if_needed(task, "cancel", exc)
                 raise
             await self._task_repo.save(updated)
+        # トランザクション commit 後に publish（業務操作成功後のみ）
+        await self._event_bus.publish(
+            TaskStateChangedEvent(
+                aggregate_id=str(task.id),
+                directive_id=str(task.directive_id),
+                old_status=str(task.status),
+                new_status=str(updated.status),
+                room_id=str(task.room_id),
+            )
+        )
         return updated
 
     async def unblock_retry(self, task_id: TaskId) -> Task:
@@ -95,6 +109,16 @@ class TaskService:
                 self._raise_conflict_if_needed(task, "unblock_retry", exc)
                 raise
             await self._task_repo.save(updated)
+        # トランザクション commit 後に publish（業務操作成功後のみ）
+        await self._event_bus.publish(
+            TaskStateChangedEvent(
+                aggregate_id=str(task.id),
+                directive_id=str(task.directive_id),
+                old_status=str(task.status),
+                new_status=str(updated.status),
+                room_id=str(task.room_id),
+            )
+        )
         return updated
 
     async def commit_deliverable(
@@ -128,6 +152,16 @@ class TaskService:
                 self._raise_conflict_if_needed(task, "commit_deliverable", exc)
                 raise
             await self._task_repo.save(updated)
+        # トランザクション commit 後に publish（業務操作成功後のみ）
+        await self._event_bus.publish(
+            TaskStateChangedEvent(
+                aggregate_id=str(task.id),
+                directive_id=str(task.directive_id),
+                old_status=str(task.status),
+                new_status=str(updated.status),
+                room_id=str(task.room_id),
+            )
+        )
         return updated
 
     async def _find_by_id_in_uow(self, task_id: TaskId) -> Task:

--- a/backend/src/bakufu/domain/events.py
+++ b/backend/src/bakufu/domain/events.py
@@ -1,0 +1,128 @@
+"""Domain Event 基底クラスおよび具体 Event クラス（REQ-WSB-001〜005）。
+
+DDD の Domain Event パターンを実装する。各 Event は Pydantic v2 BaseModel として
+定義し、バリデーションは構築時に自動適用される（Fail Fast）。
+
+実装方針は ``docs/features/websocket-broadcast/domain/detailed-design.md``
+§確定 A〜F に従う。
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class DomainEvent(BaseModel):
+    """Domain Event 抽象基底クラス（REQ-WSB-001）。
+
+    全 Domain Event に共通するフィールドと ``to_ws_message()`` を保持する。
+    具体 Event クラスは本クラスを継承し ``event_type`` / ``aggregate_type`` に
+    デフォルト値を設定する。``frozen=True`` により構築後の変更を禁止する（§確定 B）。
+
+    Pydantic v2 ``BaseModel`` として定義する（§確定 A: 既存コードと整合、
+    ``model_dump()`` による dict 変換、自動バリデーションの恩恵を受けるため）。
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    event_id: UUID = Field(default_factory=uuid4)
+    event_type: str
+    aggregate_id: str
+    aggregate_type: str
+    occurred_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    def to_ws_message(self) -> dict[str, Any]:
+        """WebSocket 送信用 dict を生成する。
+
+        ``event_id / event_type / aggregate_id / aggregate_type / occurred_at``
+        を除いた残余フィールドを ``payload`` として格納する（detailed-design §確定 C）。
+        ``occurred_at`` は ISO 8601 UTC 形式で出力する。
+        """
+        _base_fields: frozenset[str] = frozenset(
+            {"event_id", "event_type", "aggregate_id", "aggregate_type", "occurred_at"}
+        )
+        payload: dict[str, Any] = {
+            k: v for k, v in self.model_dump().items() if k not in _base_fields
+        }
+        return {
+            "event_type": self.event_type,
+            "aggregate_id": self.aggregate_id,
+            "aggregate_type": self.aggregate_type,
+            "occurred_at": self.occurred_at.isoformat(),
+            "payload": payload,
+        }
+
+
+class TaskStateChangedEvent(DomainEvent):
+    """Task 状態遷移イベント（REQ-WSB-002）。
+
+    ``TaskService.cancel()`` / ``unblock_retry()`` / ``commit_deliverable()`` が
+    業務操作成功後に発行する（M4 スコープ）。
+    event_type / aggregate_type は frozen=True により構築後変更不能（§確定 B）。
+    """
+
+    event_type: str = "task.state_changed"
+    aggregate_type: str = "Task"
+    directive_id: str
+    old_status: str
+    new_status: str
+    room_id: str
+
+
+class ExternalReviewGateStateChangedEvent(DomainEvent):
+    """ExternalReviewGate 状態遷移イベント（REQ-WSB-003）。
+
+    ``ExternalReviewGateService.approve()`` / ``reject()`` が業務操作成功後に
+    発行する（M4 スコープ）。``reviewer_comment`` は Service 層で ``masking.mask()``
+    を適用済みの値を渡すこと（§確定 F）。
+    event_type / aggregate_type は frozen=True により構築後変更不能（§確定 B）。
+    """
+
+    event_type: str = "external_review_gate.state_changed"
+    aggregate_type: str = "ExternalReviewGate"
+    task_id: str
+    old_status: str
+    new_status: str
+    reviewer_comment: str | None = None
+
+
+class AgentStatusChangedEvent(DomainEvent):
+    """Agent ステータス変化イベント（REQ-WSB-004）。
+
+    M4 では型定義のみ凍結する。実 publish（``AgentService.update_status()`` 統合）は
+    M5 Phase 2 で実装する（feature-spec.md §6 Out of Scope）。
+    event_type / aggregate_type は frozen=True により構築後変更不能（§確定 B）。
+    """
+
+    event_type: str = "agent.status_changed"
+    aggregate_type: str = "Agent"
+    room_id: str
+    old_status: str
+    new_status: str
+
+
+class DirectiveCompletedEvent(DomainEvent):
+    """Directive 完了イベント（REQ-WSB-005）。
+
+    M4 では型定義のみ凍結する。実 publish（``DirectiveService.complete()`` / ``fail()`` 統合）は
+    M5 Phase 2 で実装する（feature-spec.md §6 Out of Scope）。
+    event_type / aggregate_type は frozen=True により構築後変更不能（§確定 B）。
+    """
+
+    event_type: str = "directive.completed"
+    aggregate_type: str = "Directive"
+    empire_id: str
+    final_status: str
+
+
+__all__ = [
+    "AgentStatusChangedEvent",
+    "DirectiveCompletedEvent",
+    "DomainEvent",
+    "ExternalReviewGateStateChangedEvent",
+    "TaskStateChangedEvent",
+]

--- a/backend/src/bakufu/domain/events.py
+++ b/backend/src/bakufu/domain/events.py
@@ -10,7 +10,7 @@ DDD の Domain Event パターンを実装する。各 Event は Pydantic v2 Bas
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, ClassVar, Literal
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -29,6 +29,11 @@ class DomainEvent(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
+    #: to_ws_message() でペイロードから除外する基底フィールド名集合（クラスレベル定数）。
+    _BASE_FIELDS: ClassVar[frozenset[str]] = frozenset(
+        {"event_id", "event_type", "aggregate_id", "aggregate_type", "occurred_at"}
+    )
+
     event_id: UUID = Field(default_factory=uuid4)
     event_type: str
     aggregate_id: str
@@ -42,11 +47,8 @@ class DomainEvent(BaseModel):
         を除いた残余フィールドを ``payload`` として格納する（detailed-design §確定 C）。
         ``occurred_at`` は ISO 8601 UTC 形式で出力する。
         """
-        _base_fields: frozenset[str] = frozenset(
-            {"event_id", "event_type", "aggregate_id", "aggregate_type", "occurred_at"}
-        )
         payload: dict[str, Any] = {
-            k: v for k, v in self.model_dump().items() if k not in _base_fields
+            k: v for k, v in self.model_dump().items() if k not in self._BASE_FIELDS
         }
         return {
             "event_type": self.event_type,
@@ -62,11 +64,12 @@ class TaskStateChangedEvent(DomainEvent):
 
     ``TaskService.cancel()`` / ``unblock_retry()`` / ``commit_deliverable()`` が
     業務操作成功後に発行する（M4 スコープ）。
-    event_type / aggregate_type は frozen=True により構築後変更不能（§確定 B）。
+    event_type / aggregate_type は Literal 型で構築時バリデーションを保証し、
+    frozen=True により構築後変更不能（§確定 B）。
     """
 
-    event_type: str = "task.state_changed"
-    aggregate_type: str = "Task"
+    event_type: Literal["task.state_changed"] = "task.state_changed"  # pyright: ignore[reportIncompatibleVariableOverride]
+    aggregate_type: Literal["Task"] = "Task"  # pyright: ignore[reportIncompatibleVariableOverride]
     directive_id: str
     old_status: str
     new_status: str
@@ -79,11 +82,12 @@ class ExternalReviewGateStateChangedEvent(DomainEvent):
     ``ExternalReviewGateService.approve()`` / ``reject()`` が業務操作成功後に
     発行する（M4 スコープ）。``reviewer_comment`` は Service 層で ``masking.mask()``
     を適用済みの値を渡すこと（§確定 F）。
-    event_type / aggregate_type は frozen=True により構築後変更不能（§確定 B）。
+    event_type / aggregate_type は Literal 型で構築時バリデーションを保証し、
+    frozen=True により構築後変更不能（§確定 B）。
     """
 
-    event_type: str = "external_review_gate.state_changed"
-    aggregate_type: str = "ExternalReviewGate"
+    event_type: Literal["external_review_gate.state_changed"] = "external_review_gate.state_changed"  # pyright: ignore[reportIncompatibleVariableOverride]
+    aggregate_type: Literal["ExternalReviewGate"] = "ExternalReviewGate"  # pyright: ignore[reportIncompatibleVariableOverride]
     task_id: str
     old_status: str
     new_status: str
@@ -95,11 +99,12 @@ class AgentStatusChangedEvent(DomainEvent):
 
     M4 では型定義のみ凍結する。実 publish（``AgentService.update_status()`` 統合）は
     M5 Phase 2 で実装する（feature-spec.md §6 Out of Scope）。
-    event_type / aggregate_type は frozen=True により構築後変更不能（§確定 B）。
+    event_type / aggregate_type は Literal 型で構築時バリデーションを保証し、
+    frozen=True により構築後変更不能（§確定 B）。
     """
 
-    event_type: str = "agent.status_changed"
-    aggregate_type: str = "Agent"
+    event_type: Literal["agent.status_changed"] = "agent.status_changed"  # pyright: ignore[reportIncompatibleVariableOverride]
+    aggregate_type: Literal["Agent"] = "Agent"  # pyright: ignore[reportIncompatibleVariableOverride]
     room_id: str
     old_status: str
     new_status: str
@@ -110,11 +115,12 @@ class DirectiveCompletedEvent(DomainEvent):
 
     M4 では型定義のみ凍結する。実 publish（``DirectiveService.complete()`` / ``fail()`` 統合）は
     M5 Phase 2 で実装する（feature-spec.md §6 Out of Scope）。
-    event_type / aggregate_type は frozen=True により構築後変更不能（§確定 B）。
+    event_type / aggregate_type は Literal 型で構築時バリデーションを保証し、
+    frozen=True により構築後変更不能（§確定 B）。
     """
 
-    event_type: str = "directive.completed"
-    aggregate_type: str = "Directive"
+    event_type: Literal["directive.completed"] = "directive.completed"  # pyright: ignore[reportIncompatibleVariableOverride]
+    aggregate_type: Literal["Directive"] = "Directive"  # pyright: ignore[reportIncompatibleVariableOverride]
     empire_id: str
     final_status: str
 

--- a/backend/src/bakufu/infrastructure/event_bus.py
+++ b/backend/src/bakufu/infrastructure/event_bus.py
@@ -1,0 +1,68 @@
+"""InMemoryEventBus — EventBusPort のインプロセス実装（REQ-WSB-007）。
+
+asyncio.gather による並行ハンドラ実行。個別ハンドラのエラーは MSG-WSB-001 として
+ログ記録し他ハンドラの実行を継続する（Fail Soft）。
+
+実装方針は ``docs/features/websocket-broadcast/domain/detailed-design.md``
+§確定 D（InMemoryEventBus エラーハンドリング）に従う。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from bakufu.application.ports.event_bus import HandlerType
+from bakufu.domain.events import DomainEvent
+
+logger = logging.getLogger(__name__)
+
+
+class InMemoryEventBus:
+    """asyncio.gather による並行 Event 配信実装（REQ-WSB-007）。
+
+    ``EventBusPort`` に構造的に適合する（明示的な継承なし）。
+
+    不変条件:
+    - ``publish()`` は asyncio イベントループ内（``async def`` 内）から呼ぶ
+    - ハンドラの登録順序は保証するが、並行実行のため完了順序は不定
+    - ハンドラが 0 件の場合 ``publish()`` は即座に resolve する
+    """
+
+    def __init__(self) -> None:
+        self._handlers: list[HandlerType] = []
+
+    def subscribe(self, handler: HandlerType) -> None:
+        """購読者ハンドラをリスト末尾に追加する。"""
+        self._handlers.append(handler)
+
+    async def publish(self, event: DomainEvent) -> None:
+        """全購読者ハンドラに ``event`` を並行配信する（MSG-WSB-001 / MSG-WSB-002）。
+
+        ``asyncio.gather(..., return_exceptions=True)`` で全ハンドラを並行実行し、
+        個別ハンドラの例外を ``BaseException`` として収集する。例外があれば
+        MSG-WSB-001（WARNING）としてログ記録後、他ハンドラの実行を継続する（Fail Soft）。
+        配信完了後に MSG-WSB-002（DEBUG）を記録する。
+        """
+        if self._handlers:
+            results = await asyncio.gather(
+                *[h(event) for h in self._handlers],
+                return_exceptions=True,
+            )
+            for result in results:
+                if isinstance(result, BaseException):
+                    # MSG-WSB-001: ハンドラ例外発生時の WARNING ログ
+                    logger.warning(
+                        "EventBus handler error: %s: %s",
+                        type(result).__name__,
+                        result,
+                    )
+        # MSG-WSB-002: 配信完了 DEBUG ログ
+        logger.debug(
+            "DomainEvent published: %s aggregate_id=%s",
+            event.event_type,
+            event.aggregate_id,
+        )
+
+
+__all__ = ["InMemoryEventBus"]

--- a/backend/src/bakufu/interfaces/http/app.py
+++ b/backend/src/bakufu/interfaces/http/app.py
@@ -76,11 +76,15 @@ def _parse_allowed_origins() -> list[str]:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
-    """lifespan: startup で session_factory / event_bus を保持、shutdown で dispose (確定 B)。"""
+    """lifespan: startup で masking / session_factory / event_bus 初期化、shutdown で dispose。"""
     from bakufu.infrastructure.config import data_dir as data_dir_mod
     from bakufu.infrastructure.event_bus import InMemoryEventBus
     from bakufu.infrastructure.persistence.sqlite.engine import create_engine
     from bakufu.infrastructure.persistence.sqlite.session import make_session_factory
+    from bakufu.infrastructure.security import masking as masking_mod
+
+    # タブリーズ指摘 §確定F: dev_reload 子プロセスを含む全起動経路で Layer 1 を保証
+    masking_mod.init()
 
     resolved_data_dir = data_dir_mod.resolve()
     url = f"sqlite+aiosqlite:///{resolved_data_dir / 'bakufu.db'}"

--- a/backend/src/bakufu/interfaces/http/app.py
+++ b/backend/src/bakufu/interfaces/http/app.py
@@ -76,8 +76,9 @@ def _parse_allowed_origins() -> list[str]:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
-    """lifespan: startup で session_factory を app.state に保持、shutdown で dispose (確定 B)。"""
+    """lifespan: startup で session_factory / event_bus を保持、shutdown で dispose (確定 B)。"""
     from bakufu.infrastructure.config import data_dir as data_dir_mod
+    from bakufu.infrastructure.event_bus import InMemoryEventBus
     from bakufu.infrastructure.persistence.sqlite.engine import create_engine
     from bakufu.infrastructure.persistence.sqlite.session import make_session_factory
 
@@ -87,6 +88,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     session_factory = make_session_factory(engine)
     app.state.engine = engine
     app.state.session_factory = session_factory
+    # REQ-WSB-007: InMemoryEventBus をアプリケーションライフタイムで共有
+    # Issue #159 で ConnectionManager の subscribe() が追加される
+    app.state.event_bus = InMemoryEventBus()
 
     yield
 

--- a/backend/src/bakufu/interfaces/http/dependencies.py
+++ b/backend/src/bakufu/interfaces/http/dependencies.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from bakufu.application.ports.agent_repository import AgentRepository
 from bakufu.application.ports.directive_repository import DirectiveRepository
 from bakufu.application.ports.empire_repository import EmpireRepository
+from bakufu.application.ports.event_bus import EventBusPort
 from bakufu.application.ports.external_review_gate_repository import (
     ExternalReviewGateRepository,
 )
@@ -41,6 +42,7 @@ __all__ = [
     "DirectiveRepository",
     "DirectiveServiceDep",
     "EmpireRepository",
+    "EventBusPort",
     "ExternalReviewGateRepository",
     "GateServiceDep",
     "RoleProfileService",
@@ -55,6 +57,7 @@ __all__ = [
     "get_deliverable_template_service",
     "get_directive_service",
     "get_empire_service",
+    "get_event_bus",
     "get_external_review_gate_service",
     "get_role_profile_service",
     "get_room_matching_service",
@@ -74,6 +77,15 @@ async def get_session(request: Request) -> AsyncGenerator[AsyncSession, None]:
 
 
 SessionDep = Annotated[AsyncSession, Depends(get_session)]
+
+
+def get_event_bus(request: Request) -> EventBusPort:
+    """InMemoryEventBus を app.state から取得する DI ファクトリ（REQ-WSB-007）。
+
+    lifespan で生成された ``InMemoryEventBus`` を返す。
+    Issue #159 で ConnectionManager の subscribe() が追加される。
+    """
+    return request.app.state.event_bus  # type: ignore[no-any-return]
 
 
 async def get_empire_service(session: SessionDep) -> EmpireService:
@@ -220,7 +232,7 @@ async def get_agent_service(session: SessionDep) -> AgentService:
 AgentServiceDep = Annotated[AgentService, Depends(get_agent_service)]
 
 
-async def get_task_service(session: SessionDep) -> TaskService:
+async def get_task_service(session: SessionDep, request: Request) -> TaskService:
     """TaskService を DI 注入する。"""
     # 遅延 import: interfaces → infrastructure の直接依存を避けるため
     # モジュールロード時の循環参照リスクを回避し、
@@ -240,6 +252,7 @@ async def get_task_service(session: SessionDep) -> TaskService:
         room_repo=SqliteRoomRepository(session),
         agent_repo=SqliteAgentRepository(session),
         session=session,
+        event_bus=get_event_bus(request),
     )
 
 
@@ -275,6 +288,7 @@ DirectiveServiceDep = Annotated[DirectiveService, Depends(get_directive_service)
 
 async def get_external_review_gate_service(
     session: SessionDep,
+    request: Request,
 ) -> ExternalReviewGateService:
     """ExternalReviewGateService を DI 注入する。"""
     # 遅延 import: interfaces → infrastructure の直接依存を避けるため
@@ -289,7 +303,11 @@ async def get_external_review_gate_service(
 
     repo = SqliteExternalReviewGateRepository(session)
     template_repo = SqliteDeliverableTemplateRepository(session)
-    return ExternalReviewGateService(repo, template_repo)
+    return ExternalReviewGateService(
+        repo=repo,
+        template_repo=template_repo,
+        event_bus=get_event_bus(request),
+    )
 
 
 GateServiceDep = Annotated[ExternalReviewGateService, Depends(get_external_review_gate_service)]

--- a/backend/tests/e2e/conftest.py
+++ b/backend/tests/e2e/conftest.py
@@ -29,8 +29,11 @@ async def empire_e2e_client(tmp_path: Path) -> AsyncClient:  # type: ignore[over
     engine = make_test_engine(tmp_path / "test.db")
     await create_all_tables(engine)
     session_factory = make_test_session_factory(engine)
+    from bakufu.infrastructure.event_bus import InMemoryEventBus
+
     app.state.engine = engine
     app.state.session_factory = session_factory
+    app.state.event_bus = InMemoryEventBus()
 
     transport = ASGITransport(app=app, raise_app_exceptions=False)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -55,8 +58,11 @@ async def room_e2e_ctx(tmp_path: Path) -> AsyncIterator[object]:
     engine = make_test_engine(tmp_path / "room_e2e_test.db")
     await create_all_tables(engine)
     session_factory = make_test_session_factory(engine)
+    from bakufu.infrastructure.event_bus import InMemoryEventBus
+
     app.state.engine = engine
     app.state.session_factory = session_factory
+    app.state.event_bus = InMemoryEventBus()
 
     transport = ASGITransport(app=app, raise_app_exceptions=False)
     async with AsyncClient(transport=transport, base_url="http://test") as client:

--- a/backend/tests/e2e/test_external_review_gate_http_api.py
+++ b/backend/tests/e2e/test_external_review_gate_http_api.py
@@ -41,8 +41,11 @@ async def gate_e2e_ctx(tmp_path: Path) -> AsyncIterator[GateE2ECtx]:
     engine = make_test_engine(tmp_path / "gate_e2e_test.db")
     await create_all_tables(engine)
     session_factory = make_test_session_factory(engine)
+    from bakufu.infrastructure.event_bus import InMemoryEventBus
+
     app.state.engine = engine
     app.state.session_factory = session_factory
+    app.state.event_bus = InMemoryEventBus()
     transport = ASGITransport(app=app, raise_app_exceptions=False)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         yield GateE2ECtx(client=client, session_factory=session_factory)

--- a/backend/tests/e2e/test_external_review_gate_http_api.py
+++ b/backend/tests/e2e/test_external_review_gate_http_api.py
@@ -38,6 +38,9 @@ async def gate_e2e_ctx(tmp_path: Path) -> AsyncIterator[GateE2ECtx]:
     from tests.factories.db import create_all_tables, make_test_engine, make_test_session_factory
 
     app = create_app()
+    from bakufu.infrastructure.security import masking as masking_mod
+
+    masking_mod.init()
     engine = make_test_engine(tmp_path / "gate_e2e_test.db")
     await create_all_tables(engine)
     session_factory = make_test_session_factory(engine)

--- a/backend/tests/factories/domain_event_factory.py
+++ b/backend/tests/factories/domain_event_factory.py
@@ -1,0 +1,155 @@
+"""DomainEvent 各クラス用ファクトリ群.
+
+``docs/features/websocket-broadcast/domain/test-design.md`` §Factory 定義 準拠。
+WeakValueDictionary パターン（task.py / external_review_gate.py と同パターン）。
+各ファクトリは本番コンストラクタ経由で妥当なデフォルトインスタンスを返し、
+``_SYNTHETIC_REGISTRY`` に登録する。これにより ``is_synthetic`` が後から
+「ファクトリ由来か」を確認できる。
+
+本モジュールを本番コードから import してはならない ── 合成データ境界を
+監査可能に保つため ``tests/`` 配下に配置されている。
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+from weakref import WeakValueDictionary
+
+from bakufu.domain.events import (
+    AgentStatusChangedEvent,
+    DirectiveCompletedEvent,
+    ExternalReviewGateStateChangedEvent,
+    TaskStateChangedEvent,
+)
+from pydantic import BaseModel
+
+# モジュールスコープのレジストリ。値は弱参照で保持するので GC 圧は中立 ──
+# 「このオブジェクトはファクトリ由来か」をオブジェクト生存中だけ知ればよい。
+_SYNTHETIC_REGISTRY: WeakValueDictionary[int, BaseModel] = WeakValueDictionary()
+
+
+def is_synthetic(instance: BaseModel) -> bool:
+    """``instance`` が本モジュールのファクトリで生成されたものなら ``True`` を返す。
+
+    検査は構造的ではなく ID ベース (``id``)。これにより独立に生成された
+    等値の 2 インスタンスは区別される ── ファクトリが返した実オブジェクトのみ
+    合成印が付く。
+    """
+    cached = _SYNTHETIC_REGISTRY.get(id(instance))
+    return cached is instance
+
+
+def _register(instance: BaseModel) -> None:
+    """``instance`` を合成レジストリに記録する。"""
+    _SYNTHETIC_REGISTRY[id(instance)] = instance
+
+
+# ---------------------------------------------------------------------------
+# TaskStateChangedEvent ファクトリ
+# ---------------------------------------------------------------------------
+def make_task_state_changed_event(
+    *,
+    aggregate_id: str | None = None,
+    directive_id: str | None = None,
+    old_status: str = "PENDING",
+    new_status: str = "IN_PROGRESS",
+    room_id: str | None = None,
+) -> TaskStateChangedEvent:
+    """妥当な :class:`TaskStateChangedEvent` を構築し合成印を付ける。
+
+    デフォルトは PENDING → IN_PROGRESS 遷移の canonical な入口状態。
+    ``aggregate_id`` は task_id に相当する（DomainEvent 設計による）。
+    """
+    event = TaskStateChangedEvent(
+        aggregate_id=aggregate_id if aggregate_id is not None else str(uuid4()),
+        directive_id=directive_id if directive_id is not None else str(uuid4()),
+        old_status=old_status,
+        new_status=new_status,
+        room_id=room_id if room_id is not None else str(uuid4()),
+    )
+    _register(event)
+    return event
+
+
+# ---------------------------------------------------------------------------
+# ExternalReviewGateStateChangedEvent ファクトリ
+# ---------------------------------------------------------------------------
+def make_external_review_gate_state_changed_event(
+    *,
+    aggregate_id: str | None = None,
+    task_id: str | None = None,
+    old_status: str = "OPEN",
+    new_status: str = "PENDING",
+    reviewer_comment: str | None = None,
+) -> ExternalReviewGateStateChangedEvent:
+    """妥当な :class:`ExternalReviewGateStateChangedEvent` を構築し合成印を付ける。
+
+    デフォルトは reviewer_comment=None（省略可能フィールド）の入口状態。
+    ``aggregate_id`` は gate_id に相当する（DomainEvent 設計による）。
+    """
+    event = ExternalReviewGateStateChangedEvent(
+        aggregate_id=aggregate_id if aggregate_id is not None else str(uuid4()),
+        task_id=task_id if task_id is not None else str(uuid4()),
+        old_status=old_status,
+        new_status=new_status,
+        reviewer_comment=reviewer_comment,
+    )
+    _register(event)
+    return event
+
+
+# ---------------------------------------------------------------------------
+# AgentStatusChangedEvent ファクトリ
+# ---------------------------------------------------------------------------
+def make_agent_status_changed_event(
+    *,
+    aggregate_id: str | None = None,
+    room_id: str | None = None,
+    old_status: str = "idle",
+    new_status: str = "running",
+) -> AgentStatusChangedEvent:
+    """妥当な :class:`AgentStatusChangedEvent` を構築し合成印を付ける。
+
+    デフォルトは idle → running 遷移の canonical な入口状態。
+    ``aggregate_id`` は agent_id に相当する（DomainEvent 設計による）。
+    """
+    event = AgentStatusChangedEvent(
+        aggregate_id=aggregate_id if aggregate_id is not None else str(uuid4()),
+        room_id=room_id if room_id is not None else str(uuid4()),
+        old_status=old_status,
+        new_status=new_status,
+    )
+    _register(event)
+    return event
+
+
+# ---------------------------------------------------------------------------
+# DirectiveCompletedEvent ファクトリ
+# ---------------------------------------------------------------------------
+def make_directive_completed_event(
+    *,
+    aggregate_id: str | None = None,
+    empire_id: str | None = None,
+    final_status: str = "DONE",
+) -> DirectiveCompletedEvent:
+    """妥当な :class:`DirectiveCompletedEvent` を構築し合成印を付ける。
+
+    デフォルトは final_status="DONE" の canonical な完了状態。
+    ``aggregate_id`` は directive_id に相当する（DomainEvent 設計による）。
+    """
+    event = DirectiveCompletedEvent(
+        aggregate_id=aggregate_id if aggregate_id is not None else str(uuid4()),
+        empire_id=empire_id if empire_id is not None else str(uuid4()),
+        final_status=final_status,
+    )
+    _register(event)
+    return event
+
+
+__all__ = [
+    "is_synthetic",
+    "make_agent_status_changed_event",
+    "make_directive_completed_event",
+    "make_external_review_gate_state_changed_event",
+    "make_task_state_changed_event",
+]

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -96,8 +96,11 @@ async def empire_app_client(tmp_path: Path) -> AsyncIterator[AsyncClient]:
     engine = make_test_engine(tmp_path / "test.db")
     await create_all_tables(engine)
     session_factory = make_test_session_factory(engine)
+    from bakufu.infrastructure.event_bus import InMemoryEventBus
+
     app.state.engine = engine
     app.state.session_factory = session_factory
+    app.state.event_bus = InMemoryEventBus()
 
     transport = ASGITransport(app=app, raise_app_exceptions=False)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -125,8 +128,11 @@ async def app_client(tmp_path: Path) -> AsyncIterator[AsyncClient]:
     # ── 本番 lifespan をバイパス ────────────────────────────────────────────
     engine = make_test_engine(tmp_path / "test.db")
     session_factory = make_test_session_factory(engine)
+    from bakufu.infrastructure.event_bus import InMemoryEventBus
+
     app.state.engine = engine
     app.state.session_factory = session_factory
+    app.state.event_bus = InMemoryEventBus()
 
     app.include_router(_build_test_router())
 

--- a/backend/tests/integration/test_agent_http_api/conftest.py
+++ b/backend/tests/integration/test_agent_http_api/conftest.py
@@ -30,8 +30,11 @@ async def ag_ctx(tmp_path: Path) -> AsyncIterator[AgTestCtx]:
     engine = make_test_engine(tmp_path / "agent_test.db")
     await create_all_tables(engine)
     session_factory = make_test_session_factory(engine)
+    from bakufu.infrastructure.event_bus import InMemoryEventBus
+
     app.state.engine = engine
     app.state.session_factory = session_factory
+    app.state.event_bus = InMemoryEventBus()
 
     transport = ASGITransport(app=app, raise_app_exceptions=False)
     async with AsyncClient(transport=transport, base_url="http://test") as client:

--- a/backend/tests/integration/test_deliverable_template_http_api/conftest.py
+++ b/backend/tests/integration/test_deliverable_template_http_api/conftest.py
@@ -47,8 +47,11 @@ async def dt_ctx(tmp_path: Path) -> AsyncIterator[DtTestCtx]:
     engine = make_test_engine(tmp_path / "dt_test.db")
     await create_all_tables(engine)
     session_factory = make_test_session_factory(engine)
+    from bakufu.infrastructure.event_bus import InMemoryEventBus
+
     app.state.engine = engine
     app.state.session_factory = session_factory
+    app.state.event_bus = InMemoryEventBus()
 
     transport = ASGITransport(app=app, raise_app_exceptions=False)
     async with AsyncClient(transport=transport, base_url="http://test") as client:

--- a/backend/tests/integration/test_directive_http_api/test_atomic_uow.py
+++ b/backend/tests/integration/test_directive_http_api/test_atomic_uow.py
@@ -44,8 +44,11 @@ async def test_issue_rolls_back_directive_when_task_save_fails(tmp_path: Path) -
     engine = make_test_engine(tmp_path / "atomic_uow.db")
     await create_all_tables(engine)
     session_factory = make_test_session_factory(engine)
+    from bakufu.infrastructure.event_bus import InMemoryEventBus
+
     app.state.engine = engine
     app.state.session_factory = session_factory
+    app.state.event_bus = InMemoryEventBus()
 
     async def _override_directive_service(session: SessionDep) -> DirectiveService:
         return DirectiveService(

--- a/backend/tests/integration/test_external_review_gate_http/conftest.py
+++ b/backend/tests/integration/test_external_review_gate_http/conftest.py
@@ -28,8 +28,11 @@ async def gate_ctx(tmp_path: Path) -> AsyncIterator[GateTestCtx]:
     engine = make_test_engine(tmp_path / "gate_test.db")
     await create_all_tables(engine)
     session_factory = make_test_session_factory(engine)
+    from bakufu.infrastructure.event_bus import InMemoryEventBus
+
     app.state.engine = engine
     app.state.session_factory = session_factory
+    app.state.event_bus = InMemoryEventBus()
     transport = ASGITransport(app=app, raise_app_exceptions=False)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         yield GateTestCtx(client=client, session_factory=session_factory)

--- a/backend/tests/integration/test_role_profile_http_api/conftest.py
+++ b/backend/tests/integration/test_role_profile_http_api/conftest.py
@@ -42,8 +42,11 @@ async def rp_ctx(tmp_path: Path) -> AsyncIterator[RpTestCtx]:
     engine = make_test_engine(tmp_path / "rp_test.db")
     await create_all_tables(engine)
     session_factory = make_test_session_factory(engine)
+    from bakufu.infrastructure.event_bus import InMemoryEventBus
+
     app.state.engine = engine
     app.state.session_factory = session_factory
+    app.state.event_bus = InMemoryEventBus()
 
     transport = ASGITransport(app=app, raise_app_exceptions=False)
     async with AsyncClient(transport=transport, base_url="http://test") as client:

--- a/backend/tests/integration/test_room_http_api/conftest.py
+++ b/backend/tests/integration/test_room_http_api/conftest.py
@@ -30,8 +30,11 @@ async def room_ctx(tmp_path: Path) -> AsyncIterator[RoomTestCtx]:
     engine = make_test_engine(tmp_path / "room_test.db")
     await create_all_tables(engine)
     session_factory = make_test_session_factory(engine)
+    from bakufu.infrastructure.event_bus import InMemoryEventBus
+
     app.state.engine = engine
     app.state.session_factory = session_factory
+    app.state.event_bus = InMemoryEventBus()
 
     transport = ASGITransport(app=app, raise_app_exceptions=False)
     async with AsyncClient(transport=transport, base_url="http://test") as client:

--- a/backend/tests/integration/test_room_matching_http_api/conftest.py
+++ b/backend/tests/integration/test_room_matching_http_api/conftest.py
@@ -39,8 +39,11 @@ async def rmm_ctx(tmp_path: Path) -> AsyncIterator[RmmTestCtx]:
     engine = make_test_engine(tmp_path / "rmm_test.db")
     await create_all_tables(engine)
     session_factory = make_test_session_factory(engine)
+    from bakufu.infrastructure.event_bus import InMemoryEventBus
+
     app.state.engine = engine
     app.state.session_factory = session_factory
+    app.state.event_bus = InMemoryEventBus()
 
     transport = ASGITransport(app=app, raise_app_exceptions=False)
     async with AsyncClient(transport=transport, base_url="http://test") as client:

--- a/backend/tests/integration/test_websocket_broadcast_domain.py
+++ b/backend/tests/integration/test_websocket_broadcast_domain.py
@@ -1,0 +1,360 @@
+"""websocket-broadcast / domain 結合テスト（TC-IT-WSB-001〜004）。
+
+設計書: docs/features/websocket-broadcast/domain/test-design.md
+対象: REQ-WSB-008（ApplicationService 統合 — M4 スコープ）
+対象 Service: TaskService（cancel）/ ExternalReviewGateService（approve）
+Issue: #158
+
+前提:
+- DB: tmp_path ベースの SQLite 実接続（create_all_tables）
+- EventBus: InMemoryEventBus() に SpyHandler を登録（実実装を使用）
+- 各 Service は event_bus: EventBusPort を DI 注入した状態でインスタンス化する
+
+M4 対象: TaskService.cancel() のみ + ExternalReviewGateService.approve()
+（unblock_retry / commit_deliverable は同様のパターンなので TC-IT-WSB-001/003 で代表検証）
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from tests.factories.db import create_all_tables, make_test_engine, make_test_session_factory
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# SpyEventBus: InMemoryEventBus に SpyHandler を登録したテスト用ラッパ
+# ---------------------------------------------------------------------------
+
+
+class _SpyHandler:
+    """受け取った DomainEvent を記録する spy ハンドラ。"""
+
+    def __init__(self) -> None:
+        self.received: list[object] = []
+
+    async def __call__(self, event: object) -> None:
+        self.received.append(event)
+
+
+class _FailingHandler:
+    """常に例外を発火する ハンドラ（TC-IT-WSB-003 用）。"""
+
+    async def __call__(self, event: object) -> None:
+        raise RuntimeError("synthetic handler failure for TC-IT-WSB-003")
+
+
+# ---------------------------------------------------------------------------
+# masking 初期化フィクスチャ
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _init_masking(monkeypatch: pytest.MonkeyPatch) -> None:
+    """masking モジュールを初期化する。
+
+    ExternalReviewGateService.approve が masking.mask() を呼ぶため必要。
+    """
+    for env_key in (
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "GEMINI_API_KEY",
+        "GH_TOKEN",
+        "GITHUB_TOKEN",
+        "OAUTH_CLIENT_SECRET",
+        "BAKUFU_DISCORD_BOT_TOKEN",
+    ):
+        monkeypatch.delenv(env_key, raising=False)
+    from bakufu.infrastructure.security import masking
+
+    masking.init()
+
+
+# ---------------------------------------------------------------------------
+# DB セットアップフィクスチャ
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def session_factory(tmp_path: Path) -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    """create_all でスキーマ作成済みの session_factory を提供する。"""
+    engine = make_test_engine(tmp_path / "wsb_it_test.db")
+    await create_all_tables(engine)
+    sf = make_test_session_factory(engine)
+    try:
+        yield sf
+    finally:
+        await engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# シードヘルパー
+# ---------------------------------------------------------------------------
+
+
+async def _seed_task_with_deps(
+    session_factory: async_sessionmaker[AsyncSession],
+    *,
+    task_id: UUID | None = None,
+) -> tuple[UUID, UUID, UUID, UUID, UUID]:
+    """Empire → Workflow → Room → Directive → Task の FK チェーンを全てシードする。
+
+    Returns:
+        (empire_id, workflow_id, room_id, directive_id, task_id) のタプル。
+    """
+    from bakufu.infrastructure.persistence.sqlite.repositories.directive_repository import (
+        SqliteDirectiveRepository,
+    )
+    from bakufu.infrastructure.persistence.sqlite.repositories.empire_repository import (
+        SqliteEmpireRepository,
+    )
+    from bakufu.infrastructure.persistence.sqlite.repositories.room_repository import (
+        SqliteRoomRepository,
+    )
+    from bakufu.infrastructure.persistence.sqlite.repositories.task_repository import (
+        SqliteTaskRepository,
+    )
+    from bakufu.infrastructure.persistence.sqlite.repositories.workflow_repository import (
+        SqliteWorkflowRepository,
+    )
+
+    from tests.factories.directive import make_directive
+    from tests.factories.empire import make_empire
+    from tests.factories.room import make_room
+    from tests.factories.task import make_task
+    from tests.factories.workflow import make_workflow
+
+    _task_id = task_id if task_id is not None else uuid4()
+
+    empire = make_empire()
+    workflow = make_workflow()
+    room = make_room(workflow_id=workflow.id, members=[])
+    directive = make_directive(
+        target_room_id=room.id,
+        task_id=_task_id,
+    )
+    task = make_task(
+        task_id=_task_id,
+        room_id=room.id,
+        directive_id=directive.id,
+    )
+
+    async with session_factory() as session, session.begin():
+        await SqliteEmpireRepository(session).save(empire)
+        await SqliteWorkflowRepository(session).save(workflow)
+        await SqliteRoomRepository(session).save(room, empire.id)
+        await SqliteDirectiveRepository(session).save(directive)
+        await SqliteTaskRepository(session).save(task)
+
+    return empire.id, workflow.id, room.id, directive.id, _task_id
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-WSB-001: TaskService.cancel() → InMemoryEventBus.publish()
+# ---------------------------------------------------------------------------
+
+
+class TestTaskServiceCancelPublishesEvent:
+    """TC-IT-WSB-001: TaskService.cancel() 成功後に EventBus へ TaskStateChangedEvent が配信される。
+
+    M4 REQ-WSB-008: DB コミット後に publish が呼ばれることの結合検証。
+    """
+
+    async def test_cancel_publishes_task_state_changed_event(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        from bakufu.application.services.task_service import TaskService
+        from bakufu.domain.events import TaskStateChangedEvent
+        from bakufu.infrastructure.event_bus import InMemoryEventBus
+        from bakufu.infrastructure.persistence.sqlite.repositories.agent_repository import (
+            SqliteAgentRepository,
+        )
+        from bakufu.infrastructure.persistence.sqlite.repositories.room_repository import (
+            SqliteRoomRepository,
+        )
+        from bakufu.infrastructure.persistence.sqlite.repositories.task_repository import (
+            SqliteTaskRepository,
+        )
+
+        _, _, _, _, task_id = await _seed_task_with_deps(session_factory)
+
+        spy = _SpyHandler()
+        event_bus = InMemoryEventBus()
+        event_bus.subscribe(spy)
+
+        async with session_factory() as session:
+            task_service = TaskService(
+                task_repo=SqliteTaskRepository(session),
+                room_repo=SqliteRoomRepository(session),
+                agent_repo=SqliteAgentRepository(session),
+                session=session,
+                event_bus=event_bus,
+            )
+            await task_service.cancel(task_id)
+
+        # SpyHandler が TaskStateChangedEvent を 1 件受け取っている
+        assert len(spy.received) == 1
+        event = spy.received[0]
+        assert isinstance(event, TaskStateChangedEvent)
+        assert event.event_type == "task.state_changed"
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-WSB-002: TaskService.cancel() 失敗時に publish() が呼ばれない
+# ---------------------------------------------------------------------------
+
+
+class TestTaskServiceCancelFailureDoesNotPublish:
+    """TC-IT-WSB-002: 存在しない task_id で cancel() すると例外が発火し publish() は呼ばれない。"""
+
+    async def test_cancel_invalid_id_raises_and_does_not_publish(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        from bakufu.application.exceptions.task_exceptions import TaskNotFoundError
+        from bakufu.application.services.task_service import TaskService
+        from bakufu.infrastructure.event_bus import InMemoryEventBus
+        from bakufu.infrastructure.persistence.sqlite.repositories.agent_repository import (
+            SqliteAgentRepository,
+        )
+        from bakufu.infrastructure.persistence.sqlite.repositories.room_repository import (
+            SqliteRoomRepository,
+        )
+        from bakufu.infrastructure.persistence.sqlite.repositories.task_repository import (
+            SqliteTaskRepository,
+        )
+
+        spy = _SpyHandler()
+        event_bus = InMemoryEventBus()
+        event_bus.subscribe(spy)
+
+        invalid_task_id = uuid4()
+
+        async with session_factory() as session:
+            task_service = TaskService(
+                task_repo=SqliteTaskRepository(session),
+                room_repo=SqliteRoomRepository(session),
+                agent_repo=SqliteAgentRepository(session),
+                session=session,
+                event_bus=event_bus,
+            )
+            with pytest.raises(TaskNotFoundError):
+                await task_service.cancel(invalid_task_id)
+
+        # 例外発火のため publish() は呼ばれず spy の受信件数は 0
+        assert len(spy.received) == 0
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-WSB-003: EventBus handler 例外が業務結果をブロックしない
+# ---------------------------------------------------------------------------
+
+
+class TestTaskServiceCancelHandlerExceptionDoesNotPropagate:
+    """TC-IT-WSB-003: EventBus handler が例外を発火しても cancel() 結果は呼び出し元に返る。
+
+    InMemoryEventBus の Fail Soft 設計（asyncio.gather return_exceptions=True）の
+    結合レベル検証。
+    """
+
+    async def test_cancel_returns_result_even_when_handler_raises(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        from bakufu.application.services.task_service import TaskService
+        from bakufu.domain.task.task import Task
+        from bakufu.infrastructure.event_bus import InMemoryEventBus
+        from bakufu.infrastructure.persistence.sqlite.repositories.agent_repository import (
+            SqliteAgentRepository,
+        )
+        from bakufu.infrastructure.persistence.sqlite.repositories.room_repository import (
+            SqliteRoomRepository,
+        )
+        from bakufu.infrastructure.persistence.sqlite.repositories.task_repository import (
+            SqliteTaskRepository,
+        )
+
+        _, _, _, _, task_id = await _seed_task_with_deps(session_factory)
+
+        failing = _FailingHandler()
+        event_bus = InMemoryEventBus()
+        event_bus.subscribe(failing)
+
+        async with session_factory() as session:
+            task_service = TaskService(
+                task_repo=SqliteTaskRepository(session),
+                room_repo=SqliteRoomRepository(session),
+                agent_repo=SqliteAgentRepository(session),
+                session=session,
+                event_bus=event_bus,
+            )
+            # handler が例外を発火しても TaskService.cancel() は例外を呼び出し元に伝播させない
+            result = await task_service.cancel(task_id)
+
+        # Task が返されており、業務結果がブロックされていない
+        assert isinstance(result, Task)
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-WSB-004: ExternalReviewGateService.approve() → masking 適用確認
+# ---------------------------------------------------------------------------
+
+
+class TestExternalReviewGateServiceApprovePublishesEvent:
+    """TC-IT-WSB-004: approve() 成功後に reviewer_comment が masking 適用済みで publish される。
+
+    §確定 F: reviewer_comment は masking.mask() 適用済みの値を publish する。
+    通常のコメント "LGTM" はシークレットパターンに一致しないため masking 後も同値。
+    """
+
+    async def test_approve_publishes_event_with_masked_reviewer_comment(self) -> None:
+        from unittest.mock import AsyncMock
+
+        from bakufu.application.security import masking
+        from bakufu.application.services.external_review_gate_service import (
+            ExternalReviewGateService,
+        )
+        from bakufu.domain.events import ExternalReviewGateStateChangedEvent
+        from bakufu.infrastructure.event_bus import InMemoryEventBus
+
+        from tests.factories.external_review_gate import make_gate
+
+        reviewer_id = uuid4()
+        comment = "LGTM"
+        gate = make_gate(reviewer_id=reviewer_id)
+
+        spy = _SpyHandler()
+        event_bus = InMemoryEventBus()
+        event_bus.subscribe(spy)
+
+        # ExternalReviewGateService.approve() はリポジトリを使わない（gate 引数をそのまま受け取る）
+        service = ExternalReviewGateService(
+            repo=AsyncMock(),
+            template_repo=AsyncMock(),
+            event_bus=event_bus,
+        )
+        await service.approve(
+            gate=gate,
+            reviewer_id=reviewer_id,
+            comment=comment,
+            decided_at=datetime.now(UTC),
+        )
+
+        # SpyHandler が ExternalReviewGateStateChangedEvent を 1 件受け取っている
+        assert len(spy.received) == 1
+        event = spy.received[0]
+        assert isinstance(event, ExternalReviewGateStateChangedEvent)
+        assert event.event_type == "external_review_gate.state_changed"
+
+        # reviewer_comment は masking.mask() 適用済みの値
+        expected_comment = masking.mask(comment)
+        assert event.reviewer_comment == expected_comment

--- a/backend/tests/integration/test_workflow_http_api/conftest.py
+++ b/backend/tests/integration/test_workflow_http_api/conftest.py
@@ -28,8 +28,11 @@ async def wf_ctx(tmp_path: Path) -> AsyncIterator[WfTestCtx]:
     engine = make_test_engine(tmp_path / "workflow_test.db")
     await create_all_tables(engine)
     session_factory = make_test_session_factory(engine)
+    from bakufu.infrastructure.event_bus import InMemoryEventBus
+
     app.state.engine = engine
     app.state.session_factory = session_factory
+    app.state.event_bus = InMemoryEventBus()
 
     transport = ASGITransport(app=app, raise_app_exceptions=False)
     async with AsyncClient(transport=transport, base_url="http://test") as client:

--- a/backend/tests/unit/services/test_external_review_gate_service.py
+++ b/backend/tests/unit/services/test_external_review_gate_service.py
@@ -36,7 +36,7 @@ class TestFindByIdOrRaise:
         mock_repo = AsyncMock()
         mock_repo.find_by_id = AsyncMock(return_value=gate)
 
-        service = ExternalReviewGateService(repo=mock_repo, template_repo=AsyncMock())
+        service = ExternalReviewGateService(repo=mock_repo, template_repo=AsyncMock(), event_bus=AsyncMock())
         result = await service.find_by_id_or_raise(gate.id)
 
         assert result is gate
@@ -51,7 +51,7 @@ class TestFindByIdOrRaise:
         mock_repo = AsyncMock()
         mock_repo.find_by_id = AsyncMock(return_value=None)
 
-        service = ExternalReviewGateService(repo=mock_repo, template_repo=AsyncMock())
+        service = ExternalReviewGateService(repo=mock_repo, template_repo=AsyncMock(), event_bus=AsyncMock())
         gate_id = uuid4()
 
         with pytest.raises(GateNotFoundError):
@@ -74,7 +74,7 @@ class TestApproveGate:
         gate = make_gate(reviewer_id=reviewer_id)
         mock_repo = AsyncMock()
 
-        service = ExternalReviewGateService(repo=mock_repo, template_repo=AsyncMock())
+        service = ExternalReviewGateService(repo=mock_repo, template_repo=AsyncMock(), event_bus=AsyncMock())
         result = await service.approve(
             gate=gate,
             reviewer_id=reviewer_id,
@@ -97,7 +97,7 @@ class TestApproveGate:
         gate = make_approved_gate(reviewer_id=reviewer_id)
         mock_repo = AsyncMock()
 
-        service = ExternalReviewGateService(repo=mock_repo, template_repo=AsyncMock())
+        service = ExternalReviewGateService(repo=mock_repo, template_repo=AsyncMock(), event_bus=AsyncMock())
 
         with pytest.raises(GateAlreadyDecidedError):
             await service.approve(

--- a/backend/tests/unit/test_websocket_broadcast_domain.py
+++ b/backend/tests/unit/test_websocket_broadcast_domain.py
@@ -1,0 +1,509 @@
+"""websocket-broadcast / domain ユニットテスト（TC-UT-WSB-001〜029）。
+
+設計書: docs/features/websocket-broadcast/domain/test-design.md
+対象: REQ-WSB-001〜008 / MSG-WSB-001〜002 / 確定E(Fail Fast)
+Issue: #158
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from unittest.mock import AsyncMock
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# REQ-WSB-001: DomainEvent 基底クラス
+# ---------------------------------------------------------------------------
+
+
+class TestDomainEventBase:
+    """TC-UT-WSB-001〜005: DomainEvent 基底クラスの共通フィールドと to_ws_message()。"""
+
+    def test_event_id_is_uuid(self) -> None:
+        """TC-UT-WSB-001: event_id が UUID インスタンスである。"""
+        from uuid import UUID
+
+        from tests.factories.domain_event_factory import make_task_state_changed_event
+
+        event = make_task_state_changed_event()
+        assert isinstance(event.event_id, UUID)
+
+    def test_occurred_at_is_utc_aware(self) -> None:
+        """TC-UT-WSB-002: occurred_at が timezone.utc 付き datetime インスタンスである。"""
+        from datetime import datetime
+
+        from tests.factories.domain_event_factory import make_task_state_changed_event
+
+        event = make_task_state_changed_event()
+        assert isinstance(event.occurred_at, datetime)
+        assert event.occurred_at.tzinfo is not None
+        # UTC タイムゾーン確認: utcoffset() が timedelta(0) であることを検証
+        from datetime import timedelta
+
+        assert event.occurred_at.utcoffset() == timedelta(0)
+
+    def test_to_ws_message_keys(self) -> None:
+        """TC-UT-WSB-003: to_ws_message() の戻り値は 5 キーのみ持つ。"""
+        from tests.factories.domain_event_factory import make_task_state_changed_event
+
+        event = make_task_state_changed_event()
+        msg = event.to_ws_message()
+        assert set(msg.keys()) == {
+            "event_type",
+            "aggregate_id",
+            "aggregate_type",
+            "occurred_at",
+            "payload",
+        }
+
+    def test_occurred_at_in_ws_message_is_iso8601_utc_string(self) -> None:
+        """TC-UT-WSB-004: to_ws_message() の occurred_at が ISO 8601 UTC 形式文字列。"""
+        from tests.factories.domain_event_factory import make_task_state_changed_event
+
+        event = make_task_state_changed_event()
+        msg = event.to_ws_message()
+        occurred_at_val = msg["occurred_at"]
+        assert isinstance(occurred_at_val, str)
+        # isoformat() は +00:00 または Z を含む
+        assert "+00:00" in occurred_at_val or "Z" in occurred_at_val
+
+    def test_payload_excludes_base_fields(self) -> None:
+        """TC-UT-WSB-005: payload に基底クラス 5 フィールドが含まれない。"""
+        from tests.factories.domain_event_factory import make_task_state_changed_event
+
+        event = make_task_state_changed_event()
+        msg = event.to_ws_message()
+        payload = msg["payload"]
+        base_field_names = {
+            "event_id",
+            "event_type",
+            "aggregate_id",
+            "aggregate_type",
+            "occurred_at",
+        }
+        for field_name in base_field_names:
+            assert field_name not in payload, f"payload に {field_name} が含まれている"
+
+
+# ---------------------------------------------------------------------------
+# REQ-WSB-002: TaskStateChangedEvent
+# ---------------------------------------------------------------------------
+
+
+class TestTaskStateChangedEvent:
+    """TC-UT-WSB-006〜009: TaskStateChangedEvent の正常系・異常系。"""
+
+    def test_instantiation_succeeds(self) -> None:
+        """TC-UT-WSB-006: インスタンスが生成される（例外なし）。"""
+        from tests.factories.domain_event_factory import make_task_state_changed_event
+
+        event = make_task_state_changed_event()
+        assert event is not None
+
+    def test_event_type_is_task_state_changed(self) -> None:
+        """TC-UT-WSB-007: event_type == "task.state_changed"。"""
+        from tests.factories.domain_event_factory import make_task_state_changed_event
+
+        event = make_task_state_changed_event()
+        assert event.event_type == "task.state_changed"
+
+    def test_to_ws_message_payload_contains_task_specific_fields(self) -> None:
+        """TC-UT-WSB-008: to_ws_message() の payload に task 固有フィールドが含まれる。
+
+        TaskStateChangedEvent の payload は directive_id / old_status /
+        new_status / room_id を持つ。aggregate_id (task_id) は基底クラス
+        フィールドのため payload に含まれない。
+        """
+        from bakufu.domain.events import TaskStateChangedEvent
+
+        event = TaskStateChangedEvent(
+            aggregate_id="t1",
+            directive_id="d1",
+            old_status="PENDING",
+            new_status="IN_PROGRESS",
+            room_id="r1",
+        )
+        msg = event.to_ws_message()
+        assert msg["payload"] == {
+            "directive_id": "d1",
+            "old_status": "PENDING",
+            "new_status": "IN_PROGRESS",
+            "room_id": "r1",
+        }
+
+    def test_missing_required_field_raises_validation_error(self) -> None:
+        """TC-UT-WSB-009: 必須フィールド(directive_id)欠落 → pydantic.ValidationError。"""
+        from bakufu.domain.events import TaskStateChangedEvent
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            TaskStateChangedEvent(
+                aggregate_id="t1",
+                # directive_id は省略（必須フィールド）
+                old_status="PENDING",
+                new_status="IN_PROGRESS",
+                room_id="r1",
+            )  # type: ignore[call-arg]
+
+
+# ---------------------------------------------------------------------------
+# REQ-WSB-003: ExternalReviewGateStateChangedEvent
+# ---------------------------------------------------------------------------
+
+
+class TestExternalReviewGateStateChangedEvent:
+    """TC-UT-WSB-010〜013: ExternalReviewGateStateChangedEvent の正常系・異常系・境界値。"""
+
+    def test_reviewer_comment_none(self) -> None:
+        """TC-UT-WSB-010: reviewer_comment=None でインスタンス生成される（境界値）。"""
+        from tests.factories.domain_event_factory import (
+            make_external_review_gate_state_changed_event,
+        )
+
+        event = make_external_review_gate_state_changed_event(reviewer_comment=None)
+        assert event.reviewer_comment is None
+
+    def test_reviewer_comment_string(self) -> None:
+        """TC-UT-WSB-011: reviewer_comment="LGTM" でインスタンス生成される。"""
+        from tests.factories.domain_event_factory import (
+            make_external_review_gate_state_changed_event,
+        )
+
+        event = make_external_review_gate_state_changed_event(reviewer_comment="LGTM")
+        assert event.reviewer_comment == "LGTM"
+
+    def test_event_type_is_external_review_gate_state_changed(self) -> None:
+        """TC-UT-WSB-012: event_type == "external_review_gate.state_changed"。"""
+        from tests.factories.domain_event_factory import (
+            make_external_review_gate_state_changed_event,
+        )
+
+        event = make_external_review_gate_state_changed_event()
+        assert event.event_type == "external_review_gate.state_changed"
+
+    def test_missing_required_field_raises_validation_error(self) -> None:
+        """TC-UT-WSB-013: 必須フィールド(aggregate_id=gate_id)欠落 → pydantic.ValidationError。"""
+        from bakufu.domain.events import ExternalReviewGateStateChangedEvent
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            ExternalReviewGateStateChangedEvent(
+                # aggregate_id (gate_id) は省略（必須フィールド）
+                task_id="task-1",
+                old_status="PENDING",
+                new_status="APPROVED",
+            )  # type: ignore[call-arg]
+
+
+# ---------------------------------------------------------------------------
+# REQ-WSB-004: AgentStatusChangedEvent
+# ---------------------------------------------------------------------------
+
+
+class TestAgentStatusChangedEvent:
+    """TC-UT-WSB-014〜016: AgentStatusChangedEvent の正常系・異常系。"""
+
+    def test_instantiation_succeeds(self) -> None:
+        """TC-UT-WSB-014: インスタンスが生成される（例外なし）。"""
+        from tests.factories.domain_event_factory import make_agent_status_changed_event
+
+        event = make_agent_status_changed_event()
+        assert event is not None
+
+    def test_event_type_is_agent_status_changed(self) -> None:
+        """TC-UT-WSB-015: event_type == "agent.status_changed"。"""
+        from tests.factories.domain_event_factory import make_agent_status_changed_event
+
+        event = make_agent_status_changed_event()
+        assert event.event_type == "agent.status_changed"
+
+    def test_missing_required_field_raises_validation_error(self) -> None:
+        """TC-UT-WSB-016: 必須フィールド(aggregate_id=agent_id)欠落 → pydantic.ValidationError。"""
+        from bakufu.domain.events import AgentStatusChangedEvent
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            AgentStatusChangedEvent(
+                # aggregate_id (agent_id) は省略（必須フィールド）
+                room_id="room-1",
+                old_status="idle",
+                new_status="running",
+            )  # type: ignore[call-arg]
+
+
+# ---------------------------------------------------------------------------
+# REQ-WSB-005: DirectiveCompletedEvent
+# ---------------------------------------------------------------------------
+
+
+class TestDirectiveCompletedEvent:
+    """TC-UT-WSB-017〜019: DirectiveCompletedEvent の正常系・異常系。"""
+
+    def test_instantiation_succeeds(self) -> None:
+        """TC-UT-WSB-017: インスタンスが生成される（例外なし）。"""
+        from tests.factories.domain_event_factory import make_directive_completed_event
+
+        event = make_directive_completed_event()
+        assert event is not None
+
+    def test_event_type_is_directive_completed(self) -> None:
+        """TC-UT-WSB-018: event_type == "directive.completed"。"""
+        from tests.factories.domain_event_factory import make_directive_completed_event
+
+        event = make_directive_completed_event()
+        assert event.event_type == "directive.completed"
+
+    def test_missing_required_field_raises_validation_error(self) -> None:
+        """TC-UT-WSB-019: 必須フィールド(aggregate_id=directive_id)欠落 → ValidationError。"""
+        from bakufu.domain.events import DirectiveCompletedEvent
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            DirectiveCompletedEvent(
+                # aggregate_id (directive_id) は省略（必須フィールド）
+                empire_id="empire-1",
+                final_status="DONE",
+            )  # type: ignore[call-arg]
+
+
+# ---------------------------------------------------------------------------
+# REQ-WSB-006: EventBusPort Protocol
+# ---------------------------------------------------------------------------
+
+
+class TestEventBusPortProtocol:
+    """TC-UT-WSB-020: EventBusPort Protocol に InMemoryEventBus が構造的に適合する。"""
+
+    def test_inmemory_eventbus_satisfies_protocol_structurally(self) -> None:
+        """TC-UT-WSB-020: InMemoryEventBus が EventBusPort Protocol に構造的に適合する。
+
+        EventBusPort は @runtime_checkable でないため isinstance チェックは不可。
+        EventBusPort が要求するメンバ（subscribe / publish）を InMemoryEventBus が
+        全て実装することをシグネチャレベルで確認する（structural subtyping 検証）。
+        """
+        from bakufu.infrastructure.event_bus import InMemoryEventBus
+
+        bus = InMemoryEventBus()
+
+        # EventBusPort が要求する 2 メソッドを持つことを確認
+        assert callable(getattr(bus, "subscribe", None)), (
+            "InMemoryEventBus は subscribe メソッドを実装していない"
+        )
+        assert callable(getattr(bus, "publish", None)), (
+            "InMemoryEventBus は publish メソッドを実装していない"
+        )
+
+        # メソッドシグネチャ検証: subscribe(handler) と publish(event) を持つ
+        subscribe_sig = inspect.signature(InMemoryEventBus.subscribe)
+        publish_sig = inspect.signature(InMemoryEventBus.publish)
+        assert "handler" in subscribe_sig.parameters, "subscribe の引数に 'handler' がない"
+        assert "event" in publish_sig.parameters, "publish の引数に 'event' がない"
+
+
+# ---------------------------------------------------------------------------
+# REQ-WSB-007: InMemoryEventBus
+# ---------------------------------------------------------------------------
+
+
+class TestInMemoryEventBus:
+    """TC-UT-WSB-021〜027: InMemoryEventBus の正常系・異常系・境界値。"""
+
+    def test_subscribe_adds_handler(self) -> None:
+        """TC-UT-WSB-021: subscribe() 後、_handlers リストの長さが 1 増加する。"""
+        from bakufu.infrastructure.event_bus import InMemoryEventBus
+
+        bus = InMemoryEventBus()
+        before = len(bus._handlers)
+
+        async def dummy_handler(event: object) -> None:
+            pass
+
+        bus.subscribe(dummy_handler)
+        assert len(bus._handlers) == before + 1
+
+    async def test_publish_calls_single_handler(self) -> None:
+        """TC-UT-WSB-022: publish() 後、spy handler が event を 1 回受け取る。"""
+        from bakufu.infrastructure.event_bus import InMemoryEventBus
+
+        from tests.factories.domain_event_factory import make_task_state_changed_event
+
+        bus = InMemoryEventBus()
+        received: list[object] = []
+
+        async def spy(event: object) -> None:
+            received.append(event)
+
+        bus.subscribe(spy)
+        event = make_task_state_changed_event()
+        await bus.publish(event)
+
+        assert len(received) == 1
+        assert received[0] is event
+
+    async def test_publish_with_no_handlers_does_not_raise(self) -> None:
+        """TC-UT-WSB-023: ハンドラ未登録の空 EventBus への publish() が
+        例外なく完了する（境界値）。
+        """
+        from bakufu.infrastructure.event_bus import InMemoryEventBus
+
+        from tests.factories.domain_event_factory import make_task_state_changed_event
+
+        bus = InMemoryEventBus()
+        event = make_task_state_changed_event()
+        # 例外が発火しないことを確認
+        await bus.publish(event)
+
+    async def test_publish_calls_all_handlers(self) -> None:
+        """TC-UT-WSB-024: 3 個の spy handler 全てが event を受け取る（asyncio.gather 並行実行）。"""
+        from bakufu.infrastructure.event_bus import InMemoryEventBus
+
+        from tests.factories.domain_event_factory import make_task_state_changed_event
+
+        bus = InMemoryEventBus()
+        received_counts: list[int] = [0, 0, 0]
+
+        async def spy_0(event: object) -> None:
+            received_counts[0] += 1
+
+        async def spy_1(event: object) -> None:
+            received_counts[1] += 1
+
+        async def spy_2(event: object) -> None:
+            received_counts[2] += 1
+
+        bus.subscribe(spy_0)
+        bus.subscribe(spy_1)
+        bus.subscribe(spy_2)
+
+        event = make_task_state_changed_event()
+        await bus.publish(event)
+
+        assert received_counts == [1, 1, 1]
+
+    async def test_publish_fail_soft_continues_after_handler_exception(self) -> None:
+        """TC-UT-WSB-025: 1 個目が例外を発火しても 2 個目の spy handler が受け取る（Fail Soft）。"""
+        from bakufu.infrastructure.event_bus import InMemoryEventBus
+
+        from tests.factories.domain_event_factory import make_task_state_changed_event
+
+        bus = InMemoryEventBus()
+        received: list[object] = []
+
+        async def failing_handler(event: object) -> None:
+            raise RuntimeError("synthetic handler failure")
+
+        async def spy(event: object) -> None:
+            received.append(event)
+
+        bus.subscribe(failing_handler)
+        bus.subscribe(spy)
+
+        event = make_task_state_changed_event()
+        await bus.publish(event)
+
+        # 2 個目の spy handler は event を受け取っている
+        assert len(received) == 1
+        assert received[0] is event
+
+    async def test_publish_logs_warning_on_handler_exception(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """TC-UT-WSB-026: 例外発火ハンドラがある場合、WARNING ログに
+        "EventBus handler error:" が含まれる（MSG-WSB-001）。
+        """
+        from bakufu.infrastructure.event_bus import InMemoryEventBus
+
+        from tests.factories.domain_event_factory import make_task_state_changed_event
+
+        bus = InMemoryEventBus()
+
+        async def failing_handler(event: object) -> None:
+            raise ValueError("synthetic error for MSG-WSB-001")
+
+        bus.subscribe(failing_handler)
+
+        event = make_task_state_changed_event()
+        with caplog.at_level(logging.WARNING, logger="bakufu.infrastructure.event_bus"):
+            await bus.publish(event)
+
+        warning_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("EventBus handler error:" in msg for msg in warning_messages), (
+            f"MSG-WSB-001 ログが見つからない。実際のログ: {warning_messages}"
+        )
+
+    async def test_publish_logs_debug_on_completion(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """TC-UT-WSB-027: 正常完了後、DEBUG ログに "DomainEvent published:" が含まれる。
+
+        MSG-WSB-002 静的文字列照合。
+        """
+        from bakufu.infrastructure.event_bus import InMemoryEventBus
+
+        from tests.factories.domain_event_factory import make_task_state_changed_event
+
+        bus = InMemoryEventBus()
+        received: list[object] = []
+
+        async def spy(event: object) -> None:
+            received.append(event)
+
+        bus.subscribe(spy)
+
+        event = make_task_state_changed_event()
+        with caplog.at_level(logging.DEBUG, logger="bakufu.infrastructure.event_bus"):
+            await bus.publish(event)
+
+        debug_messages = [r.message for r in caplog.records if r.levelno == logging.DEBUG]
+        assert any("DomainEvent published:" in msg for msg in debug_messages), (
+            f"MSG-WSB-002 ログが見つからない。実際のログ: {debug_messages}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 確定E（Fail Fast）: event_bus=None 禁止
+# ---------------------------------------------------------------------------
+
+
+class TestFailFast:
+    """TC-UT-WSB-028〜029: Service.__init__ が event_bus を必須引数として要求する（Fail Fast）。"""
+
+    def test_task_service_requires_event_bus(self) -> None:
+        """TC-UT-WSB-028: TaskService.__init__ は event_bus 省略を TypeError で拒否する。
+
+        detailed-design.md §確定E: event_bus にはデフォルト値（None を含む）が設定されておらず、
+        省略すると Python が TypeError を発火する。
+        """
+        from bakufu.application.services.task_service import TaskService
+
+        with pytest.raises(TypeError):
+            TaskService(  # type: ignore[call-arg]
+                task_repo=AsyncMock(),
+                room_repo=AsyncMock(),
+                agent_repo=AsyncMock(),
+                session=AsyncMock(),
+                # event_bus は意図的に省略
+            )
+
+    def test_external_review_gate_service_requires_event_bus(self) -> None:
+        """TC-UT-WSB-029: ExternalReviewGateService.__init__ は event_bus 省略を拒否する。
+
+        detailed-design.md §確定E: event_bus には None デフォルトなし。省略で TypeError。
+        """
+        from bakufu.application.services.external_review_gate_service import (
+            ExternalReviewGateService,
+        )
+
+        with pytest.raises(TypeError):
+            ExternalReviewGateService(  # type: ignore[call-arg]
+                repo=AsyncMock(),
+                template_repo=AsyncMock(),
+                # event_bus は意図的に省略
+            )

--- a/backend/tests/unit/test_websocket_broadcast_domain.py
+++ b/backend/tests/unit/test_websocket_broadcast_domain.py
@@ -507,3 +507,75 @@ class TestFailFast:
                 template_repo=AsyncMock(),
                 # event_bus は意図的に省略
             )
+
+
+# ---------------------------------------------------------------------------
+# §確定B（Fail Fast）: Literal event_type バリデーション
+# ---------------------------------------------------------------------------
+
+
+class TestLiteralEventTypeFailFast:
+    """TC-UT-WSB-030〜033: Literal 型 event_type 違反 → ValidationError（§確定 B）。
+
+    event_type は Literal["..."] で構築時バリデーション保証。
+    不正な event_type 文字列を渡すと pydantic.ValidationError が即座に発火する。
+    """
+
+    def test_task_state_changed_event_rejects_invalid_event_type(self) -> None:
+        """TC-UT-WSB-030: TaskStateChangedEvent + event_type="hacked.value" → ValidationError。"""
+        from bakufu.domain.events import TaskStateChangedEvent
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            TaskStateChangedEvent(
+                aggregate_id="t1",
+                directive_id="d1",
+                old_status="PENDING",
+                new_status="IN_PROGRESS",
+                room_id="r1",
+                event_type="hacked.value",  # type: ignore[arg-type]
+            )
+
+    def test_external_review_gate_event_rejects_invalid_event_type(self) -> None:
+        """TC-UT-WSB-031: ExternalReviewGateStateChangedEvent Literal 型違反。
+
+        event_type="hacked.value" → pydantic.ValidationError（§確定 B）。
+        """
+        from bakufu.domain.events import ExternalReviewGateStateChangedEvent
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            ExternalReviewGateStateChangedEvent(
+                aggregate_id="g1",
+                task_id="task-1",
+                old_status="OPEN",
+                new_status="PENDING",
+                event_type="hacked.value",  # type: ignore[arg-type]
+            )
+
+    def test_agent_status_changed_event_rejects_invalid_event_type(self) -> None:
+        """TC-UT-WSB-032: AgentStatusChangedEvent + event_type="hacked.value" → ValidationError。"""
+        from bakufu.domain.events import AgentStatusChangedEvent
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            AgentStatusChangedEvent(
+                aggregate_id="a1",
+                room_id="room-1",
+                old_status="idle",
+                new_status="running",
+                event_type="hacked.value",  # type: ignore[arg-type]
+            )
+
+    def test_directive_completed_event_rejects_invalid_event_type(self) -> None:
+        """TC-UT-WSB-033: DirectiveCompletedEvent + event_type="hacked.value" → ValidationError。"""
+        from bakufu.domain.events import DirectiveCompletedEvent
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            DirectiveCompletedEvent(
+                aggregate_id="dir-1",
+                empire_id="empire-1",
+                final_status="DONE",
+                event_type="hacked.value",  # type: ignore[arg-type]
+            )

--- a/docs/features/websocket-broadcast/domain/test-design.md
+++ b/docs/features/websocket-broadcast/domain/test-design.md
@@ -84,8 +84,8 @@
 |---|---|---|---|---|
 | TC-UT-WSB-006 | `TaskStateChangedEvent` インスタンス化 | 正常系 | `TaskStateChangedEventFactory.build()` | インスタンスが生成される（例外なし） |
 | TC-UT-WSB-007 | `TaskStateChangedEvent.event_type` | 正常系 | `TaskStateChangedEventFactory.build()` | `event_type == "task.state_changed"` |
-| TC-UT-WSB-008 | `TaskStateChangedEvent.to_ws_message()` | 正常系 | `TaskStateChangedEventFactory.build(task_id="t1", directive_id="d1", old_status="PENDING", new_status="IN_PROGRESS", room_id="r1")` | `payload == {"task_id": "t1", "directive_id": "d1", "old_status": "PENDING", "new_status": "IN_PROGRESS", "room_id": "r1"}` |
-| TC-UT-WSB-009 | `TaskStateChangedEvent` インスタンス化 | 異常系 | `task_id` 欠落（必須フィールド省略） | `pydantic.ValidationError` が発火する |
+| TC-UT-WSB-008 | `TaskStateChangedEvent.to_ws_message()` | 正常系 | `TaskStateChangedEventFactory.build(aggregate_id="task-uuid-1", directive_id="d1", old_status="PENDING", new_status="IN_PROGRESS", room_id="r1")` | `payload == {"directive_id": "d1", "old_status": "PENDING", "new_status": "IN_PROGRESS", "room_id": "r1"}`（`task_id` フィールドは存在しない。task の識別子は base class フィールド `aggregate_id` に設定する）|
+| TC-UT-WSB-009 | `TaskStateChangedEvent` インスタンス化 | 異常系 | `directive_id` 欠落（必須フィールド省略） | `pydantic.ValidationError` が発火する |
 
 ### REQ-WSB-003: ExternalReviewGateStateChangedEvent
 


### PR DESCRIPTION
Closes #158

## Summary

- `domain/events.py`: `DomainEvent` 基底クラス + 4 具体イベントクラス（`TaskStateChangedEvent` / `ExternalReviewGateStateChangedEvent` / `AgentStatusChangedEvent` / `DirectiveCompletedEvent`）を実装（REQ-WSB-001〜005）
- `application/ports/event_bus.py`: `EventBusPort` Protocol 定義（REQ-WSB-006）
- `infrastructure/event_bus.py`: `InMemoryEventBus`（`asyncio.gather` + Fail Soft dispatch、WARNING ログ on error）実装（REQ-WSB-007）
- `TaskService.cancel()` / `unblock_retry()` / `commit_deliverable()`: トランザクション commit 後に `TaskStateChangedEvent` を publish
- `ExternalReviewGateService.approve()` / `reject()`: `masking.mask()` 適用後 `ExternalReviewGateStateChangedEvent` を publish（§確定 F）
- `AgentStatusChangedEvent` / `DirectiveCompletedEvent` は M4 型定義のみ（実 publish は M5 Phase 2）
- `interfaces/http/app.py`: lifespan で `InMemoryEventBus` を `app.state.event_bus` に保持
- `interfaces/http/dependencies.py`: `get_event_bus()` DI ファクトリ追加、`TaskService` / `ExternalReviewGateService` に注入
- 全テスト conftest: `app.state.event_bus = InMemoryEventBus()` 追加（lifespan バイパスフィクスチャ対応）

## Test plan

- [ ] ruff check / format: 全ファイル CLEAN 確認済み
- [ ] pyright strict: 0 errors 確認済み
- [ ] pytest: 2351 passed, 3 skipped（全テスト通過）
- [ ] `DomainEvent.to_ws_message()` の payload 構造（base_fields 除外）を確認
- [ ] `InMemoryEventBus` の Fail Soft 動作（handler 例外が他 handler に影響しないこと）を確認
- [ ] `TaskService` 3 メソッドのトランザクション後 publish（DB commit 成功時のみ）を確認
- [ ] `ExternalReviewGateService.approve() / reject()` の `masking.mask()` 適用を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)