### PR TITLE
feat(M5-C): admin-cli 実装 (#165)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -16,7 +16,12 @@ dependencies = [
     "anthropic>=0.40.0",
     "openai>=1.30.0",
     "pydantic-settings>=2.0.0",
+    "typer>=0.15",
+    "tabulate>=0.9",
 ]
+
+[project.scripts]
+"bakufu-admin" = "bakufu.interfaces.cli.admin:app"
 
 [build-system]
 requires = ["hatchling"]

--- a/backend/src/bakufu/application/exceptions/task_exceptions.py
+++ b/backend/src/bakufu/application/exceptions/task_exceptions.py
@@ -42,18 +42,27 @@ class TaskAuthorizationError(Exception):
 class IllegalTaskStateError(Exception):
     """Task が操作に対して不正な状態にある場合（Fail Fast）。
 
-    Gate 生成時に Task が IN_PROGRESS 以外の状態の場合に送出する。
-    MSG-IRG-A001 的な状況。
+    Gate 生成時に Task が IN_PROGRESS 以外の状態の場合や、admin-cli の
+    retry / cancel 操作で状態が不正な場合に送出する。
+    MSG-IRG-A001 / MSG-AC-002 / MSG-AC-003 相当。
+
+    ``message`` を省略した場合はデフォルトの汎用メッセージを使用する。
+    admin-cli では MSG-AC-002 / MSG-AC-003 の確定文言を ``message`` に渡す。
     """
 
     def __init__(
-        self, task_id: TaskId | str, current_status: TaskStatus | str, action: str
+        self,
+        task_id: TaskId | str,
+        current_status: TaskStatus | str,
+        action: str,
+        message: str | None = None,
     ) -> None:
-        super().__init__(
+        default_message = (
             f"[FAIL] Task {task_id} は action '{action}' を実行できる状態にありません"
             f"（current_status={current_status}）。\n"
             f"Next: Task が IN_PROGRESS 状態になってから再試行してください。"
         )
+        super().__init__(message or default_message)
         self.task_id = str(task_id)
         self.current_status = str(current_status)
         self.action = action

--- a/backend/src/bakufu/application/ports/audit_log_writer.py
+++ b/backend/src/bakufu/application/ports/audit_log_writer.py
@@ -1,0 +1,49 @@
+"""AuditLogWriterPort — audit_log 追記 Port（admin-cli 用）。
+
+AdminService の全 public メソッドが操作の成否に依らず audit_log を記録するために
+使う Clean Architecture Port（§確定 A / §確定 D）。
+
+SQLAlchemy の直接 import を application 層に持ち込まない（依存方向保全）。
+
+設計書: docs/features/admin-cli/application/detailed-design.md
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class AuditLogWriterPort(Protocol):
+    """audit_log 追記の Port 契約（Admin CLI 用）。
+
+    infrastructure 実装:
+      ``bakufu.infrastructure.persistence.sqlite.repositories.audit_log_writer``
+
+    全メソッドは async。
+    """
+
+    async def write(
+        self,
+        actor: str,
+        command: str,
+        args_json: dict[str, object],
+        result: str,
+        error_text: str | None = None,
+    ) -> None:
+        """audit_log テーブルに 1 行追記する。
+
+        Args:
+            actor: OS ユーザー名（``getpass.getuser()`` 相当、CLI 起動時に DI）。
+            command: 実行コマンド名（例: ``'list-blocked'``）。
+            args_json: 実行引数（識別子のみ。raw テキスト禁止 §確定 A）。
+            result: ``'OK'`` または ``'FAIL'`` の 2 値。
+            error_text: 失敗時のマスキング済み例外メッセージ（成功時は None）。
+
+        Raises:
+            Exception: 書き込み失敗時は例外を握り潰さず再 raise する。
+                audit_log の欠落は許容しない（§確定 A）。
+        """
+        ...
+
+
+__all__ = ["AuditLogWriterPort"]

--- a/backend/src/bakufu/application/ports/outbox_event_repository.py
+++ b/backend/src/bakufu/application/ports/outbox_event_repository.py
@@ -1,0 +1,75 @@
+"""OutboxEventRepositoryPort — Outbox Event 操作 Port（admin-cli 用）。
+
+AdminService が DEAD_LETTER な Outbox Event の参照・リセット操作に使う
+Clean Architecture Port。SQLAlchemy の直接 import を application 層に持ち込まない
+（§確定 D: Clean Architecture 保全）。
+
+設計書: docs/features/admin-cli/application/detailed-design.md
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import NamedTuple, Protocol
+from uuid import UUID
+
+
+class OutboxEventView(NamedTuple):
+    """Outbox Event の読み取り専用ビュー（Port の返却型）。
+
+    ORM クラス（OutboxRow）を application 層に漏らさないための境界 VO。
+    全フィールドはイミュータブル（NamedTuple）。
+    """
+
+    event_id: UUID
+    event_kind: str
+    aggregate_id: UUID
+    status: str
+    attempt_count: int
+    last_error: str | None
+    updated_at: datetime
+
+
+class OutboxEventRepositoryPort(Protocol):
+    """Outbox Event 操作の Port 契約（Admin CLI 用）。
+
+    infrastructure 実装:
+      ``bakufu.infrastructure.persistence.sqlite.repositories.outbox_event_repository``
+
+    全メソッドは async。SQLAlchemy 型はこの Port 境界を越えない。
+    """
+
+    async def find_by_id(self, event_id: UUID) -> OutboxEventView:
+        """``event_id`` で Outbox Event を 1 件取得する。
+
+        Raises:
+            OutboxEventNotFoundError: 指定 event_id が DB に存在しない場合。
+        """
+        ...
+
+    async def list_dead_letters(self) -> list[OutboxEventView]:
+        """``status == 'DEAD_LETTER'`` の Outbox Event を全件返す。
+
+        0 件の場合は空リストを返す（エラーではない）。
+        ORDER BY updated_at DESC（最近 DEAD_LETTER 化したものが先頭）。
+        """
+        ...
+
+    async def reset_to_pending(self, event_id: UUID) -> None:
+        """Outbox Event を DEAD_LETTER → PENDING にリセットする。
+
+        リセット内容:
+        - ``status = 'PENDING'``
+        - ``attempt_count = 0``
+        - ``next_attempt_at = now(UTC)``
+        - ``updated_at = now(UTC)``
+
+        Outbox Dispatcher の次回ポーリングで自動 dispatch される（R1-5）。
+
+        Raises:
+            OutboxEventNotFoundError: 指定 event_id が DB に存在しない場合。
+        """
+        ...
+
+
+__all__ = ["OutboxEventRepositoryPort", "OutboxEventView"]

--- a/backend/src/bakufu/application/ports/task_repository.py
+++ b/backend/src/bakufu/application/ports/task_repository.py
@@ -112,5 +112,17 @@ class TaskRepository(Protocol):
         """
         ...
 
+    async def list_by_status(self, status: TaskStatus) -> list[Task]:
+        """指定 ``status`` の全 Task を ``updated_at DESC, id DESC`` の順で返す。
+
+        StageWorker の起動時リカバリスキャン（§確定J）で ``IN_PROGRESS`` Task を
+        取得するために使用する。admin-cli でも任意 status の列挙に使用可能。
+
+        ORDER BY ``updated_at DESC, id DESC``（BUG-EMR-001 規約に準拠）。
+
+        該当 status の Task が存在しない場合は ``[]`` を返す。
+        """
+        ...
+
 
 __all__ = ["TaskRepository"]

--- a/backend/src/bakufu/application/services/admin_service.py
+++ b/backend/src/bakufu/application/services/admin_service.py
@@ -1,0 +1,288 @@
+"""AdminService — admin-cli 5 コマンドのアプリケーションサービス（M5-C）。
+
+全 public メソッドは try/finally 構造で audit_log の記録を保証する（§確定 A）。
+「LLM を呼ぶ」「Queue に投入する」責務を持たない — Task の状態変更のみを担う。
+StageWorker の起動時リカバリスキャン（§確定J）が IN_PROGRESS Task をピックアップして
+LLM 実行を再開する。
+
+設計書:
+  docs/features/admin-cli/application/detailed-design.md
+  docs/features/admin-cli/feature-spec.md
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import NamedTuple
+from uuid import UUID
+
+from bakufu.application.exceptions.task_exceptions import IllegalTaskStateError, TaskNotFoundError
+from bakufu.application.ports.audit_log_writer import AuditLogWriterPort
+from bakufu.application.ports.outbox_event_repository import OutboxEventRepositoryPort
+from bakufu.application.ports.task_repository import TaskRepository
+from bakufu.domain.exceptions.outbox import IllegalOutboxStateError
+from bakufu.domain.value_objects import SYSTEM_AGENT_ID, TaskId, TaskStatus
+
+logger = logging.getLogger(__name__)
+
+_DEAD_LETTER_STATUS = "DEAD_LETTER"
+
+
+class BlockedTaskSummary(NamedTuple):
+    """BLOCKED Task の表示用サマリー（list-blocked コマンドの返却型）。"""
+
+    task_id: TaskId
+    room_id: UUID
+    last_error: str
+    blocked_at: datetime
+
+
+class DeadLetterSummary(NamedTuple):
+    """dead-letter Event の表示用サマリー（list-dead-letters コマンドの返却型）。"""
+
+    event_id: UUID
+    event_kind: str
+    aggregate_id: UUID
+    attempt_count: int
+    last_error: str | None
+    updated_at: datetime
+
+
+class AdminService:
+    """Admin CLI 操作のアプリケーションサービス。
+
+    **不変条件**: 全 public メソッドは操作の成否に依らず audit_log を記録する
+    （try/finally §確定 A）。失敗操作も ``result='FAIL'`` で記録することで
+    「試みた事実」が audit_log に残る。
+
+    ``actor`` は DI 時に OS ユーザー名（``getpass.getuser()`` 相当）を注入する
+    （§確定 E: AdminService 自体は OS 環境依存の情報を取得しない）。
+    """
+
+    def __init__(
+        self,
+        task_repo: TaskRepository,
+        outbox_event_repo: OutboxEventRepositoryPort,
+        audit_log_writer: AuditLogWriterPort,
+        actor: str,
+    ) -> None:
+        self._task_repo = task_repo
+        self._outbox_event_repo = outbox_event_repo
+        self._audit_log_writer = audit_log_writer
+        self._actor = actor
+
+    # ------------------------------------------------------------------
+    # Public commands
+    # ------------------------------------------------------------------
+
+    async def list_blocked_tasks(self) -> list[BlockedTaskSummary]:
+        """BLOCKED 状態の全 Task を返す（UC-AC-001）。
+
+        ``TaskRepositoryPort.find_blocked()`` を使い、``BlockedTaskSummary`` に変換する。
+        audit_log に ``command=list-blocked`` / ``result=OK`` を記録する。
+        """
+        result: list[BlockedTaskSummary] = []
+        error_text: str | None = None
+        try:
+            tasks = await self._task_repo.find_blocked()
+            result = [
+                BlockedTaskSummary(
+                    task_id=task.id,
+                    room_id=task.room_id,
+                    last_error=task.last_error or "",
+                    blocked_at=task.updated_at,
+                )
+                for task in tasks
+            ]
+            return result
+        except Exception as exc:
+            error_text = str(exc)
+            raise
+        finally:
+            await self._write_audit(
+                command="list-blocked",
+                args_json={},
+                result="OK" if error_text is None else "FAIL",
+                error_text=error_text,
+            )
+
+    async def retry_task(self, task_id: TaskId) -> None:
+        """BLOCKED Task を IN_PROGRESS に戻す（UC-AC-002）。
+
+        Fail Fast: ``task.status != BLOCKED`` の場合は即座に ``IllegalTaskStateError``
+        を送出する（§確定 B / R1-2）。
+
+        Task.unblock_retry() を呼んで DB に保存するのみ。LLM 実行は行わない。
+        StageWorker の起動時リカバリスキャン（§確定J）が IN_PROGRESS Task を拾う。
+        """
+        error_text: str | None = None
+        try:
+            task = await self._task_repo.find_by_id(task_id)
+            if task is None:
+                raise TaskNotFoundError(task_id)
+
+            if task.status != TaskStatus.BLOCKED:
+                raise IllegalTaskStateError(
+                    task_id=task_id,
+                    current_status=task.status,
+                    action="retry",
+                    message=(
+                        f"[FAIL] Task {task_id} は BLOCKED 状態ではありません"
+                        f"（現在: {task.status}）。\n"
+                        "Next: 'bakufu admin list-blocked' で BLOCKED Task を確認してください。"
+                    ),
+                )
+
+            updated = task.unblock_retry(updated_at=datetime.now(UTC))
+            await self._task_repo.save(updated)
+        except Exception as exc:
+            error_text = str(exc)
+            raise
+        finally:
+            await self._write_audit(
+                command="retry-task",
+                args_json={"task_id": str(task_id)},
+                result="OK" if error_text is None else "FAIL",
+                error_text=error_text,
+            )
+
+    async def cancel_task(self, task_id: TaskId, reason: str) -> None:
+        """Task を CANCELLED に遷移させる（UC-AC-003）。
+
+        Fail Fast: ``task.status ∉ {BLOCKED, PENDING, IN_PROGRESS}`` の場合は
+        即座に ``IllegalTaskStateError`` を送出する（§確定 B / R1-3）。
+
+        AWAITING_EXTERNAL_REVIEW 状態の Task はスコープ外（Phase 2）。
+        """
+        _cancelable = {TaskStatus.BLOCKED, TaskStatus.PENDING, TaskStatus.IN_PROGRESS}
+        error_text: str | None = None
+        try:
+            task = await self._task_repo.find_by_id(task_id)
+            if task is None:
+                raise TaskNotFoundError(task_id)
+
+            if task.status not in _cancelable:
+                raise IllegalTaskStateError(
+                    task_id=task_id,
+                    current_status=task.status,
+                    action="cancel",
+                    message=(
+                        f"[FAIL] Task {task_id} はキャンセル可能な状態ではありません"
+                        f"（現在: {task.status}）。\n"
+                        "Next: キャンセル対象は BLOCKED / PENDING / IN_PROGRESS 状態の"
+                        " Task のみです。"
+                    ),
+                )
+
+            updated = task.cancel(
+                by_owner_id=SYSTEM_AGENT_ID,
+                reason=reason,
+                updated_at=datetime.now(UTC),
+            )
+            await self._task_repo.save(updated)
+        except Exception as exc:
+            error_text = str(exc)
+            raise
+        finally:
+            await self._write_audit(
+                command="cancel-task",
+                args_json={"task_id": str(task_id)},
+                result="OK" if error_text is None else "FAIL",
+                error_text=error_text,
+            )
+
+    async def list_dead_letters(self) -> list[DeadLetterSummary]:
+        """DEAD_LETTER 状態の全 Outbox Event を返す（UC-AC-004）。
+
+        audit_log に ``command=list-dead-letters`` / ``result=OK`` を記録する。
+        """
+        error_text: str | None = None
+        try:
+            events = await self._outbox_event_repo.list_dead_letters()
+            return [
+                DeadLetterSummary(
+                    event_id=ev.event_id,
+                    event_kind=ev.event_kind,
+                    aggregate_id=ev.aggregate_id,
+                    attempt_count=ev.attempt_count,
+                    last_error=ev.last_error,
+                    updated_at=ev.updated_at,
+                )
+                for ev in events
+            ]
+        except Exception as exc:
+            error_text = str(exc)
+            raise
+        finally:
+            await self._write_audit(
+                command="list-dead-letters",
+                args_json={},
+                result="OK" if error_text is None else "FAIL",
+                error_text=error_text,
+            )
+
+    async def retry_event(self, event_id: UUID) -> None:
+        """DEAD_LETTER な Outbox Event を PENDING にリセットする（UC-AC-005）。
+
+        Fail Fast: ``status != 'DEAD_LETTER'`` の場合は即座に
+        ``IllegalOutboxStateError`` を送出する（§確定 C / R1-5）。
+
+        ``outbox_event_repo.reset_to_pending()`` は attempt_count をリセットし
+        next_attempt_at を now(UTC) に設定する。Outbox Dispatcher の次回ポーリングで
+        自動 dispatch される。
+        """
+        error_text: str | None = None
+        try:
+            event_view = await self._outbox_event_repo.find_by_id(event_id)
+
+            if event_view.status != _DEAD_LETTER_STATUS:
+                raise IllegalOutboxStateError(
+                    event_id=event_id,
+                    current_status=event_view.status,
+                    message=(
+                        f"[FAIL] Outbox Event {event_id} は DEAD_LETTER 状態ではありません"
+                        f"（現在: {event_view.status}）。\n"
+                        "Next: 'bakufu admin list-dead-letters' で"
+                        " DEAD_LETTER Event を確認してください。"
+                    ),
+                )
+
+            await self._outbox_event_repo.reset_to_pending(event_id)
+        except Exception as exc:
+            error_text = str(exc)
+            raise
+        finally:
+            await self._write_audit(
+                command="retry-event",
+                args_json={"event_id": str(event_id)},
+                result="OK" if error_text is None else "FAIL",
+                error_text=error_text,
+            )
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    async def _write_audit(
+        self,
+        command: str,
+        args_json: dict[str, object],
+        result: str,
+        error_text: str | None,
+    ) -> None:
+        """audit_log に 1 行追記する（§確定 A: try/finally で必ず呼ばれる）。
+
+        audit_log 書き込み失敗は例外を握り潰さず再 raise する。
+        「操作証跡の欠落は許容しない」（§確定 A）。
+        """
+        await self._audit_log_writer.write(
+            actor=self._actor,
+            command=command,
+            args_json=args_json,
+            result=result,
+            error_text=error_text,
+        )
+
+
+__all__ = ["AdminService", "BlockedTaskSummary", "DeadLetterSummary"]

--- a/backend/src/bakufu/application/services/admin_service.py
+++ b/backend/src/bakufu/application/services/admin_service.py
@@ -5,6 +5,12 @@
 StageWorker の起動時リカバリスキャン（§確定J）が IN_PROGRESS Task をピックアップして
 LLM 実行を再開する。
 
+**Tx 分離方針（§確定 Option A）**:
+業務 Tx と audit_log Tx は **独立した別 session** で実行する。
+``session_factory`` を DI 注入し、各 public メソッド内で業務用 session を生成する。
+``_write_audit()`` では audit 専用 session を生成するため、業務 Tx の rollback に
+audit_log INSERT が巻き込まれることはない。
+
 設計書:
   docs/features/admin-cli/application/detailed-design.md
   docs/features/admin-cli/feature-spec.md
@@ -13,8 +19,9 @@ LLM 実行を再開する。
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from datetime import UTC, datetime
-from typing import NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
 from uuid import UUID
 
 from bakufu.application.exceptions.task_exceptions import IllegalTaskStateError, TaskNotFoundError
@@ -23,6 +30,9 @@ from bakufu.application.ports.outbox_event_repository import OutboxEventReposito
 from bakufu.application.ports.task_repository import TaskRepository
 from bakufu.domain.exceptions.outbox import IllegalOutboxStateError
 from bakufu.domain.value_objects import SYSTEM_AGENT_ID, TaskId, TaskStatus
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 logger = logging.getLogger(__name__)
 
@@ -56,20 +66,27 @@ class AdminService:
     （try/finally §確定 A）。失敗操作も ``result='FAIL'`` で記録することで
     「試みた事実」が audit_log に残る。
 
+    **Tx 分離**: ``session_factory`` を保持し、業務操作と audit_log 記録を
+    それぞれ独立した session / commit で実行する（§確定 Option A）。
+    業務 Tx が rollback されても ``_write_audit()`` は独立した session で
+    コミットするため、audit_log の欠落が発生しない。
+
     ``actor`` は DI 時に OS ユーザー名（``getpass.getuser()`` 相当）を注入する
     （§確定 E: AdminService 自体は OS 環境依存の情報を取得しない）。
     """
 
     def __init__(
         self,
-        task_repo: TaskRepository,
-        outbox_event_repo: OutboxEventRepositoryPort,
-        audit_log_writer: AuditLogWriterPort,
+        session_factory: async_sessionmaker[AsyncSession],
+        task_repo_factory: Callable[[AsyncSession], TaskRepository],
+        outbox_event_repo_factory: Callable[[AsyncSession], OutboxEventRepositoryPort],
+        audit_log_writer_factory: Callable[[AsyncSession], AuditLogWriterPort],
         actor: str,
     ) -> None:
-        self._task_repo = task_repo
-        self._outbox_event_repo = outbox_event_repo
-        self._audit_log_writer = audit_log_writer
+        self._session_factory = session_factory
+        self._task_repo_factory = task_repo_factory
+        self._outbox_event_repo_factory = outbox_event_repo_factory
+        self._audit_log_writer_factory = audit_log_writer_factory
         self._actor = actor
 
     # ------------------------------------------------------------------
@@ -82,20 +99,20 @@ class AdminService:
         ``TaskRepositoryPort.find_blocked()`` を使い、``BlockedTaskSummary`` に変換する。
         audit_log に ``command=list-blocked`` / ``result=OK`` を記録する。
         """
-        result: list[BlockedTaskSummary] = []
         error_text: str | None = None
         try:
-            tasks = await self._task_repo.find_blocked()
-            result = [
-                BlockedTaskSummary(
-                    task_id=task.id,
-                    room_id=task.room_id,
-                    last_error=task.last_error or "",
-                    blocked_at=task.updated_at,
-                )
-                for task in tasks
-            ]
-            return result
+            async with self._session_factory() as session, session.begin():
+                repo = self._task_repo_factory(session)
+                tasks = await repo.find_blocked()
+                return [
+                    BlockedTaskSummary(
+                        task_id=task.id,
+                        room_id=task.room_id,
+                        last_error=task.last_error or "",
+                        blocked_at=task.updated_at,
+                    )
+                    for task in tasks
+                ]
         except Exception as exc:
             error_text = str(exc)
             raise
@@ -118,24 +135,27 @@ class AdminService:
         """
         error_text: str | None = None
         try:
-            task = await self._task_repo.find_by_id(task_id)
-            if task is None:
-                raise TaskNotFoundError(task_id)
+            async with self._session_factory() as session, session.begin():
+                repo = self._task_repo_factory(session)
+                task = await repo.find_by_id(task_id)
+                if task is None:
+                    raise TaskNotFoundError(task_id)
 
-            if task.status != TaskStatus.BLOCKED:
-                raise IllegalTaskStateError(
-                    task_id=task_id,
-                    current_status=task.status,
-                    action="retry",
-                    message=(
-                        f"[FAIL] Task {task_id} は BLOCKED 状態ではありません"
-                        f"（現在: {task.status}）。\n"
-                        "Next: 'bakufu admin list-blocked' で BLOCKED Task を確認してください。"
-                    ),
-                )
+                if task.status != TaskStatus.BLOCKED:
+                    raise IllegalTaskStateError(
+                        task_id=task_id,
+                        current_status=task.status,
+                        action="retry",
+                        message=(
+                            f"[FAIL] Task {task_id} は BLOCKED 状態ではありません"
+                            f"（現在: {task.status}）。\n"
+                            "Next: 'bakufu admin list-blocked' で"
+                            " BLOCKED Task を確認してください。"
+                        ),
+                    )
 
-            updated = task.unblock_retry(updated_at=datetime.now(UTC))
-            await self._task_repo.save(updated)
+                updated = task.unblock_retry(updated_at=datetime.now(UTC))
+                await repo.save(updated)
         except Exception as exc:
             error_text = str(exc)
             raise
@@ -158,29 +178,31 @@ class AdminService:
         _cancelable = {TaskStatus.BLOCKED, TaskStatus.PENDING, TaskStatus.IN_PROGRESS}
         error_text: str | None = None
         try:
-            task = await self._task_repo.find_by_id(task_id)
-            if task is None:
-                raise TaskNotFoundError(task_id)
+            async with self._session_factory() as session, session.begin():
+                repo = self._task_repo_factory(session)
+                task = await repo.find_by_id(task_id)
+                if task is None:
+                    raise TaskNotFoundError(task_id)
 
-            if task.status not in _cancelable:
-                raise IllegalTaskStateError(
-                    task_id=task_id,
-                    current_status=task.status,
-                    action="cancel",
-                    message=(
-                        f"[FAIL] Task {task_id} はキャンセル可能な状態ではありません"
-                        f"（現在: {task.status}）。\n"
-                        "Next: キャンセル対象は BLOCKED / PENDING / IN_PROGRESS 状態の"
-                        " Task のみです。"
-                    ),
+                if task.status not in _cancelable:
+                    raise IllegalTaskStateError(
+                        task_id=task_id,
+                        current_status=task.status,
+                        action="cancel",
+                        message=(
+                            f"[FAIL] Task {task_id} はキャンセル可能な状態ではありません"
+                            f"（現在: {task.status}）。\n"
+                            "Next: キャンセル対象は BLOCKED / PENDING / IN_PROGRESS"
+                            " 状態の Task のみです。"
+                        ),
+                    )
+
+                updated = task.cancel(
+                    by_owner_id=SYSTEM_AGENT_ID,
+                    reason=reason,
+                    updated_at=datetime.now(UTC),
                 )
-
-            updated = task.cancel(
-                by_owner_id=SYSTEM_AGENT_ID,
-                reason=reason,
-                updated_at=datetime.now(UTC),
-            )
-            await self._task_repo.save(updated)
+                await repo.save(updated)
         except Exception as exc:
             error_text = str(exc)
             raise
@@ -199,18 +221,20 @@ class AdminService:
         """
         error_text: str | None = None
         try:
-            events = await self._outbox_event_repo.list_dead_letters()
-            return [
-                DeadLetterSummary(
-                    event_id=ev.event_id,
-                    event_kind=ev.event_kind,
-                    aggregate_id=ev.aggregate_id,
-                    attempt_count=ev.attempt_count,
-                    last_error=ev.last_error,
-                    updated_at=ev.updated_at,
-                )
-                for ev in events
-            ]
+            async with self._session_factory() as session, session.begin():
+                repo = self._outbox_event_repo_factory(session)
+                events = await repo.list_dead_letters()
+                return [
+                    DeadLetterSummary(
+                        event_id=ev.event_id,
+                        event_kind=ev.event_kind,
+                        aggregate_id=ev.aggregate_id,
+                        attempt_count=ev.attempt_count,
+                        last_error=ev.last_error,
+                        updated_at=ev.updated_at,
+                    )
+                    for ev in events
+                ]
         except Exception as exc:
             error_text = str(exc)
             raise
@@ -234,21 +258,23 @@ class AdminService:
         """
         error_text: str | None = None
         try:
-            event_view = await self._outbox_event_repo.find_by_id(event_id)
+            async with self._session_factory() as session, session.begin():
+                repo = self._outbox_event_repo_factory(session)
+                event_view = await repo.find_by_id(event_id)
 
-            if event_view.status != _DEAD_LETTER_STATUS:
-                raise IllegalOutboxStateError(
-                    event_id=event_id,
-                    current_status=event_view.status,
-                    message=(
-                        f"[FAIL] Outbox Event {event_id} は DEAD_LETTER 状態ではありません"
-                        f"（現在: {event_view.status}）。\n"
-                        "Next: 'bakufu admin list-dead-letters' で"
-                        " DEAD_LETTER Event を確認してください。"
-                    ),
-                )
+                if event_view.status != _DEAD_LETTER_STATUS:
+                    raise IllegalOutboxStateError(
+                        event_id=event_id,
+                        current_status=event_view.status,
+                        message=(
+                            f"[FAIL] Outbox Event {event_id} は DEAD_LETTER 状態ではありません"
+                            f"（現在: {event_view.status}）。\n"
+                            "Next: 'bakufu admin list-dead-letters' で"
+                            " DEAD_LETTER Event を確認してください。"
+                        ),
+                    )
 
-            await self._outbox_event_repo.reset_to_pending(event_id)
+                await repo.reset_to_pending(event_id)
         except Exception as exc:
             error_text = str(exc)
             raise
@@ -271,18 +297,23 @@ class AdminService:
         result: str,
         error_text: str | None,
     ) -> None:
-        """audit_log に 1 行追記する（§確定 A: try/finally で必ず呼ばれる）。
+        """独立した session で audit_log に 1 行追記する（§確定 A / Option A）。
+
+        業務 Tx とは **別の** session を生成してコミットするため、業務 Tx が
+        rollback されても audit_log INSERT は確実にコミットされる。
 
         audit_log 書き込み失敗は例外を握り潰さず再 raise する。
         「操作証跡の欠落は許容しない」（§確定 A）。
         """
-        await self._audit_log_writer.write(
-            actor=self._actor,
-            command=command,
-            args_json=args_json,
-            result=result,
-            error_text=error_text,
-        )
+        async with self._session_factory() as audit_session, audit_session.begin():
+            writer = self._audit_log_writer_factory(audit_session)
+            await writer.write(
+                actor=self._actor,
+                command=command,
+                args_json=args_json,
+                result=result,
+                error_text=error_text,
+            )
 
 
 __all__ = ["AdminService", "BlockedTaskSummary", "DeadLetterSummary"]

--- a/backend/src/bakufu/domain/exceptions/__init__.py
+++ b/backend/src/bakufu/domain/exceptions/__init__.py
@@ -38,6 +38,7 @@ from bakufu.domain.exceptions.llm_client import (
     LLMRateLimitError,
     LLMTimeoutError,
 )
+from bakufu.domain.exceptions.outbox import IllegalOutboxStateError, OutboxEventNotFoundError
 from bakufu.domain.exceptions.review_gate import (
     ExternalReviewGateInvariantViolation,
     ExternalReviewGateViolationKind,
@@ -69,6 +70,7 @@ __all__ = [
     "EmpireViolationKind",
     "ExternalReviewGateInvariantViolation",
     "ExternalReviewGateViolationKind",
+    "IllegalOutboxStateError",
     "InternalReviewGateInvariantViolation",
     "InternalReviewGateViolationKind",
     "LLMAPIError",
@@ -78,6 +80,7 @@ __all__ = [
     "LLMMessagesEmptyError",
     "LLMRateLimitError",
     "LLMTimeoutError",
+    "OutboxEventNotFoundError",
     "RoleProfileInvariantViolation",
     "RoleProfileViolationKind",
     "RoomInvariantViolation",

--- a/backend/src/bakufu/domain/exceptions/outbox.py
+++ b/backend/src/bakufu/domain/exceptions/outbox.py
@@ -1,0 +1,38 @@
+"""Outbox ドメイン例外（admin-cli 操作対象の Outbox Event 用）。
+
+MSG-AC-004 / MSG-AC-005 の文言はアプリケーション層（AdminService）で構築し、
+本モジュールのクラスに注入する。設計書:
+  docs/features/admin-cli/application/detailed-design.md §クラス設計（詳細）
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+
+class OutboxEventNotFoundError(Exception):
+    """Outbox Event が見つからない場合（MSG-AC-004）。
+
+    ``event_id`` で検索したが DB に存在しなかった場合に送出する。
+    """
+
+    def __init__(self, event_id: UUID, message: str) -> None:
+        super().__init__(message)
+        self.event_id: UUID = event_id
+        self.message: str = message
+
+
+class IllegalOutboxStateError(Exception):
+    """Outbox Event が操作に対して不正な状態にある場合（MSG-AC-005）。
+
+    ``retry-event`` の対象が DEAD_LETTER 以外の場合に送出する（Fail Fast）。
+    """
+
+    def __init__(self, event_id: UUID, current_status: str, message: str) -> None:
+        super().__init__(message)
+        self.event_id: UUID = event_id
+        self.current_status: str = current_status
+        self.message: str = message
+
+
+__all__ = ["IllegalOutboxStateError", "OutboxEventNotFoundError"]

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/repositories/audit_log_writer.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/repositories/audit_log_writer.py
@@ -1,0 +1,58 @@
+"""AuditLogWriterPort の SQLite 実装（admin-cli 用）。
+
+``audit_log`` テーブルへの追記専用操作を実装する。
+MaskedJSONEncoded / MaskedText TypeDecorator が永続化時に自動的にマスキングを適用する
+（BUG-PF-001 修正済み）。
+
+設計書: docs/features/admin-cli/application/detailed-design.md §確定 D
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from sqlalchemy import insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bakufu.infrastructure.persistence.sqlite.tables.audit_log import AuditLogRow
+
+
+class SqliteAuditLogWriter:
+    """``AuditLogWriterPort`` の SQLite 実装。
+
+    Core INSERT（``session.execute(insert(...))``）を使用する。
+    ``MaskedJSONEncoded`` / ``MaskedText`` TypeDecorator の ``process_bind_param``
+    は Core INSERT 経路でも発火するため（BUG-PF-001 修正）、args_json / error_text
+    は手動マスキング不要。
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def write(
+        self,
+        actor: str,
+        command: str,
+        args_json: dict[str, object],
+        result: str,
+        error_text: str | None = None,
+    ) -> None:
+        """audit_log テーブルに 1 行 INSERT する。
+
+        書き込み失敗時は例外を再 raise する（audit_log の欠落は許容しない §確定 A）。
+        """
+        await self._session.execute(
+            insert(AuditLogRow).values(
+                id=uuid4(),
+                actor=actor,
+                command=command,
+                args_json=args_json,
+                result=result,
+                error_text=error_text,
+                executed_at=datetime.now(UTC),
+            )
+        )
+
+
+__all__ = ["SqliteAuditLogWriter"]

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/repositories/outbox_event_repository.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/repositories/outbox_event_repository.py
@@ -1,0 +1,112 @@
+"""OutboxEventRepositoryPort の SQLite 実装（admin-cli 用）。
+
+``domain_event_outbox`` テーブルを対象に DEAD_LETTER 管理操作を実装する。
+設計書: docs/features/admin-cli/application/detailed-design.md §確定 D
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import UUID
+
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bakufu.application.ports.outbox_event_repository import OutboxEventView
+from bakufu.domain.exceptions.outbox import OutboxEventNotFoundError
+from bakufu.infrastructure.persistence.sqlite.tables.outbox import OutboxRow
+
+_DEAD_LETTER_STATUS = "DEAD_LETTER"
+_PENDING_STATUS = "PENDING"
+
+
+class SqliteOutboxEventRepository:
+    """``OutboxEventRepositoryPort`` の SQLite 実装。"""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def find_by_id(self, event_id: UUID) -> OutboxEventView:
+        """``event_id`` で Outbox Event を 1 件取得する。
+
+        Raises:
+            OutboxEventNotFoundError: 指定 event_id が DB に存在しない場合。
+        """
+        row = await self._session.get(OutboxRow, str(event_id))
+        if row is None:
+            raise OutboxEventNotFoundError(
+                event_id=event_id,
+                message=(
+                    f"[FAIL] Outbox Event {event_id} が見つかりません。\n"
+                    "Next: event_id を確認し、"
+                    "'bakufu admin list-dead-letters' で存在確認してください。"
+                ),
+            )
+        return self._to_view(row)
+
+    async def list_dead_letters(self) -> list[OutboxEventView]:
+        """``status == 'DEAD_LETTER'`` の Outbox Event を全件返す。
+
+        ORDER BY updated_at DESC（最近 DEAD_LETTER 化したものが先頭）。
+        0 件は空リスト。
+        """
+        rows = list(
+            (
+                await self._session.execute(
+                    select(OutboxRow)
+                    .where(OutboxRow.status == _DEAD_LETTER_STATUS)
+                    .order_by(OutboxRow.updated_at.desc())
+                )
+            )
+            .scalars()
+            .all()
+        )
+        return [self._to_view(row) for row in rows]
+
+    async def reset_to_pending(self, event_id: UUID) -> None:
+        """Outbox Event を DEAD_LETTER → PENDING にリセットする（R1-5）。
+
+        Raises:
+            OutboxEventNotFoundError: 指定 event_id が DB に存在しない場合。
+        """
+        row = await self._session.get(OutboxRow, str(event_id))
+        if row is None:
+            raise OutboxEventNotFoundError(
+                event_id=event_id,
+                message=(
+                    f"[FAIL] Outbox Event {event_id} が見つかりません。\n"
+                    "Next: event_id を確認し、"
+                    "'bakufu admin list-dead-letters' で存在確認してください。"
+                ),
+            )
+        now = datetime.now(UTC)
+        await self._session.execute(
+            update(OutboxRow)
+            .where(OutboxRow.event_id == str(event_id))
+            .values(
+                status=_PENDING_STATUS,
+                attempt_count=0,
+                next_attempt_at=now,
+                updated_at=now,
+            )
+        )
+
+    # ------------------------------------------------------------------
+    # Private
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _to_view(row: OutboxRow) -> OutboxEventView:
+        """OutboxRow → OutboxEventView 変換（TypeDecorator-trust パターン）。"""
+        return OutboxEventView(
+            event_id=row.event_id,
+            event_kind=row.event_kind,
+            aggregate_id=row.aggregate_id,
+            status=row.status,
+            attempt_count=row.attempt_count,
+            last_error=row.last_error,
+            updated_at=row.updated_at,
+        )
+
+
+__all__ = ["SqliteOutboxEventRepository"]

--- a/backend/src/bakufu/infrastructure/persistence/sqlite/repositories/task_repository.py
+++ b/backend/src/bakufu/infrastructure/persistence/sqlite/repositories/task_repository.py
@@ -263,6 +263,37 @@ class SqliteTaskRepository:
                 results.append(task)
         return results
 
+    async def list_by_status(self, status: TaskStatus) -> list[Task]:
+        """指定 ``status`` の全 Task を ``updated_at DESC, id DESC`` の順で返す。
+
+        StageWorker 起動時リカバリスキャン（§確定J）で ``IN_PROGRESS`` Task を
+        取得するために使用する。
+
+        ``(status, updated_at, id)`` 上の複合 INDEX ``ix_tasks_status_updated_id``
+        が WHERE フィルタと ORDER BY の両方をカバーする。
+        該当 Task が存在しない場合は ``[]`` を返す。
+        """
+        task_rows = list(
+            (
+                await self._session.execute(
+                    select(TaskRow)
+                    .where(TaskRow.status == status.value)
+                    .order_by(TaskRow.updated_at.desc(), TaskRow.id.desc())
+                )
+            )
+            .scalars()
+            .all()
+        )
+        if not task_rows:
+            return []
+
+        results: list[Task] = []
+        for task_row in task_rows:
+            task = await self.find_by_id(task_row.id)
+            if task is not None:
+                results.append(task)
+        return results
+
     # ---- private domain ↔ row converters (empire-repo §確定 C) -----------
 
     def _to_rows(

--- a/backend/src/bakufu/infrastructure/worker/stage_worker.py
+++ b/backend/src/bakufu/infrastructure/worker/stage_worker.py
@@ -164,22 +164,24 @@ class StageWorker:
     async def _run_loop(self) -> None:
         """Queue consumer のメインループ。
 
+        §確定J: ループ開始前に IN_PROGRESS 孤立 Task をスキャンしてキューに再投入する。
         Semaphore を acquire → dispatch_stage → release のサイクルを繰り返す。
         sentinel（None）を受信するか _running が False になると終了する。
         dispatch_stage の例外は StageExecutorService 内で Task.block() 済みのため
         ここでは catchall ログのみ出して次のアイテムへ進む（REQ-ME-006 エラー時）。
         """
+        await self._recovery_scan()
         logger.info("[INFO] StageWorker _run_loop started")
         while self._running:
             item = await self._queue.get()
             if item is _SENTINEL:
                 break
-            task_id, stage_id = item
+            task_id, stage_id = item  # type: ignore[misc]
 
             # Semaphore acquire（上限に達した場合は自然にキューイングして待機）
             await self._semaphore.acquire()
             dispatch_task = asyncio.create_task(
-                self._dispatch_and_release(task_id, stage_id),
+                self._dispatch_and_release(task_id, stage_id),  # type: ignore[arg-type]
                 name=f"stage-dispatch-{task_id}-{stage_id}",
             )
             # 完了コールバックで self._active_tasks から自動削除する（RUF006 対応）。
@@ -187,6 +189,49 @@ class StageWorker:
             dispatch_task.add_done_callback(self._active_tasks.discard)
 
         logger.info("[INFO] StageWorker _run_loop finished")
+
+    async def _recovery_scan(self) -> None:
+        """起動時 IN_PROGRESS 孤立 Task リカバリスキャン（§確定J）。
+
+        StageWorker 起動時（Queue 処理ループ開始前）に ``IN_PROGRESS`` 状態の
+        全 Task を DB から取得し、Queue に再投入する。
+
+        admin-cli の ``retry-task`` が BLOCKED → IN_PROGRESS に変更した Task を
+        次回サーバー再起動時に自動的にピックアップする機構（Q-OPEN-2 解決策 Option A）。
+
+        冪等性: 起動時は Queue が空のため、同一 Task の二重投入は発生しない。
+        Queue maxsize 超過時は ``await self._queue.put()`` で自然に backpressure が発生
+        する（正常動作）。
+        """
+        from bakufu.domain.value_objects import TaskStatus
+
+        try:
+            async with self._session_factory() as session:
+                from bakufu.infrastructure.persistence.sqlite.repositories.task_repository import (
+                    SqliteTaskRepository,
+                )
+
+                repo = SqliteTaskRepository(session)
+                in_progress_tasks = await repo.list_by_status(TaskStatus.IN_PROGRESS)
+
+            if not in_progress_tasks:
+                logger.info("[INFO] StageWorker: 起動時リカバリスキャン — 孤立 Task なし。")
+                return
+
+            count = len(in_progress_tasks)
+            for task in in_progress_tasks:
+                await self._queue.put((task.id, task.current_stage_id))
+
+            logger.info(
+                "[INFO] StageWorker: 起動時リカバリスキャン — %d 件の"
+                " IN_PROGRESS Task をキューに投入しました。",
+                count,
+            )
+        except Exception as exc:
+            logger.exception(
+                "[FAIL] StageWorker: 起動時リカバリスキャンに失敗しました: %s",
+                masking.mask(str(exc)),
+            )
 
     async def _dispatch_and_release(self, task_id: TaskId, stage_id: StageId) -> None:
         """dispatch_stage を呼び出し、完了後に Semaphore を release する。

--- a/backend/src/bakufu/interfaces/cli/__init__.py
+++ b/backend/src/bakufu/interfaces/cli/__init__.py
@@ -1,0 +1,5 @@
+"""bakufu admin CLI インターフェース（M5-C admin-cli）。
+
+エントリポイント: ``bakufu.interfaces.cli.admin:app``
+Typer ベースの 5 コマンド管理 CLI。
+"""

--- a/backend/src/bakufu/interfaces/cli/admin.py
+++ b/backend/src/bakufu/interfaces/cli/admin.py
@@ -1,0 +1,271 @@
+"""bakufu admin CLI — Typer 5 コマンド定義（M5-C）。
+
+CEO が実行する管理コマンド:
+  list-blocked      BLOCKED Task の一覧表示
+  retry-task        BLOCKED Task を IN_PROGRESS に変更
+  cancel-task       Task を CANCELLED に変更
+  list-dead-letters dead-letter Outbox Event の一覧表示
+  retry-event       dead-letter Event を PENDING にリセット
+
+設計書: docs/features/admin-cli/cli/detailed-design.md
+"""
+
+from __future__ import annotations
+
+import asyncio
+import getpass
+from typing import TYPE_CHECKING, Annotated
+from uuid import UUID
+
+import typer
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from bakufu.application.services.admin_service import AdminService
+
+from bakufu.application.exceptions.task_exceptions import IllegalTaskStateError, TaskNotFoundError
+from bakufu.domain.exceptions.outbox import IllegalOutboxStateError, OutboxEventNotFoundError
+from bakufu.interfaces.cli import formatters
+
+app = typer.Typer(
+    name="admin",
+    help="bakufu 管理 CLI — BLOCKED Task / dead-letter Event の復旧操作",
+)
+
+
+# ---------------------------------------------------------------------------
+# list-blocked
+# ---------------------------------------------------------------------------
+
+
+@app.command("list-blocked")
+def list_blocked(
+    json_output: Annotated[bool, typer.Option("--json", help="JSON 形式で出力する")] = False,
+) -> None:
+    """BLOCKED 状態の Task 一覧を表示する（UC-AC-001）。"""
+
+    async def _run() -> int:
+        service, session = await _build_service_with_session()
+        async with session, session.begin():
+            try:
+                tasks = await service.list_blocked_tasks()
+                typer.echo(formatters.format_blocked_tasks(tasks, json_output))
+                return 0
+            except Exception as exc:
+                typer.echo(formatters.format_error(str(exc)), err=True)
+                return 1
+
+    raise typer.Exit(code=asyncio.run(_run()))
+
+
+# ---------------------------------------------------------------------------
+# retry-task
+# ---------------------------------------------------------------------------
+
+
+@app.command("retry-task")
+def retry_task(
+    task_id: Annotated[str, typer.Argument(help="BLOCKED Task の UUID")],
+    json_output: Annotated[bool, typer.Option("--json", help="JSON 形式で出力する")] = False,
+) -> None:
+    """BLOCKED Task を IN_PROGRESS に変更する（UC-AC-002）。
+
+    bakufu サーバーの StageWorker が次回起動時に自動的に再実行します。
+    """
+    parsed_id = _parse_uuid(task_id, arg_name="task_id")
+
+    async def _run() -> int:
+        service, session = await _build_service_with_session()
+        async with session, session.begin():
+            try:
+                await service.retry_task(parsed_id)
+                msg = (
+                    f"Task {parsed_id} を BLOCKED → IN_PROGRESS に変更しました。"
+                    " bakufu サーバーの StageWorker が自動的に再実行します。"
+                )
+                typer.echo(
+                    formatters.format_success(
+                        msg, json_output, command="retry-task", id_=str(parsed_id)
+                    )
+                )
+                return 0
+            except (TaskNotFoundError, IllegalTaskStateError) as exc:
+                typer.echo(formatters.format_error(str(exc)), err=True)
+                return 1
+            except Exception as exc:
+                typer.echo(formatters.format_error(str(exc)), err=True)
+                return 1
+
+    raise typer.Exit(code=asyncio.run(_run()))
+
+
+# ---------------------------------------------------------------------------
+# cancel-task
+# ---------------------------------------------------------------------------
+
+
+@app.command("cancel-task")
+def cancel_task(
+    task_id: Annotated[str, typer.Argument(help="キャンセルする Task の UUID")],
+    reason: Annotated[
+        str, typer.Option("--reason", help="キャンセル理由")
+    ] = "Admin CLI による手動キャンセル",
+    json_output: Annotated[bool, typer.Option("--json", help="JSON 形式で出力する")] = False,
+) -> None:
+    """Task を CANCELLED に変更する（UC-AC-003）。
+
+    対象: BLOCKED / PENDING / IN_PROGRESS 状態の Task のみ。
+    """
+    parsed_id = _parse_uuid(task_id, arg_name="task_id")
+
+    async def _run() -> int:
+        service, session = await _build_service_with_session()
+        async with session, session.begin():
+            try:
+                await service.cancel_task(parsed_id, reason)
+                msg = f"Task {parsed_id} を CANCELLED に変更しました。"
+                typer.echo(
+                    formatters.format_success(
+                        msg, json_output, command="cancel-task", id_=str(parsed_id)
+                    )
+                )
+                return 0
+            except (TaskNotFoundError, IllegalTaskStateError) as exc:
+                typer.echo(formatters.format_error(str(exc)), err=True)
+                return 1
+            except Exception as exc:
+                typer.echo(formatters.format_error(str(exc)), err=True)
+                return 1
+
+    raise typer.Exit(code=asyncio.run(_run()))
+
+
+# ---------------------------------------------------------------------------
+# list-dead-letters
+# ---------------------------------------------------------------------------
+
+
+@app.command("list-dead-letters")
+def list_dead_letters(
+    json_output: Annotated[bool, typer.Option("--json", help="JSON 形式で出力する")] = False,
+) -> None:
+    """DEAD_LETTER 状態の Outbox Event 一覧を表示する（UC-AC-004）。"""
+
+    async def _run() -> int:
+        service, session = await _build_service_with_session()
+        async with session, session.begin():
+            try:
+                events = await service.list_dead_letters()
+                typer.echo(formatters.format_dead_letters(events, json_output))
+                return 0
+            except Exception as exc:
+                typer.echo(formatters.format_error(str(exc)), err=True)
+                return 1
+
+    raise typer.Exit(code=asyncio.run(_run()))
+
+
+# ---------------------------------------------------------------------------
+# retry-event
+# ---------------------------------------------------------------------------
+
+
+@app.command("retry-event")
+def retry_event(
+    event_id: Annotated[str, typer.Argument(help="DEAD_LETTER Outbox Event の UUID")],
+    json_output: Annotated[bool, typer.Option("--json", help="JSON 形式で出力する")] = False,
+) -> None:
+    """dead-letter Outbox Event を PENDING にリセットする（UC-AC-005）。
+
+    Outbox Dispatcher が次回ポーリングで自動的に再 dispatch します。
+    """
+    parsed_id = _parse_uuid(event_id, arg_name="event_id")
+
+    async def _run() -> int:
+        service, session = await _build_service_with_session()
+        async with session, session.begin():
+            try:
+                await service.retry_event(parsed_id)
+                msg = (
+                    f"Outbox Event {parsed_id} を DEAD_LETTER → PENDING にリセットしました。"
+                    " Outbox Dispatcher が次回ポーリングで再 dispatch します。"
+                )
+                typer.echo(
+                    formatters.format_success(
+                        msg, json_output, command="retry-event", id_=str(parsed_id)
+                    )
+                )
+                return 0
+            except (OutboxEventNotFoundError, IllegalOutboxStateError) as exc:
+                typer.echo(formatters.format_error(str(exc)), err=True)
+                return 1
+            except Exception as exc:
+                typer.echo(formatters.format_error(str(exc)), err=True)
+                return 1
+
+    raise typer.Exit(code=asyncio.run(_run()))
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_uuid(raw: str, arg_name: str) -> UUID:
+    """UUID 文字列をパースする。失敗時は MSG-AC-CLI-002 を stderr に出力して exit 1。
+
+    §確定 B: UUID パースエラーは Typer callback で Fail Fast する。
+    """
+    try:
+        return UUID(raw)
+    except ValueError:
+        msg = (
+            f"[FAIL] {arg_name} が有効な UUID ではありません: {raw}\n"
+            "Next: 'bakufu admin list-blocked' または "
+            "'bakufu admin list-dead-letters' で正しい ID を確認してください。"
+        )
+        typer.echo(msg, err=True)
+        raise typer.Exit(code=1) from None
+
+
+async def _build_service_with_session() -> tuple[AdminService, AsyncSession]:
+    """AdminService と AsyncSession を構築して返す。
+
+    セッションのライフサイクルは呼び出し元（各コマンド）が管理する。
+    遅延 import で循環参照リスクを回避する。
+    """
+    from bakufu.application.services.admin_service import AdminService
+    from bakufu.infrastructure.persistence.sqlite.repositories.audit_log_writer import (
+        SqliteAuditLogWriter,
+    )
+    from bakufu.infrastructure.persistence.sqlite.repositories.outbox_event_repository import (
+        SqliteOutboxEventRepository,
+    )
+    from bakufu.infrastructure.persistence.sqlite.repositories.task_repository import (
+        SqliteTaskRepository,
+    )
+    from bakufu.interfaces.cli.lite_bootstrap import LiteBootstrap
+
+    session_factory = await LiteBootstrap.setup_db()
+    session = session_factory()
+    actor = _resolve_actor()
+
+    service = AdminService(
+        task_repo=SqliteTaskRepository(session),
+        outbox_event_repo=SqliteOutboxEventRepository(session),
+        audit_log_writer=SqliteAuditLogWriter(session),
+        actor=actor,
+    )
+    return service, session
+
+
+def _resolve_actor() -> str:
+    """OS ユーザー名を取得する（§確定 E）。"""
+    try:
+        return getpass.getuser()
+    except Exception:
+        return "unknown"
+
+
+__all__ = ["app"]

--- a/backend/src/bakufu/interfaces/cli/admin.py
+++ b/backend/src/bakufu/interfaces/cli/admin.py
@@ -20,8 +20,6 @@ from uuid import UUID
 import typer
 
 if TYPE_CHECKING:
-    from sqlalchemy.ext.asyncio import AsyncSession
-
     from bakufu.application.services.admin_service import AdminService
 
 from bakufu.application.exceptions.task_exceptions import IllegalTaskStateError, TaskNotFoundError
@@ -46,15 +44,14 @@ def list_blocked(
     """BLOCKED 状態の Task 一覧を表示する（UC-AC-001）。"""
 
     async def _run() -> int:
-        service, session = await _build_service_with_session()
-        async with session, session.begin():
-            try:
-                tasks = await service.list_blocked_tasks()
-                typer.echo(formatters.format_blocked_tasks(tasks, json_output))
-                return 0
-            except Exception as exc:
-                typer.echo(formatters.format_error(str(exc)), err=True)
-                return 1
+        service = await _build_service()
+        try:
+            tasks = await service.list_blocked_tasks()
+            typer.echo(formatters.format_blocked_tasks(tasks, json_output))
+            return 0
+        except Exception as exc:
+            typer.echo(formatters.format_error(str(exc)), err=True)
+            return 1
 
     raise typer.Exit(code=asyncio.run(_run()))
 
@@ -76,26 +73,25 @@ def retry_task(
     parsed_id = _parse_uuid(task_id, arg_name="task_id")
 
     async def _run() -> int:
-        service, session = await _build_service_with_session()
-        async with session, session.begin():
-            try:
-                await service.retry_task(parsed_id)
-                msg = (
-                    f"Task {parsed_id} を BLOCKED → IN_PROGRESS に変更しました。"
-                    " bakufu サーバーの StageWorker が自動的に再実行します。"
+        service = await _build_service()
+        try:
+            await service.retry_task(parsed_id)
+            msg = (
+                f"Task {parsed_id} を BLOCKED → IN_PROGRESS に変更しました。"
+                " bakufu サーバーの StageWorker が自動的に再実行します。"
+            )
+            typer.echo(
+                formatters.format_success(
+                    msg, json_output, command="retry-task", id_=str(parsed_id)
                 )
-                typer.echo(
-                    formatters.format_success(
-                        msg, json_output, command="retry-task", id_=str(parsed_id)
-                    )
-                )
-                return 0
-            except (TaskNotFoundError, IllegalTaskStateError) as exc:
-                typer.echo(formatters.format_error(str(exc)), err=True)
-                return 1
-            except Exception as exc:
-                typer.echo(formatters.format_error(str(exc)), err=True)
-                return 1
+            )
+            return 0
+        except (TaskNotFoundError, IllegalTaskStateError) as exc:
+            typer.echo(formatters.format_error(str(exc)), err=True)
+            return 1
+        except Exception as exc:
+            typer.echo(formatters.format_error(str(exc)), err=True)
+            return 1
 
     raise typer.Exit(code=asyncio.run(_run()))
 
@@ -120,23 +116,22 @@ def cancel_task(
     parsed_id = _parse_uuid(task_id, arg_name="task_id")
 
     async def _run() -> int:
-        service, session = await _build_service_with_session()
-        async with session, session.begin():
-            try:
-                await service.cancel_task(parsed_id, reason)
-                msg = f"Task {parsed_id} を CANCELLED に変更しました。"
-                typer.echo(
-                    formatters.format_success(
-                        msg, json_output, command="cancel-task", id_=str(parsed_id)
-                    )
+        service = await _build_service()
+        try:
+            await service.cancel_task(parsed_id, reason)
+            msg = f"Task {parsed_id} を CANCELLED に変更しました。"
+            typer.echo(
+                formatters.format_success(
+                    msg, json_output, command="cancel-task", id_=str(parsed_id)
                 )
-                return 0
-            except (TaskNotFoundError, IllegalTaskStateError) as exc:
-                typer.echo(formatters.format_error(str(exc)), err=True)
-                return 1
-            except Exception as exc:
-                typer.echo(formatters.format_error(str(exc)), err=True)
-                return 1
+            )
+            return 0
+        except (TaskNotFoundError, IllegalTaskStateError) as exc:
+            typer.echo(formatters.format_error(str(exc)), err=True)
+            return 1
+        except Exception as exc:
+            typer.echo(formatters.format_error(str(exc)), err=True)
+            return 1
 
     raise typer.Exit(code=asyncio.run(_run()))
 
@@ -153,15 +148,14 @@ def list_dead_letters(
     """DEAD_LETTER 状態の Outbox Event 一覧を表示する（UC-AC-004）。"""
 
     async def _run() -> int:
-        service, session = await _build_service_with_session()
-        async with session, session.begin():
-            try:
-                events = await service.list_dead_letters()
-                typer.echo(formatters.format_dead_letters(events, json_output))
-                return 0
-            except Exception as exc:
-                typer.echo(formatters.format_error(str(exc)), err=True)
-                return 1
+        service = await _build_service()
+        try:
+            events = await service.list_dead_letters()
+            typer.echo(formatters.format_dead_letters(events, json_output))
+            return 0
+        except Exception as exc:
+            typer.echo(formatters.format_error(str(exc)), err=True)
+            return 1
 
     raise typer.Exit(code=asyncio.run(_run()))
 
@@ -183,26 +177,25 @@ def retry_event(
     parsed_id = _parse_uuid(event_id, arg_name="event_id")
 
     async def _run() -> int:
-        service, session = await _build_service_with_session()
-        async with session, session.begin():
-            try:
-                await service.retry_event(parsed_id)
-                msg = (
-                    f"Outbox Event {parsed_id} を DEAD_LETTER → PENDING にリセットしました。"
-                    " Outbox Dispatcher が次回ポーリングで再 dispatch します。"
+        service = await _build_service()
+        try:
+            await service.retry_event(parsed_id)
+            msg = (
+                f"Outbox Event {parsed_id} を DEAD_LETTER → PENDING にリセットしました。"
+                " Outbox Dispatcher が次回ポーリングで再 dispatch します。"
+            )
+            typer.echo(
+                formatters.format_success(
+                    msg, json_output, command="retry-event", id_=str(parsed_id)
                 )
-                typer.echo(
-                    formatters.format_success(
-                        msg, json_output, command="retry-event", id_=str(parsed_id)
-                    )
-                )
-                return 0
-            except (OutboxEventNotFoundError, IllegalOutboxStateError) as exc:
-                typer.echo(formatters.format_error(str(exc)), err=True)
-                return 1
-            except Exception as exc:
-                typer.echo(formatters.format_error(str(exc)), err=True)
-                return 1
+            )
+            return 0
+        except (OutboxEventNotFoundError, IllegalOutboxStateError) as exc:
+            typer.echo(formatters.format_error(str(exc)), err=True)
+            return 1
+        except Exception as exc:
+            typer.echo(formatters.format_error(str(exc)), err=True)
+            return 1
 
     raise typer.Exit(code=asyncio.run(_run()))
 
@@ -229,10 +222,11 @@ def _parse_uuid(raw: str, arg_name: str) -> UUID:
         raise typer.Exit(code=1) from None
 
 
-async def _build_service_with_session() -> tuple[AdminService, AsyncSession]:
-    """AdminService と AsyncSession を構築して返す。
+async def _build_service() -> AdminService:
+    """AdminService を構築して返す。
 
-    セッションのライフサイクルは呼び出し元（各コマンド）が管理する。
+    session_factory を LiteBootstrap から取得し、factory callable を DI 注入する。
+    Tx 管理（業務 Tx / audit_log Tx の分離）は AdminService 内部で行う（Option A）。
     遅延 import で循環参照リスクを回避する。
     """
     from bakufu.application.services.admin_service import AdminService
@@ -248,16 +242,13 @@ async def _build_service_with_session() -> tuple[AdminService, AsyncSession]:
     from bakufu.interfaces.cli.lite_bootstrap import LiteBootstrap
 
     session_factory = await LiteBootstrap.setup_db()
-    session = session_factory()
-    actor = _resolve_actor()
-
-    service = AdminService(
-        task_repo=SqliteTaskRepository(session),
-        outbox_event_repo=SqliteOutboxEventRepository(session),
-        audit_log_writer=SqliteAuditLogWriter(session),
-        actor=actor,
+    return AdminService(
+        session_factory=session_factory,
+        task_repo_factory=SqliteTaskRepository,
+        outbox_event_repo_factory=SqliteOutboxEventRepository,
+        audit_log_writer_factory=SqliteAuditLogWriter,
+        actor=_resolve_actor(),
     )
-    return service, session
 
 
 def _resolve_actor() -> str:

--- a/backend/src/bakufu/interfaces/cli/formatters.py
+++ b/backend/src/bakufu/interfaces/cli/formatters.py
@@ -1,0 +1,139 @@
+"""OutputFormatter — admin-cli 出力フォーマット（§確定 D）。
+
+テーブル形式（tabulate）と JSON 形式（--json フラグ）の 2 モードをサポートする。
+エラーメッセージは両モードで stderr に出力する。
+
+設計書: docs/features/admin-cli/cli/detailed-design.md §確定 D
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from tabulate import tabulate
+
+if TYPE_CHECKING:
+    from bakufu.application.services.admin_service import BlockedTaskSummary, DeadLetterSummary
+
+_MAX_ERROR_LEN = 80
+_TRUNC_SUFFIX = "..."
+
+
+def _trunc(text: str | None, max_len: int = _MAX_ERROR_LEN) -> str:
+    """テキストを max_len 文字でトランケートする。None は '-' で代替。"""
+    if text is None:
+        return "-"
+    if len(text) <= max_len:
+        return text
+    return text[:max_len] + _TRUNC_SUFFIX
+
+
+def format_blocked_tasks(tasks: list[BlockedTaskSummary], json_output: bool) -> str:
+    """list-blocked の出力文字列を返す（§確定 D）。
+
+    0 件時: テーブル形式は "(BLOCKED Task はありません)"、JSON 形式は "[]"。
+    """
+    if json_output:
+        data = [
+            {
+                "task_id": str(t.task_id),
+                "room_id": str(t.room_id),
+                "blocked_at": t.blocked_at.isoformat(),
+                "last_error": t.last_error,
+            }
+            for t in tasks
+        ]
+        return json.dumps(data, ensure_ascii=False, indent=2)
+
+    if not tasks:
+        return "（BLOCKED Task はありません）"
+
+    rows = [
+        [
+            str(t.task_id),
+            str(t.room_id),
+            t.blocked_at.strftime("%Y-%m-%d %H:%M:%S UTC"),
+            _trunc(t.last_error),
+        ]
+        for t in tasks
+    ]
+    return tabulate(
+        rows,
+        headers=["TASK ID", "ROOM ID", "BLOCKED AT", "LAST ERROR"],
+        tablefmt="simple",
+    )
+
+
+def format_dead_letters(events: list[DeadLetterSummary], json_output: bool) -> str:
+    """list-dead-letters の出力文字列を返す（§確定 D）。
+
+    0 件時: テーブル形式は "(dead-letter Event はありません)"、JSON 形式は "[]"。
+    """
+    if json_output:
+        data = [
+            {
+                "event_id": str(e.event_id),
+                "event_kind": e.event_kind,
+                "aggregate_id": str(e.aggregate_id),
+                "attempt_count": e.attempt_count,
+                "last_error": e.last_error,
+                "updated_at": e.updated_at.isoformat(),
+            }
+            for e in events
+        ]
+        return json.dumps(data, ensure_ascii=False, indent=2)
+
+    if not events:
+        return "（dead-letter Event はありません）"
+
+    rows = [
+        [
+            str(e.event_id),
+            e.event_kind,
+            str(e.aggregate_id),
+            e.attempt_count,
+            e.updated_at.strftime("%Y-%m-%d %H:%M:%S UTC"),
+            _trunc(e.last_error),
+        ]
+        for e in events
+    ]
+    return tabulate(
+        rows,
+        headers=["EVENT ID", "KIND", "AGGREGATE ID", "ATTEMPTS", "UPDATED AT", "LAST ERROR"],
+        tablefmt="simple",
+    )
+
+
+def format_success(message: str, json_output: bool, command: str = "", id_: str = "") -> str:
+    """変更コマンド成功時の出力文字列を返す（§確定 D）。
+
+    JSON 形式: ``{"result": "ok", "command": "<command>", "id": "<uuid>"}``
+    テーブル形式: ``[OK] <message>``
+    """
+    if json_output:
+        payload: dict[str, object] = {"result": "ok"}
+        if command:
+            payload["command"] = command
+        if id_:
+            payload["id"] = id_
+        return json.dumps(payload, ensure_ascii=False)
+    return f"[OK] {message}"
+
+
+def format_error(message: str) -> str:
+    """エラーメッセージ文字列を返す（常に ``[FAIL]`` で始まる形式）。
+
+    既に ``[FAIL]`` で始まっている場合はそのまま返す（二重フォーマット防止）。
+    """
+    if message.startswith("[FAIL]"):
+        return message
+    return f"[FAIL] {message}"
+
+
+__all__ = [
+    "format_blocked_tasks",
+    "format_dead_letters",
+    "format_error",
+    "format_success",
+]

--- a/backend/src/bakufu/interfaces/cli/lite_bootstrap.py
+++ b/backend/src/bakufu/interfaces/cli/lite_bootstrap.py
@@ -1,0 +1,105 @@
+"""LiteBootstrap — admin-cli 用 DB 接続のみの軽量初期化（§確定 A）。
+
+フル Bootstrap（8 Stage）のうち、admin-cli に必要な Stage 1（DATA_DIR 解決）+
+Stage 4（SQLAlchemy engine 初期化）のみを実行する。
+
+Alembic Migration / Outbox Dispatcher / StageWorker / FastAPI は起動しない。
+短命プロセス（admin-cli）に不要なコンポーネントを起動しない（関心の分離）。
+
+設計書: docs/features/admin-cli/cli/detailed-design.md §確定 A
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import NoReturn
+
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+logger = logging.getLogger(__name__)
+
+_ENV_DATA_DIR = "BAKUFU_DATA_DIR"
+_DB_FILENAME = "bakufu.db"
+
+# MSG-AC-CLI-001: DB 接続失敗
+_MSG_AC_CLI_001_TMPL = (
+    "[FAIL] bakufu DB に接続できませんでした（path: {db_path}）。\n"
+    "Next: BAKUFU_DATA_DIR 環境変数と DB ファイルの存在を確認してください。"
+)
+
+
+class LiteBootstrap:
+    """admin-cli 用の軽量 DB 初期化（§確定 A）。
+
+    `setup_db()` を呼ぶと ``async_sessionmaker`` を返す。
+    ``data_dir=None`` 時は ``BAKUFU_DATA_DIR`` 環境変数を参照する。
+    """
+
+    @staticmethod
+    async def setup_db(data_dir: Path | None = None) -> async_sessionmaker[AsyncSession]:
+        """DATA_DIR を解決して SQLAlchemy asyncio engine を初期化する。
+
+        Args:
+            data_dir: DB ディレクトリのパス。None の場合は環境変数から取得。
+
+        Returns:
+            ``async_sessionmaker[AsyncSession]``（AdminService の DI に渡す）。
+
+        Raises:
+            SystemExit: DATA_DIR が未設定 / DB ファイル不在 / engine 初期化失敗時。
+        """
+        resolved_dir = LiteBootstrap._resolve_data_dir(data_dir)
+        db_path = resolved_dir / _DB_FILENAME
+        engine = LiteBootstrap._create_engine(db_path)
+        return async_sessionmaker(engine, expire_on_commit=False)
+
+    @staticmethod
+    def _resolve_data_dir(data_dir: Path | None) -> Path:
+        """DATA_DIR を解決する。未設定 / 不在の場合は MSG-AC-CLI-001 で Fail Fast。"""
+        if data_dir is not None:
+            return data_dir
+
+        raw = os.environ.get(_ENV_DATA_DIR, "")
+        if not raw:
+            db_path = "unknown"
+            _fail_msg(db_path, reason=f"{_ENV_DATA_DIR} 環境変数が設定されていません。")
+        return Path(raw)
+
+    @staticmethod
+    def _create_engine(db_path: Path) -> AsyncEngine:
+        """SQLite asyncio engine を WAL モードで生成する。
+
+        DB ファイルが存在しない場合は MSG-AC-CLI-001 で Fail Fast（CLI は DB を新規作成しない）。
+        """
+        if not db_path.exists():
+            _fail_msg(str(db_path))
+
+        db_url = f"sqlite+aiosqlite:///{db_path}"
+        try:
+            engine = create_async_engine(
+                db_url,
+                connect_args={"check_same_thread": False},
+            )
+        except Exception as exc:
+            _fail_msg(str(db_path), reason=str(exc))
+        return engine
+
+
+def _fail_msg(db_path: str, reason: str | None = None) -> NoReturn:
+    """MSG-AC-CLI-001 を stderr に出力して exit 1 する。"""
+    msg = _MSG_AC_CLI_001_TMPL.format(db_path=db_path)
+    if reason:
+        msg = f"{msg}\n詳細: {reason}"
+    print(msg, file=sys.stderr)
+    raise SystemExit(1)
+
+
+__all__ = ["LiteBootstrap"]

--- a/backend/tests/integration/test_admin_cli.py
+++ b/backend/tests/integration/test_admin_cli.py
@@ -13,19 +13,32 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
+from collections.abc import AsyncIterator
 from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from typer.testing import CliRunner
 
 from bakufu.application.exceptions.task_exceptions import IllegalTaskStateError, TaskNotFoundError
 from bakufu.application.services.admin_service import BlockedTaskSummary, DeadLetterSummary
 from bakufu.domain.exceptions.outbox import OutboxEventNotFoundError
+from bakufu.domain.value_objects import TaskStatus
+from bakufu.infrastructure.persistence.sqlite.tables.audit_log import AuditLogRow
 from bakufu.interfaces.cli.admin import app
+from tests.factories.db import create_all_tables, make_test_engine, make_test_session_factory
+from tests.factories.directive import make_directive
+from tests.factories.empire import make_empire
+from tests.factories.room import make_room
+from tests.factories.task import make_blocked_task, make_done_task, make_task
+from tests.factories.workflow import make_workflow
 
 
 # ---------------------------------------------------------------------------
@@ -54,15 +67,17 @@ def _make_mock_session() -> AsyncMock:
 
 def _patch_build_service(
     mock_service: AsyncMock,
-    mock_session: AsyncMock,
+    mock_session: AsyncMock,  # session_factory 注入方式では不要だが呼び出し元との互換のため残す
 ) -> patch:
-    """_build_service_with_session をモックするコンテキストマネージャを返す。"""
-    from bakufu.application.services.admin_service import AdminService
+    """_build_service をモックするコンテキストマネージャを返す。
 
-    async def _fake_build() -> tuple:
-        return mock_service, mock_session
+    Option-A 修正後: Tx 管理は AdminService 内部に移動したため、
+    CLI 層では AdminService インスタンスのみを返す。
+    """
+    async def _fake_build() -> AsyncMock:
+        return mock_service
 
-    return patch("bakufu.interfaces.cli.admin._build_service_with_session", new=_fake_build)
+    return patch("bakufu.interfaces.cli.admin._build_service", new=_fake_build)
 
 
 def _make_blocked_summary(
@@ -361,3 +376,250 @@ class TestLiteBootstrapError:
         # [FAIL] メッセージが stderr または stdout に出力される（LiteBootstrap は print で出力）
         combined_output = (result.output or "") + (result.stderr or "")
         assert "[FAIL]" in combined_output
+
+
+# ---------------------------------------------------------------------------
+# TC-E2E-AC-001〜003: CLI経由フルパスでの audit_log 永続化検証（§確定A / Option-A 修正確認）
+#
+# ヘルスバーグ指摘対応:
+#   業務Tx と audit_log Tx が独立 session で実行され、業務Tx の rollback 後も
+#   audit_log INSERT が独立 commit で永続化されることを実 DB + CLI 全経路で証明する。
+#
+# 設計書: docs/features/admin-cli/cli/detailed-design.md §確定A
+#         docs/features/admin-cli/application/test-design.md §TC-E2E-AC
+#
+# テスト戦略:
+#   - _build_service_with_session を一切モックしない（CLI全経路）
+#   - 実 SQLite bakufu.db + BAKUFU_DATA_DIR 設定で LiteBootstrap を通す
+#   - 非同期操作（DB setup / audit_log 検証）は asyncio.run() で sync テスト内から呼ぶ
+#     （CliRunner が asyncio.run() を使う都合上、テスト関数を sync にする必要がある）
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# E2E テスト用ヘルパー
+# ---------------------------------------------------------------------------
+
+
+async def _create_bakufu_db(db_path: Path) -> None:
+    """テスト用 bakufu.db を作成してスキーマを展開する。"""
+    engine = make_test_engine(db_path)
+    await create_all_tables(engine)
+    await engine.dispose()
+
+
+async def _read_audit_logs_from_db(db_path: Path) -> list[AuditLogRow]:
+    """audit_log テーブルの全行を executed_at 昇順で取得する。"""
+    engine = make_test_engine(db_path)
+    sf = make_test_session_factory(engine)
+    try:
+        async with sf() as session:
+            result = await session.execute(
+                select(AuditLogRow).order_by(AuditLogRow.executed_at.asc())
+            )
+            return list(result.scalars().all())
+    finally:
+        await engine.dispose()
+
+
+async def _seed_entity_hierarchy(db_path: Path) -> tuple[UUID, UUID]:
+    """empire → workflow → room → directive をシードして (room_id, directive_id) を返す。"""
+    from bakufu.infrastructure.persistence.sqlite.repositories.directive_repository import (
+        SqliteDirectiveRepository,
+    )
+    from bakufu.infrastructure.persistence.sqlite.repositories.empire_repository import (
+        SqliteEmpireRepository,
+    )
+    from bakufu.infrastructure.persistence.sqlite.repositories.room_repository import (
+        SqliteRoomRepository,
+    )
+    from bakufu.infrastructure.persistence.sqlite.repositories.task_repository import (
+        SqliteTaskRepository,
+    )
+    from bakufu.infrastructure.persistence.sqlite.repositories.workflow_repository import (
+        SqliteWorkflowRepository,
+    )
+
+    engine = make_test_engine(db_path)
+    sf = make_test_session_factory(engine)
+    empire = make_empire()
+    workflow = make_workflow()
+    room = make_room(workflow_id=workflow.id)
+    directive = make_directive(target_room_id=room.id)
+    try:
+        async with sf() as session, session.begin():
+            await SqliteEmpireRepository(session).save(empire)
+        async with sf() as session, session.begin():
+            await SqliteWorkflowRepository(session).save(workflow)
+        async with sf() as session, session.begin():
+            await SqliteRoomRepository(session).save(room, empire.id)
+        async with sf() as session, session.begin():
+            await SqliteDirectiveRepository(session).save(directive)
+    finally:
+        await engine.dispose()
+    return room.id, directive.id
+
+
+async def _seed_task(db_path: Path, task: object) -> None:
+    """Task を DB に保存する。"""
+    from bakufu.infrastructure.persistence.sqlite.repositories.task_repository import (
+        SqliteTaskRepository,
+    )
+
+    engine = make_test_engine(db_path)
+    sf = make_test_session_factory(engine)
+    try:
+        async with sf() as session, session.begin():
+            await SqliteTaskRepository(session).save(task)
+    finally:
+        await engine.dispose()
+
+
+def _init_masking_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """masking 初期化に必要な環境変数をクリアして masking.init() を呼ぶ。"""
+    for key in (
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "GEMINI_API_KEY",
+        "GH_TOKEN",
+        "GITHUB_TOKEN",
+        "OAUTH_CLIENT_SECRET",
+        "BAKUFU_DISCORD_BOT_TOKEN",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    from bakufu.infrastructure.security import masking
+
+    masking.init()
+
+
+class TestAuditLogPersistenceViaCLI:
+    """TC-E2E-AC-001〜003: CLI経由フルパスでの audit_log 永続化検証。
+
+    **§確定A 契約**: 全 Admin CLI 操作の後（成功・失敗を問わず）、
+    audit_log テーブルに対応レコードが追記される。
+
+    ヘルスバーグ指摘（Option-A 修正後の確認テスト）:
+    - AdminService が session_factory を受け取り、業務Tx と audit_log Tx を分離する修正後、
+      業務Tx の rollback（失敗時）の影響を audit_log Tx が受けないことを実 DB で証明する。
+    - _build_service_with_session を一切モックしない（CLI全経路）。
+    """
+
+    def test_retry_nonexistent_task_fail_audit_log_persisted(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """TC-E2E-AC-001: retry-task で TaskNotFoundError → exit 1 AND audit_log result='FAIL' が永続化。
+
+        §確定A 核心検証:
+        CLI 経由フルパスで業務Tx が rollback しても audit_log の FAIL 記録が永続化される。
+        CLI が _build_service_with_session をモックしない実 DB 接続で検証する。
+        """
+        db_path = tmp_path / "bakufu.db"
+        asyncio.run(_create_bakufu_db(db_path))
+        _init_masking_env(monkeypatch)
+        monkeypatch.setenv("BAKUFU_DATA_DIR", str(tmp_path))
+
+        runner = _make_cli_runner()
+        nonexistent_id = uuid4()
+        result = runner.invoke(app, ["retry-task", str(nonexistent_id)])
+
+        # CLI は TaskNotFoundError → exit 1
+        assert result.exit_code == 1
+
+        # §確定A: audit_log に result='FAIL' が永続化されている
+        audit_logs = asyncio.run(_read_audit_logs_from_db(db_path))
+        assert len(audit_logs) == 1, (
+            f"audit_log が 1 件期待されるが {len(audit_logs)} 件。"
+            f" 業務Tx の rollback が audit_log Tx を巻き込んでいる可能性がある。"
+        )
+        assert audit_logs[0].result == "FAIL"
+        assert audit_logs[0].command == "retry-task"
+        assert str(nonexistent_id) in str(audit_logs[0].args_json)
+
+    def test_cancel_nonexistent_task_fail_audit_log_persisted(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """TC-E2E-AC-002: cancel-task で TaskNotFoundError → exit 1 AND audit_log result='FAIL' が永続化。"""
+        db_path = tmp_path / "bakufu.db"
+        asyncio.run(_create_bakufu_db(db_path))
+        _init_masking_env(monkeypatch)
+        monkeypatch.setenv("BAKUFU_DATA_DIR", str(tmp_path))
+
+        runner = _make_cli_runner()
+        nonexistent_id = uuid4()
+        result = runner.invoke(app, ["cancel-task", str(nonexistent_id)])
+
+        assert result.exit_code == 1
+
+        audit_logs = asyncio.run(_read_audit_logs_from_db(db_path))
+        assert len(audit_logs) == 1, (
+            f"audit_log が 1 件期待されるが {len(audit_logs)} 件。"
+            f" 業務Tx の rollback が audit_log Tx を巻き込んでいる可能性がある。"
+        )
+        assert audit_logs[0].result == "FAIL"
+        assert audit_logs[0].command == "cancel-task"
+
+    def test_retry_task_illegal_state_fail_audit_log_persisted(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """TC-E2E-AC-003: DONE Task の retry-task → IllegalTaskStateError + audit_log result='FAIL' 永続化。
+
+        §確定B: Fail Fast 後も audit_log FAIL が記録される。
+        Task が存在するが不正ステータスのケース（DB seed 必要）。
+        """
+        db_path = tmp_path / "bakufu.db"
+        asyncio.run(_create_bakufu_db(db_path))
+        _init_masking_env(monkeypatch)
+        monkeypatch.setenv("BAKUFU_DATA_DIR", str(tmp_path))
+
+        # entity hierarchy + DONE task をシード
+        room_id, directive_id = asyncio.run(_seed_entity_hierarchy(db_path))
+        done_task = make_done_task(room_id=room_id, directive_id=directive_id)
+        asyncio.run(_seed_task(db_path, done_task))
+
+        runner = _make_cli_runner()
+        result = runner.invoke(app, ["retry-task", str(done_task.id)])
+
+        assert result.exit_code == 1
+        assert "[FAIL]" in (result.output + result.stderr)
+
+        audit_logs = asyncio.run(_read_audit_logs_from_db(db_path))
+        assert len(audit_logs) == 1, (
+            f"audit_log が 1 件期待されるが {len(audit_logs)} 件"
+        )
+        assert audit_logs[0].result == "FAIL"
+        assert audit_logs[0].command == "retry-task"
+
+    def test_retry_blocked_task_ok_audit_log_persisted(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """TC-E2E-AC-004: BLOCKED Task の retry-task 成功 → exit 0 AND audit_log result='OK' が永続化。
+
+        正常系: 成功時も audit_log に result='OK' が記録される（§確定A の両面検証）。
+        """
+        db_path = tmp_path / "bakufu.db"
+        asyncio.run(_create_bakufu_db(db_path))
+        _init_masking_env(monkeypatch)
+        monkeypatch.setenv("BAKUFU_DATA_DIR", str(tmp_path))
+
+        # entity hierarchy + BLOCKED task をシード
+        room_id, directive_id = asyncio.run(_seed_entity_hierarchy(db_path))
+        blocked_task = make_blocked_task(room_id=room_id, directive_id=directive_id)
+        asyncio.run(_seed_task(db_path, blocked_task))
+
+        runner = _make_cli_runner()
+        result = runner.invoke(app, ["retry-task", str(blocked_task.id)])
+
+        assert result.exit_code == 0
+        assert "[OK]" in result.output
+
+        audit_logs = asyncio.run(_read_audit_logs_from_db(db_path))
+        assert len(audit_logs) == 1
+        assert audit_logs[0].result == "OK"
+        assert audit_logs[0].command == "retry-task"

--- a/backend/tests/integration/test_admin_cli.py
+++ b/backend/tests/integration/test_admin_cli.py
@@ -1,0 +1,363 @@
+"""admin-cli Typer コマンド 結合テスト（TC-IT-AC-CLI-001〜012）。
+
+設計書: docs/features/admin-cli/cli/test-design.md §結合テストケース
+
+テスト戦略:
+  - CliRunner(mix_stderr=False) で Typer コマンドを同プロセス内で呼び出す
+  - AdminService を AsyncMock でスタブ化し、CLI 層の契約のみを検証する
+    （引数解析・出力形式・exit code・エラーメッセージ）
+  - TC-IT-AC-CLI-012 のみ実 BAKUFU_DATA_DIR 設定で LiteBootstrap のエラーパスを検証
+
+注意: CliRunner は同期呼び出し。コマンド内部の asyncio.run() はランナー内で実行される。
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from typer.testing import CliRunner
+
+from bakufu.application.exceptions.task_exceptions import IllegalTaskStateError, TaskNotFoundError
+from bakufu.application.services.admin_service import BlockedTaskSummary, DeadLetterSummary
+from bakufu.domain.exceptions.outbox import OutboxEventNotFoundError
+from bakufu.interfaces.cli.admin import app
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_cli_runner() -> CliRunner:
+    # Click 8.2+ では mix_stderr が廃止され、result.stdout / result.stderr が常に独立
+    return CliRunner()
+
+
+def _make_mock_session() -> AsyncMock:
+    """async with session, session.begin(): をサポートするモックセッションを返す。"""
+    session = AsyncMock()
+    # async with session: をサポート
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    # session.begin() が返す async context manager
+    begin_ctx = AsyncMock()
+    begin_ctx.__aenter__ = AsyncMock(return_value=None)
+    begin_ctx.__aexit__ = AsyncMock(return_value=False)
+    session.begin = MagicMock(return_value=begin_ctx)
+    return session
+
+
+def _patch_build_service(
+    mock_service: AsyncMock,
+    mock_session: AsyncMock,
+) -> patch:
+    """_build_service_with_session をモックするコンテキストマネージャを返す。"""
+    from bakufu.application.services.admin_service import AdminService
+
+    async def _fake_build() -> tuple:
+        return mock_service, mock_session
+
+    return patch("bakufu.interfaces.cli.admin._build_service_with_session", new=_fake_build)
+
+
+def _make_blocked_summary(
+    *,
+    last_error: str = "test error",
+) -> BlockedTaskSummary:
+    return BlockedTaskSummary(
+        task_id=uuid4(),
+        room_id=uuid4(),
+        last_error=last_error,
+        blocked_at=datetime.now(UTC),
+    )
+
+
+def _make_dead_letter_summary() -> DeadLetterSummary:
+    return DeadLetterSummary(
+        event_id=uuid4(),
+        event_kind="TaskEventEmitted",
+        aggregate_id=uuid4(),
+        attempt_count=3,
+        last_error="dispatch failed",
+        updated_at=datetime.now(UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-AC-CLI-001: list-blocked — テーブル形式デフォルト出力
+# ---------------------------------------------------------------------------
+
+
+class TestListBlocked:
+    """TC-IT-AC-CLI-001〜003: list-blocked コマンドのテスト。"""
+
+    def test_list_blocked_default_table_format(self) -> None:
+        """TC-IT-AC-CLI-001: list-blocked → exit 0 + テーブル形式（TASK ID ヘッダ）。"""
+        runner = _make_cli_runner()
+        mock_service = AsyncMock()
+        mock_session = _make_mock_session()
+
+        summary = _make_blocked_summary()
+        mock_service.list_blocked_tasks.return_value = [summary]
+
+        with _patch_build_service(mock_service, mock_session):
+            result = runner.invoke(app, ["list-blocked"])
+
+        assert result.exit_code == 0
+        assert "TASK ID" in result.output
+        assert str(summary.task_id) in result.output
+
+    def test_list_blocked_json_format(self) -> None:
+        """TC-IT-AC-CLI-002: list-blocked --json → exit 0 + 有効な JSON 配列（§確定 D / R1-7）。"""
+        runner = _make_cli_runner()
+        mock_service = AsyncMock()
+        mock_session = _make_mock_session()
+
+        summary = _make_blocked_summary(last_error="some error")
+        mock_service.list_blocked_tasks.return_value = [summary]
+
+        with _patch_build_service(mock_service, mock_session):
+            result = runner.invoke(app, ["list-blocked", "--json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+        assert len(data) == 1
+        item = data[0]
+        assert "task_id" in item
+        assert "room_id" in item
+        assert "blocked_at" in item
+        assert "last_error" in item
+        assert str(summary.task_id) == item["task_id"]
+
+    def test_list_blocked_empty_shows_human_message(self) -> None:
+        """TC-IT-AC-CLI-003: list-blocked 0件 → exit 0 + "BLOCKED Task はありません" メッセージ（§確定 D）。"""
+        runner = _make_cli_runner()
+        mock_service = AsyncMock()
+        mock_session = _make_mock_session()
+
+        mock_service.list_blocked_tasks.return_value = []
+
+        with _patch_build_service(mock_service, mock_session):
+            result = runner.invoke(app, ["list-blocked"])
+
+        assert result.exit_code == 0
+        assert "BLOCKED Task はありません" in result.output
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-AC-CLI-004〜006: retry-task コマンド
+# ---------------------------------------------------------------------------
+
+
+class TestRetryTask:
+    """TC-IT-AC-CLI-004〜006: retry-task コマンドのテスト。"""
+
+    def test_retry_task_success_exit0_with_ok_message(self) -> None:
+        """TC-IT-AC-CLI-004: retry-task 正常系 → exit 0 + [OK] + IN_PROGRESS が stdout（§確定 C）。"""
+        runner = _make_cli_runner()
+        mock_service = AsyncMock()
+        mock_session = _make_mock_session()
+
+        mock_service.retry_task.return_value = None  # 正常終了
+        task_id = uuid4()
+
+        with _patch_build_service(mock_service, mock_session):
+            result = runner.invoke(app, ["retry-task", str(task_id)])
+
+        assert result.exit_code == 0
+        assert "[OK]" in result.output
+        assert "IN_PROGRESS" in result.output
+
+    def test_retry_task_invalid_uuid_exit1_with_fail_on_stderr(self) -> None:
+        """TC-IT-AC-CLI-005: 無効 UUID → exit 1 + [FAIL] が stderr（MSG-AC-CLI-002 / §確定 B / T2）。
+
+        AdminService は呼ばれない（Fail Fast）。
+        """
+        runner = _make_cli_runner()
+        mock_service = AsyncMock()
+        mock_session = _make_mock_session()
+
+        with _patch_build_service(mock_service, mock_session):
+            result = runner.invoke(app, ["retry-task", "not-a-uuid"])
+
+        assert result.exit_code == 1
+        assert "[FAIL]" in result.stderr
+        # AdminService が一度も呼ばれていない
+        mock_service.retry_task.assert_not_called()
+
+    def test_retry_task_not_found_exit1_with_fail_on_stderr(self) -> None:
+        """TC-IT-AC-CLI-006: TaskNotFoundError → exit 1 + [FAIL] が stderr（MSG-AC-001）。"""
+        runner = _make_cli_runner()
+        mock_service = AsyncMock()
+        mock_session = _make_mock_session()
+
+        task_id = uuid4()
+        mock_service.retry_task.side_effect = TaskNotFoundError(task_id)
+
+        with _patch_build_service(mock_service, mock_session):
+            result = runner.invoke(app, ["retry-task", str(task_id)])
+
+        assert result.exit_code == 1
+        assert "[FAIL]" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-AC-CLI-007: cancel-task コマンド
+# ---------------------------------------------------------------------------
+
+
+class TestCancelTask:
+    """TC-IT-AC-CLI-007: cancel-task コマンドのテスト。"""
+
+    def test_cancel_task_success_exit0_with_ok_message(self) -> None:
+        """TC-IT-AC-CLI-007: cancel-task 正常系 → exit 0 + [OK] + CANCELLED が stdout（§確定 C）。"""
+        runner = _make_cli_runner()
+        mock_service = AsyncMock()
+        mock_session = _make_mock_session()
+
+        mock_service.cancel_task.return_value = None
+        task_id = uuid4()
+
+        with _patch_build_service(mock_service, mock_session):
+            result = runner.invoke(app, ["cancel-task", str(task_id)])
+
+        assert result.exit_code == 0
+        assert "[OK]" in result.output
+        assert "CANCELLED" in result.output
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-AC-CLI-008〜009: list-dead-letters コマンド
+# ---------------------------------------------------------------------------
+
+
+class TestListDeadLetters:
+    """TC-IT-AC-CLI-008〜009: list-dead-letters コマンドのテスト。"""
+
+    def test_list_dead_letters_table_format(self) -> None:
+        """TC-IT-AC-CLI-008: list-dead-letters → exit 0 + テーブル形式（EVENT ID ヘッダ）（§確定 D）。"""
+        runner = _make_cli_runner()
+        mock_service = AsyncMock()
+        mock_session = _make_mock_session()
+
+        summary = _make_dead_letter_summary()
+        mock_service.list_dead_letters.return_value = [summary]
+
+        with _patch_build_service(mock_service, mock_session):
+            result = runner.invoke(app, ["list-dead-letters"])
+
+        assert result.exit_code == 0
+        assert "EVENT ID" in result.output
+        assert "KIND" in result.output
+
+    def test_list_dead_letters_json_format(self) -> None:
+        """TC-IT-AC-CLI-009a: list-dead-letters --json → exit 0 + 有効な JSON 配列（§確定 D）。"""
+        runner = _make_cli_runner()
+        mock_service = AsyncMock()
+        mock_session = _make_mock_session()
+
+        summary = _make_dead_letter_summary()
+        mock_service.list_dead_letters.return_value = [summary]
+
+        with _patch_build_service(mock_service, mock_session):
+            result = runner.invoke(app, ["list-dead-letters", "--json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+        assert len(data) == 1
+        item = data[0]
+        assert "event_id" in item
+        assert "event_kind" in item
+        assert "attempt_count" in item
+
+    def test_list_dead_letters_json_empty(self) -> None:
+        """TC-IT-AC-CLI-009b: list-dead-letters --json 0件 → exit 0 + "[]"（§確定 D JSON 0件）。"""
+        runner = _make_cli_runner()
+        mock_service = AsyncMock()
+        mock_session = _make_mock_session()
+
+        mock_service.list_dead_letters.return_value = []
+
+        with _patch_build_service(mock_service, mock_session):
+            result = runner.invoke(app, ["list-dead-letters", "--json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data == []
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-AC-CLI-010〜011: retry-event コマンド
+# ---------------------------------------------------------------------------
+
+
+class TestRetryEvent:
+    """TC-IT-AC-CLI-010〜011: retry-event コマンドのテスト。"""
+
+    def test_retry_event_success_exit0_with_ok_message(self) -> None:
+        """TC-IT-AC-CLI-010: retry-event 正常系 → exit 0 + [OK] + PENDING が stdout（§確定 C）。"""
+        runner = _make_cli_runner()
+        mock_service = AsyncMock()
+        mock_session = _make_mock_session()
+
+        mock_service.retry_event.return_value = None
+        event_id = uuid4()
+
+        with _patch_build_service(mock_service, mock_session):
+            result = runner.invoke(app, ["retry-event", str(event_id)])
+
+        assert result.exit_code == 0
+        assert "[OK]" in result.output
+        assert "PENDING" in result.output
+
+    def test_retry_event_invalid_uuid_exit1_with_fail_on_stderr(self) -> None:
+        """TC-IT-AC-CLI-011: 無効 UUID → exit 1 + [FAIL] が stderr（MSG-AC-CLI-002 / §確定 B / T2）。
+
+        AdminService は呼ばれない（Fail Fast）。
+        """
+        runner = _make_cli_runner()
+        mock_service = AsyncMock()
+        mock_session = _make_mock_session()
+
+        with _patch_build_service(mock_service, mock_session):
+            result = runner.invoke(app, ["retry-event", "invalid-uuid"])
+
+        assert result.exit_code == 1
+        assert "[FAIL]" in result.stderr
+        mock_service.retry_event.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# TC-IT-AC-CLI-012: LiteBootstrap — DB 不在 → MSG-AC-CLI-001 + exit 1
+# ---------------------------------------------------------------------------
+
+
+class TestLiteBootstrapError:
+    """TC-IT-AC-CLI-012: DB ファイル不在 → [FAIL] + exit 1（MSG-AC-CLI-001 / §確定 A）。"""
+
+    def test_list_blocked_db_not_found_exit1(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """TC-IT-AC-CLI-012: BAKUFU_DATA_DIR に存在しない DB パス → exit 1 + [FAIL] が出力（MSG-AC-CLI-001）。"""
+        runner = _make_cli_runner()
+
+        # 存在しない DATA_DIR を設定（bakufu.db が存在しないことが保証される）
+        nonexistent_dir = tmp_path / "nonexistent_db_dir"
+        monkeypatch.setenv("BAKUFU_DATA_DIR", str(nonexistent_dir))
+
+        # AdminService を mock しない → LiteBootstrap の Fail Fast パスをテスト
+        result = runner.invoke(app, ["list-blocked"])
+
+        assert result.exit_code == 1
+        # [FAIL] メッセージが stderr または stdout に出力される（LiteBootstrap は print で出力）
+        combined_output = (result.output or "") + (result.stderr or "")
+        assert "[FAIL]" in combined_output

--- a/backend/tests/integration/test_admin_service.py
+++ b/backend/tests/integration/test_admin_service.py
@@ -1,0 +1,616 @@
+"""AdminService 結合テスト（TC-ST-AC-001〜010 + TC-IT-AC-001〜013）。
+
+システムテスト設計書: docs/features/admin-cli/system-test-design.md
+結合テスト設計書:    docs/features/admin-cli/application/test-design.md
+
+テスト戦略:
+  - AdminService + 実 SQLite（create_all_tables）
+  - AuditLogWriter / OutboxEventRepository / TaskRepository はすべて実装クラス
+  - FAIL audit_log 検証: 例外を session.begin() 内部でキャッチして commit を許可
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from bakufu.application.exceptions.task_exceptions import IllegalTaskStateError, TaskNotFoundError
+from bakufu.application.services.admin_service import AdminService
+from bakufu.domain.exceptions.outbox import IllegalOutboxStateError, OutboxEventNotFoundError
+from bakufu.infrastructure.persistence.sqlite.repositories.audit_log_writer import (
+    SqliteAuditLogWriter,
+)
+from bakufu.infrastructure.persistence.sqlite.repositories.outbox_event_repository import (
+    SqliteOutboxEventRepository,
+)
+from bakufu.infrastructure.persistence.sqlite.repositories.task_repository import (
+    SqliteTaskRepository,
+)
+from bakufu.infrastructure.persistence.sqlite.tables.audit_log import AuditLogRow
+from bakufu.infrastructure.persistence.sqlite.tables.outbox import OutboxRow
+
+from tests.factories.db import create_all_tables, make_test_engine, make_test_session_factory
+from tests.factories.directive import make_directive
+from tests.factories.empire import make_empire
+from tests.factories.persistence_rows import make_outbox_row
+from tests.factories.room import make_room
+from tests.factories.task import (
+    make_awaiting_review_task,
+    make_blocked_task,
+    make_done_task,
+    make_in_progress_task,
+    make_task,
+)
+from tests.factories.workflow import make_workflow
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _init_masking(monkeypatch: pytest.MonkeyPatch) -> None:
+    """masking 初期化（MaskedText TypeDecorator 動作保証）。"""
+    for key in (
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "GEMINI_API_KEY",
+        "GH_TOKEN",
+        "GITHUB_TOKEN",
+        "OAUTH_CLIENT_SECRET",
+        "BAKUFU_DISCORD_BOT_TOKEN",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    from bakufu.infrastructure.security import masking
+
+    masking.init()
+
+
+@pytest.fixture(autouse=True)
+def _bakufu_data_dir(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BAKUFU_DATA_DIR", "/tmp/bakufu-admin-it-test")
+
+
+@pytest_asyncio.fixture
+async def session_factory(
+    tmp_path: Path,
+) -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    """create_all でスキーマ作成済みの session_factory を提供する。"""
+    engine = make_test_engine(tmp_path / "admin_service_test.db")
+    await create_all_tables(engine)
+    sf = make_test_session_factory(engine)
+    try:
+        yield sf
+    finally:
+        await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def seeded_task_ctx(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> tuple[UUID, UUID]:
+    """empire → workflow → room → directive をシードして (room_id, directive_id) を返す。"""
+    from bakufu.infrastructure.persistence.sqlite.repositories.directive_repository import (
+        SqliteDirectiveRepository,
+    )
+    from bakufu.infrastructure.persistence.sqlite.repositories.empire_repository import (
+        SqliteEmpireRepository,
+    )
+    from bakufu.infrastructure.persistence.sqlite.repositories.room_repository import (
+        SqliteRoomRepository,
+    )
+    from bakufu.infrastructure.persistence.sqlite.repositories.workflow_repository import (
+        SqliteWorkflowRepository,
+    )
+
+    empire = make_empire()
+    workflow = make_workflow()
+    room = make_room(workflow_id=workflow.id)
+    directive = make_directive(target_room_id=room.id)
+
+    async with session_factory() as session, session.begin():
+        await SqliteEmpireRepository(session).save(empire)
+    async with session_factory() as session, session.begin():
+        await SqliteWorkflowRepository(session).save(workflow)
+    async with session_factory() as session, session.begin():
+        await SqliteRoomRepository(session).save(room, empire.id)
+    async with session_factory() as session, session.begin():
+        await SqliteDirectiveRepository(session).save(directive)
+
+    return room.id, directive.id
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_admin_service(
+    session: AsyncSession,
+    actor: str = "test_actor",
+) -> AdminService:
+    """AdminService を組み立てる（実 SQLite 実装クラス経由）。"""
+    return AdminService(
+        task_repo=SqliteTaskRepository(session),
+        outbox_event_repo=SqliteOutboxEventRepository(session),
+        audit_log_writer=SqliteAuditLogWriter(session),
+        actor=actor,
+    )
+
+
+async def _get_last_audit_log(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> AuditLogRow | None:
+    """最後に書き込まれた audit_log レコードを返す（executed_at DESC LIMIT 1）。"""
+    async with session_factory() as session:
+        result = await session.execute(
+            select(AuditLogRow).order_by(AuditLogRow.executed_at.desc()).limit(1)
+        )
+        return result.scalars().first()
+
+
+async def _get_task_status(
+    session_factory: async_sessionmaker[AsyncSession],
+    task_id: UUID,
+) -> str | None:
+    """DB から task の status を直接取得する。
+
+    UUIDStr TypeDecorator は UUID を 32 文字 hex（ハイフンなし）で保存するため、
+    task_id.hex で検索する。
+    """
+    async with session_factory() as session:
+        result = await session.execute(
+            text("SELECT status FROM tasks WHERE id = :id"),
+            {"id": task_id.hex},  # 32 文字 hex（ハイフンなし）
+        )
+        row = result.fetchone()
+        return row[0] if row else None
+
+
+async def _get_outbox_row(
+    session_factory: async_sessionmaker[AsyncSession],
+    event_id: UUID,
+) -> OutboxRow | None:
+    """DB から OutboxRow を取得する。"""
+    async with session_factory() as session:
+        return await session.get(OutboxRow, str(event_id))
+
+
+# ---------------------------------------------------------------------------
+# TC-ST-AC-001 + TC-IT-AC-001: list_blocked_tasks — 正常系
+# ---------------------------------------------------------------------------
+
+
+class TestListBlockedTasks:
+    """TC-ST-AC-001 / TC-IT-AC-001: list_blocked_tasks() の正常系テスト。"""
+
+    async def test_returns_only_blocked_tasks(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_task_ctx: tuple[UUID, UUID],
+    ) -> None:
+        """TC-ST-AC-001 / TC-IT-AC-001: BLOCKED×3 + IN_PROGRESS×1 → 3件の BlockedTaskSummary。
+
+        受入基準 #11 検証。
+        """
+        room_id, directive_id = seeded_task_ctx
+
+        b1 = make_blocked_task(room_id=room_id, directive_id=directive_id, last_error="error 1")
+        b2 = make_blocked_task(room_id=room_id, directive_id=directive_id, last_error="error 2")
+        b3 = make_blocked_task(room_id=room_id, directive_id=directive_id, last_error="error 3")
+        ip = make_in_progress_task(room_id=room_id, directive_id=directive_id)
+
+        async with session_factory() as session, session.begin():
+            repo = SqliteTaskRepository(session)
+            await repo.save(b1)
+            await repo.save(b2)
+            await repo.save(b3)
+            await repo.save(ip)
+
+        async with session_factory() as session, session.begin():
+            service = _make_admin_service(session)
+            result = await service.list_blocked_tasks()
+
+        assert len(result) == 3
+        returned_ids = {s.task_id for s in result}
+        assert b1.id in returned_ids
+        assert b2.id in returned_ids
+        assert b3.id in returned_ids
+        assert ip.id not in returned_ids
+
+        # BlockedTaskSummary フィールド確認
+        first = next(s for s in result if s.task_id == b1.id)
+        assert first.room_id == room_id
+        assert "error 1" in first.last_error
+        assert isinstance(first.blocked_at, datetime)
+
+    async def test_returns_empty_list_when_no_blocked(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_task_ctx: tuple[UUID, UUID],
+    ) -> None:
+        """TC-ST-AC-010 / TC-IT-AC-013: BLOCKED 0件 → [] + audit_log OK。"""
+        room_id, directive_id = seeded_task_ctx
+        ip = make_in_progress_task(room_id=room_id, directive_id=directive_id)
+
+        async with session_factory() as session, session.begin():
+            await SqliteTaskRepository(session).save(ip)
+
+        async with session_factory() as session, session.begin():
+            service = _make_admin_service(session)
+            result = await service.list_blocked_tasks()
+
+        assert result == []
+
+        audit = await _get_last_audit_log(session_factory)
+        assert audit is not None
+        assert audit.command == "list-blocked"
+        assert audit.result == "OK"
+
+    async def test_audit_log_recorded_with_ok(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """TC-ST-AC-009: 空 DB で list_blocked → audit_log に OK が記録される（受入基準 #14）。"""
+        async with session_factory() as session, session.begin():
+            service = _make_admin_service(session, actor="ceo_user")
+            result = await service.list_blocked_tasks()
+
+        assert result == []
+
+        audit = await _get_last_audit_log(session_factory)
+        assert audit is not None
+        assert audit.command == "list-blocked"
+        assert audit.result == "OK"
+        assert audit.actor == "ceo_user"
+        assert audit.error_text is None
+
+
+# ---------------------------------------------------------------------------
+# TC-ST-AC-002/003 + TC-IT-AC-002~004: retry_task
+# ---------------------------------------------------------------------------
+
+
+class TestRetryTask:
+    """TC-ST-AC-002/003 + TC-IT-AC-002~004: retry_task() テスト。"""
+
+    async def test_retry_blocked_task_to_in_progress(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_task_ctx: tuple[UUID, UUID],
+    ) -> None:
+        """TC-ST-AC-002 / TC-IT-AC-002: BLOCKED → IN_PROGRESS + audit_log OK（受入基準 #12 / #14）。"""
+        room_id, directive_id = seeded_task_ctx
+        blocked = make_blocked_task(room_id=room_id, directive_id=directive_id)
+
+        async with session_factory() as session, session.begin():
+            await SqliteTaskRepository(session).save(blocked)
+
+        async with session_factory() as session, session.begin():
+            service = _make_admin_service(session)
+            await service.retry_task(blocked.id)
+
+        # DB 確認: status が IN_PROGRESS に変わっている
+        status = await _get_task_status(session_factory, blocked.id)
+        assert status == "IN_PROGRESS"
+
+        # audit_log 確認（受入基準 #14）
+        audit = await _get_last_audit_log(session_factory)
+        assert audit is not None
+        assert audit.command == "retry-task"
+        assert audit.result == "OK"
+        assert audit.error_text is None
+
+    async def test_retry_task_not_found_raises_and_audit_fail(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """TC-IT-AC-003: 存在しない task_id → TaskNotFoundError + audit_log FAIL。"""
+        nonexistent_id = uuid4()
+
+        caught_exc: TaskNotFoundError | None = None
+        async with session_factory() as session, session.begin():
+            service = _make_admin_service(session)
+            try:
+                await service.retry_task(nonexistent_id)
+            except TaskNotFoundError as exc:
+                caught_exc = exc
+
+        assert caught_exc is not None, "TaskNotFoundError が送出されるべき"
+        assert str(nonexistent_id) in str(caught_exc)
+
+        audit = await _get_last_audit_log(session_factory)
+        assert audit is not None
+        assert audit.command == "retry-task"
+        assert audit.result == "FAIL"
+
+    async def test_retry_non_blocked_task_raises_and_audit_fail(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_task_ctx: tuple[UUID, UUID],
+    ) -> None:
+        """TC-ST-AC-003 / TC-IT-AC-004: 非BLOCKED → IllegalTaskStateError + audit_log FAIL（§確定B/R1-2）。"""
+        room_id, directive_id = seeded_task_ctx
+        ip = make_in_progress_task(room_id=room_id, directive_id=directive_id)
+
+        async with session_factory() as session, session.begin():
+            await SqliteTaskRepository(session).save(ip)
+
+        caught_exc: IllegalTaskStateError | None = None
+        async with session_factory() as session, session.begin():
+            service = _make_admin_service(session)
+            try:
+                await service.retry_task(ip.id)
+            except IllegalTaskStateError as exc:
+                caught_exc = exc
+
+        assert caught_exc is not None
+        # メッセージに BLOCKED キーワードが含まれる（MSG-AC-002）
+        assert "BLOCKED" in str(caught_exc)
+
+        audit = await _get_last_audit_log(session_factory)
+        assert audit is not None
+        assert audit.command == "retry-task"
+        assert audit.result == "FAIL"
+
+
+# ---------------------------------------------------------------------------
+# TC-ST-AC-004/005 + TC-IT-AC-005~008: cancel_task
+# ---------------------------------------------------------------------------
+
+
+class TestCancelTask:
+    """TC-ST-AC-004/005 + TC-IT-AC-005~008: cancel_task() テスト。"""
+
+    async def test_cancel_blocked_task_succeeds(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_task_ctx: tuple[UUID, UUID],
+    ) -> None:
+        """TC-ST-AC-004 / TC-IT-AC-005: BLOCKED → CANCELLED + audit_log OK（受入基準 #12b）。"""
+        room_id, directive_id = seeded_task_ctx
+        blocked = make_blocked_task(room_id=room_id, directive_id=directive_id)
+
+        async with session_factory() as session, session.begin():
+            await SqliteTaskRepository(session).save(blocked)
+
+        async with session_factory() as session, session.begin():
+            service = _make_admin_service(session)
+            await service.cancel_task(blocked.id, reason="admin cancel")
+
+        status = await _get_task_status(session_factory, blocked.id)
+        assert status == "CANCELLED"
+
+        audit = await _get_last_audit_log(session_factory)
+        assert audit is not None
+        assert audit.command == "cancel-task"
+        assert audit.result == "OK"
+
+    async def test_cancel_in_progress_task_succeeds(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_task_ctx: tuple[UUID, UUID],
+    ) -> None:
+        """TC-IT-AC-006: IN_PROGRESS → CANCELLED + audit_log OK（R1-3 正常系）。"""
+        room_id, directive_id = seeded_task_ctx
+        ip = make_in_progress_task(room_id=room_id, directive_id=directive_id)
+
+        async with session_factory() as session, session.begin():
+            await SqliteTaskRepository(session).save(ip)
+
+        async with session_factory() as session, session.begin():
+            service = _make_admin_service(session)
+            await service.cancel_task(ip.id, reason="admin cancel in_progress")
+
+        status = await _get_task_status(session_factory, ip.id)
+        assert status == "CANCELLED"
+
+        audit = await _get_last_audit_log(session_factory)
+        assert audit is not None
+        assert audit.result == "OK"
+
+    async def test_cancel_awaiting_external_review_raises(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_task_ctx: tuple[UUID, UUID],
+    ) -> None:
+        """TC-ST-AC-005 / TC-IT-AC-007: AWAITING_EXTERNAL_REVIEW → IllegalTaskStateError + FAIL（R1-3）。"""
+        room_id, directive_id = seeded_task_ctx
+        ar = make_awaiting_review_task(room_id=room_id, directive_id=directive_id)
+
+        async with session_factory() as session, session.begin():
+            await SqliteTaskRepository(session).save(ar)
+
+        caught_exc: IllegalTaskStateError | None = None
+        async with session_factory() as session, session.begin():
+            service = _make_admin_service(session)
+            try:
+                await service.cancel_task(ar.id, reason="test")
+            except IllegalTaskStateError as exc:
+                caught_exc = exc
+
+        assert caught_exc is not None
+
+        audit = await _get_last_audit_log(session_factory)
+        assert audit is not None
+        assert audit.command == "cancel-task"
+        assert audit.result == "FAIL"
+
+    async def test_cancel_done_task_raises(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_task_ctx: tuple[UUID, UUID],
+    ) -> None:
+        """TC-IT-AC-008: DONE → IllegalTaskStateError + audit_log FAIL（R1-3）。"""
+        room_id, directive_id = seeded_task_ctx
+        done = make_done_task(room_id=room_id, directive_id=directive_id)
+
+        async with session_factory() as session, session.begin():
+            await SqliteTaskRepository(session).save(done)
+
+        caught_exc: IllegalTaskStateError | None = None
+        async with session_factory() as session, session.begin():
+            service = _make_admin_service(session)
+            try:
+                await service.cancel_task(done.id, reason="test")
+            except IllegalTaskStateError as exc:
+                caught_exc = exc
+
+        assert caught_exc is not None
+
+        audit = await _get_last_audit_log(session_factory)
+        assert audit is not None
+        assert audit.result == "FAIL"
+
+
+# ---------------------------------------------------------------------------
+# TC-ST-AC-006 + TC-IT-AC-009: list_dead_letters
+# ---------------------------------------------------------------------------
+
+
+class TestListDeadLetters:
+    """TC-ST-AC-006 + TC-IT-AC-009: list_dead_letters() テスト。"""
+
+    async def test_returns_only_dead_letters(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """TC-ST-AC-006 / TC-IT-AC-009: DEAD_LETTER×2 + PENDING×1 → 2件（受入基準 #13a）。"""
+        dl1 = make_outbox_row(status="DEAD_LETTER", attempt_count=3, last_error="timeout")
+        dl2 = make_outbox_row(status="DEAD_LETTER", attempt_count=5, last_error="connection error")
+        pending = make_outbox_row(status="PENDING")
+
+        async with session_factory() as session, session.begin():
+            session.add(dl1)
+            session.add(dl2)
+            session.add(pending)
+
+        async with session_factory() as session, session.begin():
+            service = _make_admin_service(session)
+            result = await service.list_dead_letters()
+
+        assert len(result) == 2
+        returned_ids = {s.event_id for s in result}
+        assert dl1.event_id in returned_ids
+        assert dl2.event_id in returned_ids
+        assert pending.event_id not in returned_ids
+
+        # フィールド確認
+        s1 = next(s for s in result if s.event_id == dl1.event_id)
+        assert s1.attempt_count == 3
+        assert s1.last_error == "timeout"
+
+    async def test_audit_log_recorded_for_list_dead_letters(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """list_dead_letters 後に audit_log OK が記録される（受入基準 #14）。"""
+        async with session_factory() as session, session.begin():
+            service = _make_admin_service(session)
+            await service.list_dead_letters()
+
+        audit = await _get_last_audit_log(session_factory)
+        assert audit is not None
+        assert audit.command == "list-dead-letters"
+        assert audit.result == "OK"
+
+
+# ---------------------------------------------------------------------------
+# TC-ST-AC-007/008 + TC-IT-AC-010~012: retry_event
+# ---------------------------------------------------------------------------
+
+
+class TestRetryEvent:
+    """TC-ST-AC-007/008 + TC-IT-AC-010~012: retry_event() テスト。"""
+
+    async def test_reset_dead_letter_to_pending(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """TC-ST-AC-007 / TC-IT-AC-010: DEAD_LETTER → PENDING + attempt_count=0 + audit_log OK（受入基準 #13b）。"""
+        dl = make_outbox_row(status="DEAD_LETTER", attempt_count=5)
+
+        async with session_factory() as session, session.begin():
+            session.add(dl)
+
+        before = datetime.now(UTC)
+
+        async with session_factory() as session, session.begin():
+            service = _make_admin_service(session)
+            await service.retry_event(dl.event_id)
+
+        after = datetime.now(UTC)
+
+        # DB 確認
+        row = await _get_outbox_row(session_factory, dl.event_id)
+        assert row is not None
+        assert row.status == "PENDING"
+        assert row.attempt_count == 0
+        # next_attempt_at が now(UTC) 付近に設定される
+        assert before <= row.next_attempt_at <= after
+
+        # audit_log 確認
+        audit = await _get_last_audit_log(session_factory)
+        assert audit is not None
+        assert audit.command == "retry-event"
+        assert audit.result == "OK"
+        assert audit.error_text is None
+
+    async def test_retry_event_not_found_raises_and_audit_fail(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """TC-IT-AC-011: 存在しない event_id → OutboxEventNotFoundError + audit_log FAIL。"""
+        nonexistent_id = uuid4()
+
+        caught_exc: OutboxEventNotFoundError | None = None
+        async with session_factory() as session, session.begin():
+            service = _make_admin_service(session)
+            try:
+                await service.retry_event(nonexistent_id)
+            except OutboxEventNotFoundError as exc:
+                caught_exc = exc
+
+        assert caught_exc is not None
+        assert "[FAIL]" in str(caught_exc)
+
+        audit = await _get_last_audit_log(session_factory)
+        assert audit is not None
+        assert audit.command == "retry-event"
+        assert audit.result == "FAIL"
+
+    async def test_retry_event_not_dead_letter_raises_and_audit_fail(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """TC-ST-AC-008 / TC-IT-AC-012: 非DEAD_LETTER → IllegalOutboxStateError + audit_log FAIL（§確定C/R1-5）。"""
+        pending = make_outbox_row(status="PENDING")
+
+        async with session_factory() as session, session.begin():
+            session.add(pending)
+
+        caught_exc: IllegalOutboxStateError | None = None
+        async with session_factory() as session, session.begin():
+            service = _make_admin_service(session)
+            try:
+                await service.retry_event(pending.event_id)
+            except IllegalOutboxStateError as exc:
+                caught_exc = exc
+
+        assert caught_exc is not None
+        assert "DEAD_LETTER" in str(caught_exc)
+
+        audit = await _get_last_audit_log(session_factory)
+        assert audit is not None
+        assert audit.command == "retry-event"
+        assert audit.result == "FAIL"

--- a/backend/tests/integration/test_admin_service.py
+++ b/backend/tests/integration/test_admin_service.py
@@ -136,14 +136,18 @@ async def seeded_task_ctx(
 
 
 def _make_admin_service(
-    session: AsyncSession,
+    session_factory: async_sessionmaker[AsyncSession],
     actor: str = "test_actor",
 ) -> AdminService:
-    """AdminService を組み立てる（実 SQLite 実装クラス経由）。"""
+    """AdminService を組み立てる（Option A: session_factory 注入）。
+
+    業務 Tx と audit_log Tx は AdminService 内部で独立して管理される。
+    """
     return AdminService(
-        task_repo=SqliteTaskRepository(session),
-        outbox_event_repo=SqliteOutboxEventRepository(session),
-        audit_log_writer=SqliteAuditLogWriter(session),
+        session_factory=session_factory,
+        task_repo_factory=SqliteTaskRepository,
+        outbox_event_repo_factory=SqliteOutboxEventRepository,
+        audit_log_writer_factory=SqliteAuditLogWriter,
         actor=actor,
     )
 
@@ -217,9 +221,8 @@ class TestListBlockedTasks:
             await repo.save(b3)
             await repo.save(ip)
 
-        async with session_factory() as session, session.begin():
-            service = _make_admin_service(session)
-            result = await service.list_blocked_tasks()
+        service = _make_admin_service(session_factory)
+        result = await service.list_blocked_tasks()
 
         assert len(result) == 3
         returned_ids = {s.task_id for s in result}
@@ -246,9 +249,8 @@ class TestListBlockedTasks:
         async with session_factory() as session, session.begin():
             await SqliteTaskRepository(session).save(ip)
 
-        async with session_factory() as session, session.begin():
-            service = _make_admin_service(session)
-            result = await service.list_blocked_tasks()
+        service = _make_admin_service(session_factory)
+        result = await service.list_blocked_tasks()
 
         assert result == []
 
@@ -262,9 +264,8 @@ class TestListBlockedTasks:
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
         """TC-ST-AC-009: 空 DB で list_blocked → audit_log に OK が記録される（受入基準 #14）。"""
-        async with session_factory() as session, session.begin():
-            service = _make_admin_service(session, actor="ceo_user")
-            result = await service.list_blocked_tasks()
+        service = _make_admin_service(session_factory, actor="ceo_user")
+        result = await service.list_blocked_tasks()
 
         assert result == []
 
@@ -296,9 +297,8 @@ class TestRetryTask:
         async with session_factory() as session, session.begin():
             await SqliteTaskRepository(session).save(blocked)
 
-        async with session_factory() as session, session.begin():
-            service = _make_admin_service(session)
-            await service.retry_task(blocked.id)
+        service = _make_admin_service(session_factory)
+        await service.retry_task(blocked.id)
 
         # DB 確認: status が IN_PROGRESS に変わっている
         status = await _get_task_status(session_factory, blocked.id)
@@ -318,16 +318,11 @@ class TestRetryTask:
         """TC-IT-AC-003: 存在しない task_id → TaskNotFoundError + audit_log FAIL。"""
         nonexistent_id = uuid4()
 
-        caught_exc: TaskNotFoundError | None = None
-        async with session_factory() as session, session.begin():
-            service = _make_admin_service(session)
-            try:
-                await service.retry_task(nonexistent_id)
-            except TaskNotFoundError as exc:
-                caught_exc = exc
+        service = _make_admin_service(session_factory)
+        with pytest.raises(TaskNotFoundError) as exc_info:
+            await service.retry_task(nonexistent_id)
 
-        assert caught_exc is not None, "TaskNotFoundError が送出されるべき"
-        assert str(nonexistent_id) in str(caught_exc)
+        assert str(nonexistent_id) in str(exc_info.value)
 
         audit = await _get_last_audit_log(session_factory)
         assert audit is not None
@@ -346,17 +341,12 @@ class TestRetryTask:
         async with session_factory() as session, session.begin():
             await SqliteTaskRepository(session).save(ip)
 
-        caught_exc: IllegalTaskStateError | None = None
-        async with session_factory() as session, session.begin():
-            service = _make_admin_service(session)
-            try:
-                await service.retry_task(ip.id)
-            except IllegalTaskStateError as exc:
-                caught_exc = exc
+        service = _make_admin_service(session_factory)
+        with pytest.raises(IllegalTaskStateError) as exc_info:
+            await service.retry_task(ip.id)
 
-        assert caught_exc is not None
         # メッセージに BLOCKED キーワードが含まれる（MSG-AC-002）
-        assert "BLOCKED" in str(caught_exc)
+        assert "BLOCKED" in str(exc_info.value)
 
         audit = await _get_last_audit_log(session_factory)
         assert audit is not None
@@ -384,9 +374,8 @@ class TestCancelTask:
         async with session_factory() as session, session.begin():
             await SqliteTaskRepository(session).save(blocked)
 
-        async with session_factory() as session, session.begin():
-            service = _make_admin_service(session)
-            await service.cancel_task(blocked.id, reason="admin cancel")
+        service = _make_admin_service(session_factory)
+        await service.cancel_task(blocked.id, reason="admin cancel")
 
         status = await _get_task_status(session_factory, blocked.id)
         assert status == "CANCELLED"
@@ -408,9 +397,8 @@ class TestCancelTask:
         async with session_factory() as session, session.begin():
             await SqliteTaskRepository(session).save(ip)
 
-        async with session_factory() as session, session.begin():
-            service = _make_admin_service(session)
-            await service.cancel_task(ip.id, reason="admin cancel in_progress")
+        service = _make_admin_service(session_factory)
+        await service.cancel_task(ip.id, reason="admin cancel in_progress")
 
         status = await _get_task_status(session_factory, ip.id)
         assert status == "CANCELLED"
@@ -431,15 +419,9 @@ class TestCancelTask:
         async with session_factory() as session, session.begin():
             await SqliteTaskRepository(session).save(ar)
 
-        caught_exc: IllegalTaskStateError | None = None
-        async with session_factory() as session, session.begin():
-            service = _make_admin_service(session)
-            try:
-                await service.cancel_task(ar.id, reason="test")
-            except IllegalTaskStateError as exc:
-                caught_exc = exc
-
-        assert caught_exc is not None
+        service = _make_admin_service(session_factory)
+        with pytest.raises(IllegalTaskStateError):
+            await service.cancel_task(ar.id, reason="test")
 
         audit = await _get_last_audit_log(session_factory)
         assert audit is not None
@@ -458,15 +440,9 @@ class TestCancelTask:
         async with session_factory() as session, session.begin():
             await SqliteTaskRepository(session).save(done)
 
-        caught_exc: IllegalTaskStateError | None = None
-        async with session_factory() as session, session.begin():
-            service = _make_admin_service(session)
-            try:
-                await service.cancel_task(done.id, reason="test")
-            except IllegalTaskStateError as exc:
-                caught_exc = exc
-
-        assert caught_exc is not None
+        service = _make_admin_service(session_factory)
+        with pytest.raises(IllegalTaskStateError):
+            await service.cancel_task(done.id, reason="test")
 
         audit = await _get_last_audit_log(session_factory)
         assert audit is not None
@@ -495,9 +471,8 @@ class TestListDeadLetters:
             session.add(dl2)
             session.add(pending)
 
-        async with session_factory() as session, session.begin():
-            service = _make_admin_service(session)
-            result = await service.list_dead_letters()
+        service = _make_admin_service(session_factory)
+        result = await service.list_dead_letters()
 
         assert len(result) == 2
         returned_ids = {s.event_id for s in result}
@@ -515,9 +490,8 @@ class TestListDeadLetters:
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
         """list_dead_letters 後に audit_log OK が記録される（受入基準 #14）。"""
-        async with session_factory() as session, session.begin():
-            service = _make_admin_service(session)
-            await service.list_dead_letters()
+        service = _make_admin_service(session_factory)
+        await service.list_dead_letters()
 
         audit = await _get_last_audit_log(session_factory)
         assert audit is not None
@@ -545,9 +519,8 @@ class TestRetryEvent:
 
         before = datetime.now(UTC)
 
-        async with session_factory() as session, session.begin():
-            service = _make_admin_service(session)
-            await service.retry_event(dl.event_id)
+        service = _make_admin_service(session_factory)
+        await service.retry_event(dl.event_id)
 
         after = datetime.now(UTC)
 
@@ -573,16 +546,11 @@ class TestRetryEvent:
         """TC-IT-AC-011: 存在しない event_id → OutboxEventNotFoundError + audit_log FAIL。"""
         nonexistent_id = uuid4()
 
-        caught_exc: OutboxEventNotFoundError | None = None
-        async with session_factory() as session, session.begin():
-            service = _make_admin_service(session)
-            try:
-                await service.retry_event(nonexistent_id)
-            except OutboxEventNotFoundError as exc:
-                caught_exc = exc
+        service = _make_admin_service(session_factory)
+        with pytest.raises(OutboxEventNotFoundError) as exc_info:
+            await service.retry_event(nonexistent_id)
 
-        assert caught_exc is not None
-        assert "[FAIL]" in str(caught_exc)
+        assert "[FAIL]" in str(exc_info.value)
 
         audit = await _get_last_audit_log(session_factory)
         assert audit is not None
@@ -599,16 +567,11 @@ class TestRetryEvent:
         async with session_factory() as session, session.begin():
             session.add(pending)
 
-        caught_exc: IllegalOutboxStateError | None = None
-        async with session_factory() as session, session.begin():
-            service = _make_admin_service(session)
-            try:
-                await service.retry_event(pending.event_id)
-            except IllegalOutboxStateError as exc:
-                caught_exc = exc
+        service = _make_admin_service(session_factory)
+        with pytest.raises(IllegalOutboxStateError) as exc_info:
+            await service.retry_event(pending.event_id)
 
-        assert caught_exc is not None
-        assert "DEAD_LETTER" in str(caught_exc)
+        assert "DEAD_LETTER" in str(exc_info.value)
 
         audit = await _get_last_audit_log(session_factory)
         assert audit is not None

--- a/backend/tests/integration/test_stage_worker_recovery.py
+++ b/backend/tests/integration/test_stage_worker_recovery.py
@@ -1,0 +1,233 @@
+"""StageWorker 起動時リカバリスキャン 結合テスト（§確定 J）。
+
+設計書: docs/features/admin-cli/application/test-design.md
+      docs/features/stage-executor/application/detailed-design.md §確定 J
+
+テスト戦略:
+  - StageWorker._recovery_scan() に実 SQLite session_factory を渡す
+  - IN_PROGRESS Task → Queue に投入される
+  - 他ステータス（PENDING / BLOCKED / DONE）は Queue に投入されない
+  - LLM / EventBus は MagicMock（_recovery_scan はこれらを使わない）
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from bakufu.domain.value_objects import TaskId, TaskStatus
+from bakufu.infrastructure.persistence.sqlite.repositories.task_repository import (
+    SqliteTaskRepository,
+)
+from bakufu.infrastructure.worker.stage_worker import StageWorker
+
+from tests.factories.db import create_all_tables, make_test_engine, make_test_session_factory
+from tests.factories.directive import make_directive
+from tests.factories.empire import make_empire
+from tests.factories.room import make_room
+from tests.factories.task import (
+    make_blocked_task,
+    make_done_task,
+    make_in_progress_task,
+    make_task,
+)
+from tests.factories.workflow import make_workflow
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _init_masking(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in (
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "GEMINI_API_KEY",
+        "GH_TOKEN",
+        "GITHUB_TOKEN",
+        "OAUTH_CLIENT_SECRET",
+        "BAKUFU_DISCORD_BOT_TOKEN",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    from bakufu.infrastructure.security import masking
+
+    masking.init()
+
+
+@pytest.fixture(autouse=True)
+def _bakufu_data_dir(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BAKUFU_DATA_DIR", "/tmp/bakufu-recovery-test")
+
+
+@pytest_asyncio.fixture
+async def session_factory(
+    tmp_path: Path,
+) -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = make_test_engine(tmp_path / "recovery_test.db")
+    await create_all_tables(engine)
+    sf = make_test_session_factory(engine)
+    try:
+        yield sf
+    finally:
+        await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def seeded_task_ctx(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> tuple[UUID, UUID]:
+    """empire → workflow → room → directive をシードして (room_id, directive_id) を返す。"""
+    from bakufu.infrastructure.persistence.sqlite.repositories.directive_repository import (
+        SqliteDirectiveRepository,
+    )
+    from bakufu.infrastructure.persistence.sqlite.repositories.empire_repository import (
+        SqliteEmpireRepository,
+    )
+    from bakufu.infrastructure.persistence.sqlite.repositories.room_repository import (
+        SqliteRoomRepository,
+    )
+    from bakufu.infrastructure.persistence.sqlite.repositories.workflow_repository import (
+        SqliteWorkflowRepository,
+    )
+
+    empire = make_empire()
+    workflow = make_workflow()
+    room = make_room(workflow_id=workflow.id)
+    directive = make_directive(target_room_id=room.id)
+
+    async with session_factory() as session, session.begin():
+        await SqliteEmpireRepository(session).save(empire)
+    async with session_factory() as session, session.begin():
+        await SqliteWorkflowRepository(session).save(workflow)
+    async with session_factory() as session, session.begin():
+        await SqliteRoomRepository(session).save(room, empire.id)
+    async with session_factory() as session, session.begin():
+        await SqliteDirectiveRepository(session).save(directive)
+
+    return room.id, directive.id
+
+
+def _make_stage_worker(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> StageWorker:
+    """LLM / EventBus を MagicMock とした StageWorker を構築する。"""
+    return StageWorker(
+        session_factory=session_factory,
+        llm_provider=MagicMock(),
+        event_bus=MagicMock(),
+        max_concurrent=1,
+    )
+
+
+# ---------------------------------------------------------------------------
+# TC-J-001: IN_PROGRESS Task が Queue に再投入される（§確定 J）
+# ---------------------------------------------------------------------------
+
+
+class TestRecoveryScan:
+    """StageWorker._recovery_scan() の §確定 J テスト。"""
+
+    async def test_in_progress_tasks_enqueued_on_recovery(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_task_ctx: tuple[UUID, UUID],
+    ) -> None:
+        """§確定 J: IN_PROGRESS × 2 + PENDING × 1 → 2件が Queue に投入される。
+
+        admin-cli の retry-task (BLOCKED → IN_PROGRESS) 後にサーバーが再起動した場合、
+        StageWorker 起動時に IN_PROGRESS Task が自動的にピックアップされる。
+        """
+        room_id, directive_id = seeded_task_ctx
+
+        ip1 = make_in_progress_task(room_id=room_id, directive_id=directive_id)
+        ip2 = make_in_progress_task(room_id=room_id, directive_id=directive_id)
+        pending = make_task(
+            room_id=room_id, directive_id=directive_id, status=TaskStatus.PENDING
+        )
+
+        async with session_factory() as session, session.begin():
+            repo = SqliteTaskRepository(session)
+            await repo.save(ip1)
+            await repo.save(ip2)
+            await repo.save(pending)
+
+        worker = _make_stage_worker(session_factory)
+
+        # _recovery_scan を直接呼び出す（start() は asyncio.create_task を使うためここでは不要）
+        await worker._recovery_scan()
+
+        # Queue に 2 件の IN_PROGRESS Task が投入されている
+        assert worker._queue.qsize() == 2
+
+        queued_items = []
+        while not worker._queue.empty():
+            queued_items.append(worker._queue.get_nowait())
+
+        queued_task_ids = {item[0] for item in queued_items if item is not None}
+        assert ip1.id in queued_task_ids
+        assert ip2.id in queued_task_ids
+        # PENDING Task は投入されていない
+        assert pending.id not in queued_task_ids
+
+    async def test_no_in_progress_tasks_queue_stays_empty(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_task_ctx: tuple[UUID, UUID],
+    ) -> None:
+        """§確定 J: IN_PROGRESS 0件 → Queue は空のまま（ログ出力のみ）。"""
+        room_id, directive_id = seeded_task_ctx
+
+        pending = make_task(room_id=room_id, directive_id=directive_id)
+        blocked = make_blocked_task(room_id=room_id, directive_id=directive_id)
+
+        async with session_factory() as session, session.begin():
+            repo = SqliteTaskRepository(session)
+            await repo.save(pending)
+            await repo.save(blocked)
+
+        worker = _make_stage_worker(session_factory)
+        await worker._recovery_scan()
+
+        assert worker._queue.qsize() == 0
+
+    async def test_stage_id_enqueued_with_task_id(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        seeded_task_ctx: tuple[UUID, UUID],
+    ) -> None:
+        """§確定 J: キューアイテムが (task_id, current_stage_id) タプルで投入される。"""
+        room_id, directive_id = seeded_task_ctx
+        ip = make_in_progress_task(room_id=room_id, directive_id=directive_id)
+
+        async with session_factory() as session, session.begin():
+            await SqliteTaskRepository(session).save(ip)
+
+        worker = _make_stage_worker(session_factory)
+        await worker._recovery_scan()
+
+        assert worker._queue.qsize() == 1
+        item = worker._queue.get_nowait()
+        assert item is not None
+        task_id, stage_id = item
+        assert task_id == ip.id
+        assert stage_id == ip.current_stage_id
+
+    async def test_recovery_scan_is_idempotent_on_empty_db(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """§確定 J: 空 DB での _recovery_scan は例外を発生させない（冪等性）。"""
+        worker = _make_stage_worker(session_factory)
+        # 例外なく完了することを確認
+        await worker._recovery_scan()
+        assert worker._queue.qsize() == 0

--- a/backend/tests/unit/test_admin_cli_formatter.py
+++ b/backend/tests/unit/test_admin_cli_formatter.py
@@ -1,0 +1,311 @@
+"""admin-cli OutputFormatter ユニットテスト（TC-UT-AC-CLI-001〜012）。
+
+設計書: docs/features/admin-cli/cli/test-design.md §ユニットテストケース
+
+OutputFormatter の各関数を直接呼び出し、出力文字列の正確性を確認する。
+非同期処理なし（同期テスト）。
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from bakufu.application.services.admin_service import BlockedTaskSummary, DeadLetterSummary
+from bakufu.interfaces.cli import formatters
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_blocked_summary(
+    *,
+    task_id=None,
+    room_id=None,
+    last_error: str = "test error",
+) -> BlockedTaskSummary:
+    return BlockedTaskSummary(
+        task_id=task_id or uuid4(),
+        room_id=room_id or uuid4(),
+        last_error=last_error,
+        blocked_at=datetime.now(UTC),
+    )
+
+
+def _make_dead_letter_summary(
+    *,
+    event_id=None,
+    event_kind: str = "TaskEventEmitted",
+    attempt_count: int = 3,
+    last_error: str | None = "dispatch failed",
+) -> DeadLetterSummary:
+    return DeadLetterSummary(
+        event_id=event_id or uuid4(),
+        event_kind=event_kind,
+        aggregate_id=uuid4(),
+        attempt_count=attempt_count,
+        last_error=last_error,
+        updated_at=datetime.now(UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-AC-CLI-001: format_blocked_tasks — テーブル形式
+# ---------------------------------------------------------------------------
+
+
+class TestFormatBlockedTasksTable:
+    """TC-UT-AC-CLI-001: format_blocked_tasks() テーブル形式の正常系。"""
+
+    def test_table_format_contains_task_id_header(self) -> None:
+        """TC-UT-AC-CLI-001: BlockedTaskSummary 1件 → 文字列に "TASK ID" カラムヘッダが含まれる。"""
+        task = _make_blocked_summary()
+        output = formatters.format_blocked_tasks([task], json_output=False)
+        assert "TASK ID" in output
+        assert str(task.task_id) in output
+
+    def test_table_format_contains_room_id(self) -> None:
+        """テーブル形式に ROOM ID カラムが含まれる。"""
+        task = _make_blocked_summary()
+        output = formatters.format_blocked_tasks([task], json_output=False)
+        assert str(task.room_id) in output
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-AC-CLI-002: format_blocked_tasks — JSON 形式
+# ---------------------------------------------------------------------------
+
+
+class TestFormatBlockedTasksJson:
+    """TC-UT-AC-CLI-002: format_blocked_tasks() JSON 形式の正常系。"""
+
+    def test_json_format_is_valid_array(self) -> None:
+        """TC-UT-AC-CLI-002: BlockedTaskSummary 1件 → JSON 配列として valid。"""
+        task = _make_blocked_summary()
+        output = formatters.format_blocked_tasks([task], json_output=True)
+        data = json.loads(output)
+        assert isinstance(data, list)
+        assert len(data) == 1
+
+    def test_json_format_contains_required_fields(self) -> None:
+        """TC-UT-AC-CLI-002: JSON に task_id / room_id / blocked_at / last_error の4フィールドが存在する。"""
+        task = _make_blocked_summary()
+        output = formatters.format_blocked_tasks([task], json_output=True)
+        item = json.loads(output)[0]
+        assert "task_id" in item
+        assert "room_id" in item
+        assert "blocked_at" in item
+        assert "last_error" in item
+
+    def test_json_format_task_id_matches(self) -> None:
+        """JSON の task_id が入力の task_id と一致する。"""
+        task = _make_blocked_summary()
+        output = formatters.format_blocked_tasks([task], json_output=True)
+        item = json.loads(output)[0]
+        assert item["task_id"] == str(task.task_id)
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-AC-CLI-003: format_blocked_tasks — 0件テーブル
+# ---------------------------------------------------------------------------
+
+
+class TestFormatBlockedTasksEmpty:
+    """TC-UT-AC-CLI-003: format_blocked_tasks() 0件時の境界値。"""
+
+    def test_empty_list_table_format_shows_no_task_message(self) -> None:
+        """TC-UT-AC-CLI-003: 空リスト → "BLOCKED Task はありません" が含まれる。"""
+        output = formatters.format_blocked_tasks([], json_output=False)
+        assert "BLOCKED Task はありません" in output
+
+    def test_empty_list_json_format_is_empty_array(self) -> None:
+        """0件 JSON → "[]" に等しい。"""
+        output = formatters.format_blocked_tasks([], json_output=True)
+        data = json.loads(output)
+        assert data == []
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-AC-CLI-004: format_dead_letters — テーブル形式
+# ---------------------------------------------------------------------------
+
+
+class TestFormatDeadLettersTable:
+    """TC-UT-AC-CLI-004: format_dead_letters() テーブル形式の正常系。"""
+
+    def test_table_format_contains_event_id_and_kind_headers(self) -> None:
+        """TC-UT-AC-CLI-004: DeadLetterSummary 1件 → "EVENT ID" / "KIND" カラムヘッダが含まれる。"""
+        event = _make_dead_letter_summary()
+        output = formatters.format_dead_letters([event], json_output=False)
+        assert "EVENT ID" in output
+        assert "KIND" in output
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-AC-CLI-005: format_dead_letters — JSON 形式
+# ---------------------------------------------------------------------------
+
+
+class TestFormatDeadLettersJson:
+    """TC-UT-AC-CLI-005: format_dead_letters() JSON 形式の正常系。"""
+
+    def test_json_format_is_valid_array(self) -> None:
+        """TC-UT-AC-CLI-005: DeadLetterSummary 1件 → JSON 配列として valid。"""
+        event = _make_dead_letter_summary()
+        output = formatters.format_dead_letters([event], json_output=True)
+        data = json.loads(output)
+        assert isinstance(data, list)
+
+    def test_json_format_contains_required_fields(self) -> None:
+        """TC-UT-AC-CLI-005: JSON に 6 フィールドが全て存在する。"""
+        event = _make_dead_letter_summary()
+        output = formatters.format_dead_letters([event], json_output=True)
+        item = json.loads(output)[0]
+        for field in ("event_id", "event_kind", "aggregate_id", "attempt_count", "last_error", "updated_at"):
+            assert field in item, f"フィールド '{field}' が JSON に存在しない"
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-AC-CLI-006: format_dead_letters — 0件 JSON
+# ---------------------------------------------------------------------------
+
+
+class TestFormatDeadLettersEmpty:
+    """TC-UT-AC-CLI-006: format_dead_letters() 0件 JSON → "[]"（§確定 D JSON 0件）。"""
+
+    def test_empty_dead_letters_json_is_empty_array(self) -> None:
+        """TC-UT-AC-CLI-006: 空リスト + json_output=True → "[]" に等しい。"""
+        output = formatters.format_dead_letters([], json_output=True)
+        data = json.loads(output)
+        assert data == []
+
+    def test_empty_dead_letters_table_shows_no_event_message(self) -> None:
+        """0件テーブル → "dead-letter Event はありません" が含まれる。"""
+        output = formatters.format_dead_letters([], json_output=False)
+        assert "dead-letter Event はありません" in output
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-AC-CLI-007: format_success — JSON 形式
+# ---------------------------------------------------------------------------
+
+
+class TestFormatSuccess:
+    """TC-UT-AC-CLI-007: format_success() の正常系。"""
+
+    def test_json_format_contains_result_ok(self) -> None:
+        """TC-UT-AC-CLI-007: json_output=True → {"result": "ok"} が含まれる。"""
+        output = formatters.format_success("Operation successful", json_output=True, command="retry-task")
+        data = json.loads(output)
+        assert data["result"] == "ok"
+        assert data["command"] == "retry-task"
+
+    def test_table_format_starts_with_ok_prefix(self) -> None:
+        """テーブル形式 → "[OK] <message>" で始まる。"""
+        output = formatters.format_success("Done!", json_output=False)
+        assert output == "[OK] Done!"
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-AC-CLI-008: format_error — [FAIL] プレフィックス
+# ---------------------------------------------------------------------------
+
+
+class TestFormatError:
+    """TC-UT-AC-CLI-008: format_error() の正常系。"""
+
+    def test_error_message_gets_fail_prefix(self) -> None:
+        """TC-UT-AC-CLI-008: message="エラー" → "[FAIL] エラー" で始まる。"""
+        output = formatters.format_error("エラーが発生しました")
+        assert output == "[FAIL] エラーが発生しました"
+
+    def test_already_fail_prefixed_message_not_doubled(self) -> None:
+        """既に [FAIL] で始まる文字列は [FAIL] が重複しない。"""
+        msg = "[FAIL] something went wrong"
+        output = formatters.format_error(msg)
+        assert output == msg
+        assert output.count("[FAIL]") == 1
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-AC-CLI-009: format_blocked_tasks — last_error 80文字トランケート
+# ---------------------------------------------------------------------------
+
+
+class TestTruncation:
+    """TC-UT-AC-CLI-009: last_error が 80 文字を超える場合のトランケート（§確定 D）。"""
+
+    def test_last_error_truncated_at_80_chars_in_table(self) -> None:
+        """TC-UT-AC-CLI-009: 100文字の last_error → テーブル形式で 81文字目以降が省略され ... が含まれる。"""
+        long_error = "A" * 100
+        task = _make_blocked_summary(last_error=long_error)
+        output = formatters.format_blocked_tasks([task], json_output=False)
+
+        # 81文字目以降（"AAAAA...") は出力に含まれない
+        # 代わりに ... が含まれる
+        assert "..." in output
+        # 81文字目の "A" のみの連続は ... で切られているはず（80文字 + "..."）
+        # 100個の A が全て出力されていない
+        assert "A" * 100 not in output
+
+    def test_last_error_not_truncated_when_exactly_80_chars(self) -> None:
+        """80文字ちょうどの last_error はトランケートされない。"""
+        exactly_80 = "B" * 80
+        task = _make_blocked_summary(last_error=exactly_80)
+        output = formatters.format_blocked_tasks([task], json_output=False)
+        assert "B" * 80 in output
+
+    def test_last_error_not_truncated_in_json_mode(self) -> None:
+        """JSON 形式では last_error はトランケートされない（フルテキスト）。"""
+        long_error = "C" * 100
+        task = _make_blocked_summary(last_error=long_error)
+        output = formatters.format_blocked_tasks([task], json_output=True)
+        data = json.loads(output)
+        assert data[0]["last_error"] == long_error
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-AC-CLI-010〜012: 変更コマンド成功確定文言照合
+# ---------------------------------------------------------------------------
+
+
+class TestSuccessMessageWording:
+    """TC-UT-AC-CLI-010〜012: 変更コマンド成功時の確定文言照合（detailed-design.md §確定 D）。"""
+
+    def test_retry_task_success_message_contains_in_progress_and_stage_worker(self) -> None:
+        """TC-UT-AC-CLI-010: retry-task 成功文言に [OK] / IN_PROGRESS / StageWorker が含まれる。
+
+        admin.py の retry_task コマンドで生成されるメッセージを検証。
+        """
+        task_id = uuid4()
+        msg = (
+            f"Task {task_id} を BLOCKED → IN_PROGRESS に変更しました。"
+            " bakufu サーバーの StageWorker が自動的に再実行します。"
+        )
+        output = formatters.format_success(msg, json_output=False)
+        assert "[OK]" in output
+        assert "IN_PROGRESS" in output
+        assert "StageWorker" in output
+
+    def test_cancel_task_success_message_contains_cancelled(self) -> None:
+        """TC-UT-AC-CLI-011: cancel-task 成功文言に [OK] / CANCELLED が含まれる。"""
+        task_id = uuid4()
+        msg = f"Task {task_id} を CANCELLED に変更しました。"
+        output = formatters.format_success(msg, json_output=False)
+        assert "[OK]" in output
+        assert "CANCELLED" in output
+
+    def test_retry_event_success_message_contains_pending_and_outbox_dispatcher(self) -> None:
+        """TC-UT-AC-CLI-012: retry-event 成功文言に [OK] / PENDING / Outbox Dispatcher が含まれる。"""
+        event_id = uuid4()
+        msg = (
+            f"Outbox Event {event_id} を DEAD_LETTER → PENDING にリセットしました。"
+            " Outbox Dispatcher が次回ポーリングで再 dispatch します。"
+        )
+        output = formatters.format_success(msg, json_output=False)
+        assert "[OK]" in output
+        assert "PENDING" in output
+        assert "Outbox Dispatcher" in output

--- a/backend/tests/unit/test_admin_service.py
+++ b/backend/tests/unit/test_admin_service.py
@@ -1,0 +1,361 @@
+"""AdminService ユニットテスト（TC-UT-AC-001〜014）。
+
+設計書: docs/features/admin-cli/application/test-design.md §ユニットテストケース
+
+全 Port を AsyncMock でスタブ化し、AdminService のビジネスロジック（Fail Fast
+検証 / audit_log 記録タイミング / actor DI / 確定文言）を DB 接続なしで検証する。
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, call
+from uuid import UUID, uuid4
+
+import pytest
+
+from bakufu.application.exceptions.task_exceptions import IllegalTaskStateError, TaskNotFoundError
+from bakufu.application.ports.outbox_event_repository import OutboxEventView
+from bakufu.application.services.admin_service import AdminService
+from bakufu.domain.exceptions.outbox import IllegalOutboxStateError, OutboxEventNotFoundError
+from bakufu.domain.value_objects import TaskStatus
+
+from tests.factories.task import (
+    make_blocked_task,
+    make_cancelled_task,
+    make_done_task,
+    make_in_progress_task,
+)
+
+# asyncio mark はクラスレベルで設定（sync テストクラスには付けない）
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_service(
+    *,
+    task_repo: object | None = None,
+    outbox_event_repo: object | None = None,
+    audit_log_writer: object | None = None,
+    actor: str = "test_actor",
+) -> AdminService:
+    """全 Port を AsyncMock でスタブした AdminService を構築する。"""
+    return AdminService(
+        task_repo=task_repo or AsyncMock(),
+        outbox_event_repo=outbox_event_repo or AsyncMock(),
+        audit_log_writer=audit_log_writer or AsyncMock(),
+        actor=actor,
+    )
+
+
+def _make_outbox_view(
+    *,
+    event_id: UUID | None = None,
+    status: str = "DEAD_LETTER",
+    attempt_count: int = 3,
+    last_error: str | None = "some error",
+) -> OutboxEventView:
+    return OutboxEventView(
+        event_id=event_id or uuid4(),
+        event_kind="TestEventEmitted",
+        aggregate_id=uuid4(),
+        status=status,
+        attempt_count=attempt_count,
+        last_error=last_error,
+        updated_at=datetime.now(UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-AC-001/002: _write_audit() の result=OK / FAIL 引数確認
+# ---------------------------------------------------------------------------
+
+
+class TestWriteAudit:
+    """TC-UT-AC-001/002: audit_log_writer.write() が正しい引数で呼ばれる。"""
+
+    pytestmark = pytest.mark.asyncio
+
+    async def test_write_audit_ok_on_success(self) -> None:
+        """TC-UT-AC-001: 成功時 audit_log_writer.write() に result='OK' / error_text=None が渡される。"""
+        audit_log_writer = AsyncMock()
+        task_repo = AsyncMock()
+        task_repo.find_blocked.return_value = []
+
+        service = _make_service(
+            task_repo=task_repo,
+            audit_log_writer=audit_log_writer,
+        )
+        await service.list_blocked_tasks()
+
+        audit_log_writer.write.assert_called_once()
+        _, kwargs = audit_log_writer.write.call_args
+        assert kwargs["result"] == "OK"
+        assert kwargs["error_text"] is None
+
+    async def test_write_audit_fail_on_error(self) -> None:
+        """TC-UT-AC-002: 失敗時 audit_log_writer.write() に result='FAIL' / error_text が渡される。"""
+        audit_log_writer = AsyncMock()
+        task_repo = AsyncMock()
+        task_repo.find_by_id.return_value = None  # 存在しない → TaskNotFoundError
+
+        service = _make_service(task_repo=task_repo, audit_log_writer=audit_log_writer)
+
+        with pytest.raises(TaskNotFoundError):
+            await service.retry_task(uuid4())
+
+        audit_log_writer.write.assert_called_once()
+        _, kwargs = audit_log_writer.write.call_args
+        assert kwargs["result"] == "FAIL"
+        assert kwargs["error_text"] is not None
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-AC-003/004: try/finally audit_log 保証（§確定 A）
+# ---------------------------------------------------------------------------
+
+
+class TestAuditLogFinally:
+    """TC-UT-AC-003/004: 例外発生後も audit_log が記録される（§確定 A / try/finally 保証）。"""
+
+    pytestmark = pytest.mark.asyncio
+
+    async def test_retry_task_audit_written_even_on_task_not_found(self) -> None:
+        """TC-UT-AC-003: find_by_id が None → TaskNotFoundError 送出 AND audit_log FAIL 記録。"""
+        audit_log_writer = AsyncMock()
+        task_repo = AsyncMock()
+        task_repo.find_by_id.return_value = None
+
+        service = _make_service(task_repo=task_repo, audit_log_writer=audit_log_writer)
+
+        with pytest.raises(TaskNotFoundError):
+            await service.retry_task(uuid4())
+
+        # try/finally 保証: 例外後も write() が呼ばれる
+        assert audit_log_writer.write.call_count == 1
+        _, kwargs = audit_log_writer.write.call_args
+        assert kwargs["result"] == "FAIL"
+
+    async def test_cancel_task_audit_written_even_on_illegal_state(self) -> None:
+        """TC-UT-AC-004: DONE Task の cancel → IllegalTaskStateError 送出 AND audit_log FAIL 記録。"""
+        audit_log_writer = AsyncMock()
+        task_repo = AsyncMock()
+        done_task = make_done_task()
+        task_repo.find_by_id.return_value = done_task
+
+        service = _make_service(task_repo=task_repo, audit_log_writer=audit_log_writer)
+
+        with pytest.raises(IllegalTaskStateError):
+            await service.cancel_task(done_task.id, reason="test")
+
+        assert audit_log_writer.write.call_count == 1
+        _, kwargs = audit_log_writer.write.call_args
+        assert kwargs["result"] == "FAIL"
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-AC-005/006: Fail Fast 検証（§確定 B）
+# ---------------------------------------------------------------------------
+
+
+class TestFailFast:
+    """TC-UT-AC-005/006: Fail Fast 検証 — 不正ステータス → 即座に例外（§確定 B）。"""
+
+    pytestmark = pytest.mark.asyncio
+
+    async def test_retry_done_task_raises_illegal_state(self) -> None:
+        """TC-UT-AC-005: DONE Task retry → IllegalTaskStateError（task.unblock_retry 未呼び出し）。"""
+        task_repo = AsyncMock()
+        done_task = make_done_task()
+        task_repo.find_by_id.return_value = done_task
+
+        service = _make_service(task_repo=task_repo)
+
+        with pytest.raises(IllegalTaskStateError):
+            await service.retry_task(done_task.id)
+
+        # unblock_retry が呼ばれないことを確認（save が呼ばれない）
+        task_repo.save.assert_not_called()
+
+    async def test_cancel_cancelled_task_raises_illegal_state(self) -> None:
+        """TC-UT-AC-006: CANCELLED Task cancel → IllegalTaskStateError（§確定 B）。"""
+        task_repo = AsyncMock()
+        cancelled_task = make_cancelled_task()
+        task_repo.find_by_id.return_value = cancelled_task
+
+        service = _make_service(task_repo=task_repo)
+
+        with pytest.raises(IllegalTaskStateError):
+            await service.cancel_task(cancelled_task.id, reason="test")
+
+        task_repo.save.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-AC-007: retry_event Fail Fast（§確定 C）
+# ---------------------------------------------------------------------------
+
+
+class TestRetryEventFailFast:
+    """TC-UT-AC-007: retry_event Fail Fast — PENDING → IllegalOutboxStateError（§確定 C）。"""
+
+    pytestmark = pytest.mark.asyncio
+
+    async def test_retry_pending_event_raises_illegal_outbox_state(self) -> None:
+        """TC-UT-AC-007: status=PENDING の Event → IllegalOutboxStateError（reset_to_pending 未呼び出し）。"""
+        outbox_event_repo = AsyncMock()
+        pending_view = _make_outbox_view(status="PENDING")
+        outbox_event_repo.find_by_id.return_value = pending_view
+
+        service = _make_service(outbox_event_repo=outbox_event_repo)
+
+        with pytest.raises(IllegalOutboxStateError):
+            await service.retry_event(pending_view.event_id)
+
+        outbox_event_repo.reset_to_pending.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-AC-008: actor DI 確認（§確定 E）
+# ---------------------------------------------------------------------------
+
+
+class TestActorDI:
+    """TC-UT-AC-008: actor フィールドが audit_log に記録される（§確定 E）。"""
+
+    pytestmark = pytest.mark.asyncio
+
+    async def test_actor_passed_to_audit_log_writer(self) -> None:
+        """TC-UT-AC-008: actor='ceo_operator' → audit_log_writer.write() に actor='ceo_operator' が渡される。"""
+        audit_log_writer = AsyncMock()
+        task_repo = AsyncMock()
+        task_repo.find_blocked.return_value = []
+
+        service = _make_service(
+            task_repo=task_repo,
+            audit_log_writer=audit_log_writer,
+            actor="ceo_operator",
+        )
+        await service.list_blocked_tasks()
+
+        _, kwargs = audit_log_writer.write.call_args
+        assert kwargs["actor"] == "ceo_operator"
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-AC-009~013: 確定文言（MSG-AC-001〜005）照合
+# ---------------------------------------------------------------------------
+
+
+class TestMessageWording:
+    """TC-UT-AC-009〜013: MSG-AC-001〜005 の確定文言照合。"""
+
+    def test_task_not_found_error_message(self) -> None:
+        """TC-UT-AC-009: TaskNotFoundError のメッセージに task_id が含まれる（MSG-AC-001）。"""
+        task_id = uuid4()
+        error = TaskNotFoundError(task_id)
+        assert str(task_id) in str(error)
+
+    def test_illegal_task_state_error_retry_message_contains_blocked(self) -> None:
+        """TC-UT-AC-010: IllegalTaskStateError(retry) のメッセージに BLOCKED が含まれる（MSG-AC-002）。"""
+        task_id = uuid4()
+        error = IllegalTaskStateError(
+            task_id=task_id,
+            current_status=TaskStatus.IN_PROGRESS,
+            action="retry",
+            message=(
+                f"[FAIL] Task {task_id} は BLOCKED 状態ではありません"
+                f"（現在: IN_PROGRESS）。\n"
+                "Next: 'bakufu admin list-blocked' で BLOCKED Task を確認してください。"
+            ),
+        )
+        assert "BLOCKED" in str(error)
+        assert "[FAIL]" in str(error)
+
+    def test_illegal_task_state_error_cancel_message(self) -> None:
+        """TC-UT-AC-011: IllegalTaskStateError(cancel) のメッセージに BLOCKED/PENDING/IN_PROGRESS が含まれる（MSG-AC-003）。"""
+        task_id = uuid4()
+        error = IllegalTaskStateError(
+            task_id=task_id,
+            current_status=TaskStatus.DONE,
+            action="cancel",
+            message=(
+                f"[FAIL] Task {task_id} はキャンセル可能な状態ではありません"
+                f"（現在: DONE）。\n"
+                "Next: キャンセル対象は BLOCKED / PENDING / IN_PROGRESS 状態の Task のみです。"
+            ),
+        )
+        msg = str(error)
+        assert "[FAIL]" in msg
+        # BLOCKED / PENDING / IN_PROGRESS のいずれかが含まれる
+        assert any(s in msg for s in ("BLOCKED", "PENDING", "IN_PROGRESS"))
+
+    def test_outbox_event_not_found_error_message(self) -> None:
+        """TC-UT-AC-012: OutboxEventNotFoundError のメッセージに [FAIL] と event_id が含まれる（MSG-AC-004）。"""
+        event_id = uuid4()
+        error = OutboxEventNotFoundError(
+            event_id=event_id,
+            message=(
+                f"[FAIL] Outbox Event {event_id} が見つかりません。\n"
+                "Next: event_id を確認し、"
+                "'bakufu admin list-dead-letters' で存在確認してください。"
+            ),
+        )
+        assert "[FAIL]" in str(error)
+        assert str(event_id) in str(error)
+
+    def test_illegal_outbox_state_error_message_contains_dead_letter(self) -> None:
+        """TC-UT-AC-013: IllegalOutboxStateError のメッセージに DEAD_LETTER が含まれる（MSG-AC-005）。"""
+        event_id = uuid4()
+        error = IllegalOutboxStateError(
+            event_id=event_id,
+            current_status="PENDING",
+            message=(
+                f"[FAIL] Outbox Event {event_id} は DEAD_LETTER 状態ではありません"
+                f"（現在: PENDING）。\n"
+                "Next: 'bakufu admin list-dead-letters' で DEAD_LETTER Event を確認してください。"
+            ),
+        )
+        assert "DEAD_LETTER" in str(error)
+        assert "[FAIL]" in str(error)
+
+
+# ---------------------------------------------------------------------------
+# TC-UT-AC-014: T2 対策 — args_json に raw last_error が含まれない
+# ---------------------------------------------------------------------------
+
+
+class TestArgsJsonSecurity:
+    """TC-UT-AC-014: T2 — args_json に task の last_error が含まれない。"""
+
+    pytestmark = pytest.mark.asyncio
+
+    async def test_cancel_task_args_json_contains_only_task_id(self) -> None:
+        """TC-UT-AC-014: cancel_task の args_json は task_id のみ（last_error は含まれない）。
+
+        T2 脅威対策: args_json に task の生エラーテキストをそのまま格納しない。
+        task の last_error は AuditLogWriterPort 経由で MaskedText カラムに書かれるが、
+        args_json には混入しない。
+        """
+        audit_log_writer = AsyncMock()
+        task_repo = AsyncMock()
+
+        # last_error に機密情報を含む BLOCKED Task
+        secret_error = "super_secret_token: abc123xyz"
+        blocked_task = make_blocked_task(last_error=secret_error)
+        task_repo.find_by_id.return_value = blocked_task
+
+        service = _make_service(task_repo=task_repo, audit_log_writer=audit_log_writer)
+        await service.cancel_task(blocked_task.id, reason="test")
+
+        _, kwargs = audit_log_writer.write.call_args
+        args_json = kwargs["args_json"]
+
+        # args_json は {"task_id": str(task_id)} のみ
+        assert "task_id" in args_json
+        # last_error の内容が args_json に含まれていない
+        assert secret_error not in str(args_json)
+        assert "super_secret_token" not in str(args_json)

--- a/backend/tests/unit/test_admin_service.py
+++ b/backend/tests/unit/test_admin_service.py
@@ -35,6 +35,18 @@ from tests.factories.task import (
 # ---------------------------------------------------------------------------
 
 
+def _make_mock_session() -> AsyncMock:
+    """async with session, session.begin(): をサポートするモックセッションを返す。"""
+    session = AsyncMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    begin_ctx = AsyncMock()
+    begin_ctx.__aenter__ = AsyncMock(return_value=None)
+    begin_ctx.__aexit__ = AsyncMock(return_value=False)
+    session.begin = MagicMock(return_value=begin_ctx)
+    return session
+
+
 def _make_service(
     *,
     task_repo: object | None = None,
@@ -42,11 +54,24 @@ def _make_service(
     audit_log_writer: object | None = None,
     actor: str = "test_actor",
 ) -> AdminService:
-    """全 Port を AsyncMock でスタブした AdminService を構築する。"""
+    """全 Port を AsyncMock でスタブした AdminService を構築する（Option A 対応）。
+
+    session_factory は毎回同じモックセッションを返す。
+    各 factory callable は渡された mock port をそのまま返す。
+    _write_audit() が別 session を要求するが、同一モックセッションで動作する。
+    """
+    _task_repo = task_repo or AsyncMock()
+    _outbox_event_repo = outbox_event_repo or AsyncMock()
+    _audit_log_writer = audit_log_writer or AsyncMock()
+
+    mock_session = _make_mock_session()
+    mock_session_factory = MagicMock(return_value=mock_session)
+
     return AdminService(
-        task_repo=task_repo or AsyncMock(),
-        outbox_event_repo=outbox_event_repo or AsyncMock(),
-        audit_log_writer=audit_log_writer or AsyncMock(),
+        session_factory=mock_session_factory,
+        task_repo_factory=lambda _session: _task_repo,
+        outbox_event_repo_factory=lambda _session: _outbox_event_repo,
+        audit_log_writer_factory=lambda _session: _audit_log_writer,
         actor=actor,
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -137,6 +137,8 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "sqlalchemy", extra = ["asyncio"] },
+    { name = "tabulate" },
+    { name = "typer" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -162,6 +164,8 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.9" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0" },
+    { name = "tabulate", specifier = ">=0.9" },
+    { name = "typer", specifier = ">=0.15" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.24" },
 ]
 
@@ -565,6 +569,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -625,6 +641,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -940,6 +965,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
 name = "rpds-py"
 version = "0.30.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1046,6 +1084,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1119,6 +1166,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tabulate"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
+]
+
+[[package]]
 name = "tqdm"
 version = "4.67.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1128,6 +1184,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276, upload-time = "2026-04-30T19:32:16.964Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/f9/2b3ff4e56e5fa7debfaf9eb135d0da96f3e9a1d5b27222223c7296336e5f/typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89", size = 58409, upload-time = "2026-04-30T19:32:18.271Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **AdminService** 5 コマンド（list-blocked / retry-task / cancel-task / list-dead-letters / retry-event）を try/finally audit_log 保証付きで実装
- **新規 Port**: `OutboxEventRepositoryPort` / `AuditLogWriterPort` — Clean Architecture 保全（application 層から SQLAlchemy を排除）
- **新規例外**: `OutboxEventNotFoundError` / `IllegalOutboxStateError` in `domain/exceptions/outbox.py`
- **`list_by_status()` 追加**: `TaskRepositoryPort` + `SqliteTaskRepository` — §確定J に必要
- **§確定J 起動時リカバリスキャン**: `StageWorker._recovery_scan()` — `retry-task` の end-to-end を担保
- **Typer CLI**: `interfaces/cli/admin.py` + `lite_bootstrap.py` + `formatters.py` — 5 コマンド + `--json` フラグ対応
- **依存追加**: `typer>=0.15` / `tabulate>=0.9`

## 設計準拠

- `docs/features/admin-cli/application/detailed-design.md` §確定 A〜E 完全実装
- `docs/features/admin-cli/cli/detailed-design.md` §確定 A〜D 完全実装
- `docs/features/stage-executor/application/detailed-design.md` §確定J 完全実装

## CI 結果

- `uv run pytest tests/ -q`: **2469 passed, 3 skipped**
- `uv run ruff check src/`: **All checks passed**
- `uv run pyright` (新規ファイル対象): **0 errors**

## テスト担当への確認依頼

- `AdminService` の try/finally audit_log 保証が成功・失敗の両ケースで正しく動作するか（TC-UT-AC 系）
- `StageWorker._recovery_scan()` が IN_PROGRESS Task を正しくキューに再投入するか（TC-UT-ME 系）
- CLI コマンドの `--json` フラグ出力フォーマット（TC-IT-AC 系）

Closes #165